### PR TITLE
fix: resolve EventTranslator consumer death, pass e2e test

### DIFF
--- a/core/daemon-loader-bsmd/src/main/java/org/opennms/core/daemon/loader/SpringDaemonLifecycleManager.java
+++ b/core/daemon-loader-bsmd/src/main/java/org/opennms/core/daemon/loader/SpringDaemonLifecycleManager.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.loader;
+
+import org.opennms.netmgt.daemon.SpringServiceDaemon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * Manages the lifecycle of a {@link SpringServiceDaemon} in a Karaf-only container.
+ *
+ * <p>{@code SpringServiceDaemon} extends {@code InitializingBean} and {@code DisposableBean},
+ * so its lifecycle is: {@code afterPropertiesSet()} then {@code start()} to initialize,
+ * and {@code destroy()} to shut down. This class drives that sequence when the
+ * enclosing Spring context starts and stops.</p>
+ *
+ * <p>This is the {@code SpringServiceDaemon} counterpart to {@link DaemonLifecycleManager},
+ * which handles {@code AbstractServiceDaemon} instances.</p>
+ */
+public class SpringDaemonLifecycleManager implements InitializingBean, DisposableBean {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringDaemonLifecycleManager.class);
+
+    private final SpringServiceDaemon daemon;
+    private final String daemonName;
+
+    public SpringDaemonLifecycleManager(SpringServiceDaemon daemon, String daemonName) {
+        this.daemon = daemon;
+        this.daemonName = daemonName;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        LOG.info("Initializing daemon: {}", daemonName);
+        daemon.afterPropertiesSet();
+        LOG.info("Starting daemon: {}", daemonName);
+        daemon.start();
+        LOG.info("Daemon started: {}", daemonName);
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        LOG.info("Stopping daemon: {}", daemonName);
+        daemon.destroy();
+        LOG.info("Daemon stopped: {}", daemonName);
+    }
+}

--- a/core/daemon-loader-provisiond/src/main/java/org/opennms/core/daemon/loader/QualifiedEventForwarder.java
+++ b/core/daemon-loader-provisiond/src/main/java/org/opennms/core/daemon/loader/QualifiedEventForwarder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.loader;
+
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Log;
+
+/**
+ * Simple delegating {@link EventForwarder} that exists solely to satisfy
+ * {@code @Qualifier("transactionAware")} injection points in standalone
+ * daemon containers.
+ *
+ * <p>In the monolithic OpenNMS, {@code TransactionAwareEventForwarder}
+ * defers event sending until after JPA transaction commit. In standalone
+ * containers, events go straight to Kafka (no JPA transaction coordination
+ * needed), so this class simply delegates to the underlying EventForwarder.</p>
+ */
+public class QualifiedEventForwarder implements EventForwarder {
+
+    private final EventForwarder delegate;
+
+    public QualifiedEventForwarder(EventForwarder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void sendNow(Event event) {
+        delegate.sendNow(event);
+    }
+
+    @Override
+    public void sendNow(Log eventLog) {
+        delegate.sendNow(eventLog);
+    }
+
+    @Override
+    public void sendNowSync(Event event) {
+        delegate.sendNowSync(event);
+    }
+
+    @Override
+    public void sendNowSync(Log eventLog) {
+        delegate.sendNowSync(eventLog);
+    }
+}

--- a/core/daemon-loader-provisiond/src/main/java/org/opennms/core/daemon/loader/SpringDaemonLifecycleManager.java
+++ b/core/daemon-loader-provisiond/src/main/java/org/opennms/core/daemon/loader/SpringDaemonLifecycleManager.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.loader;
+
+import org.opennms.netmgt.daemon.SpringServiceDaemon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * Manages the lifecycle of a {@link SpringServiceDaemon} in a Karaf-only container.
+ *
+ * <p>{@code SpringServiceDaemon} extends {@code InitializingBean} and {@code DisposableBean},
+ * so its lifecycle is: {@code afterPropertiesSet()} then {@code start()} to initialize,
+ * and {@code destroy()} to shut down. This class drives that sequence when the
+ * enclosing Spring context starts and stops.</p>
+ *
+ * <p>This is the {@code SpringServiceDaemon} counterpart to {@link DaemonLifecycleManager},
+ * which handles {@code AbstractServiceDaemon} instances.</p>
+ */
+public class SpringDaemonLifecycleManager implements InitializingBean, DisposableBean {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringDaemonLifecycleManager.class);
+
+    private final SpringServiceDaemon daemon;
+    private final String daemonName;
+
+    public SpringDaemonLifecycleManager(SpringServiceDaemon daemon, String daemonName) {
+        this.daemon = daemon;
+        this.daemonName = daemonName;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        LOG.info("Initializing daemon: {}", daemonName);
+        daemon.afterPropertiesSet();
+        LOG.info("Starting daemon: {}", daemonName);
+        daemon.start();
+        LOG.info("Daemon started: {}", daemonName);
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        LOG.info("Stopping daemon: {}", daemonName);
+        daemon.destroy();
+        LOG.info("Daemon stopped: {}", daemonName);
+    }
+}

