### PR TITLE
perf: reduce JVM memory footprint for daemon containers

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       KAFKA_NUM_PARTITIONS: "16"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
       CLUSTER_ID: "delta-v-kafka-cluster"
+      KAFKA_HEAP_OPTS: "-Xms512m -Xmx512m"
     volumes:
       - kafkadata:/tmp/kraft-combined-logs
     healthcheck:
@@ -74,7 +75,7 @@ services:
       OPENNMS_DBUSER: opennms
       OPENNMS_DBPASS: opennms
       JAVA_OPTS: >-
-        -Xms512m -Xmx1g
+        -Xms256m -Xmx512m
         -Djava.security.egd=file:/dev/./urandom
     volumes:
       - db-init-etc:/opt/opennms/etc
@@ -98,8 +99,8 @@ services:
       OPENNMS_DBUSER: opennms
       OPENNMS_DBPASS: opennms
       JAVA_OPTS: >-
-        -Xms512m -Xmx1536m
-        -XX:MaxMetaspaceSize=512m
+        -Xms256m -Xmx1g
+        -XX:MaxMetaspaceSize=384m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=3
       # Disable ALL daemons except JettyServer (Manager + Eventd are always on)
@@ -158,7 +159,7 @@ services:
       OPENNMS_HTTP_PASS: admin
       KAFKA_IPC_BOOTSTRAP_SERVERS: kafka:9092
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
+        -Xms128m -Xmx384m
         -Djava.security.egd=file:/dev/./urandom
     volumes:
       - minion-data:/opt/minion/data
@@ -192,8 +193,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms256m -Xmx768m
+        -XX:MaxMetaspaceSize=384m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=4
     volumes:
@@ -229,8 +230,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms256m -Xmx768m
+        -XX:MaxMetaspaceSize=384m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=5
     volumes:
@@ -266,8 +267,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=6
     volumes:
@@ -300,8 +301,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=8
     volumes:
@@ -334,8 +335,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=9
     volumes:
@@ -368,8 +369,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=10
     volumes:
@@ -405,8 +406,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=11
     volumes:
@@ -441,8 +442,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=12
     volumes:
@@ -475,8 +476,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=13
     volumes:
@@ -511,8 +512,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=14
     volumes:
@@ -545,8 +546,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=15
     volumes:
@@ -579,8 +580,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms512m -Xmx1g
-        -XX:MaxMetaspaceSize=512m
+        -Xms256m -Xmx768m
+        -XX:MaxMetaspaceSize=384m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=16
     volumes:
@@ -614,8 +615,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms256m -Xmx512m
-        -XX:MaxMetaspaceSize=256m
+        -Xms128m -Xmx384m
+        -XX:MaxMetaspaceSize=192m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=17
         -Dorg.opennms.alarms.snapshot.sync.ms=30000
@@ -654,8 +655,8 @@ services:
       POSTGRES_PASSWORD: opennms
       POSTGRES_DB: opennms
       JAVA_OPTS: >-
-        -Xms512m -Xmx1g
-        -XX:MaxMetaspaceSize=512m
+        -Xms256m -Xmx768m
+        -XX:MaxMetaspaceSize=384m
         -Djava.security.egd=file:/dev/./urandom
         -Dorg.opennms.tsid.node-id=2
     volumes:


### PR DESCRIPTION
## Summary
- Reduce memory settings across all Delta-V daemon containers to enable running more services simultaneously on Docker Desktop
- Three tiers: lightweight (384m), heavy (768m), webapp (1g)
- Cap Kafka at 512m (dev single-broker)
- Saves ~3.5 GB peak memory (from ~12 GB to ~8.5 GB)

## Changes
| Tier | Services | Before | After |
|------|----------|--------|-------|
| Lightweight | rtcd, notifd, discovery, trapd, syslogd, ticketer, eventtranslator, enlinkd, scriptd, bsmd | 512m heap, 256m meta | 384m heap, 192m meta |
| Heavy | pollerd, collectd, provisiond, alarmd | 512m-1g heap | 768m heap, 384m meta |
| Webapp | webapp | 1536m heap, 512m meta | 1g heap, 384m meta |
| Kafka | kafka | ~2g default | 512m |
| Init | db-init | 1g | 512m |

## Test plan
- [ ] Verify passive profile (trapd, eventtranslator, provisiond, alarmd, webapp) starts and stays healthy
- [ ] Run e2e test to confirm no OOM during event processing