### PR TITLE
feat: Minion-mandatory deferral, Docker Compose profiles, Default Minion

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -330,6 +330,7 @@
         <feature version="${guavaOsgiVersion}">guava</feature>
         <feature>opennms-activemq-pool</feature>
         <feature>opennms-core</feature>
+        <feature>opennms-core-messagebus-api</feature>
         <feature>opennms-config</feature>
         <feature>opennms-icmp-api</feature>
         <feature>opennms-model</feature>
@@ -1173,6 +1174,7 @@
         <feature>opennms-kafka</feature>
         <feature>opennms-mate-impl</feature>
         <feature>opennms-elastic-client</feature>
+        <feature>opennms-core-messagebus-api</feature>
         <feature>rate-limited-logger</feature>
 
         <bundle>mvn:org.opennms.core.ipc.twin/org.opennms.core.ipc.twin.api/${project.version}</bundle>
@@ -1590,6 +1592,7 @@
         <feature>quartz</feature>
         <feature>opennms-health-api</feature>
         <feature>opennms-dao</feature>
+        <feature>opennms-core-messagebus-api</feature>
         <bundle>mvn:org.opennms.features/datachoices/${project.version}</bundle>
         <bundle>mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
         <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
@@ -1819,6 +1822,7 @@
     <feature name="opennms-graph-rest" description="OpenNMS :: Features :: Graph :: ReST API" version="${project.version}">
         <feature>opennms-graph-api</feature>
         <feature>opennms-graph-service</feature>
+        <feature>opennms-core-messagebus-api</feature>
         <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.graph.rest/org.opennms.features.graph.rest.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.graph.rest/org.opennms.features.graph.rest.impl/${project.version}</bundle>
@@ -1874,6 +1878,7 @@
     <feature name="opennms-config-management" description="OpenNMS :: Features :: Config" version="${project.version}">
         <feature>jackson-dataformat-yaml</feature>
         <feature>jackson-datatype-jsr310</feature>
+        <feature>opennms-core-messagebus-api</feature>
         <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
         <bundle>mvn:org.apache.ws.xmlschema/xmlschema-core/${xmlschemaVersion}</bundle>
         <bundle>mvn:org.apache.ws.xmlschema/xmlschema-walker/${xmlschemaVersion}</bundle>

--- a/docs/plans/2026-03-09-minion-mandatory-deferral-design.md
+++ b/docs/plans/2026-03-09-minion-mandatory-deferral-design.md
@@ -1,0 +1,263 @@
+# Minion-Mandatory Architecture — Deferral & Near-Term Items
+
+## Context
+
+The eventbus-redesign branch achieved the Strike Fighter goal: 17 standalone daemon
+containers communicating via Kafka event transport, end-to-end alarm flow proven
+(trap → Trapd → EventCreator → Kafka → EventTranslator → enrich → Kafka → Alarmd →
+PostgreSQL).
+
+The next proposed goal was to make Minion the **only** component that touches the
+network — eliminating direct SNMP/ICMP/etc. execution from core and daemon containers,
+requiring a Minion for every location including "Default."
+
+After analysis, this goal is **deferred** pending prerequisites described below.
+
+## Why Minion-Mandatory Is Deferred
+
+### Non-Distributable ServiceMonitors
+
+Several `ServiceMonitor` implementations cannot run on a Minion because they depend on
+in-JVM state, database access, or filesystem resources:
+
+- **PassiveServiceMonitor** — Reads from `PassiveStatusKeeper.getInstance()`, a static
+  singleton `HashMap<PassiveStatusKey, PollStatus>` in the same JVM. Comment in source:
+  `// this retrieves data from the deamon so it is not Distributable`. Forces
+  `getEffectiveLocation()` to return `"Default"` to prevent remote execution.
+- **Other monitors TBD** — A full audit of all `ServiceMonitor` implementations is
+  required to identify which are Minion-safe and which depend on local JVM state.
+
+### Collectors Route SNMP, Not Logic
+
+The `LocationAwareCollectorClient` pattern does not delegate full collector execution to
+Minion. Instead, the collector runs locally and individual SNMP operations are proxied
+to Minion via `LocationAwareSnmpClient` / `SnmpUtils`. The `KafkaRpcClientFactory`
+decision point (line ~164) routes requests only when location differs:
+
+```java
+if (request.getLocation() == null || request.getLocation().equals(location)) {
+    return module.execute(request);  // LOCAL execution
+}
+// else → Kafka RPC to Minion at target location
+```
+
+Making Pollerd/Collectd "schedulers only" (Option A) would require all monitors and
+collectors to be fully executable on Minion — a much larger abstraction change than
+exists today.
+
+### Default Location Semantics
+
+The string `"Default"` is hardcoded in `LocationUtils.DEFAULT_LOCATION_NAME` and
+`MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID`, referenced 123 times across 50
+files. Nodes provisioned without a location get `"Default"`. This string is preserved
+as-is — no rename to "Local" or other alternative.
+
+### Prerequisites for Revisiting
+
+1. Audit all `ServiceMonitor` implementations for Minion compatibility
+2. Audit all `ServiceCollector` implementations for full delegation capability
+3. Solve PassiveStatusd shared-state problem (see below)
+4. Potentially refactor monitors/collectors that depend on in-JVM state to use
+   RPC-based communication or shared external state
+
+## PassiveStatusd / Pollerd Shared-State Audit
+
+### The Bug
+
+In delta-v today, PassiveStatusd (TSID=7) and Pollerd (TSID=4) run in separate
+containers. Both load the `opennms-services` bundle containing `PassiveStatusKeeper`
+and `PassiveServiceMonitor`. Each JVM gets its own `PassiveStatusKeeper.s_instance`
+singleton with its own `HashMap`.
+
+When Pollerd executes `PassiveServiceMonitor.poll()`:
+1. Calls `PassiveStatusKeeper.getInstance().getStatus(nodeLabel, ipAddr, svcName)`
+2. Returns from the **local** (empty, uninitialized) map
+3. Default return: `PollStatus.up()` (line 196)
+
+Meanwhile, PassiveStatusd's `PassiveStatusKeeper` is the real instance — subscribed to
+`passiveServiceStatus` events, maintaining the actual status table. The two JVMs never
+communicate.
+
+### Fix Options
+
+| Option | Approach | Complexity | Notes |
+|--------|----------|-----------|-------|
+| A | PassiveStatusd publishes state changes to Kafka, PassiveServiceMonitor consumes | Medium | New Kafka topic + consumer in Pollerd |
+| B | PassiveStatusd writes status to PostgreSQL, PassiveServiceMonitor reads from DB | Low | Adds DB latency to every poll cycle |
+| **C** | **Merge PassiveStatusKeeper into Pollerd, eliminate PassiveStatusd** | **Low** | **Recommended** |
+| D | Make PassiveServiceMonitor an RPC call to PassiveStatusd | Medium | New RPC module |
+
+### Recommendation: Option C
+
+PassiveStatusKeeper is fundamentally a Pollerd concern — it feeds poll results into the
+polling cycle. The "daemon" wrapper (`PassiveStatusd`) exists only to host event
+subscription and the hashtable. Moving `PassiveStatusKeeper` into the Pollerd container
+(subscribing to `passiveServiceStatus` events via Kafka) eliminates the cross-container
+state problem entirely. PassiveStatusd would be removed as a standalone daemon.
+
+This is a niche feature (external systems injecting poll results) likely unused in most
+deployments, so the fix priority is low. Document and defer to post-Strike-Fighter.
+
+## Default Minion in Docker Compose
+
+### Purpose
+
+Add an `opennms/minion` container to the delta-v compose for:
+- Proving IPC Sink/RPC/Twin paths work in the containerized deployment
+- Receiving traps and syslog from monitored networks (network edge)
+- Enabling SNMP RPC delegation for nodes at the Default location
+- Future foundation for Minion-mandatory architecture
+
+### Container Configuration
+
+```yaml
+minion:
+  image: opennms/minion:${VERSION}
+  hostname: minion-default-01
+  depends_on:
+    core:
+      condition: service_healthy
+  environment:
+    MINION_ID: minion-default-01
+    MINION_LOCATION: Default
+    OPENNMS_HTTP_URL: http://webapp:8980/opennms
+    OPENNMS_HTTP_USER: admin
+    OPENNMS_HTTP_PASS: admin
+    KAFKA_RPC_BOOTSTRAP_SERVERS: kafka:9092
+    KAFKA_SINK_BOOTSTRAP_SERVERS: kafka:9092
+    JAVA_OPTS: >-
+      -Xms256m -Xmx512m
+      -Djava.security.egd=file:/dev/./urandom
+  volumes:
+    - minion-data:/opt/minion/data
+  ports:
+    - "1162:1162/udp"
+    - "1514:1514/udp"
+    - "8301:8201"
+```
+
+### Key Decisions
+
+- **All profiles**: The Default Minion is included in every profile (core, lite,
+  passive, full) since it is the network edge for all deployment modes.
+- **Kafka-only transport goal**: The Minion should communicate exclusively via Kafka
+  (RPC + Sink + Twin). No gRPC dependency.
+- **REST dependency workaround**: The Minion currently requires REST API access for
+  Trapd/Syslogd configuration sync. Since core runs without JettyServer in delta-v,
+  `OPENNMS_HTTP_URL` points to the webapp container as a workaround.
+- **Port conflicts**: Trap port 1162 and syslog port 1514 overlap with standalone
+  Trapd/Syslogd containers. When Minion is running, it receives traps/syslog directly
+  from the network. The standalone Trapd/Syslogd containers listen on different internal
+  ports (10162, 10514) and consume from Minion via Sink API when co-deployed.
+
+### Investigation: Eliminate Minion REST Dependency
+
+The Minion's REST API dependency (for Trapd/Syslogd configuration) is a long-standing
+architectural concern. The Minion should operate purely over Kafka.
+
+The IPC Twin API (`TwinSubscriber` / `TwinPublisher`) already provides the mechanism:
+- Minion subscribes to a config key at boot
+- Core responds with initial config object via RPC (over Kafka)
+- Core pushes subsequent config updates via reverse Sink (over Kafka)
+
+**Proposed solution**: Publish Trapd and Syslogd configurations through Twin publishers
+on the core side. The Minion's `TwinSubscriber` receives configs at boot and on change.
+This eliminates the REST dependency entirely.
+
+**Alternative**: Reverse RPC from Minion — Minion sends an RPC request to a Trapd/Syslogd
+topic, the daemon container responds with its configuration. This adds new RPC modules
+but avoids coupling config delivery to core.
+
+Both approaches require investigation into what other configurations the Minion fetches
+via REST beyond Trapd/Syslogd. Flag as a post-Strike-Fighter investigation.
+
+## Docker Compose Profiles
+
+### Current State
+
+The `deploy.sh` script implements deployment profiles via a bash `case` statement,
+selecting which services to pass to `docker compose up -d`. This is fragile and caused
+miscommunication during integration testing when profiles were expected to be a
+docker-compose native feature.
+
+### Target State
+
+Move profile logic to native Docker Compose `profiles:` declarations.
+
+**Profile mapping:**
+
+| Profile | Services | Use Case |
+|---------|----------|----------|
+| (default) | postgres, kafka, core, webapp, minion | Infrastructure + Default Minion |
+| `lite` | default + alarmd, pollerd, collectd, notifd, discovery, rtcd | Essential daemons |
+| `passive` | default + alarmd, trapd, syslogd | Trap/syslog receivers → alarms |
+| `full` | all services | Complete deployment |
+
+**Service profile assignments:**
+
+| Service | Profiles | Notes |
+|---------|----------|-------|
+| postgres, kafka, core, webapp, minion | (none — always start) | Infrastructure |
+| alarmd | lite, passive, full | Alarm persistence |
+| pollerd, collectd | lite, full | Polling and collection |
+| notifd, discovery, rtcd | lite, full | Notifications, discovery, RTC |
+| trapd, syslogd | passive, full | UDP listeners |
+| passivestatusd | full | Pending merge into Pollerd |
+| ticketer, eventtranslator | full | Event processing |
+| enlinkd, scriptd | full | Link discovery, scripting |
+
+**deploy.sh simplification:**
+
+```bash
+do_up() {
+    local profile="${1:-}"
+    if [ -n "$profile" ]; then
+        docker compose --profile "$profile" up -d
+    else
+        docker compose up -d  # default: infra + minion only
+    fi
+}
+```
+
+**Usage:**
+```bash
+docker compose up -d                      # infra + minion
+docker compose --profile lite up -d       # + essential daemons
+docker compose --profile passive up -d    # + trap/syslog receivers
+docker compose --profile full up -d       # everything
+```
+
+## Investigate: Alarmd on opennms/daemon Image
+
+### Background
+
+The `opennms/alarmd` image was built first as a proof-of-concept standalone Karaf
+container for alarm persistence. The `opennms/daemon` image was generalized later as
+the template for all other daemon containers. Alarmd was never migrated.
+
+### Differences
+
+| Aspect | opennms/alarmd | opennms/daemon |
+|--------|---------------|----------------|
+| Assembly | `opennms-assemblies/alarmd/` | `opennms-assemblies/daemon/` |
+| Entrypoint | Direct `karaf server` | `entrypoint.sh` (SSH keys, datasource cfg, overlay) |
+| Overlay | Bash `cp` in compose command override | Built-in overlay directories |
+| Datasource | Legacy `OPENNMS_BROKER_*` env vars | Runtime `.cfg` file generation |
+| User | `alarmd` (10001) | `onmsd` (10001) |
+
+### Investigation Items
+
+1. Can Alarmd's Karaf feature (`opennms-alarm-persistence`) run on the opennms/daemon
+   image with just an overlay change (featuresBoot + config files)?
+2. What assembly differences exist — does `opennms-assemblies/alarmd/` include bundles
+   not available in the daemon assembly?
+3. Would unifying eliminate the separate Docker build, Makefile, and assembly module?
+4. The ActiveMQ broker URL config (`OPENNMS_BROKER_URL`) — does the daemon image's
+   config mechanism support this?
+
+### Recommendation
+
+Investigate migrating Alarmd to the opennms/daemon image to reduce build complexity
+(one fewer image to build, push, and maintain). Flag as a post-Strike-Fighter cleanup
+task. If the daemon assembly already contains the alarm persistence bundles, this may
+be as simple as a new overlay directory and compose service definition.

