### PR TITLE
feat(delta-v): operational readiness — pooling, image pipeline, E2E fix

### DIFF
--- a/opennms-container/delta-v/.gitignore
+++ b/opennms-container/delta-v/.gitignore
@@ -1,0 +1,1 @@
+staging/

--- a/opennms-container/delta-v/Dockerfile.daemon
+++ b/opennms-container/delta-v/Dockerfile.daemon
@@ -1,0 +1,56 @@
+# Delta-V daemon image — layers modified JARs and features.xml on top of
+# the base opennms/daemon image so that no bind mounts to ../../target/ are
+# needed at runtime.  Build with:
+#   ./build.sh deltav   (stages JARs, then builds this Dockerfile)
+#
+# The per-service config overlay (./xxx-overlay/etc) is still bind-mounted
+# at runtime via docker-compose — that's lightweight and expected.
+
+ARG VERSION
+FROM opennms/daemon:${VERSION}
+
+# ── Common JARs (all daemon containers) ──────────────────────────
+COPY staging/daemon/event-forwarder-kafka.jar \
+     /opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/${VERSION}/org.opennms.core.event-forwarder-kafka-${VERSION}.jar
+
+# Use the patched features.xml from webapp-overlay (extracted from image + Delta-V patches).
+# NOT container/features/target/classes/features.xml which is only one input to assembly.
+COPY webapp-overlay/system/org/opennms/karaf/opennms/${VERSION}/opennms-${VERSION}-features.xml \
+     /opt/sentinel/system/org/opennms/karaf/opennms/${VERSION}/opennms-${VERSION}-features.xml
+
+COPY staging/daemon/events.daemon.jar \
+     /opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/${VERSION}/org.opennms.features.events.daemon-${VERSION}.jar
+
+# ── Daemon-loader JARs (service-specific, all baked into single image) ──
+COPY staging/daemon/daemon-loader-trapd.jar \
+     /opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-trapd/${VERSION}/org.opennms.core.daemon-loader-trapd-${VERSION}.jar
+
+COPY staging/daemon/daemon-loader-syslogd.jar \
+     /opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-syslogd/${VERSION}/org.opennms.core.daemon-loader-syslogd-${VERSION}.jar
+
+COPY staging/daemon/daemon-loader-provisiond.jar \
+     /opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-provisiond/${VERSION}/org.opennms.core.daemon-loader-provisiond-${VERSION}.jar
+
+COPY staging/daemon/daemon-loader-bsmd.jar \
+     /opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-bsmd/${VERSION}/org.opennms.core.daemon-loader-bsmd-${VERSION}.jar
+
+COPY staging/daemon/daemon-loader-perspectivepoller.jar \
+     /opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-perspectivepoller/${VERSION}/org.opennms.core.daemon-loader-perspectivepoller-${VERSION}.jar
+
+COPY staging/daemon/daemon-loader-alarmd.jar \
+     /opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-alarmd/${VERSION}/org.opennms.core.daemon-loader-alarmd-${VERSION}.jar
+
+COPY staging/daemon/daemon-loader-telemetryd.jar \
+     /opt/sentinel/system/org/opennms/core/daemon-loader-telemetryd/${VERSION}/daemon-loader-telemetryd-${VERSION}.jar
+
+# ── Special JARs (service-specific but harmless to include in all) ──
+# EventTranslator: split-package fix for opennms-config + opennms-util
+COPY staging/daemon/opennms-config.jar \
+     /opt/sentinel/system/org/opennms/opennms-config/${VERSION}/opennms-config-${VERSION}.jar
+
+COPY staging/daemon/opennms-util.jar \
+     /opt/sentinel/system/org/opennms/opennms-util/${VERSION}/opennms-util-${VERSION}.jar
+
+# Alarmd: patched alarmd daemon JAR
+COPY staging/daemon/opennms-alarmd.jar \
+     /opt/sentinel/system/org/opennms/opennms-alarmd/${VERSION}/opennms-alarmd-${VERSION}.jar