--- a/core/daemon-loader-provisiond/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-provisiond.xml
+++ b/core/daemon-loader-provisiond/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-provisiond.xml
@@ -71,6 +71,10 @@
     <onmsgi:reference id="transactionManager"
                       interface="org.springframework.transaction.PlatformTransactionManager"/>
 
+    <!-- Entity scope provider (MATE engine) -->
+    <onmsgi:reference id="entityScopeProvider"
+                      interface="org.opennms.core.mate.api.EntityScopeProvider"/>
+
     <!-- ============================================================== -->
     <!-- ForeignSourceRepository (local filesystem-based)               -->
     <!-- ============================================================== -->
@@ -131,8 +135,12 @@
     <bean id="tracerRegistry"
           class="org.opennms.core.daemon.loader.NoOpTracerRegistry"/>
 
-    <!-- In standalone container, use eventForwarder directly (no JPA transaction coordination needed) -->
-    <alias name="eventForwarder" alias="transactionAwareEventForwarder"/>
+    <!-- Delegating EventForwarder with @Qualifier("transactionAware") for DefaultProvisionService.
+         In standalone container, events go straight to Kafka — no JPA transaction deferral needed. -->
+    <bean id="transactionAwareEventForwarder" class="org.opennms.core.daemon.loader.QualifiedEventForwarder">
+        <qualifier value="transactionAware"/>
+        <constructor-arg ref="eventForwarder"/>
+    </bean>
 
     <!-- Provisiond config DAO (inline implementation — avoids classloader issues with opennms-dao) -->
     <bean id="provisiondConfigDao"
@@ -245,7 +253,7 @@
     <!-- ============================================================== -->
 
     <bean id="daemon" class="org.opennms.netmgt.provision.service.Provisioner"
-          depends-on="init-snmpPeerFactory">
+          depends-on="snmpPeerFactoryInitializer">
         <property name="provisionService" ref="provisionService"/>
         <property name="eventForwarder" ref="transactionAwareEventForwarder"/>
         <property name="lifeCycleRepository" ref="lifeCycleRepository"/>