--- a/docs/plans/2026-03-09-minion-mandatory-near-term-implementation.md
+++ b/docs/plans/2026-03-09-minion-mandatory-near-term-implementation.md
@@ -1,0 +1,318 @@
+# Minion-Mandatory Near-Term Items Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Docker Compose profiles, a Default Minion container, and update deploy.sh — delivering the actionable near-term items from the Minion-mandatory deferral design.
+
+**Architecture:** Native Docker Compose `profiles:` replace deploy.sh's bash case-statement. A Default-location Minion (`opennms/minion`) joins all profiles as the network edge. The Minion uses Kafka for RPC/Sink/Twin IPC and falls back to webapp's REST API for config sync until Twin API migration.
+
+**Tech Stack:** Docker Compose profiles, opennms/minion image, Kafka IPC transport, bash.
+
+**Design Doc:** `docs/plans/2026-03-09-minion-mandatory-deferral-design.md`
+
+---
+
+## Task 1: Add Docker Compose Profiles to Existing Services
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+
+Infrastructure services (postgres, kafka, core, webapp) have NO `profiles:` — they always start. Each daemon service gets profile labels controlling which deployment modes include it.
+
+**Step 1: Add `profiles:` to each daemon service**
+
+Add the `profiles:` key after the service name (before `image:`) for each daemon service according to this mapping:
+
+| Service | profiles |
+|---------|----------|
+| postgres | (none — always starts) |
+| kafka | (none — always starts) |
+| core | (none — always starts) |
+| webapp | (none — always starts) |
+| alarmd | `[lite, passive, full]` |
+| pollerd | `[lite, full]` |
+| collectd | `[lite, full]` |
+| rtcd | `[lite, full]` |
+| passivestatusd | `[full]` |
+| notifd | `[lite, full]` |
+| discovery | `[lite, full]` |
+| trapd | `[passive, full]` |
+| syslogd | `[passive, full]` |
+| ticketer | `[full]` |
+| eventtranslator | `[full]` |
+| enlinkd | `[full]` |
+| scriptd | `[full]` |
+| alarmd | `[lite, passive, full]` |
+
+For each service that needs profiles, add the `profiles:` key as the first property under the service name. Example for pollerd:
+
+```yaml
+  pollerd:
+    profiles: [lite, full]
+    image: opennms/daemon:${VERSION}
+    # ... rest unchanged
+```
+
+Example for trapd:
+
+```yaml
+  trapd:
+    profiles: [passive, full]
+    image: opennms/daemon:${VERSION}
+    # ... rest unchanged
+```
+
+Do NOT add `profiles:` to postgres, kafka, core, or webapp — they must always start.
+
+**Step 2: Verify compose config parses**
+
+Run: `cd opennms-container/delta-v && docker compose config --profiles full --services`
+
+Expected: All 17 services listed (postgres, kafka, core, webapp, alarmd, pollerd, collectd, rtcd, passivestatusd, notifd, discovery, trapd, syslogd, ticketer, eventtranslator, enlinkd, scriptd).
+
+**Step 3: Verify profile subsets**
+
+Run: `cd opennms-container/delta-v && docker compose config --profiles lite --services`
+
+Expected: postgres, kafka, core, webapp, alarmd, pollerd, collectd, notifd, discovery, rtcd (10 services).
+
+Run: `cd opennms-container/delta-v && docker compose config --profiles passive --services`
+
+Expected: postgres, kafka, core, webapp, alarmd, trapd, syslogd (7 services).
+
+Run: `cd opennms-container/delta-v && docker compose config --services`
+
+Expected: postgres, kafka, core, webapp (4 services — only always-on infrastructure).
+
+**Step 4: Commit**
+
+```bash
+git add opennms-container/delta-v/docker-compose.yml
+git commit -m "feat: add native Docker Compose profiles to delta-v services
+
+Profiles: lite (10 svc), passive (7 svc), full (17 svc).
+Infrastructure (postgres, kafka, core, webapp) always starts.
+Replaces algorithmic profile selection in deploy.sh."
+```
+
+---
+
+## Task 2: Add Default Minion Container
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+
+**Step 1: Add minion service definition**
+
+Add the following service definition after the `webapp` service and before `pollerd` in docker-compose.yml. The minion has NO `profiles:` — it always starts (it's infrastructure, like core and webapp):
+
+```yaml
+  minion:
+    image: opennms/minion:${VERSION}
+    container_name: delta-v-minion
+    hostname: minion-default-01
+    depends_on:
+      core:
+        condition: service_healthy
+      webapp:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    environment:
+      MINION_ID: minion-default-01
+      MINION_LOCATION: Default
+      OPENNMS_HTTP_URL: http://webapp:8980/opennms
+      OPENNMS_HTTP_USER: admin
+      OPENNMS_HTTP_PASS: admin
+      KAFKA_RPC_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_SINK_BOOTSTRAP_SERVERS: kafka:9092
+      JAVA_OPTS: >-
+        -Xms256m -Xmx512m
+        -Djava.security.egd=file:/dev/./urandom
+    volumes:
+      - minion-data:/opt/minion/data
+    ports:
+      - "8301:8201"
+    healthcheck:
+      test: ["CMD", "/health.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+```
+
+Note: Trap port (1162/udp) and syslog port (1514/udp) are NOT mapped on the Minion by default. The standalone Trapd and Syslogd containers already claim these host ports. If a user wants the Minion to receive traps/syslog directly (instead of via standalone Trapd/Syslogd containers), they can add port mappings manually or use a custom override file.
+
+**Step 2: Add minion-data volume**
+
+Add `minion-data:` to the `volumes:` section at the bottom of the file, alongside the existing volume declarations:
+
+```yaml
+volumes:
+  pgdata:
+  kafkadata:
+  opennms-etc:
+  opennms-data:
+  webapp-etc:
+  webapp-data:
+  minion-data:
+  pollerd-data:
+  # ... rest unchanged
+```
+
+**Step 3: Update deploy.sh image check**
+
+In `opennms-container/delta-v/deploy.sh`, update the image verification loop (line 38) to include the minion image:
+
+```bash
+    for img in "opennms/horizon:$VERSION" "opennms/daemon:$VERSION" "opennms/alarmd:$VERSION" "opennms/minion:$VERSION"; do
+```
+
+**Step 4: Verify compose config parses with minion**
+
+Run: `cd opennms-container/delta-v && docker compose config --services`
+
+Expected: postgres, kafka, core, webapp, minion (5 always-on services).
+
+Run: `cd opennms-container/delta-v && docker compose config --profiles full --services`
+
+Expected: All 18 services (17 previous + minion).
+
+**Step 5: Commit**
+
+```bash
+git add opennms-container/delta-v/docker-compose.yml opennms-container/delta-v/deploy.sh
+git commit -m "feat: add Default Minion container to delta-v compose
+
+Minion registers at location 'Default' with Kafka IPC transport.
+Included in all profiles (no profiles: key = always starts).
+REST config sync points to webapp container as workaround
+until Twin API migration eliminates REST dependency.
+Trap/syslog ports not mapped (standalone Trapd/Syslogd own those)."
+```
+
+---
+
+## Task 3: Update deploy.sh to Use Compose Profiles
+
+**Files:**
+- Modify: `opennms-container/delta-v/deploy.sh`
+
+**Step 1: Replace do_up() function**
+
+Replace the entire `do_up()` function (lines 34-67) with:
+
+```bash
+do_up() {
+    log "Starting Delta-V (version $VERSION)..."
+
+    # Check images exist
+    for img in "opennms/horizon:$VERSION" "opennms/daemon:$VERSION" "opennms/alarmd:$VERSION" "opennms/minion:$VERSION"; do
+        docker image inspect "$img" >/dev/null 2>&1 || err "Image $img not found. Run ./build.sh first."
+    done
+
+    local profile="${1:-}"
+    if [ -n "$profile" ]; then
+        log "Using profile: $profile"
+        docker compose --profile "$profile" up -d
+    else
+        log "Starting infrastructure only (core + webapp + minion)"
+        docker compose up -d
+    fi
+
+    log "Waiting for services to start..."
+    log "Run './deploy.sh status' to check progress."
+    log "Web UI: http://localhost:8980/opennms (admin/admin)"
+}
+```
+
+**Step 2: Update usage text**
+
+Replace the `Profiles:` section in the `usage()` function with:
+
+```bash
+Profiles:
+  (none)    Infrastructure only: postgres + kafka + core + webapp + minion
+  lite      + essential daemons (alarmd, pollerd, collectd, notifd, discovery, rtcd)
+  passive   + trap/syslog receivers (alarmd, trapd, syslogd)
+  full      All 18 services
+```
+
+And update the Examples section:
+
+```bash
+Examples:
+  ./deploy.sh up                    # Infrastructure only (5 services)
+  ./deploy.sh up full               # Start everything (18 services)
+  ./deploy.sh up passive            # Trap/syslog receivers with auto-discovery
+  ./deploy.sh up lite               # Core + essential daemons (11 services)
+  ./deploy.sh logs alarmd           # Tail alarmd logs
+  ./deploy.sh shell core            # Karaf shell on core
+  ./deploy.sh test                  # Verify deployment
+  ./deploy.sh reset && ./deploy.sh up  # Fresh start
+```
+
+**Step 3: Verify deploy.sh syntax**
+
+Run: `bash -n opennms-container/delta-v/deploy.sh && echo "SYNTAX OK"`
+
+Expected: `SYNTAX OK`
+
+**Step 4: Commit**
+
+```bash
+git add opennms-container/delta-v/deploy.sh
+git commit -m "refactor: deploy.sh uses native Docker Compose profiles
+
+Removes bash case-statement profile selection. Profiles are now
+declared in docker-compose.yml. deploy.sh passes --profile flag
+directly to docker compose. Default (no profile) starts infra only."
+```
+
+---
+
+## Task 4: Verify End-to-End (Manual Smoke Test)
+
+This task is manual — not automatable in CI without running Docker.
+
+**Step 1: Test default profile (infrastructure only)**
+
+Run: `cd opennms-container/delta-v && ./deploy.sh up`
+
+Verify 5 services start: postgres, kafka, core, webapp, minion.
+
+Run: `./deploy.sh status`
+
+Expected: All 5 services running/healthy.
+
+**Step 2: Test minion registration**
+
+Once webapp is healthy, check that the Minion registered:
+
+Run: `curl -sf -u admin:admin http://localhost:8980/opennms/rest/minions | python3 -m json.tool`
+
+Expected: One minion with `id: minion-default-01`, `location: Default`, `status: UP`.
+
+If the Minion fails to register (REST dependency issue), check minion logs:
+
+Run: `docker compose logs minion --tail=50`
+
+Document any errors — this validates the REST workaround (pointing at webapp).
+
+**Step 3: Test lite profile**
+
+Run: `./deploy.sh reset && ./deploy.sh up lite`
+
+Verify 11 services start: infrastructure (5) + alarmd, pollerd, collectd, notifd, discovery, rtcd.
+
+**Step 4: Test full profile**
+
+Run: `./deploy.sh reset && ./deploy.sh up full`
+
+Verify all 18 services start.
+
+**Step 5: Run existing test suite**
+
+Run: `./deploy.sh test`
+
+Expected: All 5 tests pass (services running, web UI, REST API, PostgreSQL, Kafka topics).

--- a/opennms-container/delta-v/deploy.sh
+++ b/opennms-container/delta-v/deploy.sh
@@ -3,7 +3,7 @@
 # deploy.sh — Deploy and manage OpenNMS Delta-V
 #
 # Usage:
-#   ./deploy.sh up          Start all services
+#   ./deploy.sh up [profile] Start services (profiles: lite, passive, full)
 #   ./deploy.sh down        Stop all services (preserve data)
 #   ./deploy.sh reset       Stop and remove all data
 #   ./deploy.sh status      Show service status
@@ -39,27 +39,14 @@ do_up() {
         docker image inspect "$img" >/dev/null 2>&1 || err "Image $img not found. Run ./build.sh first."
     done
 
-    local profile="${1:-full}"
-    case "$profile" in
-        full)
-            docker compose up -d
-            ;;
-        core)
-            # Minimal: postgres + kafka + core + webapp
-            docker compose up -d postgres kafka core webapp
-            ;;
-        lite)
-            # Core + essential daemons (no trapd/syslogd/ticketer/eventtranslator/passivestatusd)
-            docker compose up -d postgres kafka core webapp alarmd pollerd collectd notifd discovery rtcd
-            ;;
-        passive)
-            # Passive monitoring: traps + syslogs → alarms, with new-suspect-on-trap/message enabled
-            docker compose up -d postgres kafka core webapp alarmd trapd syslogd
-            ;;
-        *)
-            err "Unknown profile: $profile (use: full, core, lite, passive)"
-            ;;
-    esac
+    local profile="${1:-}"
+    if [ -n "$profile" ]; then
+        log "Using profile: $profile"
+        COMPOSE_PROFILES="$profile" docker compose up -d
+    else
+        log "Starting infrastructure only (core + webapp + minion)"
+        docker compose up -d
+    fi
 
     log "Waiting for services to start..."
     log "Run './deploy.sh status' to check progress."