--- a/opennms-container/delta-v/Dockerfile.minion
+++ b/opennms-container/delta-v/Dockerfile.minion
@@ -1,0 +1,20 @@
+# Delta-V minion image — layers patched messagebus-api, tsid JARs, and
+# features.boot on top of the base opennms/minion image.
+
+ARG VERSION
+FROM opennms/minion:${VERSION}
+
+# ── messagebus-api JAR (needed in both core and default repos) ───
+COPY webapp-overlay/system/org/opennms/org.opennms.core.messagebus.api/${VERSION}/org.opennms.core.messagebus.api-${VERSION}.jar \
+     /opt/minion/repositories/core/org/opennms/org.opennms.core.messagebus.api/${VERSION}/org.opennms.core.messagebus.api-${VERSION}.jar
+COPY webapp-overlay/system/org/opennms/org.opennms.core.messagebus.api/${VERSION}/org.opennms.core.messagebus.api-${VERSION}.jar \
+     /opt/minion/repositories/default/org/opennms/org.opennms.core.messagebus.api/${VERSION}/org.opennms.core.messagebus.api-${VERSION}.jar
+
+# ── tsid JAR (needed in both core and default repos) ─────────────
+COPY webapp-overlay/system/org/opennms/org.opennms.core.tsid/${VERSION}/org.opennms.core.tsid-${VERSION}.jar \
+     /opt/minion/repositories/core/org/opennms/org.opennms.core.tsid/${VERSION}/org.opennms.core.tsid-${VERSION}.jar
+COPY webapp-overlay/system/org/opennms/org.opennms.core.tsid/${VERSION}/org.opennms.core.tsid-${VERSION}.jar \
+     /opt/minion/repositories/default/org/opennms/org.opennms.core.tsid/${VERSION}/org.opennms.core.tsid-${VERSION}.jar
+
+# ── features.boot (Delta-V feature set) ──────────────────────────
+COPY minion-overlay/features.boot /opt/minion/repositories/default/features.boot

--- a/opennms-container/delta-v/Dockerfile.webapp
+++ b/opennms-container/delta-v/Dockerfile.webapp
@@ -1,0 +1,23 @@
+# Delta-V webapp image — layers modified JARs, config overlays, and
+# Jetty WEB-INF overrides on top of the base opennms/horizon image.
+#
+# After this image is built, docker-compose only needs named volumes
+# for mutable state (webapp-etc, webapp-data) — no bind mounts.
+
+ARG VERSION
+FROM opennms/horizon:${VERSION}
+
+# ── etc overlay (config files for webapp) ────────────────────────
+COPY webapp-overlay/etc/ /opt/opennms-etc-overlay/
+
+# ── system overlay (patched features.xml, bundles) ───────────────
+COPY webapp-overlay/system/ /opt/opennms-overlay/system/
+
+# ── Jetty WEB-INF overlay (dispatcher-servlet.xml, jetty-web.xml) ─
+COPY webapp-jetty-webinf-overlay/ /opt/opennms-jetty-webinf-overlay/
+
+# ── Fixed system-report JAR (EventCountDaoHibernate bean removed) ─
+COPY webapp-overlay/lib/opennms_system_report.jar /opt/opennms/lib/opennms_system_report.jar
+
+# ── Fixed web.xml (notification servlets removed — Notifd eliminated) ─
+COPY webapp-jetty-webinf-overlay/web.xml /opt/opennms/jetty-webapps/opennms/WEB-INF/web.xml

--- a/opennms-container/delta-v/bsmd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/bsmd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V bsmd
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -3,10 +3,11 @@
 # build.sh — Build all Docker images for OpenNMS Delta-V
 #
 # Usage:
-#   ./build.sh              Build everything (compile + assemble + images)
-#   ./build.sh images       Build Docker images only (skip Maven)
+#   ./build.sh              Build everything (compile + assemble + images + deltav)
+#   ./build.sh images       Build base Docker images only (skip Maven)
+#   ./build.sh deltav       Build Delta-V layered images only (requires base images)
 #   ./build.sh compile      Compile only (skip assembly and images)
-#   ./build.sh push         Build and push images to a registry
+#   ./build.sh push         Build and push images to registry
 #
 # Environment:
 #   DOCKER_REGISTRY   Docker registry (default: docker.io)
@@ -115,6 +116,89 @@ do_images() {
     docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "(horizon|daemon|sentinel|db-init)" | head -15
 }
 