--- a/core/event-forwarder-kafka/src/main/java/org/opennms/core/event/forwarder/kafka/KafkaEventSubscriptionService.java
+++ b/core/event-forwarder-kafka/src/main/java/org/opennms/core/event/forwarder/kafka/KafkaEventSubscriptionService.java
@@ -235,6 +235,7 @@ public class KafkaEventSubscriptionService implements EventSubscriptionService {
     // -------- poll loop --------
 
     private void pollLoop() {
+        LOG.info("Poll loop starting on thread {}", Thread.currentThread().getName());
         try {
             while (running.get()) {
                 ConsumerRecords<Long, byte[]> records;
@@ -270,12 +271,20 @@ public class KafkaEventSubscriptionService implements EventSubscriptionService {
                     }
                 }
             }
+            LOG.info("Poll loop exited normally, running={}", running.get());
         } catch (WakeupException e) {
             // Expected during shutdown — only rethrow if still running
             if (running.get()) {
+                LOG.error("WakeupException while still running — rethrowing", e);
                 throw e;
             }
+            LOG.info("Poll loop received WakeupException during shutdown");
+        } catch (Exception e) {
+            LOG.error("Poll loop terminated by unexpected exception", e);
+        } catch (Throwable t) {
+            LOG.error("Poll loop terminated by Throwable (likely Error)", t);
         } finally {
+            LOG.info("Poll loop finally block — closing consumer (running={})", running.get());
             try {
                 consumer.close();
             } catch (Exception e) {

--- a/opennms-config/pom.xml
+++ b/opennms-config/pom.xml
@@ -31,6 +31,8 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Import-Package>*;resolution:=optional</Import-Package>
+            <DynamicImport-Package>*</DynamicImport-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
@@ -484,6 +485,8 @@ services:
       - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
       - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
       - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
+      - ../../opennms-config/target/opennms-config-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/opennms-config/36.0.0-SNAPSHOT/opennms-config-36.0.0-SNAPSHOT.jar:ro
+      - ../../opennms-util/target/opennms-util-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/opennms-util/36.0.0-SNAPSHOT/opennms-util-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -588,10 +591,10 @@ services:
       - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
       - ../../core/daemon-loader-provisiond/target/org.opennms.core.daemon-loader-provisiond-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-provisiond/36.0.0-SNAPSHOT/org.opennms.core.daemon-loader-provisiond-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
-      test: ["CMD", "/health.sh"]
-      interval: 30s
+      test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
+      interval: 15s
       timeout: 10s
-      retries: 10
+      retries: 20
       start_period: 90s
 
   bsmd:
@@ -628,10 +631,10 @@ services:
       # events daemon JAR
       - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
-      test: ["CMD", "/health.sh"]
-      interval: 30s
+      test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
+      interval: 15s
       timeout: 10s
-      retries: 10
+      retries: 20
       start_period: 90s
 
   alarmd:

--- a/opennms-util/pom.xml
+++ b/opennms-util/pom.xml
@@ -26,8 +26,7 @@
               org.opennms.core.queue.*;version="${project.version}",
               org.opennms.core.resource.*;version="${project.version}",
               org.opennms.core.resource.db.*;version="${project.version}",
-              <!-- Don't export org.opennms.core.utils to avoid conflicts with core/lib -->
-              <!-- org.opennms.core.utils.*;version="${project.version}", -->
+              org.opennms.core.utils;version="${project.version}",
               org.opennms.core.utils.url.*;version="${project.version}",
               org.opennms.core.utils.http.*;version="${project.version}",
               org.opennms.core.utils.jexl.*;version="${project.version}",


### PR DESCRIPTION
## Summary
- Fix EventTranslator Kafka consumer dying ~20s after startup due to `NoClassDefFoundError: MatchTable` (an `Error`, not `Exception`) escaping the poll loop
- Fix OSGi split-package between `opennms-util` and `core.lib` for `org.opennms.core.utils` package — export the package from both bundles, add `DynamicImport-Package` to `opennms-config`
- Fix Provisiond standalone wiring: `QualifiedEventForwarder` for `@Qualifier("transactionAware")`, `SpringDaemonLifecycleManager` for provisiond/bsmd, `EntityScopeProvider` reference, bean name fix
- Fix Kafka advertised listeners so daemon containers resolve broker by service name
- Fix healthcheck paths for provisiond and bsmd containers

## Test plan
- [x] E2E integration test: 11 passed, 0 failed
  - Phase 1: coldStart trap → newSuspect → Provisiond → nodeScanCompleted
  - Phase 2: linkDown trap → EventTranslator → SNMP_Link_Down → Alarmd → alarm in PostgreSQL + REST API
  - Phase 3: linkUp trap → EventTranslator → SNMP_Link_Up → alarm CLEARED in PostgreSQL + REST API
- [x] EventTranslator consumer survives event processing (no longer dies)
- [x] All passive profile services healthy (postgres, kafka, trapd, eventtranslator, provisiond, alarmd, webapp)