@@ -169,7 +156,7 @@ usage() {
 Usage: ./deploy.sh <command> [args]
 
 Commands:
-  up [profile]    Start services (profiles: full, core, lite, passive)
+  up [profile]    Start services (profiles: lite, passive, full)
   down            Stop services (preserve data volumes)
   reset           Stop and destroy all data (clean slate)
   status          Show service status
@@ -179,15 +166,16 @@ Commands:
   help            Show this help
 
 Profiles:
-  full    All 15 services (default)
-  core    Minimal: postgres + kafka + core + webapp
-  lite    Core + essential daemons (10 services)
-  passive Traps + syslogs → alarms (7 services, new-suspect enabled)
+  (none)    Infrastructure only: postgres + kafka + core + webapp + minion
+  lite      + essential daemons (alarmd, pollerd, collectd, notifd, discovery, rtcd)
+  passive   + trap/syslog receivers (alarmd, trapd, syslogd)
+  full      All 18 services
 
 Examples:
-  ./deploy.sh up                    # Start everything
+  ./deploy.sh up                    # Infrastructure only (5 services)
+  ./deploy.sh up full               # Start everything (18 services)
   ./deploy.sh up passive            # Trap/syslog receivers with auto-discovery
-  ./deploy.sh up lite               # Start without trapd/syslogd/etc.
+  ./deploy.sh up lite               # Core + essential daemons (11 services)
   ./deploy.sh logs alarmd           # Tail alarmd logs
   ./deploy.sh shell core            # Karaf shell on core
   ./deploy.sh test                  # Verify deployment

--- a/opennms-container/delta-v/deploy.sh
+++ b/opennms-container/delta-v/deploy.sh
@@ -35,7 +35,7 @@ do_up() {
     log "Starting Delta-V (version $VERSION)..."
 
     # Check images exist
-    for img in "opennms/horizon:$VERSION" "opennms/daemon:$VERSION" "opennms/alarmd:$VERSION"; do
+    for img in "opennms/horizon:$VERSION" "opennms/daemon:$VERSION" "opennms/alarmd:$VERSION" "opennms/minion:$VERSION"; do
         docker image inspect "$img" >/dev/null 2>&1 || err "Image $img not found. Run ./build.sh first."
     done
 

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -193,6 +193,39 @@ services:
       retries: 3
       start_period: 120s
 
+  minion:
+    image: opennms/minion:${VERSION}
+    container_name: delta-v-minion
+    hostname: minion-default-01
+    depends_on:
+      core:
+        condition: service_healthy
+      webapp:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    environment:
+      MINION_ID: minion-default-01
+      MINION_LOCATION: Default
+      OPENNMS_HTTP_URL: http://webapp:8980/opennms
+      OPENNMS_HTTP_USER: admin
+      OPENNMS_HTTP_PASS: admin
+      KAFKA_RPC_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_SINK_BOOTSTRAP_SERVERS: kafka:9092
+      JAVA_OPTS: >-
+        -Xms256m -Xmx512m
+        -Djava.security.egd=file:/dev/./urandom
+    volumes:
+      - minion-data:/opt/minion/data
+    ports:
+      - "8301:8201"
+    healthcheck:
+      test: ["CMD", "/health.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
   pollerd:
     profiles: [lite, full]
     image: opennms/daemon:${VERSION}
@@ -634,6 +667,7 @@ volumes:
   opennms-data:
   webapp-etc:
   webapp-data:
+  minion-data:
   pollerd-data:
   collectd-data:
   rtcd-data:

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -194,6 +194,7 @@ services:
       start_period: 120s
 
   pollerd:
+    profiles: [lite, full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-pollerd
     hostname: pollerd
@@ -228,6 +229,7 @@ services:
       start_period: 60s
 
   collectd:
+    profiles: [lite, full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-collectd
     hostname: collectd
@@ -262,6 +264,7 @@ services:
       start_period: 60s
 
   rtcd:
+    profiles: [lite, full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-rtcd
     hostname: rtcd
@@ -293,6 +296,7 @@ services:
       start_period: 60s
 
   passivestatusd:
+    profiles: [full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-passivestatusd
     hostname: passivestatusd
@@ -324,6 +328,7 @@ services:
       start_period: 60s
 
   notifd:
+    profiles: [lite, full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-notifd
     hostname: notifd
@@ -355,6 +360,7 @@ services:
       start_period: 60s
 
   discovery:
+    profiles: [lite, full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-discovery
     hostname: discovery
@@ -386,6 +392,7 @@ services:
       start_period: 60s
 
   trapd:
+    profiles: [passive, full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-trapd
     hostname: trapd
@@ -420,6 +427,7 @@ services:
       start_period: 60s
 
   syslogd:
+    profiles: [passive, full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-syslogd
     hostname: syslogd
@@ -453,6 +461,7 @@ services:
       start_period: 60s
 
   ticketer:
+    profiles: [full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-ticketer
     hostname: ticketer
@@ -484,6 +493,7 @@ services:
       start_period: 60s
 
   eventtranslator:
+    profiles: [full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-eventtranslator
     hostname: eventtranslator
@@ -515,6 +525,7 @@ services:
       start_period: 60s
 
   enlinkd:
+    profiles: [full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-enlinkd
     hostname: enlinkd
@@ -546,6 +557,7 @@ services:
       start_period: 60s
 
   scriptd:
+    profiles: [full]
     image: opennms/daemon:${VERSION}
     container_name: delta-v-scriptd
     hostname: scriptd
@@ -577,6 +589,7 @@ services:
       start_period: 60s
 
   alarmd:
+    profiles: [lite, passive, full]
     image: opennms/alarmd:${VERSION}
     entrypoint: ["/bin/bash", "-c"]
     command:

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -210,13 +210,16 @@ services:
       OPENNMS_HTTP_URL: http://webapp:8980/opennms
       OPENNMS_HTTP_USER: admin
       OPENNMS_HTTP_PASS: admin
-      KAFKA_RPC_BOOTSTRAP_SERVERS: kafka:9092
-      KAFKA_SINK_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_IPC_BOOTSTRAP_SERVERS: kafka:9092
       JAVA_OPTS: >-
         -Xms256m -Xmx512m
         -Djava.security.egd=file:/dev/./urandom
     volumes:
       - minion-data:/opt/minion/data
+      - ./webapp-overlay/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:/opt/minion/repositories/core/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
+      - ./webapp-overlay/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:/opt/minion/repositories/default/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
+      - ./webapp-overlay/system/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:/opt/minion/repositories/core/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:ro
+      - ./webapp-overlay/system/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:/opt/minion/repositories/default/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:ro
     ports:
       - "8301:8201"
     healthcheck:

--- a/opennms-container/delta-v/webapp-jetty-webinf-overlay/dispatcher-servlet.xml
+++ b/opennms-container/delta-v/webapp-jetty-webinf-overlay/dispatcher-servlet.xml
@@ -548,6 +548,14 @@
         <property name="resourceService" ref="resourceService"/>
     </bean>
 
+    <bean id="statisticsReportCommandValidator" class="org.opennms.web.validator.StatisticsReportCommandValidator">
+        <property name="statisticsReportDao" ref="statisticsReportDao"/>
+    </bean>
+
+    <bean name="/statisticsReports/index.htm" class="org.opennms.web.controller.statisticsReports.ListController">
+        <property name="statisticsReportService" ref="statisticsReportService"/>
+    </bean>
+
     <bean id="notifdConfigFactory-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod"><value>org.opennms.netmgt.config.NotifdConfigFactory.init</value></property>
     </bean>

--- a/opennms-container/delta-v/webapp-overlay/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml
+++ b/opennms-container/delta-v/webapp-overlay/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml
@@ -1,0 +1,2168 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features name="opennms-36.0.0-SNAPSHOT" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">
+    <repository>mvn:org.opennms.karaf/opennms/36.0.0-SNAPSHOT/xml/core</repository>
+    <repository>mvn:org.opennms.karaf/opennms/36.0.0-SNAPSHOT/xml/camel</repository>
+    <repository>mvn:org.apache.cxf.karaf/apache-cxf/3.6.8/xml/features</repository>
+    <repository>mvn:org.apache.activemq/activemq-karaf/5.16.8/xml/features</repository>
+    <repository>mvn:org.ops4j.pax.jdbc/pax-jdbc-features/1.0.1/xml/features</repository>
+    <repository>mvn:org.apache.activemq/activemq-karaf/5.16.8/xml/features</repository>
+    <repository>mvn:org.opennms.integration.api/karaf-features/2.0.0/xml</repository>
+    <repository>mvn:com.eclipsesource.jaxrs/features/1.1.0.ONMS/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/framework/4.3.10/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/standard/4.3.10/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/enterprise/4.3.10/xml/features</repository>
+
+    <!-- Newts Features -->
+    <repository>mvn:org.opennms.newts/newts-karaf/3.0.0/xml/features</repository>
+    <feature name="opennms-camel-amqp" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: AMQP :: Camel Wrapper">
+        <!-- start this early so camel-amqp doesn't use its old version -->
+        <bundle start-level="60">mvn:org.apache.qpid/proton-j/0.34.0</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-resolver/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-common/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-buffer/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-transport/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-handler/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-transport-classes-epoll/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-transport-native-epoll/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-transport-native-kqueue/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-transport-native-unix-common/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:io.netty/netty-codec/4.1.128.Final</bundle>
+        <bundle start-level="60">mvn:commons-pool/commons-pool/1.6</bundle>
+        <bundle start-level="60">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+
+        <feature>camel-core</feature>
+        <feature>camel-blueprint</feature>
+        <feature>camel-http</feature>
+        <feature>camel-amqp</feature>
+    </feature>
+    <feature name="opennms-amqp-event-forwarder" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: AMQP :: Event Forwarder">
+        <feature>opennms-camel-amqp</feature>
+        <feature version="31.1">guava</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-dao-api</feature>
+        <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.event-forwarder/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-amqp-event-receiver" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: AMQP :: Event Receiver">
+        <feature>opennms-camel-amqp</feature>
+        <feature version="31.1">guava</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-dao-api</feature>
+        <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.event-receiver/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-amqp-alarm-northbounder" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: AMQP :: Alarm Northbounder">
+        <feature>opennms-camel-amqp</feature>
+        <feature>opennms-core-camel</feature>
+        <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.alarm-northbounder/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="atomikos" version="3.9.2" description="Atomikos :: TransactionEssentials">
+        <bundle>wrap:mvn:com.atomikos/atomikos-util/3.9.2$Bundle-SymbolicName=com.atomikos.util&amp;Bundle-Version=3.9.2</bundle>
+        <bundle>wrap:mvn:com.atomikos/transactions-api/3.9.2$Bundle-SymbolicName=com.atomikos.transactions.api&amp;Bundle-Version=3.9.2</bundle>
+        <bundle>wrap:mvn:com.atomikos/transactions/3.9.2$Bundle-SymbolicName=com.atomikos.transactions&amp;Bundle-Version=3.9.2</bundle>
+        <bundle>wrap:mvn:com.atomikos/transactions-jta/3.9.2$Bundle-SymbolicName=com.atomikos.transactions.jta&amp;Bundle-Version=3.9.2</bundle>
+        <bundle>wrap:mvn:com.atomikos/transactions-jdbc/3.9.2$Bundle-SymbolicName=com.atomikos.transactions.jdbc&amp;Bundle-Version=3.9.2</bundle>
+    </feature>
+    <feature name="batik" version="1.17" description="Apache :: XML Graphics :: Batik">
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.3_3</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan-serializer/2.7.3_1</bundle>
+        <bundle dependency="true">wrap:mvn:xml-apis/xml-apis-ext/1.3.04$Bundle-SymbolicName=org.w3c.xml-apis.ext&amp;Bundle-Version=1.3.04</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-anim/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.anim&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-awt-util/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.awk.util&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-bridge/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.bridge&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-css/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.css&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-dom/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.dom&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-ext/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.ext&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-gvt/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.gvt&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-parser/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.parser&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-script/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.script&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-svggen/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.svggen&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-svg-dom/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.svg.dom&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-transcoder/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.transcoder&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-util/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.util&amp;Bundle-Version=1.17</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/batik-xml/1.17$Bundle-SymbolicName=org.apache.xmlgraphics.batik.xml&amp;Bundle-Version=1.17</bundle>
+    </feature>
+    <feature name="bsf" version="2.4.0" description="Apache :: Bean Scripting Framework">
+        <bundle>wrap:mvn:bsf/bsf/2.4.0$Bundle-SymbolicName=org.apache.bsf&amp;Bundle-Version=2.4.0</bundle>
+    </feature>
+    <feature name="c3p0" version="0.9.5.5" description="c3p0">
+        <feature>postgresql</feature>
+        <bundle>wrap:mvn:com.mchange/c3p0/0.9.5.5$Bundle-SymbolicName=c3p0&amp;Bundle-Version=0.9.5.5&amp;Import-Package=javax.management,javax.naming,javax.sql,javax.xml.parsers,org.postgresql;resolution:=optional,org.w3c.dom</bundle>
+    </feature>
+    <feature name="hikari-cp" version="5.0.1" description="HikariCP">
+        <feature>postgresql</feature>
+        <bundle>mvn:com.zaxxer/HikariCP/5.0.1</bundle>
+    </feature>
+    <feature name="cron-parser-core" version="3.5" description="Redhogs :: cron-parser-core">
+        <bundle>wrap:mvn:net.redhogs.cronparser/cron-parser-core/3.5$Bundle-SymbolicName=net.redhogs.cronparser.core&amp;Bundle-Version=3.5</bundle>
+    </feature>
+    <feature name="dnsjava" version="3.5.3_1" description="dnsjava">
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dnsjava/3.5.3_1</bundle>
+    </feature>
+    <feature name="fop" version="2.10" description="Apache :: XML Graphics :: FOP">
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/fop/2.10$Bundle-SymbolicName=org.apache.xmlgraphics.fop&amp;Bundle-Version=2.10</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.xmlgraphics/xmlgraphics-commons/2.9$Bundle-SymbolicName=org.apache.xmlgraphics.commons&amp;Bundle-Version=2.9</bundle>
+        <feature>batik</feature>
+    </feature>
+    <feature name="gemini-blueprint" version="2.1.0.RELEASE" description="Eclipse :: Gemini Blueprint">
+        <feature version="[4.2,4.3)">spring</feature>
+        <bundle>mvn:org.eclipse.gemini.blueprint/gemini-blueprint-core/2.1.0.RELEASE</bundle>
+        <bundle>mvn:org.eclipse.gemini.blueprint/gemini-blueprint-extender/2.1.0.RELEASE</bundle>
+        <bundle>mvn:org.eclipse.gemini.blueprint/gemini-blueprint-io/2.1.0.RELEASE</bundle>
+    </feature>
+    <feature name="groovy" version="3.0.21" description="Groovy">
+        <!-- needed by spifly -->
+        <feature version="[9.4,10)">asm</feature>
+        <bundle>mvn:org.codehaus.groovy/groovy/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-ant/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-bsf/3.0.21</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-cli-commons/3.0.21</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-cli-picocli/3.0.21</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-console/3.0.21</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-datetime/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-dateutil/3.0.21</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-docgenerator/3.0.21</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-groovydoc/3.0.21</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-groovysh/3.0.21</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-jaxb/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-jmx/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-json/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-jsr223/3.0.21</bundle>
+        <!-- needed by jsr223 support -->
+        <bundle>mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/1.3.6</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-macro/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-nio/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-servlet/3.0.21</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-sql/3.0.21</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-swing/3.0.21</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-templates/3.0.21</bundle>
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-test/3.0.21</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-test-junit5/3.0.21</bundle> -->
+        <!-- <bundle>mvn:org.codehaus.groovy/groovy-testng/3.0.21</bundle> -->
+        <bundle>mvn:org.codehaus.groovy/groovy-xml/3.0.21</bundle>
+    </feature>
+    <feature name="dom4j" version="2.1.4" description="DOM4J">
+        <bundle dependency="true">wrap:mvn:org.dom4j/dom4j/2.1.4$Bundle-SymbolicName=org.dom4j&amp;Bundle-Version=2.1.4</bundle>
+    </feature>
+    <feature name="hibernate36" version="3.6.11.ONMS_RELEASE_1" description="Hibernate :: Hibernate ORM">
+        <feature>commons-collections</feature>
+        <feature>dom4j</feature>
+        <bundle dependency="true">wrap:mvn:antlr/antlr/2.7.7$Bundle-SymbolicName=antlr&amp;Bundle-Version=2.7.7&amp;Import-Package=org.hibernate.hql.ast</bundle>
+        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+        <bundle dependency="true">mvn:org.javassist/javassist/3.29.2-GA</bundle>
+        <bundle>wrap:mvn:org.hibernate.javax.persistence/hibernate-jpa-2.0-api/1.0.1.Final$Bundle-SymbolicName=org.hibernate.jpa20.api&amp;Bundle-Version=1.0.1</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-core/3.6.11.ONMS_RELEASE_1$Bundle-SymbolicName=org.hibernate.core&amp;Bundle-Version=3.6.11&amp;Export-Package=org.hibernate*;version="3.6.11"</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-commons-annotations/3.2.0.Final$Bundle-SymbolicName=org.hibernate.commons.annotations&amp;Bundle-Version=3.2.0</bundle>
+    </feature>
+    <feature name="hibernate-validator4" version="4.3.2.Final" description="Hibernate :: Hibernate Validator">
+        <feature>javax.validation</feature>
+        <bundle>wrap:mvn:org.hibernate/hibernate-validator-annotation-processor/4.3.2.Final$Bundle-SymbolicName=org.hibernate.validator.annotation-processor&amp;Bundle-Version=4.3.2.Final</bundle>
+        <bundle>wrap:mvn:org.hibernate/hibernate-validator/4.3.2.Final$Bundle-SymbolicName=org.hibernate.validator&amp;Bundle-Version=4.3.2.Final</bundle>
+    </feature>
+    <feature name="jaxb" version="2.5.1" description="EclipseLink :: MOXy">
+        <feature>javax.mail</feature>
+        <bundle>mvn:org.eclipse.persistence/org.eclipse.persistence.moxy/2.5.1</bundle>
+        <bundle>mvn:org.eclipse.persistence/org.eclipse.persistence.core/2.5.1</bundle>
+        <bundle>mvn:org.eclipse.persistence/org.eclipse.persistence.asm/2.5.1</bundle>
+        <bundle>mvn:org.eclipse.persistence/org.eclipse.persistence.antlr/2.5.1</bundle>
+    </feature>
+    <feature name="jcifs" version="2.1.6" description="jcifs">
+        <feature>bouncycastle</feature>
+        <bundle>mvn:eu.agno3.jcifs/jcifs-ng/2.1.6</bundle>
+    </feature>
+    <feature name="jldap" version="4.3" description="OpenLDAP :: JLDAP">
+        <bundle>wrap:mvn:com.novell.ldap/jldap/4.3$Bundle-SymbolicName=com.novell.ldap&amp;Bundle-Version=4.3</bundle>
+    </feature>
+    <feature name="joda-time" version="2.12.5" description="Joda :: Joda-Time">
+        <bundle>mvn:joda-time/joda-time/2.12.5</bundle>
+    </feature>
+    <feature name="jolokia-client" version="1.7.2" description="Jolokia-Client">
+        <feature>javax.servlet</feature>
+        <feature>json-simple</feature>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16</bundle>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14</bundle>
+        <bundle>mvn:org.jolokia/jolokia-client-java/1.7.2</bundle>
+    </feature>
+    <feature name="json-lib" version="2.2.3" description="json-lib">
+        <bundle>wrap:mvn:net.sf.ezmorph/ezmorph/1.0.6$Bundle-SymbolicName=net.sf.ezmorph&amp;Bundle-Version=1.0.6</bundle>
+        <bundle>wrap:mvn:net.sf.json-lib/json-lib/2.2.3/jar/jdk15$Bundle-SymbolicName=net.sf.json-lib&amp;Bundle-Version=2.2.3</bundle>
+    </feature>
+    <feature name="lmax-disruptor" version="3.4.4" description="LMAX :: Disruptor">
+        <bundle>mvn:com.lmax/disruptor/3.4.4</bundle>
+    </feature>
+    <feature name="org.json" version="20240303" description="org.json">
+        <bundle>wrap:mvn:org.json/json/20240303$Bundle-SymbolicName=org.json&amp;Bundle-Version=20240303&amp;Export-Package=org.json</bundle>
+    </feature>
+    <feature name="json-simple" version="1.1.1" description="json-simple">
+        <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/1.1.1$Bundle-SymbolicName=com.googlecode.json-simple&amp;Bundle-Version=1.1.1</bundle>
+    </feature>
+    <feature name="owasp-encoder" version="1.2.3" description="OWASP :: Encoder">
+        <bundle>wrap:mvn:org.owasp.encoder/encoder/1.2.3$Bundle-SymbolicName=org.owasp.encoder&amp;Bundle-Version=1.2.3&amp;Export-Package=org.owasp.encoder</bundle>
+    </feature>
+    <feature name="owasp-html-sanitizer" version="20211018.2" description="OWASP :: HTML Sanitizer">
+        <feature version="31.1">guava</feature>
+        <bundle>wrap:mvn:com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/20211018.2$overwrite=merge&amp;Import-Package=javax.annotation;version=!,*</bundle>
+    </feature>
+    <feature name="postgresql" version="42.5.5" description="PostgreSQL :: JDBC Driver">
+        <feature>pax-jdbc-spec</feature>
+        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+        <bundle>mvn:org.postgresql/postgresql/42.5.5</bundle>
+    </feature>
+    <feature name="rate-limited-logger" version="2.0.2" description="Rate Limited Logger">
+        <feature>joda-time</feature>
+        <bundle>wrap:mvn:com.swrve/rate-limited-logger/2.0.2$Bundle-SymbolicName=com.swrve.rate-limited-logger&amp;Bundle-Version=2.0.2</bundle>
+    </feature>
+    <feature name="spring-security-opennms" version="4.2.21.RELEASE_ONMS_3" description="Spring :: Security">
+        <feature version="[4.2,4.3)">spring-web</feature>
+        <feature>commons-codec</feature>
+        <feature>javax.servlet</feature>
+        <bundle>wrap:mvn:org.openid4java/openid4java-nodeps/0.9.6$Export-Package=org.openid4java*;version="0.9.6"</bundle>
+        <bundle>wrap:mvn:org.springframework.ldap/spring-ldap-core/2.3.8.RELEASE$Bundle-SymbolicName=org.springframework.ldap.core&amp;Bundle-Version=2.3.8.RELEASE&amp;Export-Package=org.springframework.ldap*;version="2.3.8.RELEASE"</bundle>
+        <bundle>wrap:mvn:org.springframework.security/spring-security-aspects/4.2.21.RELEASE_ONMS_3$Bundle-SymbolicName=org.springframework.security.aspects&amp;Bundle-Version=4.2.21.RELEASE_ONMS_3</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-core/4.2.21.RELEASE_ONMS_3</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-config/4.2.21.RELEASE_ONMS_3</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-ldap/4.2.21.RELEASE_ONMS_3</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-openid/4.2.21.RELEASE_ONMS_3</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-remoting/4.2.21.RELEASE_ONMS_3</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-web/4.2.21.RELEASE_ONMS_3</bundle>
+    </feature>
+    <feature name="jicmp" version="3.0.4" description="jicmp">
+        <feature version="31.1">guava</feature>
+        <bundle>mvn:org.opennms/jicmp-api/3.0.4</bundle>
+    </feature>
+    <feature name="jicmp6" version="3.0.4" description="jicmp6">
+        <bundle>mvn:org.opennms/jicmp6-api/3.0.4</bundle>
+    </feature>
+    <feature name="quartz" version="2.3.2" description="quartz">
+        <feature>c3p0</feature>
+        <!-- Quartz needs HikariCP [2,3) - so we use the latest 2.x here -->
+        <bundle>mvn:com.zaxxer/HikariCP/2.7.9</bundle>
+        <bundle>mvn:org.quartz-scheduler/quartz/2.3.2</bundle>
+    </feature>
+    <feature name="twitter4j" version="3.0.6" description="Twitter4J">
+        <bundle>wrap:mvn:org.twitter4j/twitter4j-core/3.0.6$Bundle-SymbolicName=org.twitter4j.core&amp;Bundle-Version=3.0.6</bundle>
+    </feature>
+    <feature name="opentracing-api" version="0.32.0" description="OpenTracing API">
+        <bundle dependency="true">wrap:mvn:io.opentracing/opentracing-api/0.32.0$Bundle-SymbolicName=io.opentracing.api&amp;Bundle-Version=0.32.0</bundle>
+        <bundle dependency="true">wrap:mvn:io.opentracing/opentracing-noop/0.32.0$Bundle-SymbolicName=io.opentracing.noop&amp;Bundle-Version=0.32.0</bundle>
+        <bundle dependency="true">wrap:mvn:io.opentracing/opentracing-util/0.32.0$Bundle-SymbolicName=io.opentracing.util&amp;Bundle-Version=0.32.0</bundle>
+    </feature>
+    <feature name="opennms-core-tracing" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: Tracing">
+        <feature>opentracing-api</feature>
+        <bundle>mvn:org.opennms.core.tracing/org.opennms.core.tracing.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.tracing/org.opennms.core.tracing.registry/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.xml/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-tracing-jaeger" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: Tracing :: Jeager Tracer">
+        <feature>opennms-core-tracing</feature>
+        <bundle>mvn:org.opennms.core.tracing/org.opennms.core.tracing.jaeger-osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.tracing/org.opennms.core.tracing.jaeger-tracer/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-activemq-pool" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: ActiveMQ :: Pool">
+        <feature prerequisite="true">zookeeper-dependencies</feature>
+        <feature>activemq-client</feature>
+        <feature>asm</feature>
+        <feature>camel-core</feature>
+        <feature>camel-jms</feature>
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>opennms-core</feature>
+        <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.pool/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-activemq-shell" description="OpenNMS :: Features :: ActiveMQ :: Shell" version="36.0.0-SNAPSHOT">
+      <!-- Additional dependenices are expected to be pulled from the root classloader -->
+      <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-bootstrap" version="36.0.0-SNAPSHOT" description="opennms-bootstrap">
+        <bundle>mvn:org.opennms/opennms-bootstrap/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-identity" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: OpenNMS Identity">
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.opennms-identity/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-util" version="36.0.0-SNAPSHOT" description="OpenNMS :: Util">
+        <feature>owasp-encoder</feature>
+        <feature>owasp-html-sanitizer</feature>
+        <feature>commons-io</feature>
+        <feature>commons-jexl</feature>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.api/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.soa/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.sysprops/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-util/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-core" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core">
+        <feature>commons-io</feature>
+        <feature>dnsjava</feature>
+        <feature>jackson1</feature>
+        <feature>jaxb</feature>
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature version="[4.2,4.3)">spring-orm</feature>
+        <feature>opennms-util</feature>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_3</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.commands/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.criteria/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.lib/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.logging/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.soa/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.spring/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.xml/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.fileutils/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-camel" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: Camel">
+        <bundle start-level="60">mvn:io.netty/netty-transport-classes-epoll/4.1.128.Final</bundle>
+        <feature>camel-core</feature>
+        <feature>camel-http</feature>
+        <feature>camel-netty4</feature>
+        <feature>opennms-core</feature>
+        <bundle>mvn:org.opennms.core/org.opennms.core.camel/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-daemon" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: Daemon">
+        <feature>activemq-client</feature>
+        <feature>opennms-core-messagebus-api</feature>
+        <feature>asm</feature>
+        <feature>camel-jms</feature>
+        <feature version="31.1">guava</feature>
+        <feature>opennms-activemq-pool</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-config</feature>
+        <feature>opennms-icmp-api</feature>
+        <feature>opennms-model</feature>
+        <bundle>mvn:org.opennms.core/org.opennms.core.daemon/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-db" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: Database">
+        <feature>atomikos</feature>
+        <feature>c3p0</feature>
+        <feature>hikari-cp</feature>
+        <feature>commons-io</feature>
+        <feature>postgresql</feature>
+        <feature>opennms-core</feature>
+        <bundle>mvn:org.opennms.core/org.opennms.core.db/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-web" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: Web">
+        <feature>opennms-core</feature>
+        <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.web/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-distributed-core-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Distributed :: Core :: API">
+        <bundle>mvn:org.opennms.features.distributed/core-api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-distributed-core-impl" description="OpenNMS :: Distributed :: Core :: Impl" version="36.0.0-SNAPSHOT">
+        <feature>opennms-distributed-core-api</feature>
+        <bundle>mvn:org.opennms.features.distributed/core-impl/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-distributed-core-jms" description="OpenNMS :: Distributed :: Core :: JMS" version="36.0.0-SNAPSHOT">
+        <feature>camel-jms</feature>
+        <feature>activemq-camel</feature>
+        <feature>activemq-client</feature>
+        <feature>jms</feature>
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>opennms-distributed-core-api</feature>
+        <feature>opennms-health-api</feature>
+        <feature>scv-api</feature>
+
+        <!-- spring put these MFs at start-level 10, so I gotta beat them -->
+        <bundle start-level="8">mvn:javax.jms/javax.jms-api/2.0.1</bundle>
+        <bundle start-level="8">mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+
+        <bundle>mvn:org.opennms.features.distributed/jms/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-model" version="36.0.0-SNAPSHOT" description="OpenNMS :: Model">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature version="[4.2,4.3)">spring-jdbc</feature>
+        <feature version="[4.2,4.3)">spring-orm</feature>
+        <feature version="[4.2,4.3)">spring-tx</feature>
+        <feature>commons-io</feature>
+        <feature>commons-lang</feature>
+        <feature>dnsjava</feature>
+        <feature>hibernate36</feature>
+        <feature>jaxb</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-events-api</feature>
+        <feature>opennms-poller-api</feature>
+        <feature>opennms-rrd-api</feature>
+        <feature>opennms-snmp</feature>
+        <bundle>mvn:org.opennms/opennms-model/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-collection-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Collection :: API">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>commons-jexl</feature>
+        <feature>opennms-model</feature>
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-collection-commands" version="36.0.0-SNAPSHOT" description="OpenNMS :: Collection :: Shell Commands">
+        <feature>dropwizard-metrics</feature>
+        <feature version="31.1">guava</feature>
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.commands/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-collection-core" version="36.0.0-SNAPSHOT" description="OpenNMS :: Collection :: Core">
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-config</feature>
+        <feature>opennms-core-ipc-rpc-api</feature>
+        <feature>opennms-dao-api</feature>
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.core/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-collection-persistence-rrd" version="36.0.0-SNAPSHOT" description="OpenNMS :: Collection :: Persistence :: RRD">
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-rrd-api</feature>
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.persistence.rrd/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-config-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Configuration :: API">
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-model</feature>
+        <feature>jackson-core</feature>
+        <bundle>mvn:org.opennms/opennms-config-api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-config-model/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-config-jaxb/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-config-jaxb" version="36.0.0-SNAPSHOT" description="OpenNMS :: Configuration :: JAXB">
+        <feature>hibernate36</feature>
+        <feature>commons-lang</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-snmp</feature>
+        <bundle>mvn:org.opennms/opennms-config-jaxb/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-config" version="36.0.0-SNAPSHOT" description="OpenNMS :: Configuration">
+        <feature>c3p0</feature>
+        <feature>hikari-cp</feature>
+        <feature>commons-codec</feature>
+        <feature>opennms-config-api</feature>
+        <feature>opennms-core-db</feature>
+        <feature>opennms-mate-api</feature>
+        <feature>opennms-poller-api</feature>
+        <feature>opennms-rrd-api</feature>
+        <feature>opennms-snmp</feature>
+        <feature>scv-api</feature>
+        <bundle dependency="true">wrap:mvn:com.googlecode.concurrent-locks/concurrent-locks/1.0.0$Bundle-SymbolicName=com.googlecode.concurrent-locks&amp;Bundle-Version=1.0.0</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/1.9.3_1</bundle>
+        <bundle>mvn:org.opennms/opennms-config/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-kafka" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Kafka">
+        <feature>jackson-core</feature>
+        <feature>zookeeper-dependencies</feature>
+        <bundle dependency="true">mvn:org.scala-lang/scala-library/2.13.12</bundle>
+        <bundle dependency="true">mvn:com.typesafe.scala-logging/scala-logging_2.13/3.9.5</bundle>
+        <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-core/2.2.0$Bundle-SymbolicName=com.yammer.metrics.core&amp;Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
+        <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-annotation/2.2.0$Bundle-SymbolicName=com.yammer.metrics.annotation&amp;Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka_2.13/3.6.2_1</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/3.6.2_1</bundle>
+        <bundle dependency="true">mvn:com.github.luben/zstd-jni/1.5.2-1</bundle>
+        <bundle>mvn:at.yawk.lz4/lz4-java/1.10.2</bundle>
+        <bundle dependency="true">mvn:org.xerial.snappy/snappy-java/1.1.10.5</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: API">
+        <feature>dropwizard-metrics</feature>
+        <feature version="31.1">guava</feature>
+        <feature>javax.mail</feature>
+        <feature>org.json</feature>
+        <feature>rate-limited-logger</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-distributed-core-api</feature>
+        <feature>opennms-integration-api</feature>
+        <feature>opennms-core-tracing</feature>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.xml/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-offheap" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: OffHeap">
+        <feature>opennms-core-ipc-sink-api</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>rate-limited-logger</feature>
+        <feature>fst</feature>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.offheap/36.0.0-SNAPSHOT</bundle>
+        <bundle>wrap:mvn:com.squareup.tape2/tape/2.0.0-beta1$Bundle-SymbolicName=com.squareup.tape2&amp;Bundle-Version=2.0</bundle>
+        <bundle dependency="true">wrap:mvn:org.rocksdb/rocksdbjni/8.5.4$Bundle-SymbolicName=org.rocksdb.jni&amp;Bundle-Version=8.5.4</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-camel-common" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: Camel :: Common">
+        <feature>camel-blueprint</feature>
+        <feature>camel-jms</feature>
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>opennms-core-ipc-sink-api</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-dao-api</feature>
+        <bundle>mvn:org.opennms.core.ipc.sink.camel/org.opennms.core.ipc.sink.camel.common/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-camel" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: Camel :: Client">
+        <feature>opennms-core-ipc-sink-camel-common</feature>
+        <bundle>mvn:org.opennms.core.ipc.sink.camel/org.opennms.core.ipc.sink.camel.client/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-camel-server" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: Camel :: Server">
+        <feature>opennms-core-ipc-sink-camel-common</feature>
+        <bundle>mvn:org.opennms.core.ipc.sink.camel/org.opennms.core.ipc.sink.camel.server/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-kafka-common" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: Kafka :: Common">
+        <feature>opennms-core-ipc-sink-api</feature>
+        <feature>opennms-kafka</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-core-ipc-kafka-shell</feature>
+        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-kafka" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: Kafka :: Client">
+        <feature>opennms-core-ipc-sink-kafka-common</feature>
+        <bundle>mvn:org.opennms.core.ipc.sink.kafka/org.opennms.core.ipc.sink.kafka.client/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-sink-kafka-server" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Sink :: Kafka :: Server">
+        <feature>opennms-core-ipc-sink-kafka-common</feature>
+        <bundle>mvn:org.opennms.core.ipc.sink.kafka/org.opennms.core.ipc.sink.kafka.server/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-rpc-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: RPC :: API">
+        <feature>camel-blueprint</feature>
+        <feature>camel-jms</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>org.json</feature>
+        <feature>javax.mail</feature>
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-core-tracing</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-distributed-core-api</feature>
+        <feature>opennms-health-api</feature>
+        <feature>opennms-rpc-utils</feature>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.xml/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.camel/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-rpc-utils" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC : RPC :: Utils">
+        <feature>opennms-mate-api</feature>
+        <feature>opennms-mate-shell</feature>
+        <bundle>mvn:org.opennms.features.scv/org.opennms.features.scv.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.utils/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-rpc-jms" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: RPC :: JMS Impl.">
+        <feature>opennms-core-ipc-rpc-api</feature>
+        <feature>opennms-dao-api</feature>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.jms-impl/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-rpc-kafka" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: RPC :: Kafka Impl.">
+        <feature>opennms-kafka</feature>
+        <feature>opennms-core-ipc-rpc-api</feature>
+        <feature>opennms-core-ipc-kafka-shell</feature>
+        <feature>resilience4j</feature>
+        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.kafka/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-rpc-commands" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: RPC :: Shell Commands">
+        <feature>dropwizard-metrics</feature>
+        <feature version="31.1">guava</feature>
+        <feature>opennms-core-ipc-rpc-api</feature>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.commands/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-kafka-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Kafka :: Shell Commands">
+        <feature>opennms-kafka</feature>
+        <feature>opennms-distributed-core-api</feature>
+        <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka-shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-dao-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: DAO :: API">
+        <feature>opennms-core</feature>
+        <feature>opennms-model</feature>
+        <feature>opennms-config-api</feature>
+        <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.model/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.dao-api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-dao" version="36.0.0-SNAPSHOT" description="OpenNMS :: DAO">
+        <feature>commons-jxpath</feature>
+        <feature version="31.1">guava</feature>
+        <feature>hibernate-validator4</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-collection-core</feature>
+        <feature>opennms-collection-persistence-rrd</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-core-daemon</feature>
+        <feature>opennms-measurements-api</feature>
+        <feature>opennms-xml-collector</feature>
+        <feature>opennms-core-web</feature>
+        <feature>opennms-config-dao-api</feature>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.dao-impl/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-events-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Events :: API">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>camel-core</feature>
+        <feature>commons-lang3</feature>
+        <feature>jaxb</feature>
+        <feature>javax.validation</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-core-tsid</feature>
+        <feature>opennms-snmp</feature>
+        <feature>opennms-core-ipc-sink-api</feature>
+        <bundle>mvn:org.opennms.features.events/org.opennms.features.events.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-events-commands" version="36.0.0-SNAPSHOT" description="OpenNMS :: Events :: Shell Commands">
+        <feature>commons-jexl</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature version="31.1">guava</feature>
+        <bundle>mvn:org.opennms.features.events/org.opennms.features.events.commands/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <!--This feature lives on Minion, OpenNMS and Sentinel is the reason it needs separate feature.-->
+    <feature name="opennms-send-event-command" version="36.0.0-SNAPSHOT" description="OpenNMS :: Events :: Send :: Command">
+        <feature>opennms-events-api</feature>
+        <feature>opennms-model</feature>
+        <bundle>mvn:org.opennms.features.events.sink/org.opennms.features.events.sink.command/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-events-sink-dispatcher" version="36.0.0-SNAPSHOT" description="OpenNMS :: Events :: Sink Dispatcher">
+        <feature>opennms-config-api</feature>
+        <feature>opennms-events-api</feature>
+        <feature>opennms-mate-api</feature>
+        <bundle>mvn:org.opennms.features.events.sink/org.opennms.features.events.sink.dispatcher/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-events-collector" description="OpenNMS :: Events :: Collector" version="36.0.0-SNAPSHOT">
+        <feature>opennms-config-api</feature>
+        <feature>opennms-events-api</feature>
+        <feature>opennms-rrd-api</feature>
+        <feature>opennms-thresholding-api</feature>
+        <bundle>mvn:org.opennms.features.events/org.opennms.features.events.collector/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-icmp-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: ICMP :: API">
+        <feature version="31.1">guava</feature>
+        <feature>opennms-core</feature>
+        <bundle>mvn:org.opennms/opennms-icmp-api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-icmp-best" version="36.0.0-SNAPSHOT" description="OpenNMS :: ICMP :: Best Match">
+        <feature>opennms-icmp-api</feature>
+        <feature>opennms-icmp-jna</feature>
+        <feature>opennms-icmp-jni</feature>
+        <feature>opennms-icmp-jni6</feature>
+        <bundle>mvn:org.opennms/opennms-icmp-best/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-icmp-jna" version="36.0.0-SNAPSHOT" description="OpenNMS :: ICMP :: JNA">
+        <feature version="31.1">guava</feature>
+        <feature>opennms-icmp-api</feature>
+        <feature>java-native-access</feature>
+        <bundle>mvn:org.opennms.core/org.opennms.core.icmp-jna/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-icmp-jna/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-icmp-jni" version="36.0.0-SNAPSHOT" description="OpenNMS :: ICMP :: JNI">
+        <feature>opennms-icmp-api</feature>
+        <feature>jicmp</feature>
+        <bundle>mvn:org.opennms/opennms-icmp-jni/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-icmp-jni6" version="36.0.0-SNAPSHOT" description="OpenNMS :: ICMP :: JNI (with IPv6 support)">
+        <feature>opennms-icmp-jni</feature>
+        <feature>jicmp6</feature>
+        <bundle>mvn:org.opennms/opennms-icmp-jni6/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-javamail" version="36.0.0-SNAPSHOT" description="OpenNMS :: Javamail">
+        <feature>commons-lang</feature>
+        <feature>javax.mail</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-config-api</feature>
+        <bundle>mvn:org.opennms/opennms-javamail-api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-poller-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Poller :: API">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>hibernate36</feature>
+        <feature>opennms-core</feature>
+        <bundle>mvn:org.opennms.features.poller/org.opennms.features.poller.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-measurements-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Measurements :: API">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>commons-lang</feature>
+        <feature version="31.1">guava</feature>
+        <bundle>mvn:org.opennms.features.measurements/org.opennms.features.measurements.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-measurements-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Measurements :: Shell">
+        <!-- Dependencies pulled from root classloader -->
+        <bundle>mvn:org.opennms.features.measurements/org.opennms.features.measurements.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-osgi-jsr223" version="36.0.0-SNAPSHOT" description="OpenNMS :: OSGi JSR-223">
+        <bundle>mvn:org.opennms.features/org.opennms.features.osgi-jsr223/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-provisioning" version="36.0.0-SNAPSHOT" description="OpenNMS :: Provisioning">
+        <feature>commons-lang</feature>
+        <feature>commons-beanutils</feature>
+        <feature>javax.validation</feature>
+        <feature>joda-time</feature>
+        <feature>opennms-provisioning-api</feature>
+        <bundle>mvn:org.opennms/opennms-provision-persistence/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-registry/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-provisioning-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Provisioning :: API">
+        <feature>opennms-model</feature>
+        <feature version="4.1.128.Final">netty</feature>
+        <bundle dependency="true">mvn:org.apache.mina/mina-core/2.2.4</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.lib/36.0.0-SNAPSHOT</bundle>
+        <feature>opentracing-api</feature>
+        <feature>commons-lang</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-model</feature>
+        <bundle>mvn:org.opennms/opennms-provision-api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-rrd-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: RRD :: API">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>opennms-core</feature>
+        <bundle>mvn:org.opennms/opennms-rrd-api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-rrd-util" version="36.0.0-SNAPSHOT" description="OpenNMS :: RRD :: Utilities">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>opennms-rrd-api</feature>
+        <!-- only used to convert .jrb files -->
+        <bundle>mvn:org.jrobin/jrobin/1.6.0</bundle>
+        <bundle>mvn:org.opennms/opennms-rrd-util/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-snmp" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: SNMP">
+        <feature>commons-lang</feature>
+        <feature>org.json</feature>
+        <bundle>mvn:org.opennms.core/org.opennms.core.logging/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.implementations.snmp4j/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.joesnmp/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.lib/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-snmp-commands" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: SNMP :: Commands">
+        <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.commands/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.profile-mapper/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-icmp-commands" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: ICMP :: Commands">
+        <feature>opennms-icmp-api</feature>
+        <bundle>mvn:org.opennms/opennms-icmp-commands/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-syslogd" version="36.0.0-SNAPSHOT" description="OpenNMS :: Syslogd">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>camel-core</feature>
+        <feature>camel-http</feature>
+        <feature>camel-netty4</feature>
+        <feature version="31.1">guava</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-core-daemon</feature>
+        <feature>opennms-core-db</feature>
+        <feature>opennms-config</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-core-ipc-sink-api</feature>
+        <bundle>mvn:org.opennms.features.events/org.opennms.features.events.syslog/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-syslogd-listener-javanet" version="36.0.0-SNAPSHOT" description="OpenNMS :: Syslogd :: Listener :: java.net">
+        <feature>camel-blueprint</feature>
+        <feature>opennms-syslogd</feature>
+        <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/36.0.0-SNAPSHOT/xml/blueprint-syslog-listener-javanet</bundle>
+    </feature>
+    <feature name="opennms-syslogd-listener-camel-netty" version="36.0.0-SNAPSHOT" description="OpenNMS :: Syslogd :: Listener :: camel-netty">
+        <feature>camel-blueprint</feature>
+        <feature>opennms-syslogd</feature>
+        <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/36.0.0-SNAPSHOT/xml/blueprint-syslog-listener-camel-netty</bundle>
+    </feature>
+    <feature name="opennms-thresholding-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Thresholding :: API">
+        <feature>opennms-config</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-collection-api</feature>
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.thresholding.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-trapd" version="36.0.0-SNAPSHOT" description="OpenNMS :: Trapd">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>camel-core</feature>
+        <feature>camel-http</feature>
+        <feature version="31.1">guava</feature>
+        <feature>opennms-distributed-core-api</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-core-daemon</feature>
+        <feature>opennms-core-db</feature>
+        <feature>opennms-config</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-events-api</feature>
+        <feature>opennms-snmp</feature>
+        <feature>opennms-core-ipc-sink-api</feature>
+        <feature>opennms-core-ipc-twin-common</feature>
+        <bundle>mvn:org.opennms.features.events/org.opennms.features.events.traps/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="tsrm-troubleticketer" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Ticketing :: Tivoli Service Request Manager (TSRM)">
+        <feature version="3.6.8">cxf-jaxws</feature>
+        <feature>javax.servlet</feature>
+        <!-- early start-level to override jettison version in 3rd-party feature files -->
+        <bundle start-level="60">mvn:org.codehaus.jettison/jettison/1.5.4</bundle>
+        <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features/opennms-integration-tsrm/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="eif-adapter" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: EIF Adapter">
+        <feature>camel-core</feature>
+        <feature>camel-blueprint</feature>
+        <feature>camel-netty4</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-dao-api</feature>
+        <bundle>mvn:org.opennms.features/org.opennms.features.eif-adapter/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="smack" version="4.0.6" description="Ignite Realtime :: Smack">
+        <bundle>mvn:org.igniterealtime.smack/smack-core/4.0.6$Bundle-Sym</bundle>
+        <bundle>mvn:org.igniterealtime.smack/smack-tcp/4.0.6</bundle>
+        <bundle>mvn:org.igniterealtime.smack/smack-extensions/4.0.6</bundle>
+        <bundle>mvn:org.igniterealtime.smack/smack-resolver-javax/4.0.6</bundle>
+        <bundle>wrap:mvn:xmlpull/xmlpull/1.1.3.1$Bundle-SymbolicName=xmlpull&amp;Bundle-Version=1.1.3.1</bundle>
+    </feature>
+    <feature name="wsman-integration" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: WS-Man Integration">
+        <feature>guava</feature>
+        <feature>javax.servlet</feature>
+        <feature version="3.6.8">cxf-jaxws</feature>
+        <feature version="3.6.8">cxf-ws-addr</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-poller-monitors-core</feature>
+        <feature>opennms-provisioning-api</feature>
+        <feature>opennms-dao-api</feature>
+        <!-- early start-level to override jettison version in 3rd-party feature files -->
+        <bundle start-level="60">mvn:org.codehaus.jettison/jettison/1.5.4</bundle>
+        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/2.9.0</bundle>
+        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/2.9.0</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.2_1</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bcel/5.2_4</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.3_3</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan-serializer/2.7.3_1</bundle>
+        <bundle>mvn:org.opennms.core.wsman/org.opennms.core.wsman.api/1.3.3</bundle>
+        <bundle>mvn:org.opennms.core.wsman/org.opennms.core.wsman.cxf/1.3.3</bundle>
+        <bundle>mvn:org.opennms.features/org.opennms.features.wsman/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="wmi-integration" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: WMI Integration">
+        <feature>commons-cli</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-provisioning-api</feature>
+        <feature>jcifs</feature>
+        <bundle dependency="true">wrap:mvn:com.github.skyghis/j-interop-ng/3.4.0$Bundle-SymbolicName=com.github.skyghis.j-interop-ng&amp;Bundle-Version=3.4.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.github.skyghis/j-interop-ng-deps/3.4.0$Bundle-SymbolicName=com.github.skyghis.j-interop-ng.deps&amp;Bundle-Version=3.4.0</bundle>
+        <bundle>mvn:org.opennms/opennms-wmi/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-prometheus-collector" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Prometheus Collector">
+        <feature>opennms-core-web</feature>
+        <feature>opennms-collection-api</feature>
+        <bundle>mvn:org.opennms.features/org.opennms.features.prometheus-collector/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-xml-collector" version="36.0.0-SNAPSHOT" description="OpenNMS :: Protocols :: XML Collector">
+        <feature>commons-io</feature>
+        <feature>commons-jxpath</feature>
+        <feature>commons-lang</feature>
+        <feature version="31.1">guava</feature>
+        <feature>jackson1</feature>
+        <feature>joda-time</feature>
+        <feature>opennms-core-web</feature>
+        <bundle>mvn:com.github.mwiede/jsch/0.2.11</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.oro/2.0.8_6</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ezmorph/1.0.6_1</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.json-lib/2.4_1</bundle>
+        <bundle dependency="true">mvn:org.jsoup/jsoup/1.15.3</bundle>
+        <bundle>mvn:org.opennms.protocols/org.opennms.protocols.xml/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-provisioning-detectors" version="36.0.0-SNAPSHOT" description="OpenNMS :: Provisioning :: Detectors">
+        <feature>bsf</feature>
+        <feature>commons-cli</feature>
+        <feature>javax.servlet</feature>
+        <feature>jcifs</feature>
+        <feature>jldap</feature>
+        <feature>spring-security-opennms</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-core-web</feature>
+        <feature>opennms-dhcpd</feature>
+        <feature>opennms-icmp-api</feature>
+        <feature>opennms-provisioning-api</feature>
+        <feature>wsman-integration</feature>
+        <feature>wmi-integration</feature>
+        <bundle>mvn:org.opennms.core.jmx/org.opennms.core.jmx.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.jmx/org.opennms.core.jmx.impl/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-bsf/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-datagram/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-dhcp/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-generic/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-jdbc/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-jmx/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-jms/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-lineoriented/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-rdns-lookup/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-simple/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-ssh/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-web/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-detector-registry/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-dhcpd" description="OpenNMS :: Features :: DHCPD" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.features/org.opennms.features.dhcpd/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:com.helger/dhcp4java/1.1.0</bundle>
+    </feature>
+    <feature name="opennms-provisioning-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Provisioning :: Shell">
+        <bundle>mvn:org.opennms/opennms-provision-shell/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16</bundle>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14</bundle>
+    </feature>
+    <feature name="opennms-vmware" version="36.0.0-SNAPSHOT" description="OpenNMS :: Integrations :: VMware Integration">
+        <feature>commons-cli</feature>
+        <feature>commons-io</feature>
+        <feature>commons-lang</feature>
+        <feature>dom4j</feature>
+        <feature version="31.1">guava</feature>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16</bundle>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14</bundle>
+        <bundle>wrap:mvn:com.toastcoders/yavijava/6.0.05$Bundle-SymbolicName=com.toastcoders.yavijava&amp;Bundle-Version=6.0.05</bundle>
+        <bundle>wrap:mvn:org.sblim.slp/sblimSLPClient/1.17$Bundle-SymbolicName=org.sblim.slp.client&amp;Bundle-Version=1.17</bundle>
+        <bundle>wrap:mvn:org.sblim.wbem/sblimCIMClient/1.17$Bundle-SymbolicName=org.sblim.webm.client&amp;Bundle-Version=1.17</bundle>
+        <bundle>mvn:org.opennms/opennms-vmware/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-poller-monitors-core" version="36.0.0-SNAPSHOT" description="OpenNMS :: Poller :: Monitors :: Core">
+        <feature>activemq-client</feature>
+        <feature>bsf</feature>
+        <feature>camel-core</feature>
+        <feature>camel-http</feature>
+        <feature>commons-io</feature>
+        <feature>commons-jexl</feature>
+        <feature>commons-lang</feature>
+        <feature>commons-net</feature>
+        <feature>dnsjava</feature>
+        <feature>hibernate36</feature>
+        <feature>jldap</feature>
+        <feature>jolokia-client</feature>
+        <feature>json-simple</feature>
+        <feature>jcifs</feature>
+        <feature>ssh</feature>
+        <feature>opennms-core-web</feature>
+        <feature>opennms-core-ipc-rpc-api</feature>
+        <feature>opennms-dhcpd</feature>
+        <feature>opennms-icmp-api</feature>
+        <feature>opennms-poller-api</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-config</feature>
+        <feature>opennms-javamail</feature>
+        <bundle>mvn:org.opennms.core.jmx/org.opennms.core.jmx.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.jmx/org.opennms.core.jmx.impl/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.poller.monitors/org.opennms.features.poller.monitors.core/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-poller-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Poller :: Shell">
+        <bundle>mvn:org.opennms.features.poller/org.opennms.features.poller.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-notifications-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Notifications :: Shell">
+        <bundle>mvn:org.opennms.features.notifications/org.opennms.features.notifications.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-situation-feedback-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Situation-Feedback :: API">
+        <feature>jackson-core</feature>
+        <bundle>mvn:org.opennms.features.situation-feedback/org.opennms.features.situation-feedback.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-situation-feedback" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Situation-Feedback">
+        <feature>opennms-osgi-core-rest</feature>
+        <feature>opennms-jest</feature>
+        <feature>opennms-situation-feedback-api</feature>
+        <bundle>mvn:org.opennms.features.situation-feedback/org.opennms.features.situation-feedback.elastic/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.situation-feedback.rest/org.opennms.features.situation-feedback.rest.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.situation-feedback.rest/org.opennms.features.situation-feedback.rest.impl/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-alarm-history-api" description="OpenNMS :: Features :: Alarms :: History :: API" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.features.alarms.history/org.opennms.features.alarms.history.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-alarm-history-rest" description="OpenNMS :: Features :: Alarms :: History :: REST" version="36.0.0-SNAPSHOT">
+        <feature>jax-rs-connector</feature>
+        <feature>pax-http</feature>
+        <feature>opennms-alarm-history-api</feature>
+        <feature>opennms-es-rest</feature>
+        <bundle>mvn:org.opennms.features.alarms.history.rest/org.opennms.features.alarms.history.rest.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.alarms.history.rest/org.opennms.features.alarms.history.rest.impl/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-alarm-history-elastic" description="OpenNMS :: Features :: Alarms :: History :: Elasticsearch" version="36.0.0-SNAPSHOT">
+        <feature>javax.validation</feature>
+        <feature>opennms-alarm-history-rest</feature>
+        <feature>opennms-health-api</feature>
+        <feature>opennms-jest</feature>
+        <bundle>mvn:org.freemarker/freemarker/2.3.32</bundle>
+        <bundle dependency="true">mvn:org.mapstruct/mapstruct/1.5.2.Final</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.lib/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:org.opennms/opennms-alarm-api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.alarms.history/org.opennms.features.alarms.history.elastic/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="kafka-streams" description="Kafka Streams" version="3.6.2">
+        <!-- This is only needed for servicemix implementation of kafka streams -->
+        <!--
+        <feature>jackson-core</feature>
+        -->
+        <!-- Wrap the kafka-streams bundle instead of using the servicemix implementation since the later doesn't include the required imports for rocksdb -->
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/kafka-streams/3.6.2$Bundle-Version=3.6.2&amp;Export-Package=*;-noimport:=true:version="3.6.2"</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/3.6.2_1</bundle>
+        <bundle dependency="true">mvn:com.github.luben/zstd-jni/1.5.2-1</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-json/3.6.2</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-api/3.6.2</bundle>
+        <bundle>mvn:at.yawk.lz4/lz4-java/1.10.2</bundle>
+        <bundle dependency="true">mvn:org.xerial.snappy/snappy-java/1.1.10.5</bundle>
+        <bundle dependency="true">mvn:com.typesafe.scala-logging/scala-logging_2.13/3.9.5</bundle>
+        <bundle dependency="true">wrap:mvn:org.rocksdb/rocksdbjni/8.5.4</bundle>
+    </feature>
+    <feature name="opennms-kafka-producer" version="36.0.0-SNAPSHOT" description="OpenNMS :: Kafka :: Producer">
+        <feature version="31.1">guava</feature>
+        <feature version="3.6.2">kafka-streams</feature>
+        <feature>rate-limited-logger</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-situation-feedback-api</feature>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:at.yawk.lz4/lz4-java/1.10.2</bundle>
+        <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.kafka/org.opennms.features.kafka.producer/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-kafka-consumer" version="36.0.0-SNAPSHOT" description="OpenNMS :: Kafka :: Consumer">
+        <feature>opennms-kafka</feature>
+        <feature>opennms-events-api</feature>
+        <feature>opennms-model</feature>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.kafka/org.opennms.features.kafka.consumer/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-telemetry-collection" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: Collection">
+        <feature version="31.1">guava</feature>
+        <feature version="4.1.128.Final">netty</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-thresholding-api</feature>
+        <feature>opennms-osgi-jsr223</feature>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:com.google.code.gson/gson/2.9.1</bundle>
+        <bundle>wrap:mvn:io.pkts/pkts-core/3.0.10</bundle>
+        <bundle>wrap:mvn:io.pkts/pkts-buffers/3.0.10</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.lib/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.listeners/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.fileutils/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.adapters/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-telemetry-daemon" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: Daemon">
+        <feature>bson</feature>
+        <feature>camel-spring</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature version="4.1.128.Final">netty</feature>
+        <feature>opennms-core-daemon</feature>
+        <feature>opennms-core-ipc-sink-api</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-dao</feature>
+        <feature>opennms-telemetry-collection</feature>
+        <feature>opennms-util</feature>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.registry/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.daemon/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.jaxb/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.listeners/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-telemetry-bmp" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: BMP">
+        <feature>opennms-telemetry-bmp-adapter</feature>
+        <feature>rate-limited-logger</feature>
+        <feature>resilience4j</feature>
+        <feature>opennms-dnsresolver-api</feature>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.parser/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-telemetry-bmp-adapter" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: BMP :: Adapter">
+        <feature>opennms-telemetry-collection</feature>
+        <feature>opennms-kafka</feature>
+        <feature>rate-limited-logger</feature>
+        <feature>opennms-rpc-utils</feature>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.adapter/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.transport/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <!-- Currently, this only runs on OpenNMS -->
+    <feature name="opennms-telemetry-bmp-stats" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: BMP :: Stats Aggregator">
+        <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.stats/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:com.google.code.gson/gson/2.9.1</bundle>
+        <feature>commons-net</feature>
+    </feature>
+    <feature name="opennms-telemetry-jti" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: JTI">
+        <feature>opennms-telemetry-collection</feature>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.jti/org.opennms.features.telemetry.protocols.jti.adapter/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-telemetry-nxos" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: NX-OS">
+        <feature>opennms-telemetry-collection</feature>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.nxos/org.opennms.features.telemetry.protocols.nxos.adapter/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-telemetry-graphite" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Telemetry :: Graphite">
+        <feature>opennms-telemetry-collection</feature>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.graphite/org.opennms.features.telemetry.protocols.graphite.adapter/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-telemetry-openconfig" start-level="60" description="OpenNMS :: Telemetry :: OpenConfig" version="36.0.0-SNAPSHOT">
+        <feature>opennms-telemetry-collection</feature>
+        <feature>opennms-telemetry-openconfig-client</feature>
+        <feature>opennms-rpc-utils</feature>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core.grpc/org.opennms.core.grpc.osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.openconfig/org.opennms.features.openconfig.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.openconfig/org.opennms.features.openconfig.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.distributed/org.opennms.features.telemetry.distributed.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.jaxb/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.openconfig/org.opennms.features.telemetry.protocols.openconfig.adapter/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.openconfig/org.opennms.features.telemetry.protocols.openconfig.connector/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.connectors/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-telemetry-openconfig-client" description="OpenNMS :: Telemetry :: OpenConfig :: Client" version="36.0.0-SNAPSHOT">
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core.grpc/org.opennms.core.grpc.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.grpc/org.opennms.core.grpc.osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.openconfig/org.opennms.features.openconfig.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.openconfig/org.opennms.features.openconfig.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.openconfig/org.opennms.features.openconfig.telemetry-client/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-health-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Health :: API">
+        <feature>commons-lang3</feature>
+        <bundle dependency="true">mvn:io.vavr/vavr/0.10.0</bundle>
+        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-health" version="36.0.0-SNAPSHOT" description="OpenNMS :: Health :: Core">
+        <feature>commons-io</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>opennms-health-api</feature>
+        <feature>opennms-util</feature>
+        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.impl/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-health-rest" version="36.0.0-SNAPSHOT" description="OpenNMS :: Health :: Rest">
+        <feature>opennms-health</feature>
+        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.rest/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-karaf-health" description="OpenNMS :: Karaf Health">
+        <bundle start-level="100">mvn:org.opennms.features/org.opennms.features.karaf-health/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-persistence" version="36.0.0-SNAPSHOT" description="OpenNMS :: Persistence">
+        <feature>opennms-model</feature>
+        <feature>opennms-dao</feature>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.datasource/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-spring-extender" version="36.0.0-SNAPSHOT" description="OpenNMS :: Spring Extender">
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature version="[4.2,4.3)">spring-jdbc</feature>
+        <feature version="[4.2,4.3)">spring-orm</feature>
+        <feature version="[4.2,4.3)">spring-jms</feature>
+        <feature version="[4.2,4.3)">spring-tx</feature>
+        <feature version="31.1">guava</feature>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.soa/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.sysprops/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.container/spring-extender/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.serviceregistry/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-flows" start-level="60" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Flows :: Feature Definition">
+        <details>Feature definition to start all required bundles related to *flow-support.</details>
+        <feature>bson</feature>
+        <feature>opennms-core-messagebus-api</feature>
+        <feature>commons-csv</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>opennms-health</feature>
+        <feature>opennms-jest</feature>
+        <feature version="31.1">guava</feature>
+        <feature version="4.1.128.Final">netty</feature>
+        <feature>quartz</feature>
+        <feature>opennms-core-tracing</feature>
+        <feature>opennms-distributed-core-api</feature>
+        <feature>opennms-integration-api</feature>
+        <feature>opennms-telemetry-collection</feature>
+        <feature>opennms-dnsresolver-api</feature>
+        <feature>opennms-kafka</feature>
+        <feature>opennms-mate-impl</feature>
+        <feature>opennms-elastic-client</feature>
+        <feature>rate-limited-logger</feature>
+
+        <bundle>mvn:org.opennms.core.ipc.twin/org.opennms.core.ipc.twin.api/36.0.0-SNAPSHOT</bundle>
+
+        <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.flows.classification.engine/org.opennms.features.flows.classification.engine.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.flows.rest/org.opennms.features.flows.rest.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-web-api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.flows.rest/org.opennms.features.flows.rest.impl/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.freemarker/freemarker/2.3.32</bundle>
+        <bundle>mvn:org.opennms.features.flows.classification.engine/org.opennms.features.flows.classification.engine.impl/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.elastic/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.fileutils/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.processing/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.flows/org.opennms.features.flows.kafka-persistence/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.cache/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.listeners/36.0.0-SNAPSHOT</bundle>
+
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>wrap:mvn:com.google.protobuf/protobuf-java-util/3.25.5$overwrite=merge&amp;Import-Package=javax.annotation;version=!,*</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.cache/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.flows/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.netflow/org.opennms.features.telemetry.protocols.netflow.parser/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.netflow/org.opennms.features.telemetry.protocols.netflow.adapter/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.netflow/org.opennms.features.telemetry.protocols.netflow.transport/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.sflow/org.opennms.features.telemetry.protocols.sflow.parser/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.sflow/org.opennms.features.telemetry.protocols.sflow.adapter/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.flows.classification/org.opennms.features.flows.classification.shell/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.netflow.xml/org.opennms.features.telemetry.protocols.netflow.xml.core/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-api-layer" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: API Layer">
+        <feature>opennms-health</feature>
+        <feature>opennms-situation-feedback-api</feature>
+        <feature version="2.0.0">opennms-integration-api</feature>
+        <feature>scv-api</feature>
+        <bundle dependency="true">mvn:org.mapstruct/mapstruct/1.5.2.Final</bundle>
+        <bundle>mvn:org.opennms.features.api-layer/org.opennms.features.api-layer.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.api-layer/org.opennms.features.api-layer.dao-common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.api-layer/org.opennms.features.api-layer.core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features/ui-extension/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-enlinkd-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Enlinkd :: Shell">
+        <feature>opennms-dao</feature>
+        <feature>opennms-core-daemon</feature>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.adapters.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.adapters.collectors.bridge/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.adapters.collectors.cdp/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.adapters.collectors.ipnettomedia/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.adapters.collectors.isis/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.adapters.collectors.ospf/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.adapters.collectors.lldp/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.shell/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.generator/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-osgi-core-rest" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: OSGI :: Core :: Rest">
+        <details>Core module which provides features to install to listen for rest related services,
+            such as @Path annotated interfaces.</details>
+        <feature>jax-rs-connector</feature>
+        <feature>jax-rs-provider-jackson</feature>
+        <bundle>mvn:org.opennms.features/org.opennms.features.rest-provider/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.container.bridge/org.opennms.container.bridge.rest/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-jaas-login-module" version="36.0.0-SNAPSHOT" description="OpenNMS :: OSGi Container :: Karaf JAAS Login Module">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <bundle>mvn:org.opennms.container/org.opennms.container.jaas-login-module/36.0.0-SNAPSHOT</bundle>
+        <bundle start-level="30">mvn:org.apache.karaf.jaas/org.apache.karaf.jaas.modules/4.3.10</bundle>
+        <bundle start-level="30">mvn:org.apache.karaf.jaas/org.apache.karaf.jaas.config/4.3.10</bundle>
+    </feature>
+    <feature name="jmxconfiggenerator" version="36.0.0-SNAPSHOT" description="OpenNMS JMX Configuration Generator">
+        <feature version="31.1">guava</feature>
+        <feature>commons-io</feature>
+        <feature>commons-lang3</feature>
+        <bundle>mvn:org.opennms.features/jmxconfiggenerator/36.0.0-SNAPSHOT</bundle>
+        <bundle>wrap:mvn:args4j/args4j/2.33</bundle>
+        <bundle>wrap:mvn:org.jvnet.opendmk/jmxremote_optional/1.0_01-ea</bundle>
+        <bundle>mvn:org.apache.velocity/velocity-engine-core/2.3</bundle>
+        <bundle>mvn:org.opennms.features/org.opennms.features.name-cutter/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="vaadin-jmxconfiggenerator" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: JMX Config Generator :: Web UI">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature prerequisite="true">vaadin</feature>
+        <feature>jmxconfiggenerator</feature>
+        <bundle>mvn:org.opennms.features/vaadin-jmxconfiggenerator/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/widgetset/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.themes/jmxconfiggenerator-theme/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="org.opennms.features.enlinkd.service.api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Enlinkd :: Service :: API">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature version="31.1">guava</feature>
+        <feature>jung</feature>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.persistence.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.enlinkd/org.opennms.features.enlinkd.service.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.criteria/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="org.opennms.features.bsm.service.api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: BSM :: Service :: API">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature version="31.1">guava</feature>
+        <feature>jung</feature>
+        <bundle>mvn:org.opennms.features.bsm/org.opennms.features.bsm.persistence.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.bsm/org.opennms.features.bsm.service.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.criteria/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="org.opennms.features.bsm.shell-commands" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: BSM :: Shell Commands">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature>org.opennms.features.bsm.service.api</feature>
+        <bundle>mvn:org.opennms.features.bsm/org.opennms.features.bsm.shell-commands/36.0.0-SNAPSHOT</bundle>
+        <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.core/4.3.10</bundle>
+    </feature>
+    <feature name="vaadin-adminpage" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: BSM :: Vaadin Adminpage">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature prerequisite="true">vaadin</feature>
+        <feature>org.opennms.features.bsm.service.api</feature>
+        <bundle>mvn:org.opennms.features.bsm/vaadin-adminpage/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/widgetset/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.link/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="geolocation" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Geolocation :: Feature">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature version="31.1">guava</feature>
+        <feature>opennms-core-web</feature>
+        <bundle>mvn:org.opennms.features.geocoder/org.opennms.features.geocoder.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.geocoder/org.opennms.features.geocoder.rest/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.geocoder/org.opennms.features.geocoder.service/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.geolocation/org.opennms.features.geolocation.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.geolocation/org.opennms.features.geolocation.services/36.0.0-SNAPSHOT</bundle>
+        <bundle start-level="100">mvn:org.opennms.features.geocoder/org.opennms.features.geocoder.google/36.0.0-SNAPSHOT</bundle>
+        <bundle start-level="100">mvn:org.opennms.features.geocoder/org.opennms.features.geocoder.mapquest/36.0.0-SNAPSHOT</bundle>
+        <bundle start-level="100">mvn:org.opennms.features.geocoder/org.opennms.features.geocoder.nominatim/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="vaadin-snmp-events-and-metrics" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: SNMP Events and Metrics Admin UI">
+        <details>OpenNMS Vaadin Administration UI for handling SNMP related configuration files for events and data collection.</details>
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features/vaadin-snmp-events-and-metrics/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/widgetset/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.themes/onms-default-theme/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features/org.opennms.features.mib-compiler/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:commons-lang/commons-lang/2.6</bundle>
+    </feature>
+    <feature name="osgi-nrtg-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: API">
+        <details>The API contains the models for the NRTG OSGI projects. It has models for collection jobs, measurements and protocol collectors.</details>
+        <bundle>mvn:org.opennms.features.nrtg/nrtg-api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="osgi-nrtg-protocolcollector-snmp" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: Collectors :: SNMP">
+        <details>Plugin for the NRTCollector OSGI Satellit to collect data from snmp agents</details>
+        <feature>osgi-nrtg-api</feature>
+        <bundle>mvn:org.opennms.features.nrtg.protocolcollector/nrtg-protocolcollector-snmp/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="osgi-nrtg-protocolcollector-tca" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: Collectors :: TCA">
+        <details>Plugin for the NRTCollector OSGI Satellite to collect data from TCA agents.</details>
+        <feature>osgi-nrtg-api</feature>
+        <bundle>mvn:org.opennms.features.nrtg.protocolcollector/nrtg-protocolcollector-tca/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="osgi-nrtg-web" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: Web">
+        <details>NRTG Web Runtime Feature</details>
+        <feature>osgi-nrtg-api</feature>
+        <bundle>mvn:org.opennms.features.nrtg/nrtg-web/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="osgi-nrtg-base" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: Base">
+        <details>OSGI Runtime for the NRTCollector.</details>
+        <feature>osgi-nrtg-protocolcollector-snmp</feature>
+        <feature>osgi-nrtg-protocolcollector-tca</feature>
+        <feature>osgi-nrtg-web</feature>
+    </feature>
+    <feature name="osgi-nrtg-jms" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: JMS">
+        <details>OSGI Runtime for the NRTCollector.</details>
+        <feature>osgi-nrtg-base</feature>
+        <feature>activemq</feature>
+        <feature>activemq-blueprint</feature>
+        <feature version="4.2.9.RELEASE_1">spring-jms</feature>
+        <bundle>mvn:org.opennms.features.nrtg/nrtg-collector/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.nrtg/nrtg-nrtbroker-jms/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.nrtg/nrtg-broker/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="osgi-nrtg-local" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: Local">
+        <details>OSGI Runtime for the NRTCollector.</details>
+        <feature>osgi-nrtg-base</feature>
+        <bundle>mvn:org.opennms.features.nrtg/nrtg-nrtbroker-local/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="nrtg" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: NRTG :: Features :: All">
+        <details>OSGI Runtime for the NRTCollector.</details>
+        <feature>osgi-nrtg-jms</feature>
+        <feature>osgi-nrtg-local</feature>
+    </feature>
+
+    <feature name="vaadin" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Vaadin + Dependencies">
+        <details>The Vaadin web application framework including some addons and osgi related packages.</details>
+        <feature>scr</feature>
+        <feature version="31.1">guava</feature>
+        <feature prerequisite="true">opennms-http-whiteboard</feature>
+
+        <!-- OpenNMS Vaadin Base -->
+        <bundle>mvn:org.opennms.features.vaadin-components/extender-service/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.osgi/opennms-osgi-core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.themes/onms-default-theme/36.0.0-SNAPSHOT</bundle>
+
+        <!-- Dependencies -->
+        <bundle>mvn:com.vaadin.external.gwt/gwt-elemental/2.8.2.vaadin2</bundle>
+        <bundle>wrap:mvn:com.google.gwt/gwt-user/2.9.0/$Export-Package=com.google.*</bundle>
+        <bundle>mvn:com.vaadin.external/gentyref/1.2.0.vaadin1</bundle>
+        <bundle>mvn:org.jsoup/jsoup/1.15.3</bundle>
+        <bundle>mvn:org.json/json/20240303</bundle>
+
+        <!-- Vaadin -->
+        <bundle>mvn:com.vaadin/vaadin-shared/8.14.3</bundle>
+        <bundle>mvn:com.vaadin/vaadin-server/8.14.3</bundle>
+        <bundle>mvn:com.vaadin/vaadin-client/8.14.3</bundle>
+        <bundle>mvn:com.vaadin/vaadin-client-compiled/8.14.3</bundle>
+        <bundle>mvn:com.vaadin/vaadin-themes/8.14.3</bundle>
+
+        <!-- Vaadin Compatibility -->
+        <bundle>mvn:com.vaadin/vaadin-compatibility-shared/8.14.3</bundle>
+        <bundle>mvn:com.vaadin/vaadin-compatibility-server/8.14.3</bundle>
+        <bundle>mvn:com.vaadin/vaadin-compatibility-client-compiled/8.14.3</bundle>
+        <bundle>wrap:mvn:com.vaadin/vaadin-compatibility-client/8.14.3</bundle>
+        <bundle>mvn:com.vaadin/vaadin-compatibility-themes/8.14.3</bundle>
+
+        <!-- Add Ons -->
+        <bundle>mvn:com.vaadin/vaadin-context-menu/3.1.0</bundle>
+        <bundle>mvn:org.vaadin.addon/confirmdialog/3.2.0</bundle>
+    </feature>
+    <feature name="opennms-topology-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: API">
+        <details>APIs for creating topology OSGi plugins.</details>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-base" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: Base">
+        <details>Base runtime and plugins for the OpenNMS topology web app.</details>
+        <feature>opennms-core</feature>
+        <feature>opennms-topology-api</feature>
+        <feature>geolocation</feature>
+        <feature>commons-collections4</feature>
+        <feature>commons-lang3</feature>
+        <feature>commons-net</feature>
+        <feature version="31.1" prerequisite="true">guava</feature>
+        <feature>jackson-core</feature>
+        <feature>jackson-dataformat-yaml</feature>
+        <feature>jackson-datatype-jdk8</feature>
+
+        <bundle>mvn:jakarta.annotation/jakarta.annotation-api/3.0.0</bundle>
+        <bundle>mvn:com.google.code.findbugs/annotations/3.0.1</bundle>
+
+        <bundle>wrap:mvn:com.hubspot.immutables/immutables-exceptions/1.9</bundle>
+        <bundle>wrap:mvn:com.hubspot.immutables/hubspot-style/1.9</bundle>
+        <bundle>wrap:mvn:com.hubspot/algebra/1.5</bundle>
+
+        <feature>jung</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <feature>jackson-datatype-jdk8</feature>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.app/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/org.opennms.features.topology.plugins.topo.history/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.link/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.topology.plugins/org.opennms.features.topology.plugins.layout/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.netutils/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.topology.themes/org.opennms.features.topology.themes.default-theme/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/graph/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/header/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-linkd" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: Linkd">
+        <details>Linkd-based runtime and plugins for the OpenNMS topology web app.</details>
+        <feature>opennms-topology-runtime-base</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/org.opennms.features.topology.plugins.topo.linkd/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-browsers" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: Browsers">
+        <details>Alarm browser to enhance the Linkd topology UI.</details>
+        <feature>opennms-topology-api</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins/org.opennms.features.topology.plugins.browsers/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-vmware" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: VMware">
+        <details>Runtime and plugins for the OpenNMS VMware topology web app.</details>
+        <feature>opennms-topology-runtime-base</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/org.opennms.features.topology.plugins.topo.vmware/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-application" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: Application">
+        <details>Runtime and plugins for the OpenNMS Application Topology Provider</details>
+        <feature>opennms-topology-runtime-base</feature>
+        <feature>opennms-graph-provider-application</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/org.opennms.features.topology.plugins.topo.application/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-bsm" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: BSM">
+        <details>Generated using Pax-Construct</details>
+        <feature>opennms-topology-runtime-base</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/org.opennms.features.topology.plugins.topo.bsm/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-pathoutage" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: PathOutage">
+        <details>Generated using Pax-Construct</details>
+        <feature>opennms-topology-runtime-base</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/org.opennms.features.topology.plugins.topo.pathoutage/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-graphml" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: GraphML">
+        <details>GraphML runtime and plugins for the OpenNMS topology web app.</details>
+        <feature>groovy</feature>
+        <feature>opennms-graphml</feature>
+        <feature>opennms-topology-runtime-base</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/graphml/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features/org.opennms.features.osgi-jsr223/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-topology-runtime-asset" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Features :: Runtime :: Asset">
+        <details>Asset runtime and plugins for the OpenNMS topology web app.</details>
+        <feature prerequisite="true">shell-compat</feature>
+        <feature>opennms-topology-runtime-graphml</feature>
+        <feature>opennms-topology-runtime-base</feature>
+        <bundle>mvn:org.opennms.features.topology.plugins.topo/asset/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="org.opennms.features.topology.shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topology :: Shell Commands">
+        <details>Generated using Pax-Construct</details>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="vaadin-dashboard" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashboard">
+        <details>OpenNMS Vaadin Dashboard</details>
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features/vaadin-dashboard/36.0.0-SNAPSHOT</bundle>
+        <bundle>wrap:mvn:org.vaadin.addons/dragdroplayouts/1.4.2</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.themes/dashboard-theme/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.vaadin.addons/dragdroplayouts/1.4.2</bundle>
+    </feature>
+    <feature name="dashlet-alarms" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Alarms">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-alarms/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-bsm" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: BSM">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-bsm/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-summary" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Summary">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-summary/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-map" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Map">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-map/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-image" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Image">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-image/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-charts" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Charts">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-charts/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-rtc" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: RTC">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-rtc/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-rrd" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: RRD">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-rrd/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-ksc" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: KSC">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-ksc/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-topology" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Topology">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-topology/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.link/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-surveillance" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Surveillance">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-surveillance/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-url" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: URL">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-url/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="dashlet-grafana" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Dashlets :: Grafana">
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features.vaadin-dashlets/dashlet-grafana/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="vaadin-surveillance-views" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Surveillance Views">
+        <details>OpenNMS Vaadin Surveillance Views</details>
+        <feature>opennms-core</feature>
+        <feature prerequisite="true">vaadin</feature>
+        <bundle>mvn:org.opennms.features/vaadin-surveillance-views/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/graph/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/core/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.vaadin-components/widgetset/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="jira-troubleticketer" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Ticketing :: JIRA">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <bundle>mvn:org.opennms.features/jira-troubleticketer/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.lib/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:joda-time/joda-time/2.12.5</bundle>
+        <bundle>mvn:org.opennms.features/jira-client/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-inmemory-ticketer" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Ticketing :: InMemory">
+        <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.inmemory/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="datachoices" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Data Choices">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature prerequisite="true">shell-compat</feature>
+        <feature>opennms-core-messagebus-api</feature>
+        <feature version="31.1">guava</feature>
+        <feature>hibernate36</feature>
+        <feature>jackson1</feature>
+        <feature>javax.servlet</feature>
+        <feature>quartz</feature>
+        <feature>opennms-health-api</feature>
+        <feature>opennms-dao</feature>
+        <bundle>mvn:org.opennms.features/datachoices/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.freemarker/freemarker/2.3.32</bundle>
+        <bundle>mvn:org.opennms/opennms-web-api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.usageanalytics/org.opennms.features.usageanalytics.api/36.0.0-SNAPSHOT</bundle>
+        <feature>java-native-access</feature>
+        <bundle>mvn:com.github.oshi/oshi-core/6.7.1</bundle>
+    </feature>
+    <feature name="opennms-es-rest" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: ElasticSearch Rest">
+        <details>OpenNMS :: Features :: ElasticSearch Rest</details>
+        <feature>commons-io</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>opentracing-api</feature>
+        <feature>rate-limited-logger</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-jest</feature>
+        <feature>opennms-mate-impl</feature>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.cache/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.xml/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.xml/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features/org.opennms.features.opennms-es-rest/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:com.googlecode.json-simple/json-simple/1.1.1</bundle>
+    </feature>
+    <feature name="opennms-jest" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Jest :: Feature definition">
+        <details>Feature definition for Jest (ElasticSearch Java ReST Client)</details>
+        <feature>commons-codec</feature>
+        <feature>guava</feature>
+        <feature>resilience4j</feature>
+        <feature>opennms-events-api</feature>
+        <feature>opennms-model</feature>
+        <feature>opennms-util</feature>
+        <!-- do we need to specifically pull in an older Guava for Jest? -->
+        <!-- <bundle>mvn:com.google.guava/guava/21.0</bundle> -->
+        <bundle>mvn:com.google.code.gson/gson/2.9.1</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/4.4.16</bundle>
+        <bundle>mvn:org.opennms.features.jest/org.opennms.features.jest.client/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.jest/jest-complete-osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpasyncclient-osgi/4.1.5</bundle>
+    </feature>
+    <feature name="opennms-search" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Search">
+        <details>OpenNMS :: Features :: Search</details>
+        <bundle>mvn:org.opennms.features.search/org.opennms.features.search.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.search/org.opennms.features.search.providers/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.search/org.opennms.features.search.service/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.search/org.opennms.features.search.rest/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-mate-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Metadata :: API">
+        <feature version="31.1" prerequisite="true">guava</feature>
+        <feature>opennms-core</feature>
+        <feature>scv-api</feature>
+        <bundle>mvn:org.opennms.core.mate/org.opennms.core.mate.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-mate-impl" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Metadata :: Implementation">
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-mate-api</feature>
+        <bundle>wrap:mvn:ch.hsr/geohash/1.4.0$Bundle-SymbolicName=ch.hsr.geohash&amp;Bundle-Version=1.4.0</bundle>
+        <bundle>mvn:org.opennms.core.mate/org.opennms.core.mate.model/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-mate-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Metadata :: Karaf Shell Commands">
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-mate-api</feature>
+        <bundle>mvn:org.opennms.core.mate/org.opennms.core.mate.shell-commands/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="ifttt-integration" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: IFTTT Integration">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature version="31.1">guava</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>opennms-mate-api</feature>
+        <bundle>mvn:org.opennms.features/org.opennms.features.ifttt/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="org.opennms.features.topologies.service.api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Topologies :: Service :: API">
+        <details>OpenNMS is the world's first enterprise grade network management platform developed under the open source model. It consists of a community supported open-source project as well as a commercial services, training and support organization.</details>
+        <feature version="31.1">guava</feature>
+        <feature>jung</feature>
+        <bundle>mvn:org.opennms.features.topologies/org.opennms.features.topologies.service.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/opennms-model/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-endpoints-grafana" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Endpoints :: Grafana">
+        <bundle>mvn:org.opennms.features.endpoints.grafana/org.opennms.features.endpoints.grafana.client/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.endpoints.grafana/org.opennms.features.endpoints.grafana.service/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.endpoints.grafana/org.opennms.features.endpoints.grafana.rest/36.0.0-SNAPSHOT</bundle>
+        <!-- These are pulled in via lib directory -->
+        <!--<bundle>mvn:org.opennms.features.endpoints.grafana/org.opennms.features.endpoints.grafana.api/36.0.0-SNAPSHOT</bundle>-->
+        <!--<bundle>mvn:org.opennms.features.endpoints.grafana.persistence/org.opennms.features.endpoints.grafana.persistence.api/36.0.0-SNAPSHOT</bundle>-->
+        <!--<bundle>mvn:org.opennms.features.endpoints.grafana.persistence/org.opennms.features.endpoints.grafana.persistence.impl/36.0.0-SNAPSHOT</bundle>-->
+        <bundle dependency="true">mvn:org.jetbrains.kotlin/kotlin-osgi-bundle/1.9.10</bundle>
+    </feature>
+    <feature name="opennms-reporting" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Reporting">
+        <!-- All other dependencies are wired in through custom.properties -->
+        <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.rest/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-dnsresolver-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: DNS Resolver :: API">
+        <bundle>mvn:org.opennms.features.dnsresolver/org.opennms.features.dnsresolver.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-dnsresolver-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: DNS Resolver :: Shell">
+        <feature version="36.0.0-SNAPSHOT">opennms-dnsresolver-api</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature version="31.1">guava</feature>
+        <bundle>mvn:org.opennms.features.dnsresolver/org.opennms.features.dnsresolver.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-dnsresolver-netty" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: DNS Resolver :: Netty">
+        <feature version="36.0.0-SNAPSHOT">opennms-dnsresolver-api</feature>
+        <feature version="31.1">guava</feature>
+        <feature>dropwizard-metrics</feature>
+        <feature>dnsjava</feature>
+        <feature version="4.1.128.Final">netty</feature>
+        <feature>resilience4j</feature>
+        <feature>opennms-events-api</feature>
+        <feature>opennms-model</feature>
+
+        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/36.0.0-SNAPSHOT</bundle>
+        <bundle dependency="true">mvn:com.github.ben-manes.caffeine/caffeine/2.8.0</bundle>
+        <bundle>mvn:org.opennms.features.dnsresolver/org.opennms.features.dnsresolver.netty/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="resilience4j" version="0.17.0" description="resilience4j">
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsr305/3.0.2_1</bundle>
+        <bundle>mvn:io.vavr/vavr/0.10.0</bundle>
+        <bundle>mvn:io.vavr/vavr-match/0.10.0</bundle>
+        <bundle>mvn:io.github.resilience4j/resilience4j-core/0.17.0</bundle>
+        <bundle>mvn:io.github.resilience4j/resilience4j-circuitbreaker/0.17.0</bundle>
+        <bundle>mvn:io.github.resilience4j/resilience4j-bulkhead/0.17.0</bundle>
+        <bundle>mvn:io.github.resilience4j/resilience4j-retry/0.17.0</bundle>
+    </feature>
+
+    <feature name="opennms-blobstore-shell" description="OpenNMS :: Features :: Distributed :: Key Value Store :: Blob :: Shell" version="36.0.0-SNAPSHOT">
+        <feature>resilience4j</feature>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.blob.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-blobstore-noop"
+             description="OpenNMS :: Features :: Distributed :: Key Value Store :: Blob :: No-Op" version="36.0.0-SNAPSHOT">
+        <feature>opennms-blobstore-shell</feature>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.blob.no-op/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-blobstore-postgres"
+             description="OpenNMS :: Features :: Distributed :: Key Value Store :: Blob :: Postgres" version="36.0.0-SNAPSHOT">
+        <feature>opennms-blobstore-shell</feature>
+        <bundle dependency="true">mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.postgres-shared/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.blob.postgres/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-jsonstore-shell" description="OpenNMS :: Features :: Distributed :: Key Value Store :: JSON :: Shell" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.json.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-config-dao-api" description="OpenNMS :: Config DAO :: API" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms/org.opennms.config-dao.common-api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/org.opennms.config-dao.poll-outages.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms/org.opennms.config-dao.thresholding.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-threshold-states-shell" description="OpenNMS :: Features :: Collection :: Thresholding :: Shell" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.thresholding.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-core-ipc-grpc-server" description="OpenNMS :: Core :: IPC :: GRPC :: Server" version="36.0.0-SNAPSHOT">
+        <feature>dropwizard-metrics</feature>
+        <feature>opennms-core-ipc-sink-api</feature>
+        <feature>opennms-identity</feature>
+        <feature>opennms-core-ipc-rpc-api</feature>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core.grpc/org.opennms.core.grpc.osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.grpc/org.opennms.core.ipc.grpc.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.grpc/org.opennms.core.ipc.grpc.server/36.0.0-SNAPSHOT</bundle>
+        <feature>opennms-core-ipc-twin-grpc-publisher</feature>
+    </feature>
+
+    <feature name="opennms-core-ipc-twin-grpc-publisher" description="OpenNMS :: Core :: IPC :: Twin :: GRPC :: Publisher" version="36.0.0-SNAPSHOT">
+        <feature>opennms-core-ipc-twin-common</feature>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core.grpc/org.opennms.core.grpc.osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.twin.grpc/org.opennms.core.ipc.twin.grpc.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.twin.grpc/org.opennms.core.ipc.twin.grpc.publisher/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-graphml" description="OpenNMS :: Features :: GraphML :: API + Service + ReST" version="36.0.0-SNAPSHOT">
+        <feature version="31.1">guava</feature>
+        <bundle>mvn:org.opennms.features.graphml/org.opennms.features.graphml.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.graphml/org.opennms.features.graphml.service/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.graphml/org.opennms.features.graphml.rest/36.0.0-SNAPSHOT</bundle>
+        <!-- Provided by ${OPENNMS_HOME}/lib -->
+        <!-- <bundle>mvn:org.opennms.core/org.opennms.core.xml/36.0.0-SNAPSHOT</bundle> -->
+    </feature>
+
+    <!-- Convenient feature to install all graph related features-->
+    <feature name="opennms-graphs" description="OpenNMS :: Features :: Graph" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-api</feature>
+        <feature>opennms-graph-service</feature>
+        <feature>opennms-graph-domain</feature>
+        <feature>opennms-graph-persistence</feature>
+        <feature>opennms-graph-shell</feature>
+        <feature>opennms-graph-rest</feature>
+        <feature>opennms-graph-provider-graphml</feature>
+        <feature>opennms-graph-provider-bsm</feature>
+        <feature>opennms-graph-provider-application</feature>
+        <feature>opennms-graph-provider-legacy</feature>
+        <feature>opennms-graph-provider-topology</feature>
+    </feature>
+    <feature name="opennms-graph-api" description="OpenNMS :: Features :: Graph :: API" version="36.0.0-SNAPSHOT">
+        <feature version="31.1">guava</feature>
+        <feature>jung</feature>
+        <feature>opennms-model</feature>
+        <bundle>mvn:org.opennms.features.graph/org.opennms.features.graph.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-service" description="OpenNMS :: Features :: Graph :: Service" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-api</feature>
+        <feature>opennms-graph-domain</feature>
+        <bundle>wrap:mvn:com.google.code.gson/gson/2.9.1</bundle>
+        <bundle>mvn:com.github.ben-manes.caffeine/caffeine/2.8.0</bundle>
+        <bundle>mvn:org.opennms.features.graph/org.opennms.features.graph.service/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-persistence" description="OpenNMS :: Features :: Graph :: Persistence" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-api</feature>
+        <!-- Provided by ${OPENNMS_HOME}/lib -->
+        <!-- <feature>opennms-dao-api</feature> -->
+        <!-- <feature>opennms-dao</feature> -->
+        <!-- <bundle>mvn:org.opennms.features.graph.dao/org.opennms.features.graph.dao.api/36.0.0-SNAPSHOT</bundle> -->
+        <!-- <bundle>mvn:org.opennms.features.graph.dao/org.opennms.features.graph.dao.impl/36.0.0-SNAPSHOT</bundle> -->
+    </feature>
+    <feature name="opennms-graph-rest" description="OpenNMS :: Features :: Graph :: ReST API" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-api</feature>
+        <feature>opennms-core-messagebus-api</feature>
+        <feature>opennms-graph-service</feature>
+        <bundle>mvn:org.opennms/opennms-web-api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.graph.rest/org.opennms.features.graph.rest.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.graph.rest/org.opennms.features.graph.rest.impl/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-domain" description="OpenNMS :: Features :: Graph :: Domain" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-api</feature>
+        <bundle>mvn:org.opennms.features.graph/org.opennms.features.graph.domain/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-shell" description="OpenNMS :: Features :: Graph :: Shell" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-service</feature>
+        <bundle>mvn:org.opennms.features.graph/org.opennms.features.graph.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <!-- Graph Providers -->
+    <feature name="opennms-graph-provider-graphml" description="OpenNMS :: Features :: Graph :: Provider :: GraphML" version="36.0.0-SNAPSHOT">
+        <feature>jung</feature>
+        <feature>opennms-graph-service</feature>
+        <feature>opennms-core</feature>
+        <feature>opennms-graphml</feature>
+        <bundle>mvn:org.opennms.features.graph.provider/org.opennms.features.graph.provider.graphml/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-provider-bsm" description="OpenNMS :: Features :: Graph :: Provider :: Business Services" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-service</feature>
+        <feature>opennms-model</feature>
+        <bundle>mvn:org.opennms.features.graph.provider/org.opennms.features.graph.provider.bsm/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-provider-application" description="OpenNMS :: Features :: Graph :: Provider :: Application" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-service</feature>
+        <feature>opennms-model</feature>
+        <bundle>mvn:org.opennms.features.graph.provider/org.opennms.features.graph.provider.application/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-provider-legacy" description="OpenNMS :: Features :: Graph :: Provider :: VMware + Enlinkd" version="36.0.0-SNAPSHOT">
+        <feature>opennms-graph-service</feature>
+        <feature>opennms-model</feature>
+        <feature>opennms-topology-api</feature>
+        <bundle>mvn:org.opennms.features.graph.provider/org.opennms.features.graph.provider.legacy/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-graph-provider-topology" description="OpenNMS :: Features :: Graph :: Provider :: Topology" version="36.0.0-SNAPSHOT">
+        <feature>opennms-model</feature>
+        <feature>opennms-graph-service</feature>
+        <bundle>mvn:org.opennms.features.topology/org.opennms.features.topology.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.graph.provider/org.opennms.features.graph.provider.topology/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <!-- For now it is only used for test purposes -->
+    <feature name="opennms-graph-provider-persistence-test" description="OpenNMS :: Features :: Graph :: Provider :: Persistence Test" version="36.0.0-SNAPSHOT">
+        <feature>opennms-model</feature>
+        <feature>opennms-graph-service</feature>
+        <feature>opennms-graph-domain</feature>
+        <bundle>mvn:org.opennms.features.graph.provider/org.opennms.features.graph.provider.persistence-test/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-perspective-poller" description="OpenNMS :: Features :: Perspective Poller" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.features/org.opennms.features.perspectivepoller/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-config-management" description="OpenNMS :: Features :: Config" version="36.0.0-SNAPSHOT">
+        <feature>jackson-dataformat-yaml</feature>
+        <feature>opennms-core-messagebus-api</feature>
+        <feature>jackson-datatype-jsr310</feature>
+        <bundle>mvn:org.opennms/opennms-web-api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.ws.xmlschema/xmlschema-core/2.3.1</bundle>
+        <bundle>mvn:org.apache.ws.xmlschema/xmlschema-walker/2.3.1</bundle>
+        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxp-api-1.4/2.9.0</bundle>
+        <bundle>mvn:org.opennms.features.config.rest/org.opennms.features.config.rest.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:net.minidev/accessors-smart/2.5.0</bundle>
+        <bundle>mvn:net.minidev/json-smart/2.5.0</bundle>
+        <bundle>wrap:mvn:com.jayway.jsonpath/json-path/2.8.0</bundle>
+        <bundle>mvn:org.opennms.features.config.rest/org.opennms.features.config.rest.impl/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-config-management-osgi-del" description="OpenNMS :: Features :: Config :: Osgi :: Delegate" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.features.config.osgi/org.opennms.features.config.osgi.del/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-config-management-osgi-cm" description="OpenNMS :: Features :: Config :: Osgi :: CM" version="36.0.0-SNAPSHOT">
+        <feature>opennms-config-management</feature>
+        <feature>opennms-config-management-osgi-del</feature>
+        <bundle>mvn:org.json/json/20240303</bundle>
+        <bundle start-level="30">mvn:org.opennms.features.config.osgi/org.opennms.features.config.osgi.cm/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-timeseries-shell" version="36.0.0-SNAPSHOT" description="OpenNMS :: Features :: Timeseries :: Shell Commands">
+        <bundle>mvn:org.opennms.features/org.opennms.features.timeseries.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-http-whiteboard" description="Provide HTTP Whiteboard pattern support" version="36.0.0.SNAPSHOT">
+        <feature>opennms-bridge-http-service</feature>
+    </feature>
+
+    <feature name="opennms-bridge-http-service" description="OpenNMS Bridge OSGi HTTP Service" version="36.0.0.SNAPSHOT">
+        <bundle dependency="true" start-level="30">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+        <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.bridge/4.1.6</bundle>
+        <capability>http-service;provider:=pax-http</capability>
+        <conditional>
+            <condition>webconsole</condition>
+            <bundle start-level="60">mvn:org.apache.karaf.webconsole/org.apache.karaf.webconsole.http/4.3.10</bundle>
+        </conditional>
+    </feature>
+
+    <feature name="opennms-core-ipc-twin-jms" description="OpenNMS :: Core :: IPC :: Twin :: JMS" version="36.0.0-SNAPSHOT">
+        <feature>camel-blueprint</feature>
+        <feature>camel-jms</feature>
+        <feature version="[4.2,4.3)">spring</feature>
+        <feature>opennms-core-camel</feature>
+        <feature>opennms-core-ipc-twin-common</feature>
+        <bundle>mvn:org.opennms.core.ipc.twin.jms/org.opennms.core.ipc.twin.jms.subscriber/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-core-ipc-twin-common" description="OpenNMS :: Core :: IPC :: Twin :: Common" version="36.0.0-SNAPSHOT">
+        <feature>dropwizard-metrics</feature>
+        <feature version="31.1">guava</feature>
+        <feature>json-patch</feature>
+        <feature>opennms-core-tracing</feature>
+        <feature>opennms-distributed-core-api</feature>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.opennms.core.ipc.twin/org.opennms.core.ipc.twin.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.twin/org.opennms.core.ipc.twin.common/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="json-patch" description="OpenNMS :: Json Patch " version="36.0.0-SNAPSHOT">
+        <feature>jackson-core</feature>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsr305/3.0.2_1</bundle>
+        <bundle>wrap:mvn:com.github.java-json-tools/btf/1.3</bundle>
+        <bundle>wrap:mvn:com.github.java-json-tools/msg-simple/1.2</bundle>
+        <bundle>wrap:mvn:com.github.java-json-tools/jackson-coreutils/2.0$overwrite=merge&amp;Import-Package=*;</bundle>
+        <bundle>wrap:mvn:com.github.java-json-tools/json-patch/1.13$overwrite=merge&amp;Import-Package=*;resolution:=optional&amp;Export-Package=com.github.fge.jsonpatch.diff,com.github.fge.jsonpatch</bundle>
+    </feature>
+
+    <feature name="opennms-core-ipc-jms" description="OpenNMS :: Core :: IPC :: JMS" version="36.0.0-SNAPSHOT">
+        <feature>opennms-core-ipc-sink-camel</feature>
+        <feature>opennms-core-ipc-rpc-jms</feature>
+        <feature>opennms-core-ipc-twin-jms</feature>
+    </feature>
+    <feature name="opennms-core-ipc-kafka" description="OpenNMS :: Core :: IPC :: Kafka" version="36.0.0-SNAPSHOT">
+        <feature>opennms-core-ipc-sink-kafka</feature>
+        <feature>opennms-core-ipc-rpc-kafka</feature>
+        <feature>opennms-core-ipc-twin-kafka</feature>
+    </feature>
+
+    <feature name="opennms-core-ipc-twin-kafka-common" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Twin :: Kafka :: Common">
+        <feature>opennms-kafka</feature>
+        <feature>opennms-core-ipc-twin-common</feature>
+        <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core.ipc.twin.kafka/org.opennms.core.ipc.twin.kafka.common/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.sysprops/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-ipc-twin-kafka" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: IPC :: Twin :: Kafka :: Subscriber">
+        <feature>opennms-core-ipc-twin-kafka-common</feature>
+        <bundle>mvn:org.opennms.core.ipc.twin.kafka/org.opennms.core.ipc.twin.kafka.subscriber/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-core-ipc-twin-shell" description="OpenNMS :: Core :: IPC :: Twin :: Shell" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.core.ipc.twin/org.opennms.core.ipc.twin.shell/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-deviceconfig-deps" description="OpenNMS :: Features :: Device Config :: Deps" version="36.0.0-SNAPSHOT">
+        <feature>commons-net</feature>
+        <feature>opennms-util</feature>
+        <feature>commons-compress</feature>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.lib/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-deviceconfig-tftp" description="OpenNMS :: Features :: Device Config :: TFTP" version="36.0.0-SNAPSHOT">
+        <feature>opennms-deviceconfig-deps</feature>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.shell/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.tftp/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-deviceconfig-monitor" description="OpenNMS :: Features :: Device Config :: Monitor" version="36.0.0-SNAPSHOT">
+        <feature>opennms-deviceconfig-tftp</feature>
+        <feature>quartz</feature>
+        <feature>opennms-util</feature>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.ssh-scripting/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.retrieval/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.monitor/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-deviceconfig-rest" description="OpenNMS :: Features :: Device Config :: Rest" version="36.0.0-SNAPSHOT">
+        <feature>commons-compress</feature>
+        <feature>cron-parser-core</feature>
+        <feature>opennms-osgi-core-rest</feature>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.rest/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-deviceconfig-service" description="OpenNMS :: Features :: Device Config :: Service" version="36.0.0-SNAPSHOT">
+        <feature>opennms-deviceconfig-tftp</feature>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.device-config/org.opennms.features.device-config.service/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <!-- common module for sink client and server -->
+    <feature name="opennms-deviceconfig-sink-module" description="OpenNMS :: Features :: Device Config :: Sink :: Common" version="36.0.0-SNAPSHOT">
+        <feature>opennms-deviceconfig-deps</feature>
+        <bundle>mvn:org.opennms.features.device-config.sink/org.opennms.features.device-config.sink.module/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <!-- server side feature for the device config sink -->
+    <feature name="opennms-deviceconfig-sink-consumer" description="OpenNMS :: Features :: Device Config :: Sink :: Consumer" version="36.0.0-SNAPSHOT">
+        <feature>opennms-deviceconfig-sink-module</feature>
+        <bundle>mvn:org.opennms.features.device-config.sink/org.opennms.features.device-config.sink.consumer/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <!-- client side feature for the device config sink -->
+    <feature name="opennms-deviceconfig-sink" description="OpenNMS :: Features :: Device Config :: Sink :: Dispatcher" version="36.0.0-SNAPSHOT">
+        <feature>opennms-deviceconfig-sink-module</feature>
+        <feature>opennms-deviceconfig-tftp</feature>
+        <bundle>mvn:org.opennms.features.device-config.sink/org.opennms.features.device-config.sink.dispatcher/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-health-rest-service" description="OpenNMS :: Feature :: Health :: ReST Service" version="36.0.0-SNAPSHOT">
+        <feature>org.json</feature>
+        <feature>opennms-health-rest</feature>
+        <feature version="3.6.8">cxf-core</feature>
+        <feature version="3.6.8">cxf-jaxrs</feature>
+        <feature>jackson-dataformat-yaml</feature>
+        <!-- early start-level to override jettison version in 3rd-party feature files -->
+        <bundle start-level="60">mvn:org.codehaus.jettison/jettison/1.5.4</bundle>
+        <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.16.2</bundle>
+        <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.16.2</bundle>
+        <bundle>mvn:org.opennms.core.health/org.opennms.core.health.rest-cxf/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-scv-rest" description="OpenNMS :: Features :: Scv :: Rest" version="36.0.0-SNAPSHOT">
+        <feature>opennms-osgi-core-rest</feature>
+        <bundle>mvn:org.opennms.features.scv/org.opennms.features.scv.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.scv/org.opennms.features.scv.rest/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-newts-api" description="OpenNMS :: Newts API" version="36.0.0-SNAPSHOT">
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.16.2</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.16.2</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.16.2</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/31.1-jre</bundle>
+        <bundle dependency="true">mvn:com.google.guava/failureaccess/1.0.1</bundle>
+        <bundle dependency="true">mvn:org.apache.commons/commons-jexl3/3.3</bundle>
+        <bundle>mvn:org.opennms.newts/newts-api/3.0.0</bundle>
+        <bundle>mvn:org.opennms.newts/newts-aggregate/3.0.0</bundle>
+    </feature>
+
+    <feature name="opennms-timeseries-api" description="OpenNMS :: Timeseries Storage API" version="36.0.0-SNAPSHOT">
+        <feature>dropwizard-metrics</feature>
+        <feature version="31.1" prerequisite="true">guava</feature>
+        <feature>fst</feature>
+        <feature>opennms-health</feature>
+        <feature>opennms-measurements-api</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-core-ipc-rpc-api</feature>
+        <feature version="2.0.0">opennms-integration-api</feature>
+        <feature>opennms-mate-impl</feature>
+        <feature>opennms-newts-api</feature>
+
+        <bundle dependency="true">mvn:com.lmax/disruptor/3.4.4</bundle>
+        <bundle dependency="true">wrap:mvn:net.agkn/hll/1.6.0</bundle>
+        <bundle>mvn:org.opennms.core/org.opennms.core.cache/36.0.0-SNAPSHOT</bundle>
+
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.persistence.osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features/org.opennms.features.timeseries/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    
+    <feature name="inmemory-timeseries-plugin" description="FOR TESTING ONLY" version="36.0.0-SNAPSHOT">
+        <feature>opennms-timeseries-api</feature>
+        <bundle dependency="true">wrap:mvn:com.google.re2j/re2j/1.7</bundle>
+        <bundle >mvn:org.opennms.features/inmemory-timeseries-plugin/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-newts" description="OpenNMS :: Newts" version="36.0.0-SNAPSHOT">
+        <feature>commons-pool2</feature>
+        <feature>groovy</feature>
+        <feature version="31.1" prerequisite="true">guava</feature>
+        <feature>opennms-measurements-api</feature>
+        <feature>opennms-collection-api</feature>
+        <feature>opennms-dao-api</feature>
+        <feature>newts-cassandra</feature>
+        <feature>newts-cassandra-search</feature>
+        <feature>fst</feature>
+
+        <bundle dependency="true">wrap:mvn:com.googlecode.concurrent-trees/concurrent-trees/2.6.1</bundle>
+        <bundle dependency="true">mvn:com.lmax/disruptor/3.4.4</bundle>
+        <bundle dependency="true">wrap:mvn:com.swrve/rate-limited-logger/2.0.2</bundle>
+        <bundle dependency="true">mvn:redis.clients/jedis/2.8.1</bundle>
+        <bundle dependency="true">mvn:args4j/args4j/2.33</bundle>
+
+        <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.persistence.osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features/org.opennms.features.newts/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-grpc-exporter" description="OpenNMS :: Grpc :: Exporter" version="36.0.0-SNAPSHOT">
+        <feature version="2.0.0" dependency="true">opennms-integration-api</feature>
+        <feature>opennms-zenith-connect</feature>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java/3.25.5</bundle>
+        <bundle>mvn:org.mapstruct/mapstruct/1.5.2.Final</bundle>
+        <bundle>mvn:org.opennms.core.grpc/org.opennms.core.grpc.osgi/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.grpc/org.opennms.features.grpc.exporter/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-zenith-connect" description="OpenNMS :: Zenith Connect" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.api/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.kv-store.json.postgres/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.zenith-connect/org.opennms.features.zenith-connect.persistence/36.0.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.opennms.features.zenith-connect/org.opennms.features.zenith-connect.rest/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+    <feature name="opennms-elastic-client" description="OpenNMS :: Elastic Client" version="36.0.0-SNAPSHOT">
+        <bundle>mvn:com.google.code.gson/gson/2.9.1</bundle>
+        <bundle>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client/8.18.1</bundle>
+        <bundle>mvn:org.opennms.features.elastic/org.opennms.features.elastic.client/36.0.0-SNAPSHOT</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/4.4.16</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpasyncclient-osgi/4.1.5</bundle>
+    </feature>
+
+    <!-- EventBus redesign: TSID, MessageBus, Kafka fault event consumer -->
+    <feature name="opennms-core-tsid" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: TSID">
+        <bundle>mvn:org.opennms/org.opennms.core.tsid/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-messagebus-api" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: MessageBus :: API">
+        <bundle>mvn:org.opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-core-messagebus-jms" version="36.0.0-SNAPSHOT" description="OpenNMS :: Core :: MessageBus :: JMS">
+        <feature>opennms-core-messagebus-api</feature>
+        <feature>activemq-client</feature>
+        <bundle>mvn:org.opennms/org.opennms.core.messagebus.jms/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-events-kafka-consumer" version="36.0.0-SNAPSHOT" description="OpenNMS :: Events :: Kafka Consumer">
+        <feature>opennms-kafka</feature>
+        <feature>opennms-events-api</feature>
+        <bundle>mvn:org.opennms.features.events/org.opennms.features.events.kafka-consumer/36.0.0-SNAPSHOT</bundle>
+    </feature>
+    <feature name="opennms-events-store" version="36.0.0-SNAPSHOT" description="OpenNMS :: Events :: Event Store">
+        <feature>opennms-events-api</feature>
+        <feature>opennms-events-kafka-consumer</feature>
+        <feature>spring</feature>
+        <bundle>mvn:org.opennms.features.events/org.opennms.features.events.event-store/36.0.0-SNAPSHOT</bundle>
+    </feature>
+
+</features>


### PR DESCRIPTION
## Summary

- **Minion-mandatory architecture deferred** with design doc explaining why (non-distributable monitors, PassiveStatusd shared-state bug, collector delegation gaps)
- **Native Docker Compose profiles** replace deploy.sh case-statement: `lite` (11 svc), `passive` (8 svc), `full` (18 svc). Infrastructure (postgres, kafka, core, webapp, minion) always starts.
- **Default Minion container** added to all profiles — location "Default", Kafka IPC transport (RPC + Sink + Twin), REST config sync via webapp
- **Karaf feature resolution fixes** — patched features.xml adds `opennms-core-messagebus-api` dependency to 5 features; fixed webapp dispatcher-servlet.xml missing beans; corrected Minion env var to `KAFKA_IPC_BOOTSTRAP_SERVERS`

## Key changes

- `docs/plans/2026-03-09-minion-mandatory-deferral-design.md` — deferral rationale, PassiveStatusd audit, Alarmd image investigation
- `docs/plans/2026-03-09-minion-mandatory-near-term-implementation.md` — implementation plan
- `opennms-container/delta-v/docker-compose.yml` — profiles on all daemon services, minion service definition, overlay volume mounts
- `opennms-container/delta-v/deploy.sh` — simplified to pass `COMPOSE_PROFILES` env var
- `container/features/src/main/resources/features.xml` — messagebus-api dependency on 5 features
- `opennms-container/delta-v/webapp-overlay/` — patched features.xml (from image, not source), messagebus-api JAR
- `opennms-container/delta-v/webapp-jetty-webinf-overlay/dispatcher-servlet.xml` — restored missing bean definitions

## Smoke test results

- 5 infrastructure services: postgres ✅, kafka ✅, core ✅, webapp ✅, minion ✅ (Kafka RPC/Sink/Twin connected)
- Profile verification: default=5, passive=8, lite=11, full=18 services
- Minion Echo RPC (passive) fails as expected — Core doesn't run RPC responder in delta-v config

## Test plan

- [ ] `./deploy.sh up` — verify 5 services start
- [ ] `./deploy.sh up lite` — verify 11 services
- [ ] `./deploy.sh up full` — verify 18 services
- [ ] `./deploy.sh test` — run deployment verification
- [ ] Verify Minion Kafka connectivity via `curl localhost:8181/minion/rest/health`