+do_stage_daemon_jars() {
+    log "Staging daemon JARs for Delta-V image..."
+    local staging="$SCRIPT_DIR/staging/daemon"
+    rm -rf "$staging"
+    mkdir -p "$staging"
+
+    # Common JARs (all daemon containers)
+    # NOTE: features.xml is copied directly from webapp-overlay/ in Dockerfile.daemon,
+    # not staged here. The patched features.xml must come from the image extraction,
+    # not from container/features/target/classes/features.xml (which is only one input).
+    local pairs=(
+        "core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-$VERSION.jar:event-forwarder-kafka.jar"
+        "features/events/daemon/target/org.opennms.features.events.daemon-$VERSION.jar:events.daemon.jar"
+        # Daemon-loader JARs
+        "core/daemon-loader-trapd/target/org.opennms.core.daemon-loader-trapd-$VERSION.jar:daemon-loader-trapd.jar"
+        "core/daemon-loader-syslogd/target/org.opennms.core.daemon-loader-syslogd-$VERSION.jar:daemon-loader-syslogd.jar"
+        "core/daemon-loader-provisiond/target/org.opennms.core.daemon-loader-provisiond-$VERSION.jar:daemon-loader-provisiond.jar"
+        "core/daemon-loader-bsmd/target/org.opennms.core.daemon-loader-bsmd-$VERSION.jar:daemon-loader-bsmd.jar"
+        "core/daemon-loader-perspectivepoller/target/org.opennms.core.daemon-loader-perspectivepoller-$VERSION.jar:daemon-loader-perspectivepoller.jar"
+        "core/daemon-loader-alarmd/target/org.opennms.core.daemon-loader-alarmd-$VERSION.jar:daemon-loader-alarmd.jar"
+        "core/daemon-loader-telemetryd/target/daemon-loader-telemetryd-$VERSION.jar:daemon-loader-telemetryd.jar"
+        # Special JARs (EventTranslator split-package fix, Alarmd)
+        "opennms-config/target/opennms-config-$VERSION.jar:opennms-config.jar"
+        "opennms-util/target/opennms-util-$VERSION.jar:opennms-util.jar"
+        "opennms-alarms/daemon/target/opennms-alarmd-$VERSION.jar:opennms-alarmd.jar"
+    )
+
+    local missing=0
+    for pair in "${pairs[@]}"; do
+        local src="${pair%%:*}"
+        local dst="${pair##*:}"
+        if [ -f "$REPO_ROOT/$src" ]; then
+            cp "$REPO_ROOT/$src" "$staging/$dst"
+        else
+            log "WARNING: $src not found — run './build.sh compile' first"
+            missing=$((missing + 1))
+        fi
+    done
+
+    log "Staged $(ls "$staging" | wc -l | tr -d ' ') files ($missing missing)"
+    [ "$missing" -gt 0 ] && [ "$missing" -gt 3 ] && err "Too many missing JARs — run './build.sh compile' first"
+}
+
+do_deltav_images() {
+    log "Building Delta-V layered images..."
+
+    do_stage_daemon_jars
+
+    # Daemon image (all 15 daemon services share one image)
+    log "Building opennms/daemon-deltav:$VERSION..."
+    cd "$SCRIPT_DIR"
+    docker build \
+        --build-arg "VERSION=$VERSION" \
+        -f Dockerfile.daemon \
+        -t "opennms/daemon-deltav:$VERSION" \
+        -t "opennms/daemon-deltav:latest" \
+        .
+
+    # Webapp image
+    log "Building opennms/horizon-deltav:$VERSION..."
+    docker build \
+        --build-arg "VERSION=$VERSION" \
+        -f Dockerfile.webapp \
+        -t "opennms/horizon-deltav:$VERSION" \
+        -t "opennms/horizon-deltav:latest" \
+        .
+
+    # Minion image
+    log "Building opennms/minion-deltav:$VERSION..."
+    docker build \
+        --build-arg "VERSION=$VERSION" \
+        -f Dockerfile.minion \
+        -t "opennms/minion-deltav:$VERSION" \
+        -t "opennms/minion-deltav:latest" \
+        .
+
+    # Clean up staging
+    rm -rf "$SCRIPT_DIR/staging"
+
+    log "Delta-V images built:"
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "deltav" | head -10
+}
+
 do_webapp_overlay() {
     log "Preparing webapp overlay..."
     local overlay_dir="$SCRIPT_DIR/webapp-jetty-webinf-overlay"
@@ -149,10 +233,11 @@ usage() {
 Usage: ./build.sh [command]
 
 Commands:
-  (none)    Full build: compile + assemble + images
+  (none)    Full build: compile + assemble + images + deltav
   compile   Compile only (Maven)
   assemble  Assemble distributions (Horizon + Daemon + Alarmd)
-  images    Build Docker images only (requires prior assembly)
+  images    Build base Docker images only (requires prior assembly)
+  deltav    Build Delta-V layered images (stages JARs into derived images)
   overlay   Prepare webapp overlay files
   push      Build and push images to registry
   clean     Remove named Docker volumes (fresh start)
@@ -188,6 +273,7 @@ main() {
             do_assemble
             do_webapp_overlay
             do_images
+            do_deltav_images
             log "Build complete! Run: cd $SCRIPT_DIR && docker compose up -d"
             ;;
         compile)
@@ -199,6 +285,9 @@ main() {
         images)
             do_images
             ;;
+        deltav)
+            do_deltav_images
+            ;;
         overlay)
             do_webapp_overlay
             ;;
@@ -207,6 +296,7 @@ main() {
             do_assemble
             do_webapp_overlay
             do_images push
+            do_deltav_images
             ;;
         clean)
             do_clean

--- a/opennms-container/delta-v/collectd-daemon-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/collectd-daemon-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V collectd-daemon
+# Medium daemon — active polling/collection/scanning workload
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=5
+connection.pool.maxPool=25
+connection.pool.maxSize=25

--- a/opennms-container/delta-v/discovery-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/discovery-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V discovery
+# Medium daemon — active polling/collection/scanning workload
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=5
+connection.pool.maxPool=25
+connection.pool.maxSize=25

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -3,7 +3,11 @@
 # db-init (schema migration, runs once) + Webapp + Minion
 # + Alarmd + Pollerd + Collectd + Rtcd
 # + Discovery + Trapd + Syslogd + Ticketer + EventTranslator + Enlinkd + Scriptd
-# + Provisiond + Bsmd + PerspectivePollerd
+# + Provisiond + Bsmd + PerspectivePollerd + Telemetryd
+#
+# Images: Uses Delta-V layered images (opennms/*-deltav) which bake all
+# modified JARs and features.xml into the image. Build with: ./build.sh deltav
+# Per-service config overlays remain as local bind mounts.
 #
 # Usage:
 #   docker compose up -d
@@ -14,7 +18,7 @@ services:
 
   postgres:
     image: postgres:15
-    command: ["-c", "max_connections=500"]
+    command: ["-c", "max_connections=350"]
     environment:
       POSTGRES_DB: opennms
       POSTGRES_USER: opennms
@@ -76,7 +80,7 @@ services:
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m
 
   webapp:
-    image: opennms/horizon:${VERSION}
+    image: opennms/horizon-deltav:${VERSION}
     container_name: delta-v-webapp
     hostname: webapp
     command: ["-f"]
@@ -122,13 +126,6 @@ services:
     volumes:
       - webapp-etc:/opt/opennms/etc
       - webapp-data:/opennms-data
-      - ./webapp-overlay/etc/:/opt/opennms-etc-overlay/:ro
-      - ./webapp-overlay/system/:/opt/opennms-overlay/system/:ro
-      - ./webapp-jetty-webinf-overlay/:/opt/opennms-jetty-webinf-overlay/
-      # Fix: updated system-report JAR (removed EventCountDaoHibernate bean)
-      - ./webapp-overlay/lib/opennms_system_report.jar:/opt/opennms/lib/opennms_system_report.jar:ro
-      # Fix: web.xml with notification servlets removed (Notifd eliminated)
-      - ./webapp-jetty-webinf-overlay/web.xml:/opt/opennms/jetty-webapps/opennms/WEB-INF/web.xml:ro
     ports:
       - "8980:8980"
       - "8102:8101"
@@ -140,7 +137,7 @@ services:
       start_period: 120s
 
   minion:
-    image: opennms/minion:${VERSION}
+    image: opennms/minion-deltav:${VERSION}
     container_name: delta-v-minion
     hostname: minion-default-01
     depends_on:
@@ -155,11 +152,6 @@ services:
         -Djava.security.egd=file:/dev/./urandom
     volumes:
       - minion-data:/opt/minion/data
-      - ./webapp-overlay/system/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:/opt/minion/repositories/core/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:ro
-      - ./webapp-overlay/system/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:/opt/minion/repositories/default/org/opennms/org.opennms.core.messagebus.api/36.0.0-SNAPSHOT/org.opennms.core.messagebus.api-36.0.0-SNAPSHOT.jar:ro
-      - ./webapp-overlay/system/org/opennms/org.opennms.core.tsid/36.0.0-SNAPSHOT/org.opennms.core.tsid-36.0.0-SNAPSHOT.jar:/opt/minion/repositories/core/org/opennms/org.opennms.core.tsid/36.0.0-SNAPSHOT/org.opennms.core.tsid-36.0.0-SNAPSHOT.jar:ro
-      - ./webapp-overlay/system/org/opennms/org.opennms.core.tsid/36.0.0-SNAPSHOT/org.opennms.core.tsid-36.0.0-SNAPSHOT.jar:/opt/minion/repositories/default/org/opennms/org.opennms.core.tsid/36.0.0-SNAPSHOT/org.opennms.core.tsid-36.0.0-SNAPSHOT.jar:ro
-      - ./minion-overlay/features.boot:/opt/minion/repositories/default/features.boot:ro
     ports:
       - "8301:8201"
       - "11162:1162/udp"
@@ -173,7 +165,7 @@ services:
 
   pollerd:
     profiles: [lite, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-pollerd
     hostname: pollerd
     depends_on:
@@ -197,13 +189,9 @@ services:
     volumes:
       - pollerd-data:/opt/sentinel/data
       - ./pollerd-daemon-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     ports:
       - "8103:8181"
     healthcheck:
-      # CXF servlet context is /sentinel (inherited from sentinel base)
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
       timeout: 10s
@@ -212,7 +200,7 @@ services:
 
   collectd:
     profiles: [lite, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-collectd
     hostname: collectd
     depends_on:
@@ -236,13 +224,9 @@ services:
     volumes:
       - collectd-data:/opt/sentinel/data
       - ./collectd-daemon-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     ports:
       - "8104:8181"
     healthcheck:
-      # CXF servlet context is /sentinel (inherited from sentinel base)
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
       timeout: 10s
@@ -251,7 +235,7 @@ services:
 
   rtcd:
     profiles: [lite, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-rtcd
     hostname: rtcd
     depends_on:
@@ -273,9 +257,6 @@ services:
     volumes:
       - rtcd-data:/opt/sentinel/data
       - ./rtcd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -285,7 +266,7 @@ services:
 
   discovery:
     profiles: [lite, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-discovery
     hostname: discovery
     depends_on:
@@ -309,9 +290,6 @@ services:
     volumes:
       - discovery-data:/opt/sentinel/data
       - ./discovery-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -321,7 +299,7 @@ services:
 
   trapd:
     profiles: [passive, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-trapd
     hostname: trapd
     depends_on:
@@ -344,10 +322,6 @@ services:
     volumes:
       - trapd-data:/opt/sentinel/data
       - ./trapd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
-      - ../../core/daemon-loader-trapd/target/org.opennms.core.daemon-loader-trapd-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-trapd/36.0.0-SNAPSHOT/org.opennms.core.daemon-loader-trapd-36.0.0-SNAPSHOT.jar:ro
     ports:
       - "1162:10162/udp"
     healthcheck:
@@ -359,7 +333,7 @@ services:
 
   syslogd:
     profiles: [passive, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-syslogd
     hostname: syslogd
     depends_on:
@@ -383,10 +357,6 @@ services:
     volumes:
       - syslogd-data:/opt/sentinel/data
       - ./syslogd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
-      - ../../core/daemon-loader-syslogd/target/org.opennms.core.daemon-loader-syslogd-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-syslogd/36.0.0-SNAPSHOT/org.opennms.core.daemon-loader-syslogd-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -396,7 +366,7 @@ services:
 
   ticketer:
     profiles: [full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-ticketer
     hostname: ticketer
     depends_on:
@@ -418,9 +388,6 @@ services:
     volumes:
       - ticketer-data:/opt/sentinel/data
       - ./ticketer-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -430,7 +397,7 @@ services:
 
   eventtranslator:
     profiles: [passive, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-eventtranslator
     hostname: eventtranslator
     depends_on:
@@ -452,11 +419,6 @@ services:
     volumes:
       - eventtranslator-data:/opt/sentinel/data
       - ./eventtranslator-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
-      - ../../opennms-config/target/opennms-config-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/opennms-config/36.0.0-SNAPSHOT/opennms-config-36.0.0-SNAPSHOT.jar:ro
-      - ../../opennms-util/target/opennms-util-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/opennms-util/36.0.0-SNAPSHOT/opennms-util-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -466,7 +428,7 @@ services:
 
   enlinkd:
     profiles: [full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-enlinkd
     hostname: enlinkd
     depends_on:
@@ -490,9 +452,6 @@ services:
     volumes:
       - enlinkd-data:/opt/sentinel/data
       - ./enlinkd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -502,7 +461,7 @@ services:
 
   scriptd:
     profiles: [full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-scriptd
     hostname: scriptd
     depends_on:
@@ -524,9 +483,6 @@ services:
     volumes:
       - scriptd-data:/opt/sentinel/data
       - ./scriptd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -536,7 +492,7 @@ services:
 
   provisiond:
     profiles: [lite, passive, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-provisiond
     hostname: provisiond
     depends_on:
@@ -560,10 +516,6 @@ services:
     volumes:
       - provisiond-data:/opt/sentinel/data
       - ./provisiond-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
-      - ../../core/daemon-loader-provisiond/target/org.opennms.core.daemon-loader-provisiond-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-provisiond/36.0.0-SNAPSHOT/org.opennms.core.daemon-loader-provisiond-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -573,7 +525,7 @@ services:
 
   bsmd:
     profiles: [lite, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-bsmd
     hostname: bsmd
     depends_on:
@@ -596,14 +548,6 @@ services:
     volumes:
       - bsmd-data:/opt/sentinel/data
       - ./bsmd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      # daemon-loader JAR
-      - ../../core/daemon-loader-bsmd/target/org.opennms.core.daemon-loader-bsmd-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-bsmd/36.0.0-SNAPSHOT/org.opennms.core.daemon-loader-bsmd-36.0.0-SNAPSHOT.jar:ro
-      # event-forwarder-kafka JAR
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      # features.xml
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      # events daemon JAR
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -613,7 +557,7 @@ services:
 
   perspectivepollerd:
     profiles: [full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-perspectivepollerd
     hostname: perspectivepollerd
     depends_on:
@@ -637,14 +581,6 @@ services:
     volumes:
       - perspectivepollerd-data:/opt/sentinel/data
       - ./perspectivepollerd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      # daemon-loader JAR
-      - ../../core/daemon-loader-perspectivepoller/target/org.opennms.core.daemon-loader-perspectivepoller-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-perspectivepoller/36.0.0-SNAPSHOT/org.opennms.core.daemon-loader-perspectivepoller-36.0.0-SNAPSHOT.jar:ro
-      # event-forwarder-kafka JAR
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      # features.xml
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      # events daemon JAR
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -654,7 +590,7 @@ services:
 
   alarmd:
     profiles: [lite, passive, full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-alarmd
     hostname: alarmd
     depends_on:
@@ -676,10 +612,6 @@ services:
     volumes:
       - alarmd-data:/opt/sentinel/data
       - ./alarmd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/daemon-loader-alarmd/target/org.opennms.core.daemon-loader-alarmd-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.daemon-loader-alarmd/36.0.0-SNAPSHOT/org.opennms.core.daemon-loader-alarmd-36.0.0-SNAPSHOT.jar:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../opennms-alarms/daemon/target/opennms-alarmd-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/opennms-alarmd/36.0.0-SNAPSHOT/opennms-alarmd-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s
@@ -689,7 +621,7 @@ services:
 
   telemetryd:
     profiles: [full]
-    image: opennms/daemon:${VERSION}
+    image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-telemetryd
     hostname: telemetryd
     depends_on:
@@ -713,10 +645,6 @@ services:
     volumes:
       - telemetryd-data:/opt/sentinel/data
       - ./telemetryd-overlay/etc:/opt/sentinel-etc-overlay:ro
-      - ../../core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/org.opennms.core.event-forwarder-kafka/36.0.0-SNAPSHOT/org.opennms.core.event-forwarder-kafka-36.0.0-SNAPSHOT.jar:ro
-      - ../../container/features/target/classes/features.xml:/opt/sentinel/system/org/opennms/karaf/opennms/36.0.0-SNAPSHOT/opennms-36.0.0-SNAPSHOT-features.xml:ro
-      - ../../features/events/daemon/target/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/features/events/org.opennms.features.events.daemon/36.0.0-SNAPSHOT/org.opennms.features.events.daemon-36.0.0-SNAPSHOT.jar:ro
-      - ../../core/daemon-loader-telemetryd/target/daemon-loader-telemetryd-36.0.0-SNAPSHOT.jar:/opt/sentinel/system/org/opennms/core/daemon-loader-telemetryd/36.0.0-SNAPSHOT/daemon-loader-telemetryd-36.0.0-SNAPSHOT.jar:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
       interval: 15s

--- a/opennms-container/delta-v/enlinkd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/enlinkd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V enlinkd
+# Medium daemon — active polling/collection/scanning workload
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=5
+connection.pool.maxPool=25
+connection.pool.maxSize=25

--- a/opennms-container/delta-v/eventtranslator-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/eventtranslator-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V eventtranslator
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10

--- a/opennms-container/delta-v/pollerd-daemon-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/pollerd-daemon-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V pollerd-daemon
+# Medium daemon — active polling/collection/scanning workload
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=5
+connection.pool.maxPool=25
+connection.pool.maxSize=25

--- a/opennms-container/delta-v/provisiond-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/provisiond-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V provisiond
+# Medium daemon — active polling/collection/scanning workload
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=5
+connection.pool.maxPool=25
+connection.pool.maxSize=25

--- a/opennms-container/delta-v/rtcd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/rtcd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V rtcd
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10

--- a/opennms-container/delta-v/scriptd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/scriptd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V scriptd
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10

--- a/opennms-container/delta-v/syslogd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/syslogd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V syslogd
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10

--- a/opennms-container/delta-v/telemetryd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/telemetryd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V telemetryd
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10

--- a/opennms-container/delta-v/test-e2e.sh
+++ b/opennms-container/delta-v/test-e2e.sh
@@ -185,6 +185,16 @@ else
     exit 1
 fi
 
+# Wait for Trapd's InterfaceToNodeCache to refresh so the newly provisioned
+# node (192.168.65.1) is mapped. The cache refresh interval is configured
+# to 15s via org.opennms.interface-node-cache.refresh-timer in Trapd's JAVA_OPTS.
+# Without this, the linkDown event gets nodeId=0 in the reduction key, which
+# prevents alarm clearing when linkUp arrives with the correct nodeId.
+CACHE_WAIT=20
+log ""
+log "Waiting ${CACHE_WAIT}s for Trapd InterfaceToNodeCache to refresh..."
+sleep "$CACHE_WAIT"
+
 # ══════════════════════════════════════════════════════════════════
 # Phase 2: Alarm Creation via linkDown Trap
 # ══════════════════════════════════════════════════════════════════

--- a/opennms-container/delta-v/ticketer-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/ticketer-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V ticketer
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10

--- a/opennms-container/delta-v/trapd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/opennms-container/delta-v/trapd-overlay/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,0 +1,9 @@
+# Distributed datasource configuration for Delta-V trapd
+# Light daemon — minimal DB access
+datasource.url=jdbc:postgresql://postgres:5432/opennms
+datasource.username=opennms
+datasource.password=opennms
+datasource.databaseName=opennms
+connection.pool.minPool=3
+connection.pool.maxPool=10
+connection.pool.maxSize=10


### PR DESCRIPTION
## Summary

- **Fix E2E test race condition**: Add 20s InterfaceToNodeCache wait between Phase 1 (provisioning) and Phase 2 (linkDown) in `test-e2e.sh`, matching `test-minion-e2e.sh` pattern. Fixes consistent 9/11 test failures.
- **HikariCP connection pooling**: Add per-daemon datasource configs for all 13 daemons missing them. Tiered pool sizes (3/10 light, 5/25 medium) reduce max connections from 850+ to 305, well within the now-reduced PostgreSQL limit of 350.
- **Docker image rebuild pipeline**: Eliminate all 54 `../../target/` bind mounts by baking JARs into layered Docker images (`opennms/*-deltav`). Three new Dockerfiles + `build.sh deltav` command. Only per-service config overlays remain as bind mounts.

## Test plan

- [ ] Run `test-e2e.sh` — should pass 11/11 (was 9/11)
- [ ] Run `test-minion-e2e.sh` — should still pass 13/13
- [ ] Run `./build.sh deltav` — stages JARs, builds 3 derived images
- [ ] `COMPOSE_PROFILES=full docker compose up -d` with deltav images — all 19 services healthy
- [ ] Verify no `../../` paths remain in docker-compose.yml
- [ ] Verify PostgreSQL connection count stays under 350 with all daemons running