### PR TITLE
feat: add opennms-model-jakarta with Hibernate 7 entities for Alarmd

### DIFF
--- a/container/features/src/main/resources/features-experimental.xml
+++ b/container/features/src/main/resources/features-experimental.xml
@@ -77,45 +77,4 @@
       <bundle>mvn:org.opennms.features.events/org.opennms.features.events.daemon/${project.version}</bundle>
     </feature>
 
-    <feature name="opennms-webapp" description="OpenNMS :: Webapp" version="${project.version}">
-      <feature>war</feature>
-
-      <feature>commons-beanutils</feature>
-      <feature>commons-configuration</feature>
-      <feature>commons-jexl</feature>
-      <feature>fop</feature>
-      <feature>hibernate-validator4</feature>
-      <feature>joda-time</feature>
-      <feature>opennms-rrd-util</feature>
-      <feature>json-lib</feature>
-      <feature>quartz</feature>
-
-      <feature>opennms-config</feature>
-      <feature>opennms-dao</feature>
-      <feature>opennms-provisioning</feature>
-
-      <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/${xalanServicemixVersion}</bundle>
-      <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan-serializer/${xalanSerializerServicemixVersion}</bundle>
-      <bundle>wrap:mvn:org.w3c.css/sac/1.3$Bundle-SymbolicName=org.w3c.css.sac&amp;Bundle-Version=1.3</bundle>
-      <bundle>mvn:com.vaadin.external.flute/flute/1.3.0.gg2</bundle>
-      <bundle>wrap:mvn:net.sourceforge.cssparser/cssparser/0.9.11$Bundle-SymbolicName=net.sourceforge.cssparser&amp;Bundle-Version=0.9.11</bundle>
-      <!-- <bundle>wrap:mvn:com.google.gwt/gwt-servlet/${gwtVersion}$Bundle-SymbolicName=com.google.gwt.servlet&amp;Bundle-Version=${gwtVersion}</bundle> -->
-
-      <feature>commons-cli</feature>
-      <feature>commons-exec</feature>
-      <feature>commons-net</feature>
-      <bundle>mvn:org.opennms.features/org.opennms.features.system-report/${project.version}</bundle>
-
-      <feature>opennms-core-web</feature>
-      <bundle>mvn:org.opennms.features/org.opennms.features.request-tracker/${project.version}</bundle>
-
-      <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
-
-      <feature>spring-security-opennms</feature>
-      <bundle>mvn:org.opennms.features/org.opennms.features.springframework-security/${project.version}</bundle>
-
-      <!-- The main webapp WAR file -->
-      <bundle>mvn:org.opennms/opennms-webapp/${project.version}/war</bundle>
-    </feature>
-
 </features>

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -73,60 +73,71 @@
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>2.0.17</version>
             </dependency>
-            <!-- Pin JUnit to 5.12.2 / Platform 1.12.2 which is the latest
+            <!-- Pin JUnit to 6.0.3 / Platform 6.0.3 which is the latest
                  version supported by maven-surefire-plugin 3.5.5.
                  Must be explicit entries (not BOM import) to override
                  the parent POM's managed versions at 5.9.2 / 1.9.2. -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.12.2</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>5.12.2</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.12.2</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
-                <version>5.12.2</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-commons</artifactId>
-                <version>1.12.2</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-engine</artifactId>
-                <version>1.12.2</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-launcher</artifactId>
-                <version>1.12.2</version>
+                <version>6.0.3</version>
+            </dependency>
+            <!-- Testcontainers — use 2.0.3 to align with Spring Boot 4.0.3's managed version -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>2.0.3</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+        <!-- Jakarta entity classes and JPA DAOs — MUST be listed before any
+             dependency that transitively pulls in opennms-config-model, so that
+             the Jakarta OnmsMonitoringLocation.class wins over the legacy one
+             (which uses javax.persistence annotations incompatible with Hibernate 7). -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-jakarta</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Shared daemon infrastructure -->
         <dependency>
             <groupId>org.opennms.core</groupId>
             <artifactId>org.opennms.core.daemon-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <!-- Jakarta entity classes and JPA DAOs -->
-        <dependency>
-            <groupId>org.opennms.core</groupId>
-            <artifactId>org.opennms.core.model-jakarta</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -170,6 +181,9 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <!-- Exclude commons-logging — Spring Boot uses jcl-over-slf4j -->
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <!-- Exclude config-model which contains legacy OnmsMonitoringLocation with
+                     javax.persistence annotations — the Jakarta version from model-jakarta is used instead -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -199,6 +213,19 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <!-- javax.persistence API — needed at runtime so that Spring's class scanner
+             can read legacy entity bytecodes without NoClassDefFoundError.
+             The legacy opennms-model classes reference javax.persistence annotations
+             and share the same package as the Jakarta entities. Spring 7's
+             PersistenceManagedTypesScanner reads all class metadata and fails if
+             javax.persistence types are absent. Only jakarta.persistence entities
+             will be registered with Hibernate 7. -->
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
         </dependency>
 
         <!-- SLF4J 2.x — must be explicit to override old 1.7.x from transitive deps -->
@@ -231,6 +258,32 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- JUnit Platform Launcher — must be explicit test dep so that
+             surefire/failsafe pick up the correct version from the classpath
+             rather than resolving their own (older) transitive version -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers 2.x (artifact IDs have testcontainers- prefix) -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -253,13 +306,18 @@
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                        <configuration>
+                            <!-- Use a classifier so the original JAR stays available
+                                 for failsafe integration tests (which need plain classes) -->
+                            <classifier>boot</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- Override to 3.5.5 which supports JUnit Platform 1.12.2
+                <!-- Override to 3.5.5 which supports JUnit Platform 6.0.3
                      required by Spring Boot 4 -->
                 <version>3.5.5</version>
                 <configuration>
@@ -273,12 +331,54 @@
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.12.2</version>
+                        <version>6.0.3</version>
                     </dependency>
                     <dependency>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-launcher</artifactId>
-                        <version>1.12.2</version>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <!-- Override parent's vintage engine (5.9.2) to align versions -->
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <!-- Override parent's vintage engine (5.9.2) to align versions -->
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>6.0.3</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -232,6 +232,18 @@
             </exclusions>
         </dependency>
 
+        <!-- javax.persistence API — needed at runtime so legacy opennms-model classes
+             on the classpath (pulled transitively for enums/utilities) don't cause
+             ClassNotFoundException when Spring's classpath scanner encounters them.
+             Hibernate 7 ignores javax.persistence annotations; only jakarta.persistence
+             entities from opennms-model-jakarta are registered. -->
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Jakarta XML Bind — needed by Hibernate 7 for XML mapping support -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -123,6 +123,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Jakarta entity classes and JPA DAOs -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-jakarta</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Alarmd implementation -->
         <dependency>
             <groupId>org.opennms</groupId>
@@ -176,42 +183,6 @@
                 <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- DAOs -->
-        <dependency>
-            <groupId>org.opennms</groupId>
-            <artifactId>opennms-dao-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.opennms</groupId>
-            <artifactId>opennms-model</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
-                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
-                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
-                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
-                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
-                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
-                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
-                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- javax.persistence API — needed at runtime for class scanning of legacy
-             OpenNMS entities that use javax.persistence annotations. Hibernate 7
-             won't process these as JPA annotations, but needs the classes loadable. -->
-        <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-            <version>2.2</version>
         </dependency>
 
         <!-- Jakarta XML Bind — needed by Hibernate 7 for XML mapping support -->

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -260,6 +260,15 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
+        <!-- javax.xml.bind API — needed at runtime for legacy Event XML unmarshalling
+             in KafkaEventSubscriptionService (events use JAXB javax.xml.bind annotations) -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- javax.persistence API — needed at runtime so that Spring's class scanner
              can read legacy entity bytecodes without NoClassDefFoundError.
              The legacy opennms-model classes reference javax.persistence annotations

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -73,6 +73,39 @@
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>2.0.17</version>
             </dependency>
+            <!-- Pin Jackson 2.19.4 — parent POM manages 2.16.2 which lacks JsonFormat$Shape.POJO
+                 required by Spring Boot 4.0.3. Explicit entries here override the parent's
+                 managed versions even though the Spring Boot BOM is imported first. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>2.19.4</version>
+            </dependency>
             <!-- Pin JUnit to 6.0.3 / Platform 6.0.3 which is the latest
                  version supported by maven-surefire-plugin 3.5.5.
                  Must be explicit entries (not BOM import) to override

--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdApplication.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication(scanBasePackages = {
     "org.opennms.core.daemon.common",
-    "org.opennms.netmgt.alarmd",
+    "org.opennms.netmgt.alarmd.boot",
     "org.opennms.netmgt.model.jakarta.dao"
 })
 public class AlarmdApplication {

--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdApplication.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdApplication.java
@@ -5,7 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication(scanBasePackages = {
     "org.opennms.core.daemon.common",
-    "org.opennms.netmgt.alarmd"
+    "org.opennms.netmgt.alarmd",
+    "org.opennms.netmgt.model.jakarta.dao"
 })
 public class AlarmdApplication {
 

--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -29,6 +29,7 @@ import org.opennms.netmgt.alarmd.AlarmPersisterImpl;
 import org.opennms.netmgt.alarmd.NorthbounderManager;
 import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
 import org.opennms.netmgt.events.api.EventSubscriptionService;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +49,7 @@ import org.springframework.context.annotation.Configuration;
  * registering Alarmd as an event listener during {@code afterPropertiesSet()}.</p>
  */
 @Configuration
+@EntityScan(basePackages = "org.opennms.netmgt.model")
 public class AlarmdConfiguration {
 
     @Bean

--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -21,6 +21,8 @@
  */
 package org.opennms.netmgt.alarmd.boot;
 
+import java.util.List;
+
 import org.opennms.core.daemon.common.DaemonSmartLifecycle;
 import org.opennms.netmgt.alarmd.Alarmd;
 import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
@@ -29,10 +31,23 @@ import org.opennms.netmgt.alarmd.AlarmPersisterImpl;
 import org.opennms.netmgt.alarmd.NorthbounderManager;
 import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
 import org.opennms.netmgt.events.api.EventSubscriptionService;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.opennms.netmgt.model.AlarmAssociation;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsDistPoller;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMemo;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsReductionKeyMemo;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
 
 /**
  * Spring Boot @Configuration that wires all Alarmd beans.
@@ -47,10 +62,40 @@ import org.springframework.context.annotation.Configuration;
  * <p>The {@link AnnotationBasedEventListenerAdapter} bridges Alarmd's
  * {@code @EventHandler}-annotated methods to the {@link EventSubscriptionService},
  * registering Alarmd as an event listener during {@code afterPropertiesSet()}.</p>
+ *
+ * <p>Entity classes are listed explicitly via a custom {@link PersistenceManagedTypes}
+ * bean instead of using package-based {@code @EntityScan} because the legacy
+ * opennms-model module shares the same package ({@code org.opennms.netmgt.model})
+ * and contains classes with incompatible javax.persistence / Hibernate 3.x
+ * annotations that cause scanning failures with Hibernate 7.</p>
  */
 @Configuration
-@EntityScan(basePackages = "org.opennms.netmgt.model")
 public class AlarmdConfiguration {
+
+    /**
+     * Explicitly lists the Jakarta entity classes to register with Hibernate 7.
+     * This replaces {@code @EntityScan(basePackages = "org.opennms.netmgt.model")}
+     * which would scan ALL classes in the package, including legacy entities
+     * with incompatible javax.persistence annotations.
+     */
+    @Bean
+    public PersistenceManagedTypes persistenceManagedTypes() {
+        return PersistenceManagedTypes.of(
+            OnmsAlarm.class.getName(),
+            AlarmAssociation.class.getName(),
+            OnmsCategory.class.getName(),
+            OnmsDistPoller.class.getName(),
+            OnmsIpInterface.class.getName(),
+            OnmsMemo.class.getName(),
+            OnmsMonitoredService.class.getName(),
+            OnmsMonitoringSystem.class.getName(),
+            OnmsNode.class.getName(),
+            OnmsReductionKeyMemo.class.getName(),
+            OnmsServiceType.class.getName(),
+            OnmsSnmpInterface.class.getName(),
+            OnmsMonitoringLocation.class.getName()
+        );
+    }
 
     @Bean
     public AlarmPersisterImpl alarmPersister() {

--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -44,6 +44,7 @@ import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsServiceType;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -71,6 +72,17 @@ import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
  */
 @Configuration
 public class AlarmdConfiguration {
+
+    /**
+     * Use standard JPA naming — table/column names from @Table/@Column annotations
+     * are used as-is, without Spring Boot's default CamelCase→snake_case conversion.
+     * This is required because the OpenNMS schema uses camelCase table names
+     * (e.g., monitoringSystems, ipInterface, ifServices).
+     */
+    @Bean
+    public PhysicalNamingStrategyStandardImpl physicalNamingStrategy() {
+        return new PhysicalNamingStrategyStandardImpl();
+    }
 
     /**
      * Explicitly lists the Jakarta entity classes to register with Hibernate 7.

--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -24,6 +24,9 @@ package org.opennms.netmgt.alarmd.boot;
 import java.util.List;
 
 import org.opennms.core.daemon.common.DaemonSmartLifecycle;
+import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
+import org.opennms.netmgt.eventd.EventUtil;
+import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.alarmd.Alarmd;
 import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
 import org.opennms.netmgt.alarmd.AlarmPersister;
@@ -49,6 +52,7 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
+import org.springframework.transaction.support.TransactionOperations;
 
 /**
  * Spring Boot @Configuration that wires all Alarmd beans.
@@ -109,6 +113,97 @@ public class AlarmdConfiguration {
         );
     }
 
+    /**
+     * SessionUtils implementation backed by Spring's TransactionTemplate.
+     * Replaces the OSGi-era SessionUtils that was used to bridge Hibernate
+     * sessions across OSGi bundles.
+     */
+    @Bean
+    public org.opennms.netmgt.dao.api.SessionUtils sessionUtils(
+            org.springframework.transaction.PlatformTransactionManager txManager) {
+        var txTemplate = new org.springframework.transaction.support.TransactionTemplate(txManager);
+        var readOnlyTxTemplate = new org.springframework.transaction.support.TransactionTemplate(txManager);
+        readOnlyTxTemplate.setReadOnly(true);
+        return new org.opennms.netmgt.dao.api.SessionUtils() {
+            @Override
+            public <V> V withTransaction(java.util.function.Supplier<V> supplier) {
+                return txTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withReadOnlyTransaction(java.util.function.Supplier<V> supplier) {
+                return readOnlyTxTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withManualFlush(java.util.function.Supplier<V> supplier) {
+                return supplier.get();
+            }
+        };
+    }
+
+    /**
+     * Provides TransactionOperations for AlarmPersisterImpl.
+     * Spring Boot auto-creates a PlatformTransactionManager; we wrap it
+     * in a TransactionTemplate for the @Autowired TransactionOperations field.
+     */
+    @Bean
+    public TransactionOperations transactionOperations(
+            org.springframework.transaction.PlatformTransactionManager txManager) {
+        return new org.springframework.transaction.support.TransactionTemplate(txManager);
+    }
+
+    /**
+     * No-op AlarmEntityNotifier — alarm lifecycle notifications are not needed
+     * until REST API or BSMd integration is added.
+     */
+    @Bean
+    public AlarmEntityNotifier alarmEntityNotifier() {
+        return new AlarmEntityNotifier() {
+            @Override public void didCreateAlarm(OnmsAlarm alarm) {}
+            @Override public void didUpdateAlarmWithReducedEvent(OnmsAlarm alarm) {}
+            @Override public void didAcknowledgeAlarm(OnmsAlarm alarm, String u, java.util.Date d) {}
+            @Override public void didUnacknowledgeAlarm(OnmsAlarm alarm, String u, java.util.Date d) {}
+            @Override public void didUpdateAlarmSeverity(OnmsAlarm alarm, OnmsSeverity s) {}
+            @Override public void didArchiveAlarm(OnmsAlarm alarm, String k) {}
+            @Override public void didDeleteAlarm(OnmsAlarm alarm) {}
+            @Override public void didUpdateStickyMemo(OnmsAlarm a, String b, String au, java.util.Date d) {}
+            @Override public void didUpdateReductionKeyMemo(OnmsAlarm a, String b, String au, java.util.Date d) {}
+            @Override public void didDeleteStickyMemo(OnmsAlarm a, OnmsMemo m) {}
+            @Override public void didDeleteReductionKeyMemo(OnmsAlarm a, OnmsReductionKeyMemo m) {}
+            @Override public void didUpdateLastAutomationTime(OnmsAlarm a, java.util.Date d) {}
+            @Override public void didUpdateRelatedAlarms(OnmsAlarm a, java.util.Set<OnmsAlarm> s) {}
+            @Override public void didChangeTicketStateForAlarm(OnmsAlarm a, org.opennms.netmgt.model.TroubleTicketState s) {}
+        };
+    }
+
+    /**
+     * Minimal EventUtil implementation for alarm parameter expansion.
+     * The full EventUtilDaoImpl depends on the legacy Hibernate DAO layer.
+     * This pass-through implementation handles the expandParms() calls that
+     * AlarmPersisterImpl makes — returning the input unchanged when no
+     * database-backed token resolution is available.
+     */
+    @Bean
+    public EventUtil eventUtil() {
+        return new EventUtil() {
+            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
+            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
+            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
+            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
+            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
+            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
+            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
+            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
+            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
+            @Override public String getForeignId(long nodeId) { return ""; }
+            @Override public String getForeignSource(long nodeId) { return ""; }
+            @Override public String getNodeLabel(long nodeId) { return ""; }
+            @Override public String getNodeLocation(long nodeId) { return ""; }
+            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
+            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
+            @Override public String getPrimaryInterface(long nodeId) { return ""; }
+        };
+    }
+
     @Bean
     public AlarmPersisterImpl alarmPersister() {
         return new AlarmPersisterImpl();
@@ -117,6 +212,18 @@ public class AlarmdConfiguration {
     @Bean
     public AlarmLifecycleListenerManager alarmLifecycleListenerManager() {
         return new AlarmLifecycleListenerManager();
+    }
+
+    /**
+     * No-op EventProxy — Alarmd's NorthbounderManager uses this to send events
+     * for northbound interface state changes. Not needed until NBI integration.
+     */
+    @Bean(name = "eventProxy")
+    public org.opennms.netmgt.events.api.EventProxy eventProxy() {
+        return new org.opennms.netmgt.events.api.EventProxy() {
+            @Override public void send(org.opennms.netmgt.xml.event.Event event) {}
+            @Override public void send(org.opennms.netmgt.xml.event.Log eventLog) {}
+        };
     }
 
     @Bean
@@ -134,6 +241,7 @@ public class AlarmdConfiguration {
     @Bean
     public AnnotationBasedEventListenerAdapter alarmdEventListenerAdapter(
             Alarmd alarmd,
+            @org.springframework.beans.factory.annotation.Qualifier("kafkaEventSubscriptionService")
             EventSubscriptionService eventSubscriptionService) {
         var adapter = new AnnotationBasedEventListenerAdapter();
         adapter.setAnnotatedListener(alarmd);

--- a/core/daemon-boot-alarmd/src/main/resources/application.yml
+++ b/core/daemon-boot-alarmd/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       ddl-auto: none
     properties:
       hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+      hibernate.archive.autodetection: none
     open-in-view: false
 
 server:

--- a/core/daemon-boot-alarmd/src/main/resources/application.yml
+++ b/core/daemon-boot-alarmd/src/main/resources/application.yml
@@ -10,6 +10,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+        implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
     properties:
       hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
       hibernate.archive.autodetection: none

--- a/core/daemon-boot-alarmd/src/test/java/org/opennms/netmgt/alarmd/boot/AlarmdApplicationIT.java
+++ b/core/daemon-boot-alarmd/src/test/java/org/opennms/netmgt/alarmd/boot/AlarmdApplicationIT.java
@@ -1,101 +1,183 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
 package org.opennms.netmgt.alarmd.boot;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Date;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
+import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.events.api.EventSubscriptionService;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsDistPoller;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Smoke test for the Alarmd Spring Boot application.
+ * Integration test for the Alarmd Spring Boot application.
  *
- * <p>This is a prototype-level integration test. The full flow (send event,
- * verify alarm created) cannot work yet because:
- * <ul>
- *   <li>DAO beans (AlarmDao, NodeDao, etc.) have no JPA implementations</li>
- *   <li>The database schema (Liquibase/db-init) is not available in tests</li>
- *   <li>EventUtilDaoImpl requires DAOs that lack JPA backing</li>
- * </ul>
- *
- * <p>A {@code @SpringBootTest} variant is included but {@code @Disabled} until
- * the DAO layer is migrated. See the inline comments for what is needed.
+ * <p>Starts a full Spring Boot context backed by Testcontainers PostgreSQL
+ * (with schema.sql). Verifies that JPA DAOs are functional and can
+ * persist/retrieve alarms.</p>
  */
+@SpringBootTest(classes = AlarmdApplication.class)
+@Testcontainers
+@Import(AlarmdApplicationIT.TestConfig.class)
 class AlarmdApplicationIT {
 
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("opennms")
+            .withUsername("opennms")
+            .withPassword("opennms")
+            .withInitScript("schema.sql");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("opennms.kafka.bootstrap-servers", () -> "localhost:9092");
+    }
+
+    /**
+     * Provides mock beans for services that Alarmd requires but that are
+     * not part of the JPA/DAO layer being tested.
+     */
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        public EventSubscriptionService eventSubscriptionService() {
+            return mock(EventSubscriptionService.class);
+        }
+
+        @Bean
+        public AlarmEntityNotifier alarmEntityNotifier() {
+            return mock(AlarmEntityNotifier.class);
+        }
+
+        @Bean
+        public org.opennms.netmgt.eventd.EventUtil eventUtil() {
+            return mock(org.opennms.netmgt.eventd.EventUtil.class);
+        }
+
+        @Bean
+        public TransactionOperations transactionOperations(PlatformTransactionManager txManager) {
+            return new TransactionTemplate(txManager);
+        }
+
+        @Bean
+        public org.opennms.netmgt.dao.api.SessionUtils sessionUtils() {
+            return mock(org.opennms.netmgt.dao.api.SessionUtils.class);
+        }
+
+        @Bean(name = "eventProxy")
+        public org.opennms.netmgt.events.api.EventProxy eventProxy() {
+            return mock(org.opennms.netmgt.events.api.EventProxy.class);
+        }
+
+    }
+
+    @Autowired
+    private AlarmDao alarmDao;
+
+    @Autowired
+    private DistPollerDao distPollerDao;
+
+    @Autowired
+    private NodeDao nodeDao;
+
     @Test
-    void applicationClassExists() {
-        assertThat(AlarmdApplication.class).isNotNull();
+    void contextLoads() {
+        assertThat(alarmDao).isNotNull();
+        assertThat(distPollerDao).isNotNull();
+        assertThat(nodeDao).isNotNull();
     }
 
     @Test
-    void hasSpringBootApplicationAnnotation() {
-        assertThat(AlarmdApplication.class.isAnnotationPresent(SpringBootApplication.class))
-                .as("AlarmdApplication must be annotated with @SpringBootApplication")
-                .isTrue();
+    void canPersistAndRetrieveAlarm() {
+        OnmsDistPoller distPoller = distPollerDao.whoami();
+        assertThat(distPoller).isNotNull();
+
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setUei("uei.opennms.org/test/alarm");
+        alarm.setDistPoller(distPoller);
+        alarm.setCounter(1);
+        alarm.setSeverity(OnmsSeverity.MAJOR);
+        alarm.setReductionKey("uei.opennms.org/test/alarm::1");
+        alarm.setFirstEventTime(new Date());
+        alarm.setLastEventTime(new Date());
+        alarm.setLogMsg("Test alarm");
+
+        alarmDao.save(alarm);
+        alarmDao.flush();
+
+        assertThat(alarm.getId()).isNotNull();
+
+        OnmsAlarm retrieved = alarmDao.get(alarm.getId());
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.getUei()).isEqualTo("uei.opennms.org/test/alarm");
+        assertThat(retrieved.getSeverity()).isEqualTo(OnmsSeverity.MAJOR);
+        assertThat(retrieved.getCounter()).isEqualTo(1);
     }
 
     @Test
-    void scanBasePackagesIncludeAlarmd() {
-        SpringBootApplication annotation =
-                AlarmdApplication.class.getAnnotation(SpringBootApplication.class);
-        assertThat(annotation.scanBasePackages())
-                .as("Scan packages must include the alarmd package")
-                .contains("org.opennms.netmgt.alarmd");
-    }
+    void findByReductionKey() {
+        OnmsDistPoller distPoller = distPollerDao.whoami();
 
-    @Test
-    void scanBasePackagesIncludeDaemonCommon() {
-        SpringBootApplication annotation =
-                AlarmdApplication.class.getAnnotation(SpringBootApplication.class);
-        assertThat(annotation.scanBasePackages())
-                .as("Scan packages must include daemon-common infrastructure")
-                .contains("org.opennms.core.daemon.common");
-    }
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setUei("uei.opennms.org/test/findByKey");
+        alarm.setDistPoller(distPoller);
+        alarm.setCounter(1);
+        alarm.setSeverity(OnmsSeverity.WARNING);
+        alarm.setReductionKey("uei.opennms.org/test/findByKey::unique");
+        alarm.setFirstEventTime(new Date());
+        alarm.setLastEventTime(new Date());
+        alarm.setLogMsg("Test find by key");
 
-    @Test
-    void mainMethodExists() throws NoSuchMethodException {
-        var method = AlarmdApplication.class.getMethod("main", String[].class);
-        assertThat(method).isNotNull();
-        assertThat(java.lang.reflect.Modifier.isStatic(method.getModifiers()))
-                .as("main() must be static")
-                .isTrue();
-    }
+        alarmDao.save(alarm);
+        alarmDao.flush();
 
-    // -----------------------------------------------------------------------
-    // Full context-load test — @Disabled until DAO layer is migrated.
-    //
-    // To enable this test, the following must be in place:
-    //   1. JPA-backed implementations of AlarmDao, NodeDao, EventDao, etc.
-    //   2. A Liquibase changelog or Flyway migration that creates the OpenNMS
-    //      schema inside the Testcontainers PostgreSQL instance.
-    //   3. spring-boot-starter-data-jpa on the classpath.
-    //   4. Testcontainers PostgreSQL + Kafka dependencies in test scope.
-    //
-    // Once those are available, uncomment and adapt:
-    //
-    // @org.springframework.boot.test.context.SpringBootTest
-    // @org.testcontainers.junit.jupiter.Testcontainers
-    // class FullContextTest {
-    //
-    //     @org.testcontainers.junit.jupiter.Container
-    //     static PostgreSQLContainer<?> postgres =
-    //             new PostgreSQLContainer<>("postgres:16-alpine");
-    //
-    //     @org.testcontainers.junit.jupiter.Container
-    //     static KafkaContainer kafka =
-    //             new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
-    //
-    //     @org.springframework.test.context.DynamicPropertySource
-    //     static void configureProperties(DynamicPropertyRegistry registry) {
-    //         registry.add("spring.datasource.url", postgres::getJdbcUrl);
-    //         registry.add("spring.datasource.username", postgres::getUsername);
-    //         registry.add("spring.datasource.password", postgres::getPassword);
-    //         registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
-    //     }
-    //
-    //     @Test
-    //     void contextLoads() {
-    //         // If we get here, the Spring Boot context started successfully
-    //     }
-    // }
-    // -----------------------------------------------------------------------
+        OnmsAlarm found = alarmDao.findByReductionKey("uei.opennms.org/test/findByKey::unique");
+        assertThat(found).isNotNull();
+        assertThat(found.getId()).isEqualTo(alarm.getId());
+    }
 }

--- a/core/daemon-boot-alarmd/src/test/java/org/opennms/netmgt/alarmd/boot/AlarmdApplicationIT.java
+++ b/core/daemon-boot-alarmd/src/test/java/org/opennms/netmgt/alarmd/boot/AlarmdApplicationIT.java
@@ -43,6 +43,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -60,6 +61,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest(classes = AlarmdApplication.class)
 @Testcontainers
 @Import(AlarmdApplicationIT.TestConfig.class)
+@Transactional
 class AlarmdApplicationIT {
 
     @Container

--- a/core/daemon-boot-alarmd/src/test/resources/schema.sql
+++ b/core/daemon-boot-alarmd/src/test/resources/schema.sql
@@ -1,0 +1,357 @@
+-- ============================================================================
+-- DDL for Alarmd integration tests
+--
+-- Derived from Jakarta entity annotations in:
+--   core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/
+--
+-- Tables cover only the entities mapped with jakarta.persistence annotations
+-- that Hibernate 7 will discover via @EntityScan.
+-- ============================================================================
+
+-- -------------------------------------------------------
+-- Sequences
+-- -------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS alarmsNxtId    START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS catNxtId       START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS memoNxtId      START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS serviceNxtId   START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS nodeNxtId      START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS opennmsNxtId   START WITH 1 INCREMENT BY 1;
+
+-- -------------------------------------------------------
+-- monitoringLocations (referenced by node.location FK)
+-- Normally managed by the legacy model, but needed as a
+-- target for the foreign key from the node table.
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS monitoringLocations (
+    id              VARCHAR(255) NOT NULL,
+    monitoringArea  VARCHAR(255) NOT NULL,
+    geolocation     VARCHAR(255),
+    longitude       FLOAT,
+    latitude        FLOAT,
+    priority        BIGINT,
+    CONSTRAINT pk_monitoringLocations PRIMARY KEY (id)
+);
+
+-- -------------------------------------------------------
+-- monitoringSystems  (OnmsMonitoringSystem / OnmsDistPoller)
+-- Single-table inheritance: discriminator column = "type"
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS monitoringSystems (
+    id              VARCHAR(255) NOT NULL,
+    type            VARCHAR(31)  NOT NULL,
+    label           VARCHAR(255),
+    location        VARCHAR(255) NOT NULL,
+    last_updated    TIMESTAMP,
+    last_checked_in TIMESTAMP,
+    CONSTRAINT pk_monitoringSystems PRIMARY KEY (id)
+);
+
+-- Element collection for MonitoringSystem properties
+CREATE TABLE IF NOT EXISTS monitoringSystemsProperties (
+    monitoringSystemId VARCHAR(255) NOT NULL,
+    property           VARCHAR(255) NOT NULL,
+    propertyValue      VARCHAR(255),
+    CONSTRAINT fk_msp_system FOREIGN KEY (monitoringSystemId)
+        REFERENCES monitoringSystems(id) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- node  (OnmsNode)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS node (
+    nodeId            INTEGER      NOT NULL DEFAULT nextval('nodeNxtId'),
+    nodeCreateTime    TIMESTAMP    NOT NULL,
+    nodeParentID      INTEGER,
+    nodeType          VARCHAR(1),
+    nodeSysOID        VARCHAR(256),
+    nodeSysName       VARCHAR(256),
+    nodeSysDescription VARCHAR(256),
+    nodeSysLocation   VARCHAR(256),
+    nodeSysContact    VARCHAR(256),
+    nodeLabel         VARCHAR(256) NOT NULL,
+    nodeLabelSource   VARCHAR(1),
+    nodeNetBIOSName   VARCHAR(16),
+    nodeDomainName    VARCHAR(16),
+    operatingSystem   VARCHAR(64),
+    lastCapsdPoll     TIMESTAMP,
+    foreignId         VARCHAR(255),
+    foreignSource     VARCHAR(255),
+    location          VARCHAR(255) NOT NULL,
+    last_ingress_flow TIMESTAMP,
+    last_egress_flow  TIMESTAMP,
+    CONSTRAINT pk_node PRIMARY KEY (nodeId),
+    CONSTRAINT fk_node_parent FOREIGN KEY (nodeParentID)
+        REFERENCES node(nodeId) ON DELETE SET NULL,
+    CONSTRAINT fk_node_location FOREIGN KEY (location)
+        REFERENCES monitoringLocations(id)
+);
+
+-- pathOutage  (@SecondaryTable for OnmsNode)
+CREATE TABLE IF NOT EXISTS pathOutage (
+    nodeId                  INTEGER NOT NULL,
+    criticalPathIp          VARCHAR(255),
+    criticalPathServiceName VARCHAR(255),
+    CONSTRAINT pk_pathOutage PRIMARY KEY (nodeId),
+    CONSTRAINT fk_pathOutage_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE
+);
+
+-- node_metadata (ElementCollection for OnmsNode)
+CREATE TABLE IF NOT EXISTS node_metadata (
+    id      INTEGER      NOT NULL,
+    context VARCHAR(256) NOT NULL,
+    key     VARCHAR(256) NOT NULL,
+    value   TEXT,
+    CONSTRAINT fk_node_metadata FOREIGN KEY (id)
+        REFERENCES node(nodeId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- categories  (OnmsCategory)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS categories (
+    categoryid          INTEGER      NOT NULL DEFAULT nextval('catNxtId'),
+    categoryName        VARCHAR(255) NOT NULL UNIQUE,
+    categoryDescription VARCHAR(255),
+    CONSTRAINT pk_categories PRIMARY KEY (categoryid)
+);
+
+-- category_node  (ManyToMany join table: Node <-> Category)
+CREATE TABLE IF NOT EXISTS category_node (
+    nodeId      INTEGER NOT NULL,
+    categoryId  INTEGER NOT NULL,
+    CONSTRAINT pk_category_node PRIMARY KEY (nodeId, categoryId),
+    CONSTRAINT fk_cn_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE,
+    CONSTRAINT fk_cn_category FOREIGN KEY (categoryId)
+        REFERENCES categories(categoryid) ON DELETE CASCADE
+);
+
+-- category_group  (ElementCollection for OnmsCategory.authorizedGroups)
+CREATE TABLE IF NOT EXISTS category_group (
+    categoryId INTEGER      NOT NULL,
+    groupId    VARCHAR(64)  NOT NULL,
+    CONSTRAINT fk_cg_category FOREIGN KEY (categoryId)
+        REFERENCES categories(categoryid) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- service  (OnmsServiceType)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS service (
+    serviceId   INTEGER      NOT NULL DEFAULT nextval('serviceNxtId'),
+    serviceName VARCHAR(255) NOT NULL UNIQUE,
+    CONSTRAINT pk_service PRIMARY KEY (serviceId)
+);
+
+-- -------------------------------------------------------
+-- snmpInterface  (OnmsSnmpInterface)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS snmpInterface (
+    id                INTEGER NOT NULL DEFAULT nextval('opennmsNxtId'),
+    nodeId            INTEGER NOT NULL,
+    snmpPhysAddr      VARCHAR(32),
+    snmpIfIndex       INTEGER,
+    snmpIfDescr       VARCHAR(256),
+    snmpIfType        INTEGER,
+    snmpIfName        VARCHAR(32),
+    snmpIfSpeed       BIGINT,
+    snmpIfAdminStatus INTEGER,
+    snmpIfOperStatus  INTEGER,
+    snmpIfAlias       VARCHAR(256),
+    snmpLastCapsdPoll TIMESTAMP,
+    snmpCollect       VARCHAR(255),
+    snmpPoll          VARCHAR(255),
+    snmpLastSnmpPoll  TIMESTAMP,
+    last_ingress_flow TIMESTAMP,
+    last_egress_flow  TIMESTAMP,
+    CONSTRAINT pk_snmpInterface PRIMARY KEY (id),
+    CONSTRAINT fk_snmpIf_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- ipInterface  (OnmsIpInterface)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ipInterface (
+    id               INTEGER     NOT NULL DEFAULT nextval('opennmsNxtId'),
+    nodeId           INTEGER     NOT NULL,
+    ipAddr           VARCHAR(255),
+    netmask          VARCHAR(255),
+    ipHostName       VARCHAR(256),
+    isManaged        VARCHAR(1),
+    isSnmpPrimary    VARCHAR(1),
+    ipLastCapsdPoll  TIMESTAMP,
+    snmpInterfaceId  INTEGER,
+    CONSTRAINT pk_ipInterface PRIMARY KEY (id),
+    CONSTRAINT fk_ipIf_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE,
+    CONSTRAINT fk_ipIf_snmpIf FOREIGN KEY (snmpInterfaceId)
+        REFERENCES snmpInterface(id) ON DELETE SET NULL
+);
+
+-- ipInterface_metadata (ElementCollection for OnmsIpInterface)
+CREATE TABLE IF NOT EXISTS ipInterface_metadata (
+    id      INTEGER      NOT NULL,
+    context VARCHAR(256) NOT NULL,
+    key     VARCHAR(256) NOT NULL,
+    value   TEXT,
+    CONSTRAINT fk_ipIf_metadata FOREIGN KEY (id)
+        REFERENCES ipInterface(id) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- ifServices  (OnmsMonitoredService)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ifServices (
+    id              INTEGER NOT NULL DEFAULT nextval('opennmsNxtId'),
+    ipInterfaceId   INTEGER NOT NULL,
+    serviceId       INTEGER NOT NULL,
+    lastGood        TIMESTAMP,
+    lastFail        TIMESTAMP,
+    qualifier       VARCHAR(16),
+    status          VARCHAR(1),
+    source          VARCHAR(1),
+    notify          VARCHAR(1),
+    CONSTRAINT pk_ifServices PRIMARY KEY (id),
+    CONSTRAINT fk_ifSvc_ipIf FOREIGN KEY (ipInterfaceId)
+        REFERENCES ipInterface(id) ON DELETE CASCADE,
+    CONSTRAINT fk_ifSvc_service FOREIGN KEY (serviceId)
+        REFERENCES service(serviceId)
+);
+
+-- ifServices_metadata (ElementCollection for OnmsMonitoredService)
+CREATE TABLE IF NOT EXISTS ifServices_metadata (
+    id      INTEGER      NOT NULL,
+    context VARCHAR(256) NOT NULL,
+    key     VARCHAR(256) NOT NULL,
+    value   TEXT,
+    CONSTRAINT fk_ifSvc_metadata FOREIGN KEY (id)
+        REFERENCES ifServices(id) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- memos  (OnmsMemo / OnmsReductionKeyMemo — single-table inheritance)
+-- Discriminator column: "type"
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS memos (
+    id           INTEGER     NOT NULL DEFAULT nextval('memoNxtId'),
+    type         VARCHAR(31) NOT NULL,
+    body         TEXT,
+    author       VARCHAR(255),
+    updated      TIMESTAMP,
+    created      TIMESTAMP,
+    reductionkey VARCHAR(255),
+    CONSTRAINT pk_memos PRIMARY KEY (id)
+);
+
+-- -------------------------------------------------------
+-- alarms  (OnmsAlarm)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS alarms (
+    alarmId             INTEGER      NOT NULL DEFAULT nextval('alarmsNxtId'),
+    eventUEI            VARCHAR(256) NOT NULL,
+    systemId            VARCHAR(255) NOT NULL,
+    nodeId              INTEGER,
+    ipAddr              VARCHAR(255),
+    serviceid           INTEGER,
+    reductionKey        VARCHAR(255) UNIQUE,
+    alarmType           INTEGER,
+    ifIndex             INTEGER,
+    counter             INTEGER      NOT NULL,
+    severity            INTEGER      NOT NULL,
+    firstEventTime      TIMESTAMP,
+    lastEventTime       TIMESTAMP,
+    firstAutomationTime TIMESTAMP,
+    lastAutomationTime  TIMESTAMP,
+    description         VARCHAR(4000),
+    logmsg              VARCHAR(1024),
+    operinstruct        TEXT,
+    tticketId           VARCHAR(128),
+    tticketState        INTEGER,
+    mouseOverText       VARCHAR(64),
+    suppressedUntil     TIMESTAMP,
+    suppressedUser      VARCHAR(256),
+    suppressedTime      TIMESTAMP,
+    alarmAckUser        VARCHAR(256),
+    alarmAckTime        TIMESTAMP,
+    clearKey            VARCHAR(255),
+    stickymemo          INTEGER,
+    managedObjectInstance VARCHAR(512),
+    managedObjectType   VARCHAR(512),
+    applicationDN       VARCHAR(512),
+    ossPrimaryKey       VARCHAR(512),
+    x733AlarmType       VARCHAR(31),
+    x733ProbableCause   INTEGER      NOT NULL DEFAULT 0,
+    qosAlarmState       VARCHAR(31),
+    event_tsid          BIGINT,
+    event_uei           VARCHAR(256),
+    event_source        VARCHAR(256),
+    event_severity      INTEGER,
+    event_timestamp     TIMESTAMP,
+    event_node_id       BIGINT,
+    event_log_msg       TEXT,
+    last_event_data     TEXT,
+    CONSTRAINT pk_alarms PRIMARY KEY (alarmId),
+    CONSTRAINT fk_alarm_system FOREIGN KEY (systemId)
+        REFERENCES monitoringSystems(id),
+    CONSTRAINT fk_alarm_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE SET NULL,
+    CONSTRAINT fk_alarm_service FOREIGN KEY (serviceid)
+        REFERENCES service(serviceId),
+    CONSTRAINT fk_alarm_stickymemo FOREIGN KEY (stickymemo)
+        REFERENCES memos(id) ON DELETE SET NULL
+);
+
+-- alarm_attributes  (ElementCollection for OnmsAlarm.details)
+CREATE TABLE IF NOT EXISTS alarm_attributes (
+    alarmId        INTEGER      NOT NULL,
+    attributename  VARCHAR(255) NOT NULL,
+    attributeValue VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_alarm_attr FOREIGN KEY (alarmId)
+        REFERENCES alarms(alarmId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- alarm_situations  (AlarmAssociation entity)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS alarm_situations (
+    id               INTEGER NOT NULL DEFAULT nextval('alarmsNxtId'),
+    situation_id     INTEGER,
+    related_alarm_id INTEGER,
+    mapped_time      TIMESTAMP,
+    CONSTRAINT pk_alarm_situations PRIMARY KEY (id),
+    CONSTRAINT uk_alarm_situations UNIQUE (situation_id, related_alarm_id),
+    CONSTRAINT fk_as_situation FOREIGN KEY (situation_id)
+        REFERENCES alarms(alarmId) ON DELETE CASCADE,
+    CONSTRAINT fk_as_related FOREIGN KEY (related_alarm_id)
+        REFERENCES alarms(alarmId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- accesslocks  (used by AbstractDaoJpa.lock())
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS accesslocks (
+    lockname VARCHAR(40) NOT NULL,
+    CONSTRAINT pk_accesslocks PRIMARY KEY (lockname)
+);
+
+-- -------------------------------------------------------
+-- Seed data
+-- -------------------------------------------------------
+
+-- Default monitoring location (required by node FK)
+INSERT INTO monitoringLocations (id, monitoringArea)
+VALUES ('Default', 'Default')
+ON CONFLICT (id) DO NOTHING;
+
+-- Local OpenNMS system (required by alarm FK)
+INSERT INTO monitoringSystems (id, type, label, location)
+VALUES ('00000000-0000-0000-0000-000000000000', 'OpenNMS', 'localhost', 'Default')
+ON CONFLICT (id) DO NOTHING;
+
+-- Access lock for alarm DAO
+INSERT INTO accesslocks (lockname)
+VALUES ('ONMSALARM_ACCESS')
+ON CONFLICT (lockname) DO NOTHING;

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -50,6 +50,39 @@
                 <artifactId>logback-core</artifactId>
                 <version>1.5.32</version>
             </dependency>
+            <!-- Pin Jackson 2.19.4 — parent POM manages 2.16.2 which lacks JsonFormat$Shape.POJO
+                 required by Spring Boot 4.0.3. Explicit entries here override the parent's
+                 managed versions even though the Spring Boot BOM is imported first. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>2.19.4</version>
+            </dependency>
             <!-- Pin JUnit to 5.12.2 / Platform 1.12.2 which is the latest
                  version supported by maven-surefire-plugin 3.5.5.
                  Must be explicit entries (not BOM import) to override

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonDataSourceConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonDataSourceConfiguration.java
@@ -1,18 +1,17 @@
 package org.opennms.core.daemon.common;
 
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @EnableTransactionManagement
-@EntityScan(basePackages = "org.opennms.netmgt.model")
 public class DaemonDataSourceConfiguration {
     // Spring Boot auto-configuration handles:
     // - HikariCP DataSource from spring.datasource.* properties
     // - Hibernate SessionFactory from spring.jpa.* properties
     // - JpaTransactionManager
     //
-    // Entity scanning finds @Entity classes in opennms-model.
+    // @EntityScan is placed on each boot application's configuration
+    // to scan the correct entity package for that daemon.
     // Schema management is "none" (Liquibase manages via db-init container).
 }

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -47,6 +47,24 @@
                 <artifactId>logback-core</artifactId>
                 <version>1.5.32</version>
             </dependency>
+            <!-- Pin Jackson 2.19.4 — parent POM manages 2.16.2 which lacks JsonFormat$Shape.POJO
+                 required by Spring Boot 4.0.3. Explicit entries here override the parent's
+                 managed versions even though the Spring Boot BOM is imported first. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.19.4</version>
+            </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.core</artifactId>
+        <version>36.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.model-jakarta</artifactId>
+    <packaging>jar</packaging>
+    <name>OpenNMS :: Core :: Model Jakarta</name>
+    <description>
+        Jakarta Persistence entity classes for Spring Boot 4 daemons.
+        Same package (org.opennms.netmgt.model) as legacy opennms-model,
+        different module. Only one should be on the classpath at runtime.
+    </description>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-boot.version>4.0.3</spring-boot.version>
+        <enforcer-skip-banned-dependencies>true</enforcer-skip-banned-dependencies>
+        <enforcer-skip-dependency-convergence>true</enforcer-skip-dependency-convergence>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Jakarta Persistence API (from Spring Boot 4 BOM) -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+
+        <!-- Hibernate 7 core — for @Filter, @Formula, @SQLRestriction annotations -->
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+
+        <!-- AbstractDaoJpa base class -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.daemon-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- DAO interfaces (AlarmDao, NodeDao, DistPollerDao, ServiceTypeDao) -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-dao-api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Shared enums and utilities (OnmsSeverity, InetAddressUtils, NodeType, etc.) -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-model</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Jackson for @JsonIgnoreProperties -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+                <configuration>
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.12.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>1.12.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
@@ -71,7 +71,7 @@ public class AlarmAssociation implements Serializable {
     }
 
     @Id
-    @SequenceGenerator(name="alarmSequence", sequenceName="alarmsNxtId")
+    @SequenceGenerator(name="alarmSequence", sequenceName="alarmsNxtId", allocationSize = 1)
     @GeneratedValue(generator="alarmSequence")
     @Column(name="id", nullable=false)
     public Integer getId() {

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.UniqueConstraint;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * <p> Entity to store situations and their associated (related) alarms with other details like mappedTime </p>
+ */
+@Entity
+@Table(name = "alarm_situations", uniqueConstraints={@UniqueConstraint(columnNames={"situation_id", "related_alarm_id"})})
+public class AlarmAssociation implements Serializable {
+
+    private static final long serialVersionUID = 4115687014888009683L;
+
+    private Integer id;
+
+    private OnmsAlarm situationAlarm;
+
+    private OnmsAlarm relatedAlarm;
+
+    private Date mappedTime;
+
+    public AlarmAssociation() {
+    }
+
+    public AlarmAssociation(OnmsAlarm situationAlarm, OnmsAlarm relatedAlarm) {
+        this(situationAlarm, relatedAlarm, new Date());
+    }
+
+    public AlarmAssociation(OnmsAlarm situationAlarm, OnmsAlarm relatedAlarm, Date mappedTime) {
+        this.mappedTime = mappedTime;
+        this.situationAlarm = situationAlarm;
+        this.relatedAlarm = relatedAlarm;
+    }
+
+    @Id
+    @SequenceGenerator(name="alarmSequence", sequenceName="alarmsNxtId")
+    @GeneratedValue(generator="alarmSequence")
+    @Column(name="id", nullable=false)
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @ManyToOne
+    @JoinColumn(name = "situation_id")
+    public OnmsAlarm getSituationAlarm() {
+        return situationAlarm;
+    }
+
+    public void setSituationAlarm(OnmsAlarm situationAlarm) {
+        this.situationAlarm = situationAlarm;
+    }
+
+    @OneToOne
+    @JoinColumn(name = "related_alarm_id")
+    public OnmsAlarm getRelatedAlarm() {
+        return relatedAlarm;
+    }
+
+    public void setRelatedAlarm(OnmsAlarm relatedAlarm) {
+        this.relatedAlarm = relatedAlarm;
+    }
+
+    public void setMappedTime(Date mappedTime) {
+        this.mappedTime = mappedTime;
+    }
+
+    @Column(name = "mapped_time")
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date getMappedTime() {
+        return mappedTime;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("situation", getSituationAlarm().getId())
+                .add("alarm", getRelatedAlarm().getId())
+                .add("time", getMappedTime())
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AlarmAssociation that = (AlarmAssociation) o;
+        return Objects.equals(situationAlarm, that.situationAlarm) &&
+                Objects.equals(relatedAlarm, that.relatedAlarm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(situationAlarm, relatedAlarm);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -239,7 +239,7 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
      * @return a {@link java.lang.Integer} object.
      */
     @Id
-    @SequenceGenerator(name="alarmSequence", sequenceName="alarmsNxtId")
+    @SequenceGenerator(name="alarmSequence", sequenceName="alarmsNxtId", allocationSize = 1)
     @GeneratedValue(generator="alarmSequence")
     @Column(name="alarmId", nullable=false)
     public Integer getId() {

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -56,7 +56,9 @@ import jakarta.persistence.Transient;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.ParamDef;
 import org.opennms.netmgt.model.jakarta.converter.InetAddressConverter;
 import org.opennms.netmgt.model.jakarta.converter.OnmsSeverityConverter;
 import com.google.common.base.MoreObjects;
@@ -66,6 +68,8 @@ import com.google.common.base.MoreObjects;
  */
 @Entity
 @Table(name="alarms")
+@FilterDef(name = FilterManager.AUTH_FILTER_NAME,
+    parameters = @ParamDef(name = "userGroups", type = String.class))
 @Filter(name=FilterManager.AUTH_FILTER_NAME, condition="exists (select distinct x.nodeid from node x join category_node cn on x.nodeid = cn.nodeid join category_group cg on cn.categoryId = cg.categoryId where x.nodeid = nodeid and cg.groupId in (:userGroups))")
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class OnmsAlarm implements Acknowledgeable, Serializable {

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -1,0 +1,1258 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.Formula;
+import org.opennms.netmgt.model.jakarta.converter.InetAddressConverter;
+import org.opennms.netmgt.model.jakarta.converter.OnmsSeverityConverter;
+import com.google.common.base.MoreObjects;
+
+/**
+ * <p>OnmsAlarm class.</p>
+ */
+@Entity
+@Table(name="alarms")
+@Filter(name=FilterManager.AUTH_FILTER_NAME, condition="exists (select distinct x.nodeid from node x join category_node cn on x.nodeid = cn.nodeid join category_group cg on cn.categoryId = cg.categoryId where x.nodeid = nodeid and cg.groupId in (:userGroups))")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsAlarm implements Acknowledgeable, Serializable {
+    private static final long serialVersionUID = 7275548439687562161L;
+
+    /** Constant <code>PROBLEM_TYPE=1</code> */
+    public static final int PROBLEM_TYPE = 1;
+
+    /** Constant <code>RESOLUTION_TYPE=2</code> */
+    public static final int RESOLUTION_TYPE = 2;
+
+    /** Constant <code>PROBLEM_WITHOUT_RESOLUTION_TYPE=3</code> */
+    public static final int PROBLEM_WITHOUT_RESOLUTION_TYPE = 3;
+
+    public static final String ARCHIVED = "Archived";
+
+    /** identifier field */
+    private Integer m_id;
+
+    /** persistent field */
+    private String m_uei;
+
+    /** persistent field */
+    private OnmsMonitoringSystem m_distPoller;
+
+    /** nullable persistent field */
+    private OnmsNode m_node;
+
+    /** nullable persistent field */
+    private InetAddress m_ipAddr;
+
+    /** nullable persistent field */
+    private OnmsServiceType m_serviceType;
+
+    /** nullable persistent field */
+    private String m_reductionKey;
+
+    /** nullable persistent field */
+    private Integer m_alarmType;
+
+    /** nullable persistent field */
+    private Integer m_ifIndex;
+
+    /** persistent field */
+    private Integer m_counter;
+
+    /** persistent field */
+    private OnmsSeverity m_severity = OnmsSeverity.INDETERMINATE;
+
+    /** persistent field */
+    private Date m_firstEventTime;
+
+    /** persistent field */
+    private Date m_lastEventTime;
+
+    /** persistent field */
+    private Date m_firstAutomationTime;
+
+    /** persistent field */
+    private Date m_lastAutomationTime;
+
+    /** nullable persistent field */
+    private String m_description;
+
+    /** nullable persistent field */
+    private String m_logMsg;
+
+    /** nullable persistent field */
+    private String m_operInstruct;
+
+    /** nullable persistent field */
+    private String m_tTicketId;
+
+    /** nullable persistent field */
+    private TroubleTicketState m_tTicketState;
+
+    /** nullable persistent field */
+    private String m_mouseOverText;
+
+    /** nullable persistent field */
+    private Date m_suppressedUntil;
+
+    /** nullable persistent field */
+    private String m_suppressedUser;
+
+    /** nullable persistent field */
+    private Date m_suppressedTime;
+
+    /** nullable persistent field */
+    private String m_alarmAckUser;
+
+    /** nullable persistent field */
+    private Date m_alarmAckTime;
+
+    /** nullable persistent field */
+    private String m_clearKey;
+
+    /** denormalized event fields (replacing m_lastEvent FK) */
+    private Long m_eventTsid;
+    private String m_eventUei;
+    private String m_eventSource;
+    private Integer m_eventSeverity;
+    private Date m_eventTimestamp;
+    private Long m_eventNodeId;
+    private String m_eventLogMsg;
+    private String m_lastEventData;
+
+    /** persistent field */
+    private String m_managedObjectInstance;
+
+    /** persistent field */
+    private String m_managedObjectType;
+
+    /** persistent field */
+    private String m_applicationDN;
+
+    private String m_ossPrimaryKey;
+
+    private String m_x733AlarmType;
+
+    private String m_qosAlarmState;
+
+    private int m_x733ProbableCause = 0;
+
+    private Map<String, String> m_details;
+
+    private OnmsMemo m_stickyMemo;
+
+    private OnmsReductionKeyMemo m_reductionKeyMemo;
+
+    private Set<AlarmAssociation> m_associatedAlarms = new HashSet<>();
+
+    private Set<OnmsAlarm> m_relatedSituations = new HashSet<>();
+
+    private boolean m_situation;
+
+    private boolean m_partOfSituation;
+
+    /**
+     * default constructor
+     */
+    public OnmsAlarm() {
+    }
+
+    /**
+     * minimal constructor
+     *
+     * @param alarmid a {@link java.lang.Integer} object.
+     * @param eventuei a {@link java.lang.String} object.
+     * @param distPoller a {@link org.opennms.netmgt.model.OnmsDistPoller} object.
+     * @param counter a {@link java.lang.Integer} object.
+     * @param severity a {@link java.lang.Integer} object.
+     * @param firsteventtime a {@link java.util.Date} object.
+     */
+    public OnmsAlarm(Integer alarmid, String eventuei, OnmsDistPoller distPoller, Integer counter, Integer severity, Date firsteventtime) {
+        this.m_id = alarmid;
+        this.m_uei = eventuei;
+        this.m_distPoller = distPoller;
+        this.m_counter = counter;
+        this.m_severity = OnmsSeverity.get(severity);
+        this.m_firstEventTime = firsteventtime;
+    }
+
+    /**
+     * <p>getId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @SequenceGenerator(name="alarmSequence", sequenceName="alarmsNxtId")
+    @GeneratedValue(generator="alarmSequence")
+    @Column(name="alarmId", nullable=false)
+    public Integer getId() {
+        return this.m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param alarmid a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer alarmid) {
+        this.m_id = alarmid;
+    }
+
+    /**
+     * <p>getUei</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="eventUEI", length=256, nullable=false)
+    public String getUei() {
+        return this.m_uei;
+    }
+
+    /**
+     * <p>setUei</p>
+     *
+     * @param eventuei a {@link java.lang.String} object.
+     */
+    public void setUei(String eventuei) {
+        this.m_uei = eventuei;
+    }
+
+    /**
+     * <p>getDistPoller</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsDistPoller} object.
+     */
+    @ManyToOne
+    @JoinColumn(name="systemId", nullable=false)
+    public OnmsMonitoringSystem getDistPoller() {
+        return this.m_distPoller;
+    }
+
+    /**
+     * <p>setDistPoller</p>
+     *
+     * @param distPoller a {@link org.opennms.netmgt.model.OnmsDistPoller} object.
+     */
+    public void setDistPoller(OnmsMonitoringSystem distPoller) {
+        this.m_distPoller = distPoller;
+    }
+
+    /**
+     * <p>getNode</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="nodeId")
+    @Override
+    public OnmsNode getNode() {
+        return this.m_node;
+    }
+
+    /**
+     * <p>setNode</p>
+     *
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void setNode(OnmsNode node) {
+        this.m_node = node;
+    }
+
+    @Transient
+    public Integer getNodeId() {
+        if (m_node == null) return null;
+        return m_node.getId();
+    }
+
+    @Transient
+    public String getNodeLabel() {
+        if (m_node == null) return null;
+        return m_node.getLabel();
+    }
+
+    /**
+     * <p>getIpAddr</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="ipAddr")
+    @Convert(converter = InetAddressConverter.class)
+    public InetAddress getIpAddr() {
+        return this.m_ipAddr;
+    }
+
+    /**
+     * <p>setIpAddr</p>
+     *
+     * @param ipaddr a {@link java.lang.String} object.
+     */
+    public void setIpAddr(InetAddress ipaddr) {
+        this.m_ipAddr = ipaddr;
+    }
+
+    /**
+     * <p>getServiceType</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsServiceType} object.
+     */
+    @ManyToOne
+    @JoinColumn(name="serviceid")
+    public OnmsServiceType getServiceType() {
+        return this.m_serviceType;
+    }
+
+    /**
+     * <p>setServiceType</p>
+     *
+     * @param service a {@link org.opennms.netmgt.model.OnmsServiceType} object.
+     */
+    public void setServiceType(OnmsServiceType service) {
+        this.m_serviceType = service;
+    }
+
+    /**
+     * <p>getReductionKey</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="reductionKey", unique=true)
+    public String getReductionKey() {
+        return this.m_reductionKey;
+    }
+
+    /**
+     * <p>setReductionKey</p>
+     *
+     * @param reductionkey a {@link java.lang.String} object.
+     */
+    public void setReductionKey(String reductionkey) {
+        this.m_reductionKey = reductionkey;
+    }
+
+    /**
+     * <p>getAlarmType</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Column(name="alarmType")
+    public Integer getAlarmType() {
+        return this.m_alarmType;
+    }
+
+    /**
+     * <p>setAlarmType</p>
+     *
+     * @param alarmtype a {@link java.lang.Integer} object.
+     */
+    public void setAlarmType(Integer alarmtype) {
+        this.m_alarmType = alarmtype;
+    }
+
+    /**
+     * <p>getCounter</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Column(name="counter", nullable=false)
+    public Integer getCounter() {
+        return this.m_counter;
+    }
+
+    /**
+     * <p>setCounter</p>
+     *
+     * @param counter a {@link java.lang.Integer} object.
+     */
+    public void setCounter(Integer counter) {
+        this.m_counter = counter;
+    }
+
+    /**
+     * <p>getSeverityLabel</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public String getSeverityLabel() {
+        return this.m_severity.name();
+    }
+
+    /**
+     * <p>setSeverityLabel</p>
+     *
+     * @param label a {@link java.lang.String} object.
+     */
+    public void setSeverityLabel(final String label) {
+        m_severity = OnmsSeverity.get(label);
+    }
+
+    /**
+     * <p>getSeverity</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsSeverity} object.
+     */
+    @Override
+    @Column(name="severity", nullable=false)
+    @Convert(converter = OnmsSeverityConverter.class)
+    public OnmsSeverity getSeverity() {
+        return this.m_severity;
+    }
+
+    /**
+     * <p>setSeverity</p>
+     *
+     * @param severity a {@link org.opennms.netmgt.model.OnmsSeverity} object.
+     */
+    public void setSeverity(final OnmsSeverity severity) {
+        m_severity = severity;
+    }
+
+    /**
+     * <p>getSeverityId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    public Integer getSeverityId() {
+        return this.m_severity.getId();
+    }
+
+    /**
+     * <p>setSeverityId</p>
+     *
+     * @param severity a {@link java.lang.Integer} object.
+     */
+    public void setSeverityId(final Integer severity) {
+        this.m_severity = OnmsSeverity.get(severity);
+    }
+
+    /**
+     * <p>getFirstEventTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="firstEventTime")
+    public Date getFirstEventTime() {
+        return this.m_firstEventTime;
+    }
+
+    /**
+     * <p>setFirstEventTime</p>
+     *
+     * @param firsteventtime a {@link java.util.Date} object.
+     */
+    public void setFirstEventTime(Date firsteventtime) {
+        this.m_firstEventTime = firsteventtime;
+    }
+
+    /**
+     * <p>getDescription</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="description", length=4000)
+    public String getDescription() {
+        return this.m_description;
+    }
+
+    /**
+     * <p>setDescription</p>
+     *
+     * @param description a {@link java.lang.String} object.
+     */
+    public void setDescription(String description) {
+        this.m_description = description;
+    }
+
+    /**
+     * <p>getLogMsg</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="logmsg", length=1024)
+    public String getLogMsg() {
+        return this.m_logMsg;
+    }
+
+    /**
+     * <p>setLogMsg</p>
+     *
+     * @param logmsg a {@link java.lang.String} object.
+     */
+    public void setLogMsg(String logmsg) {
+        this.m_logMsg = logmsg;
+    }
+
+    /**
+     * <p>getOperInstruct</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="operinstruct")
+    public String getOperInstruct() {
+        return this.m_operInstruct;
+    }
+
+    /**
+     * <p>setOperInstruct</p>
+     *
+     * @param operinstruct a {@link java.lang.String} object.
+     */
+    public void setOperInstruct(String operinstruct) {
+        this.m_operInstruct = operinstruct;
+    }
+
+    /**
+     * <p>getTTicketId</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="tticketId", length=128)
+    public String getTTicketId() {
+        return this.m_tTicketId;
+    }
+
+    /**
+     * <p>setTTicketId</p>
+     *
+     * @param tticketid a {@link java.lang.String} object.
+     */
+    public void setTTicketId(String tticketid) {
+        this.m_tTicketId = tticketid;
+    }
+
+    /**
+     * <p>getTTicketState</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.TroubleTicketState} object.
+     */
+    @Column(name="tticketState")
+    public TroubleTicketState getTTicketState() {
+        return this.m_tTicketState;
+    }
+
+    /**
+     * <p>setTTicketState</p>
+     *
+     * @param tticketstate a {@link org.opennms.netmgt.model.TroubleTicketState} object.
+     */
+    public void setTTicketState(TroubleTicketState tticketstate) {
+        this.m_tTicketState = tticketstate;
+    }
+
+    /**
+     * <p>getMouseOverText</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="mouseOverText", length=64)
+    public String getMouseOverText() {
+        return this.m_mouseOverText;
+    }
+
+    /**
+     * <p>setMouseOverText</p>
+     *
+     * @param mouseovertext a {@link java.lang.String} object.
+     */
+    public void setMouseOverText(String mouseovertext) {
+        this.m_mouseOverText = mouseovertext;
+    }
+
+    /**
+     * <p>getSuppressedUntil</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="suppressedUntil")
+    public Date getSuppressedUntil() {
+        return this.m_suppressedUntil;
+    }
+
+    /**
+     * <p>setSuppressedUntil</p>
+     *
+     * @param suppresseduntil a {@link java.util.Date} object.
+     */
+    public void setSuppressedUntil(Date suppresseduntil) {
+        this.m_suppressedUntil = suppresseduntil;
+    }
+
+    /**
+     * <p>getSuppressedUser</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="suppressedUser", length=256)
+    public String getSuppressedUser() {
+        return this.m_suppressedUser;
+    }
+
+    /**
+     * <p>setSuppressedUser</p>
+     *
+     * @param suppresseduser a {@link java.lang.String} object.
+     */
+    public void setSuppressedUser(String suppresseduser) {
+        this.m_suppressedUser = suppresseduser;
+    }
+
+    /**
+     * <p>getSuppressedTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="suppressedTime")
+    public Date getSuppressedTime() {
+        return this.m_suppressedTime;
+    }
+
+    /**
+     * <p>setSuppressedTime</p>
+     *
+     * @param suppressedtime a {@link java.util.Date} object.
+     */
+    public void setSuppressedTime(Date suppressedtime) {
+        this.m_suppressedTime = suppressedtime;
+    }
+
+    /**
+     * <p>getAlarmAckUser</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="alarmAckUser", length=256)
+    public String getAlarmAckUser() {
+        return this.m_alarmAckUser;
+    }
+
+    /**
+     * <p>setAlarmAckUser</p>
+     *
+     * @param alarmackuser a {@link java.lang.String} object.
+     */
+    public void setAlarmAckUser(String alarmackuser) {
+        this.m_alarmAckUser = alarmackuser;
+    }
+
+    @Transient
+    public boolean isAcknowledged() {
+        return getAlarmAckUser() != null;
+    }
+
+    /**
+     * <p>getAlarmAckTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="alarmAckTime")
+    public Date getAlarmAckTime() {
+        return this.m_alarmAckTime;
+    }
+
+    /**
+     * <p>setAlarmAckTime</p>
+     *
+     * @param alarmacktime a {@link java.util.Date} object.
+     */
+    public void setAlarmAckTime(Date alarmacktime) {
+        this.m_alarmAckTime = alarmacktime;
+    }
+
+    /**
+     * <p>getClearKey</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="clearKey")
+    public String getClearKey() {
+        return this.m_clearKey;
+    }
+
+    /**
+     * <p>setClearKey</p>
+     *
+     * @param clearKey a {@link java.lang.String} object.
+     */
+    public void setClearKey(String clearKey) {
+        this.m_clearKey = clearKey;
+    }
+
+    @Column(name="event_tsid")
+    public Long getEventTsid() { return m_eventTsid; }
+    public void setEventTsid(Long eventTsid) { m_eventTsid = eventTsid; }
+
+    @Column(name="event_uei", length=256)
+    public String getEventUei() { return m_eventUei; }
+    public void setEventUei(String eventUei) { m_eventUei = eventUei; }
+
+    @Column(name="event_source", length=256)
+    public String getEventSource() { return m_eventSource; }
+    public void setEventSource(String eventSource) { m_eventSource = eventSource; }
+
+    @Column(name="event_severity")
+    public Integer getEventSeverity() { return m_eventSeverity; }
+    public void setEventSeverity(Integer eventSeverity) { m_eventSeverity = eventSeverity; }
+
+    @Column(name="event_timestamp")
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date getEventTimestamp() { return m_eventTimestamp; }
+    public void setEventTimestamp(Date eventTimestamp) { m_eventTimestamp = eventTimestamp; }
+
+    @Column(name="event_node_id")
+    public Long getEventNodeId() { return m_eventNodeId; }
+    public void setEventNodeId(Long eventNodeId) { m_eventNodeId = eventNodeId; }
+
+    @Column(name="event_log_msg")
+    public String getEventLogMsg() { return m_eventLogMsg; }
+    public void setEventLogMsg(String eventLogMsg) { m_eventLogMsg = eventLogMsg; }
+
+    @Column(name="last_event_data", columnDefinition="TEXT")
+    public String getLastEventData() { return m_lastEventData; }
+    public void setLastEventData(String lastEventData) { m_lastEventData = lastEventData; }
+
+    @Transient
+    public List<OnmsEventParameter> getEventParameters() {
+        return null;
+    }
+
+    public Optional<OnmsEventParameter> findEventParameter(final String name) {
+        List<OnmsEventParameter> params = this.getEventParameters();
+        if (params == null) return Optional.empty();
+        return params.stream().filter(p -> Objects.equals(name, p.getName())).findAny();
+    }
+
+    public String getEventParameter(final String name) {
+        List<OnmsEventParameter> params = this.getEventParameters();
+        if (params == null) return null;
+        return params.stream().filter(p -> Objects.equals(name, p.getName())).findAny().map(OnmsEventParameter::getValue).orElse(null);
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("alarmid", getId())
+            .add("distPoller", getDistPoller())
+            .add("uei", getUei())
+            .add("severity", getSeverity())
+            .add("lastEventTime",getLastEventTime())
+            .add("counter", getCounter())
+            .toString();
+    }
+
+    /**
+     * <p>getLastEventTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="lastEventTime")
+    public Date getLastEventTime() {
+        return m_lastEventTime;
+    }
+
+    /**
+     * <p>setLastEventTime</p>
+     *
+     * @param lastEventTime a {@link java.util.Date} object.
+     */
+    public void setLastEventTime(Date lastEventTime) {
+        m_lastEventTime = lastEventTime;
+    }
+
+    /**
+     * <p>getApplicationDN</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="applicationDN", length=512)
+    public String getApplicationDN() {
+        return m_applicationDN;
+    }
+
+    /**
+     * <p>setApplicationDN</p>
+     *
+     * @param applicationDN a {@link java.lang.String} object.
+     */
+    public void setApplicationDN(String applicationDN) {
+        m_applicationDN = applicationDN;
+    }
+
+    /**
+     * <p>getManagedObjectInstance</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="managedObjectInstance", length=512)
+    public String getManagedObjectInstance() {
+        return m_managedObjectInstance;
+    }
+
+    /**
+     * <p>setManagedObjectInstance</p>
+     *
+     * @param managedObjectInstance a {@link java.lang.String} object.
+     */
+    public void setManagedObjectInstance(String managedObjectInstance) {
+        m_managedObjectInstance = managedObjectInstance;
+    }
+
+    /**
+     * <p>getManagedObjectType</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="managedObjectType", length=512)
+    public String getManagedObjectType() {
+        return m_managedObjectType;
+    }
+
+    /**
+     * <p>setManagedObjectType</p>
+     *
+     * @param managedObjectType a {@link java.lang.String} object.
+     */
+    public void setManagedObjectType(String managedObjectType) {
+        m_managedObjectType = managedObjectType;
+    }
+
+    /**
+     * <p>getOssPrimaryKey</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="ossPrimaryKey", length=512)
+    public String getOssPrimaryKey() {
+        return m_ossPrimaryKey;
+    }
+
+    /**
+     * <p>setOssPrimaryKey</p>
+     *
+     * @param key a {@link java.lang.String} object.
+     */
+    public void setOssPrimaryKey(String key) {
+        m_ossPrimaryKey = key;
+    }
+
+    /**
+     * <p>getX733AlarmType</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="x733AlarmType", length=31)
+    public String getX733AlarmType() {
+        return m_x733AlarmType;
+    }
+
+    /**
+     * <p>setX733AlarmType</p>
+     *
+     * @param alarmType a {@link java.lang.String} object.
+     */
+    public void setX733AlarmType(String alarmType) {
+        m_x733AlarmType = alarmType;
+    }
+
+    /**
+     * <p>getX733ProbableCause</p>
+     *
+     * @return a int.
+     */
+    @Column(name="x733ProbableCause", nullable=false)
+    public int getX733ProbableCause() {
+        return m_x733ProbableCause;
+    }
+
+    /**
+     * <p>setX733ProbableCause</p>
+     *
+     * @param cause a int.
+     */
+    public void setX733ProbableCause(int cause) {
+        m_x733ProbableCause = cause;
+    }
+
+    /**
+     * <p>getQosAlarmState</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="qosAlarmState", length=31)
+    public String getQosAlarmState() {
+        return m_qosAlarmState;
+    }
+
+    /**
+     * <p>setQosAlarmState</p>
+     *
+     * @param alarmState a {@link java.lang.String} object.
+     */
+    public void setQosAlarmState(String alarmState) {
+        m_qosAlarmState = alarmState;
+    }
+
+    /**
+     * <p>getFirstAutomationTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="firstAutomationTime")
+    public Date getFirstAutomationTime() {
+        return m_firstAutomationTime;
+    }
+
+    /**
+     * <p>setFirstAutomationTime</p>
+     *
+     * @param firstAutomationTime a {@link java.util.Date} object.
+     */
+    public void setFirstAutomationTime(Date firstAutomationTime) {
+        m_firstAutomationTime = firstAutomationTime;
+    }
+
+    /**
+     * <p>getLastAutomationTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="lastAutomationTime")
+    public Date getLastAutomationTime() {
+        return m_lastAutomationTime;
+    }
+
+    /**
+     * <p>setLastAutomationTime</p>
+     *
+     * @param lastAutomationTime a {@link java.util.Date} object.
+     */
+    public void setLastAutomationTime(Date lastAutomationTime) {
+        m_lastAutomationTime = lastAutomationTime;
+    }
+
+    /**
+     * <p>getDetails</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
+    @ElementCollection
+    @JoinTable(name="alarm_attributes", joinColumns = @JoinColumn(name="alarmId"))
+    @MapKeyColumn(name="attributename")
+    @Column(name="attributeValue", nullable=false)
+    public Map<String, String> getDetails() {
+        return m_details;
+    }
+
+    /**
+     * <p>setDetails</p>
+     *
+     * @param alarmDetails a {@link java.util.Map} object.
+     */
+    public void setDetails(Map<String, String> alarmDetails) {
+        m_details = alarmDetails;
+    }
+
+    /**
+     * <p>getIfIndex</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Column(name="ifIndex")
+    public Integer getIfIndex() {
+        return m_ifIndex;
+    }
+
+    /**
+     * <p>setIfIndex</p>
+     *
+     * @param ifIndex a {@link java.lang.Integer} object.
+     */
+    public void setIfIndex(Integer ifIndex) {
+        m_ifIndex = ifIndex;
+    }
+
+    @ManyToOne
+    @JoinColumn(name="reductionKey", referencedColumnName="reductionkey", updatable=false, insertable=false)
+    public OnmsReductionKeyMemo getReductionKeyMemo() {
+        return m_reductionKeyMemo;
+    }
+
+    public void setReductionKeyMemo(OnmsReductionKeyMemo reductionKeyMemo) {
+        this.m_reductionKeyMemo = reductionKeyMemo;
+    }
+
+    @OneToOne(cascade=CascadeType.ALL)
+    @JoinColumn(name="stickymemo")
+    public OnmsMemo getStickyMemo() {
+        return m_stickyMemo;
+    }
+
+    public void setStickyMemo(OnmsMemo stickyMemo) {
+        this.m_stickyMemo = stickyMemo;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void acknowledge(String user) {
+        if (m_alarmAckTime == null || m_alarmAckUser == null) {
+            m_alarmAckTime = Calendar.getInstance().getTime();
+            m_alarmAckUser = user;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unacknowledge(String ackUser) {
+        m_alarmAckTime = null;
+        m_alarmAckUser = null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void clear(String ackUser) {
+        m_severity = OnmsSeverity.CLEARED;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void escalate(String ackUser) {
+        m_severity = OnmsSeverity.escalate(m_severity);
+    }
+
+    /**
+     * This marks an alarm as archived and prevents it from being used again in during reduction.
+     */
+    public void archive() {
+        m_qosAlarmState = ARCHIVED;
+        m_severity = OnmsSeverity.CLEARED;
+        m_reductionKey = getReductionKey() + ":ID:"+ getId();
+    }
+
+    // Alarms that are archived
+    @Transient
+    public boolean isArchived() {
+        return ARCHIVED.equals(m_qosAlarmState);
+    }
+
+    /**
+     * <p>getType</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.AckType} object.
+     */
+    @Transient
+    @Override
+    public AckType getType() {
+        return AckType.ALARM;
+    }
+
+    /**
+     * <p>getAckId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    @Override
+    public Integer getAckId() {
+        return m_id;
+    }
+
+    /**
+     * <p>getAckUser</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    @Override
+    public String getAckUser() {
+        return m_alarmAckUser;
+    }
+
+    /**
+     * <p>getAckTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Transient
+    @Override
+    public Date getAckTime() {
+        return m_alarmAckTime;
+    }
+
+    /**
+     * <p>getRelatedAlarms</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @Transient
+    public Set<OnmsAlarm> getRelatedAlarms() {
+        return m_associatedAlarms.stream().map(AlarmAssociation::getRelatedAlarm).collect(Collectors.toSet());
+    }
+
+    @Transient
+    public Set<Integer> getRelatedAlarmIds() {
+        return getRelatedAlarms().stream()
+                .map(OnmsAlarm::getId)
+                .collect(Collectors.toSet());
+    }
+
+    @OneToMany(mappedBy = "situationAlarm", orphanRemoval = true, cascade = CascadeType.ALL)
+    public Set<AlarmAssociation> getAssociatedAlarms() {
+        return m_associatedAlarms;
+    }
+
+    public void setAssociatedAlarms(Set<AlarmAssociation> alarms) {
+        m_associatedAlarms = alarms;
+        m_situation = !m_associatedAlarms.isEmpty();
+    }
+
+    public void setRelatedAlarms(Set<OnmsAlarm> alarms) {
+        m_associatedAlarms.clear();
+        alarms.forEach(relatedAlarm -> m_associatedAlarms.add(new AlarmAssociation(this, relatedAlarm)));
+        m_situation = !m_associatedAlarms.isEmpty();
+    }
+
+    public void setRelatedAlarms(Set<OnmsAlarm> alarms, Date associationEventTime) {
+        m_associatedAlarms.clear();
+        alarms.forEach(relatedAlarm -> m_associatedAlarms.add(new AlarmAssociation(this, relatedAlarm, associationEventTime)));
+        m_situation = !m_associatedAlarms.isEmpty();
+    }
+
+    public void addRelatedAlarm(OnmsAlarm alarm) {
+        m_associatedAlarms.add(new AlarmAssociation(this, alarm));
+        m_situation = !m_associatedAlarms.isEmpty();
+    }
+
+    public void removeRelatedAlarm(OnmsAlarm alarm) {
+        m_associatedAlarms.removeIf(associatedAlarm -> associatedAlarm.getRelatedAlarm().getId().equals(alarm.getId()));
+        m_situation = !m_associatedAlarms.isEmpty();
+    }
+
+    public void removeRelatedAlarmWithId(Integer relatedAlarmId) {
+        m_associatedAlarms.removeIf(associatedAlarm -> associatedAlarm.getRelatedAlarm().getId().equals(relatedAlarmId));
+        m_situation = !m_associatedAlarms.isEmpty();
+    }
+
+    @Formula(value = "(SELECT COUNT(*)>0 FROM ALARM_SITUATIONS S WHERE S.SITUATION_ID=ALARMID)")
+    public boolean isSituation() {
+        return m_situation;
+    }
+
+    public void setSituation(final boolean situation) {
+        m_situation = situation;
+    }
+
+    @Formula(value = "(SELECT COUNT(*)>0 FROM ALARM_SITUATIONS S WHERE S.RELATED_ALARM_ID=ALARMID)")
+    public boolean isPartOfSituation() {
+        return m_partOfSituation;
+    }
+
+    public void setPartOfSituation(final boolean partOfSituation) {
+        m_partOfSituation = partOfSituation;
+    }
+
+    @ElementCollection
+    @JoinTable(name = "alarm_situations", joinColumns = @JoinColumn(name = "related_alarm_id"), inverseJoinColumns = @JoinColumn(name = "situation_id"))
+    @Column(name="alarm_id", nullable=false)
+    public Set<OnmsAlarm> getRelatedSituations() {
+        return m_relatedSituations;
+    }
+
+    @Transient
+    public Set<Integer> getRelatedSituationIds() {
+        return getRelatedSituations().stream()
+                .map(OnmsAlarm::getId)
+                .collect(Collectors.toSet());
+    }
+
+    public void setRelatedSituations(Set<OnmsAlarm> alarms) {
+        m_relatedSituations = alarms;
+        m_partOfSituation = !m_relatedSituations.isEmpty();
+    }
+
+    @Transient
+    public Integer getAffectedNodeCount() {
+        if (m_associatedAlarms == null || m_associatedAlarms.isEmpty()) {
+            return m_node == null ? 0 : 1;
+        }
+        Set<Integer> nodes = getRelatedAlarms().stream().map(OnmsAlarm::getNode).filter(Objects::nonNull).map(OnmsNode::getId).collect(Collectors.toSet());
+        // count the Situation's node if it is different
+        if (m_node != null) {
+            nodes.add(m_node.getId());
+        }
+        return nodes.size();
+    }
+
+    @Transient
+    public Date getLastUpdateTime() {
+        if (getLastAutomationTime() != null && getLastAutomationTime().compareTo(getLastEventTime()) > 0) {
+            return getLastAutomationTime();
+        }
+        return getLastEventTime();
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsCategory.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsCategory.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.hibernate.annotations.Filter;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * <p>OnmsCategory class.</p>
+ */
+@Entity
+@Table(name="categories")
+@Filter(name=FilterManager.AUTH_FILTER_NAME, condition="categoryid in (select distinct cn.categoryId from category_node cn join category_node cn2 on cn.nodeid = cn2.nodeid join category_group cg on cn2.categoryId = cg.categoryId where cg.groupId in (:userGroups))")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsCategory implements Serializable, Comparable<OnmsCategory> {
+
+    private static final long serialVersionUID = 4694348093332239377L;
+
+    /** identifier field */
+    private Integer m_id;
+
+    /** persistent field */
+    private String m_name;
+
+    /** persistent field */
+    private String m_description;
+
+    private Set<String> m_authorizedGroups = new HashSet<>();
+
+    //private Set<OnmsNode> m_memberNodes;
+
+    /**
+     * <p>Constructor for OnmsCategory.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param descr a {@link java.lang.String} object.
+     */
+    public OnmsCategory(String name, String descr) {
+        m_name = name;
+        m_description = descr;
+    }
+
+    /**
+     * default constructor
+     */
+    public OnmsCategory() {
+    }
+
+    /**
+     * <p>Constructor for OnmsCategory.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
+    public OnmsCategory(String name) {
+        this();
+        setName(name);
+    }
+
+    /**
+     * <p>getId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @Column(name="categoryid", nullable=false)
+    @SequenceGenerator(name="categorySequence", sequenceName="catNxtId")
+    @GeneratedValue(generator="categorySequence")
+    public Integer getId() {
+        return m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param id a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer id) {
+        m_id = id;
+    }
+
+    /**
+     * <p>getName</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="categoryName", unique=true, nullable=false)
+    public String getName() {
+        return m_name;
+    }
+
+    /**
+     * <p>setName</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
+    public void setName(String name) {
+        m_name = name;
+    }
+
+    /**
+     * <p>getDescription</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="categoryDescription")
+    public String getDescription() {
+        return m_description;
+    }
+
+    /**
+     * <p>setDescription</p>
+     *
+     * @param description a {@link java.lang.String} object.
+     */
+    public void setDescription(String description) {
+        m_description = description;
+    }
+
+    /**
+     * <p>getAuthorizedGroups</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @ElementCollection
+    @JoinTable(name="category_group", joinColumns=@JoinColumn(name="categoryId"))
+    @Column(name="groupId", nullable=false, length=64)
+    public Set<String> getAuthorizedGroups() {
+        return m_authorizedGroups;
+    }
+
+    /**
+     * <p>setAuthorizedGroups</p>
+     *
+     * @param authorizedGroups a {@link java.util.Set} object.
+     */
+    public void setAuthorizedGroups(Set<String> authorizedGroups) {
+        m_authorizedGroups = authorizedGroups;
+    }
+
+    /*
+    @ManyToMany(mappedBy="categories")
+    public Set<OnmsNode> getMemberNodes() {
+        return m_memberNodes;
+    }
+
+    public void setMemberNodes(Set<OnmsNode> memberNodes) {
+        m_memberNodes = memberNodes;
+    }
+    */
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("id", getId())
+            .add("name", getName())
+            .add("description", getDescription())
+            .add("authorizedGroups", getAuthorizedGroups())
+            .toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof OnmsCategory) {
+            OnmsCategory t = (OnmsCategory)obj;
+            return m_name.equals(t.m_name);
+        }
+        return false;
+    }
+
+    /**
+     * <p>hashCode</p>
+     *
+     * @return a int.
+     */
+    @Override
+    public int hashCode() {
+        return m_name.hashCode();
+    }
+
+    /**
+     * <p>compareTo</p>
+     *
+     * @param o a {@link org.opennms.netmgt.model.OnmsCategory} object.
+     * @return a int.
+     */
+    @Override
+    public int compareTo(OnmsCategory o) {
+        return m_name.compareToIgnoreCase(o.m_name);
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsCategory.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsCategory.java
@@ -98,7 +98,7 @@ public class OnmsCategory implements Serializable, Comparable<OnmsCategory> {
      */
     @Id
     @Column(name="categoryid", nullable=false)
-    @SequenceGenerator(name="categorySequence", sequenceName="catNxtId")
+    @SequenceGenerator(name="categorySequence", sequenceName="catNxtId", allocationSize = 1)
     @GeneratedValue(generator="categorySequence")
     public Integer getId() {
         return m_id;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsDistPoller.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsDistPoller.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+/**
+ * Represents an OpenNMS Distributed Poller.
+ */
+@Entity
+@DiscriminatorValue(OnmsMonitoringSystem.TYPE_OPENNMS)
+public class OnmsDistPoller extends OnmsMonitoringSystem implements Serializable {
+
+    private static final long serialVersionUID = -1094353783612066524L;
+
+    /**
+     * default constructor
+     */
+    public OnmsDistPoller() {}
+
+    /**
+     * minimal constructor
+     *
+     * @param id a {@link java.lang.String} object.
+     */
+    public OnmsDistPoller(String id) {
+        // org.opennms.netmgt.dao.api.MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID
+        super(id, "Default");
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
@@ -1,0 +1,724 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.hibernate.annotations.Cascade;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.events.AddEventVisitor;
+import org.opennms.netmgt.model.events.DeleteEventVisitor;
+import org.opennms.netmgt.model.jakarta.converter.InetAddressConverter;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * <p>OnmsIpInterface class.</p>
+ */
+@Entity
+@Table(name="ipInterface")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsIpInterface extends OnmsEntity implements Serializable {
+    private static final long serialVersionUID = 8463903013592837114L;
+
+    private Integer m_id;
+
+    private InetAddress m_ipAddress;
+
+    private InetAddress m_netMask;
+
+    private String m_ipHostName;
+
+    private String m_isManaged;
+
+    private PrimaryType m_isSnmpPrimary = PrimaryType.NOT_ELIGIBLE;
+
+    private Date m_ipLastCapsdPoll;
+
+    private OnmsNode m_node;
+
+    private Set<OnmsMonitoredService> m_monitoredServices = new LinkedHashSet<>();
+
+    private OnmsSnmpInterface m_snmpInterface;
+
+    private List<OnmsMetaData> m_metaData = new ArrayList<>();
+
+    private List<OnmsMetaData> m_requisitionedMetaData = new ArrayList<>();
+
+    /**
+     * <p>Constructor for OnmsIpInterface.</p>
+     */
+    public OnmsIpInterface() {
+    }
+
+    /**
+     * minimal constructor
+     * @deprecated Use the {@link InetAddress} version instead.
+     * @param ipAddr a {@link java.lang.String} object.
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public OnmsIpInterface(String ipAddr, OnmsNode node) {
+        this(InetAddressUtils.getInetAddress(ipAddr), node);
+    }
+
+    /**
+     * minimal constructor
+     *
+     * @param ipAddr a {@link java.net.InetAddress} object.
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public OnmsIpInterface(InetAddress ipAddr, OnmsNode node) {
+        m_ipAddress = ipAddr;
+        m_node = node;
+        if (node != null) {
+            node.getIpInterfaces().add(this);
+        }
+    }
+
+    /**
+     * Unique identifier for ipInterface.
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @Column(nullable=false)
+    @SequenceGenerator(name="opennmsSequence", sequenceName="opennmsNxtId")
+    @GeneratedValue(generator="opennmsSequence")
+    public Integer getId() {
+        return m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param id a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer id) {
+        m_id = id;
+    }
+
+    /**
+     * <p>getInterfaceId</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public String getInterfaceId() {
+        return getId() == null? null : getId().toString();
+    }
+
+    public void setInterfaceId(final String id) {
+        setId(Integer.valueOf(id));
+    }
+
+    @Transient
+    public Date getLastIngressFlow() {
+        if (m_snmpInterface == null) {
+            return null;
+        }
+        return m_snmpInterface.getLastIngressFlow();
+    }
+
+    @Transient
+    public Date getLastEgressFlow() {
+        if (m_snmpInterface == null) {
+            return null;
+        }
+        return m_snmpInterface.getLastEgressFlow();
+    }
+
+    /**
+     * <p>getIpAddressAsString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     * @deprecated
+     */
+    @Transient
+    public String getIpAddressAsString() {
+        return InetAddressUtils.toIpAddrString(m_ipAddress);
+    }
+
+    /**
+     * <p>getIfIndex</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    public Integer getIfIndex() {
+        if (m_snmpInterface == null) {
+            return null;
+        }
+        return m_snmpInterface.getIfIndex();
+    }
+
+    /**
+     * <p>setIfIndex</p>
+     *
+     * @param ifindex a {@link java.lang.Integer} object.
+     */
+    public void setIfIndex(Integer ifindex) {
+        if (m_snmpInterface == null) {
+            throw new IllegalStateException("Cannot set ifIndex if snmpInterface relation isn't setup");
+        }
+        m_snmpInterface.setIfIndex(ifindex);
+    }
+
+    /**
+     * <p>getIpHostName</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="ipHostName", length=256)
+    public String getIpHostName() {
+        return m_ipHostName;
+    }
+
+    /**
+     * <p>setIpHostName</p>
+     *
+     * @param iphostname a {@link java.lang.String} object.
+     */
+    public void setIpHostName(String iphostname) {
+        m_ipHostName = iphostname;
+    }
+
+    /**
+     * <p>getIsManaged</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="isManaged", length=1)
+    public String getIsManaged() {
+        return m_isManaged;
+    }
+
+    /**
+     * <p>setIsManaged</p>
+     *
+     * @param ismanaged a {@link java.lang.String} object.
+     */
+    public void setIsManaged(String ismanaged) {
+        m_isManaged = ismanaged;
+    }
+
+    /**
+     * <p>isManaged</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isManaged() {
+        return "M".equals(getIsManaged());
+    }
+
+    /**
+     * <p>getIpLastCapsdPoll</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="ipLastCapsdPoll")
+    public Date getIpLastCapsdPoll() {
+        return m_ipLastCapsdPoll;
+    }
+
+    /**
+     * <p>setIpLastCapsdPoll</p>
+     *
+     * @param iplastcapsdpoll a {@link java.util.Date} object.
+     */
+    public void setIpLastCapsdPoll(Date iplastcapsdpoll) {
+        m_ipLastCapsdPoll = iplastcapsdpoll;
+    }
+
+    /**
+     * Returns the snmpPrimary value as a single character code.
+     * The CharacterUserType is replaced by the getter/setter logic — no @Convert needed
+     * since this getter returns a String directly.
+     */
+    @Column(name="isSnmpPrimary", length=1)
+    public String getSnmpPrimary() {
+        final PrimaryType type = m_isSnmpPrimary == null? PrimaryType.NOT_ELIGIBLE : m_isSnmpPrimary;
+        return type.getCode();
+    }
+
+    public void setSnmpPrimary(final String primary) {
+        this.m_isSnmpPrimary = PrimaryType.get(primary);
+    }
+
+    /**
+     * <p>getIsSnmpPrimary</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.PrimaryType} object.
+     */
+    @Transient
+    public PrimaryType getIsSnmpPrimary() {
+        return m_isSnmpPrimary == null? PrimaryType.NOT_ELIGIBLE : m_isSnmpPrimary;
+    }
+
+    /**
+     * <p>setIsSnmpPrimary</p>
+     *
+     * @param issnmpprimary a {@link org.opennms.netmgt.model.PrimaryType} object.
+     */
+    public void setIsSnmpPrimary(PrimaryType issnmpprimary) {
+        m_isSnmpPrimary = issnmpprimary;
+    }
+
+    /**
+     * <p>isPrimary</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isPrimary(){
+        return PrimaryType.PRIMARY.equals(m_isSnmpPrimary);
+    }
+
+    @Transient
+    public List<OnmsMetaData> getRequisitionedMetaData() {
+        return m_requisitionedMetaData;
+    }
+
+    public void setRequisionedMetaData(final List<OnmsMetaData> requisitionedMetaData) {
+        m_requisitionedMetaData = requisitionedMetaData;
+    }
+
+    public void addRequisionedMetaData(final OnmsMetaData onmsMetaData) {
+        m_requisitionedMetaData.add(onmsMetaData);
+    }
+
+    @JsonIgnore
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name="ipInterface_metadata", joinColumns = @JoinColumn(name = "id"))
+    public List<OnmsMetaData> getMetaData() {
+        return m_metaData;
+    }
+
+    public void setMetaData(final List<OnmsMetaData> metaData) {
+        m_metaData = metaData;
+    }
+
+    public void addMetaData(final String context, final String key, final String value) {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+
+        final Optional<OnmsMetaData> entry = getMetaData().stream()
+                .filter(m -> m.getContext().equals(context))
+                .filter(m -> m.getKey().equals(key))
+                .findFirst();
+
+        // Update the value if present, otherwise create a new entry
+        if (entry.isPresent()) {
+            entry.get().setValue(value);
+        } else {
+            getMetaData().add(new OnmsMetaData(context, key, value));
+        }
+    }
+
+    public void removeMetaData(final String context, final String key) {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(key);
+        final Iterator<OnmsMetaData> iterator = getMetaData().iterator();
+
+        while (iterator.hasNext()) {
+            final OnmsMetaData onmsNodeMetaData = iterator.next();
+
+            if (context.equals(onmsNodeMetaData.getContext()) && key.equals(onmsNodeMetaData.getKey())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public void removeMetaData(final String context) {
+        Objects.requireNonNull(context);
+        final Iterator<OnmsMetaData> iterator = getMetaData().iterator();
+
+        while (iterator.hasNext()) {
+            final OnmsMetaData onmsNodeMetaData = iterator.next();
+
+            if (context.equals(onmsNodeMetaData.getContext())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
+     * <p>getNode</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    @ManyToOne(optional=false, fetch=FetchType.LAZY)
+    @JoinColumn(name="nodeId")
+    public OnmsNode getNode() {
+        return m_node;
+    }
+
+    /**
+     * <p>setNode</p>
+     *
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void setNode(org.opennms.netmgt.model.OnmsNode node) {
+        m_node = node;
+    }
+
+    @Transient
+    public Integer getNodeId() {
+        if (m_node != null) {
+            return m_node.getId();
+        }
+        return null;
+    }
+
+    /**
+     * The services on this interface
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @OneToMany(mappedBy="ipInterface",orphanRemoval=true)
+    @Cascade(org.hibernate.annotations.CascadeType.ALL)
+    public Set<OnmsMonitoredService> getMonitoredServices() {
+        return m_monitoredServices ;
+    }
+
+    /**
+     * <p>setMonitoredServices</p>
+     *
+     * @param ifServices a {@link java.util.Set} object.
+     */
+    public void setMonitoredServices(Set<OnmsMonitoredService> ifServices) {
+        m_monitoredServices = ifServices;
+    }
+
+    public void addMonitoredService(final OnmsMonitoredService svc) {
+        m_monitoredServices.add(svc);
+    }
+
+    public void removeMonitoredService(final OnmsMonitoredService svc) {
+        m_monitoredServices.remove(svc);
+    }
+
+    /**
+     * The SnmpInterface associated with this interface if any
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsSnmpInterface} object.
+     */
+    @ManyToOne(optional=true, fetch=FetchType.LAZY)
+    @JoinColumn(name="snmpInterfaceId")
+    public OnmsSnmpInterface getSnmpInterface() {
+        return m_snmpInterface;
+    }
+
+    /**
+     * <p>setSnmpInterface</p>
+     *
+     * @param snmpInterface a {@link org.opennms.netmgt.model.OnmsSnmpInterface} object.
+     */
+    public void setSnmpInterface(OnmsSnmpInterface snmpInterface) {
+        m_snmpInterface = snmpInterface;
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+        .add("id", m_id)
+        .add("ipAddr", InetAddressUtils.str(m_ipAddress))
+        .add("netMask", InetAddressUtils.str(m_netMask))
+        .add("ipHostName", m_ipHostName)
+        .add("isManaged", m_isManaged)
+        .add("snmpPrimary", m_isSnmpPrimary)
+        .add("ipLastCapsdPoll", m_ipLastCapsdPoll)
+        .add("nodeId", getNodeId())
+        .toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visit(EntityVisitor visitor) {
+        visitor.visitIpInterface(this);
+
+        for (OnmsMonitoredService monSvc : getMonitoredServices()) {
+            monSvc.visit(visitor);
+        }
+
+        visitor.visitIpInterfaceComplete(this);
+    }
+
+    /**
+     * <p>getIpAddress</p>
+     *
+     * @return a {@link java.net.InetAddress} object.
+     */
+    @Column(name="ipAddr")
+    @Convert(converter = InetAddressConverter.class)
+    public InetAddress getIpAddress() {
+        return m_ipAddress;
+    }
+
+    /**
+     * <p>setIpAddress</p>
+     *
+     * @param ipaddr a {@link java.net.InetAddress} object.
+     */
+    public void setIpAddress(InetAddress ipaddr) {
+        m_ipAddress = ipaddr;
+    }
+
+    @Column(name = "netmask")
+    @Convert(converter = InetAddressConverter.class)
+    public InetAddress getNetMask() {
+        return m_netMask;
+    }
+
+    public void setNetMask(final InetAddress netMask) {
+        m_netMask = netMask;
+    }
+
+    /**
+     * <p>isDown</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isDown() {
+        boolean down = true;
+        for (OnmsMonitoredService svc : m_monitoredServices) {
+            if (!svc.isDown()) {
+                return !down;
+            }
+        }
+        return down;
+    }
+
+    @Transient
+    public int getMonitoredServiceCount() {
+        return m_monitoredServices.size();
+    }
+
+    /**
+     * <p>getMonitoredServiceByServiceType</p>
+     *
+     * @param svcName a {@link java.lang.String} object.
+     * @return a {@link org.opennms.netmgt.model.OnmsMonitoredService} object.
+     */
+    @JsonIgnore
+    public OnmsMonitoredService getMonitoredServiceByServiceType(String svcName) {
+        for (OnmsMonitoredService monSvc : getMonitoredServices()) {
+            if (monSvc.getServiceType().getName().equals(svcName)) {
+                return monSvc;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>mergeInterfaceAttributes</p>
+     *
+     * @param scannedIface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    public void mergeInterfaceAttributes(OnmsIpInterface scannedIface) {
+
+        if (hasNewValue(scannedIface.getIfIndex(), getIfIndex())) {
+            setIfIndex(scannedIface.getIfIndex());
+        }
+
+        if (hasNewValue(scannedIface.getNetMask(), getNetMask())) {
+            setNetMask(scannedIface.getNetMask());
+        }
+
+        if (hasNewValue(scannedIface.getIsManaged(), getIsManaged())) {
+            setIsManaged(scannedIface.getIsManaged());
+        }
+
+        if (hasNewCollectionTypeValue(scannedIface.getIsSnmpPrimary(), getIsSnmpPrimary())) {
+            setIsSnmpPrimary(scannedIface.getIsSnmpPrimary());
+        }
+
+        if (hasNewValue(scannedIface.getIpHostName(), getIpHostName())) {
+            setIpHostName(scannedIface.getIpHostName());
+        }
+
+        if (hasNewValue(scannedIface.getIpLastCapsdPoll(), getIpLastCapsdPoll())) {
+            setIpLastCapsdPoll(scannedIface.getIpLastCapsdPoll());
+        }
+    }
+
+    /**
+     * <p>hasNewCollectionTypeValue</p>
+     *
+     * @param newVal a {@link org.opennms.netmgt.model.PrimaryType} object.
+     * @param existingVal a {@link org.opennms.netmgt.model.PrimaryType} object.
+     * @return a boolean.
+     */
+    protected static boolean hasNewCollectionTypeValue(PrimaryType newVal, PrimaryType existingVal) {
+        return newVal != null && !newVal.equals(existingVal) && newVal != PrimaryType.NOT_ELIGIBLE;
+    }
+
+    /**
+     * <p>mergeMonitoredServices</p>
+     *
+     * @param scannedIface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     * @param eventForwarder a {@link org.opennms.netmgt.events.api.EventForwarder} object.
+     * @param deleteMissing a boolean.
+     */
+    public void mergeMonitoredServices(OnmsIpInterface scannedIface, EventForwarder eventForwarder, boolean deleteMissing) {
+
+        // create map of services to serviceType
+        Map<OnmsServiceType, OnmsMonitoredService> serviceTypeMap = new HashMap<OnmsServiceType, OnmsMonitoredService>();
+        for (OnmsMonitoredService svc : scannedIface.getMonitoredServices()) {
+            serviceTypeMap.put(svc.getServiceType(), svc);
+        }
+
+        // for each service in the database
+        for (Iterator<OnmsMonitoredService> it = getMonitoredServices().iterator(); it.hasNext();) {
+            OnmsMonitoredService svc = it.next();
+
+            // find the corresponding scanned service
+            OnmsMonitoredService imported = serviceTypeMap.get(svc.getServiceType());
+            if (imported == null) {
+                if (deleteMissing) {
+                    // there is no scanned service... delete it from the database
+                    it.remove();
+                    svc.visit(new DeleteEventVisitor(eventForwarder));
+                }
+            }
+            else {
+                // otherwise update the service attributes
+                svc.mergeServiceAttributes(imported);
+                svc.mergeMetaData(imported);
+            }
+
+            // mark the service is updated
+            serviceTypeMap.remove(svc.getServiceType());
+        }
+
+        // for any services not found in the database, add them
+        Collection<OnmsMonitoredService> newServices = serviceTypeMap.values();
+        for (OnmsMonitoredService svc : newServices) {
+            svc.setIpInterface(this);
+            getMonitoredServices().add(svc);
+            svc.visit(new AddEventVisitor(eventForwarder));
+        }
+    }
+
+    public void mergeMetaData(OnmsIpInterface scanned) {
+        if (!getMetaData().equals(scanned.getMetaData())) {
+            setMetaData(scanned.getMetaData());
+        }
+    }
+
+    /**
+     * <p>updateSnmpInterface</p>
+     *
+     * @param scannedIface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    public void updateSnmpInterface(OnmsIpInterface scannedIface) {
+
+        if (!hasNewValue(scannedIface.getIfIndex(), getIfIndex())) {
+            /* no ifIndex in currently scanned interface so don't bother
+             * we must have failed to collect data
+             */
+            return;
+        }
+
+        if (scannedIface.getSnmpInterface() == null) {
+            // there is no longer an snmpInterface associated with the ipInterface
+            setSnmpInterface(null);
+        } else {
+            // locate the snmpInterface on this node that has the new ifIndex and set it
+            // into the interface
+            OnmsSnmpInterface snmpIface = getNode().getSnmpInterfaceWithIfIndex(scannedIface.getIfIndex());
+            setSnmpInterface(snmpIface);
+        }
+    }
+
+    /**
+     * <p>mergeInterface</p>
+     *
+     * @param scannedIface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     * @param eventForwarder a {@link org.opennms.netmgt.events.api.EventForwarder} object.
+     * @param deleteMissing a boolean.
+     */
+    public void mergeInterface(OnmsIpInterface scannedIface, EventForwarder eventForwarder, boolean deleteMissing) {
+        updateSnmpInterface(scannedIface);
+        mergeInterfaceAttributes(scannedIface);
+        mergeMonitoredServices(scannedIface, eventForwarder, deleteMissing);
+        mergeMetaData(scannedIface);
+    }
+
+    @Transient
+    @JsonIgnore
+    public String getForeignSource() {
+        if (getNode() != null) {
+            return getNode().getForeignSource();
+        }
+        return null;
+    }
+
+    @Transient
+    @JsonIgnore
+    public String getForeignId() {
+        if (getNode() != null) {
+            return getNode().getForeignId();
+        }
+        return null;
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
@@ -339,9 +339,9 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
         m_requisitionedMetaData.add(onmsMetaData);
     }
 
+    // OnmsMetaData is not yet migrated to Jakarta Persistence (@Embeddable).
+    @Transient
     @JsonIgnore
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name="ipInterface_metadata", joinColumns = @JoinColumn(name = "id"))
     public List<OnmsMetaData> getMetaData() {
         return m_metaData;
     }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
@@ -133,7 +133,7 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
      */
     @Id
     @Column(nullable=false)
-    @SequenceGenerator(name="opennmsSequence", sequenceName="opennmsNxtId")
+    @SequenceGenerator(name="opennmsSequence", sequenceName="opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator="opennmsSequence")
     public Integer getId() {
         return m_id;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMemo.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMemo.java
@@ -59,7 +59,7 @@ public class OnmsMemo implements Serializable {
 
     @Id
     @Column(name = "id", nullable = false)
-    @SequenceGenerator(name = "memoSequence", sequenceName = "memoNxtId")
+    @SequenceGenerator(name = "memoSequence", sequenceName = "memoNxtId", allocationSize = 1)
     @GeneratedValue(generator = "memoSequence")
     private Integer m_id;
 

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMemo.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMemo.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * <p>Generic memo for any element inside OpenNMS</p>
+ *
+ * @author <a href="mailto:Markus@OpenNMS.com">Markus Neumann</a>
+ */
+@Entity
+@Table(name = "memos")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name="type", discriminatorType= DiscriminatorType.STRING)
+@DiscriminatorValue(value="Memo")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsMemo implements Serializable {
+
+    private static final long serialVersionUID = 7272348439687562161L;
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @SequenceGenerator(name = "memoSequence", sequenceName = "memoNxtId")
+    @GeneratedValue(generator = "memoSequence")
+    private Integer m_id;
+
+    @Column(name = "body")
+    private String m_body;
+
+    @Column(name = "author")
+    private String m_author;
+
+    @Column(name = "updated")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date m_updated;
+
+    @Column(name = "created")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date m_created;
+
+    @PreUpdate
+    private void preUpdate() {
+        m_updated = new Date();
+    }
+
+    @PrePersist
+    private void prePersist() {
+        m_created = new Date();
+    }
+
+    public String getBody() {
+        return m_body;
+    }
+
+    public void setBody(String body) {
+        this.m_body = body;
+    }
+
+    public Date getCreated() {
+        return m_created;
+    }
+
+    public Integer getId() {
+        return m_id;
+    }
+
+    public void setId(final Integer id) {
+        m_id = id;
+    }
+
+    public Date getUpdated() {
+        return m_updated;
+    }
+
+    public void setCreated(Date created) {
+        this.m_created = created;
+    }
+
+    public void setUpdated(Date updated) {
+        this.m_updated = updated;
+    }
+
+    public String getAuthor() {
+        return m_author;
+    }
+
+    public void setAuthor(String author) {
+        this.m_author = author;
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
@@ -1,0 +1,667 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import static org.opennms.core.utils.InetAddressUtils.toInteger;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.annotations.SQLRestriction;
+
+import com.google.common.base.MoreObjects;
+
+@Entity
+@Table(name="ifServices")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsMonitoredService extends OnmsEntity implements Serializable, Comparable<OnmsMonitoredService> {
+    private static final long serialVersionUID = 7899180234592272274L;
+
+    private Integer m_id;
+
+    private Date m_lastGood;
+
+    private Date m_lastFail;
+
+    private String m_qualifier;
+
+    private String m_status;
+
+    private String m_source;
+
+    private String m_notify;
+
+    private OnmsServiceType m_serviceType;
+
+    private OnmsIpInterface m_ipInterface;
+
+    /*
+     * This is a set only because we want it to be lazy
+     * and we need a better query language (i.e. HQL)
+     * to make this work.  In this case, the Set size
+     * will always be 1 or empty because there can only
+     * be one outage at a time on a service.
+     *
+     * With distributed monitoring, there will probably
+     * be a model change were one service can be represented
+     * by more than one outage.
+     */
+    private Set<OnmsOutage> m_currentOutages = new LinkedHashSet<>();
+
+    private Set<OnmsApplication> m_applications = new LinkedHashSet<>();
+
+    private List<OnmsMetaData> m_metaData = new ArrayList<>();
+
+    public static final Map<String, String> STATUS_MAP;
+
+    static {
+        STATUS_MAP = new HashMap<String, String>();
+        STATUS_MAP.put("A", "Managed");
+        STATUS_MAP.put("U", "Unmanaged");
+        STATUS_MAP.put("D", "Deleted");
+        STATUS_MAP.put("F", "Forced Unmanaged");
+        STATUS_MAP.put("N", "Not Monitored");
+        STATUS_MAP.put("R", "Rescan to Resume");
+        STATUS_MAP.put("S", "Rescan to Suspend");
+        STATUS_MAP.put("X", "Remotely Monitored");
+    }
+
+    /**
+     * <p>Constructor for OnmsMonitoredService.</p>
+     */
+    public OnmsMonitoredService() {
+    }
+
+    /**
+     * <p>Constructor for OnmsMonitoredService.</p>
+     *
+     * @param ipIf a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     * @param serviceType a {@link org.opennms.netmgt.model.OnmsServiceType} object.
+     */
+    public OnmsMonitoredService(OnmsIpInterface ipIf, OnmsServiceType serviceType) {
+        m_ipInterface = ipIf;
+        m_ipInterface.getMonitoredServices().add(this);
+        m_serviceType = serviceType;
+    }
+
+    /**
+     * Unique identifier for ifService.
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @Column(nullable=false)
+    @SequenceGenerator(name="opennmsSequence", sequenceName="opennmsNxtId")
+    @GeneratedValue(generator="opennmsSequence")
+    public Integer getId() {
+        return m_id;
+    }
+
+    @Transient
+    @JsonProperty("id")
+    public Integer getJsonId() {
+        return m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param id a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer id) {
+        m_id = id;
+    }
+
+    /**
+     * This id is used for the serialized representation such as json, xml etc.
+     */
+    @Transient
+    @JsonIgnore
+    public String getXmlId() {
+        return getId() == null? null : getId().toString();
+    }
+
+    public void setXmlId(final String id) {
+        setId(Integer.valueOf(id));
+    }
+
+    /**
+     * <p>getIpAddress</p>
+     *
+     * @return a {@link java.net.InetAddress} object.
+     */
+    @Transient
+    @JsonIgnore
+    public InetAddress getIpAddress() {
+        return m_ipInterface.getIpAddress();
+    }
+
+    /**
+     * <p>getIpAddressAsString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     *
+     * @deprecated
+     */
+    @Transient
+    @JoinColumn(name="ipInterfaceId")
+    @JsonProperty("ipAddress")
+    public String getIpAddressAsString() {
+        return m_ipInterface.getIpAddressAsString();
+    }
+
+    /**
+     * <p>getIfIndex</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    @JsonIgnore
+    public Integer getIfIndex() {
+        return m_ipInterface.getIfIndex();
+    }
+
+    /**
+     * <p>getLastGood</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="lastGood")
+    public Date getLastGood() {
+        return m_lastGood;
+    }
+
+    /**
+     * <p>setLastGood</p>
+     *
+     * @param lastgood a {@link java.util.Date} object.
+     */
+    public void setLastGood(Date lastgood) {
+        m_lastGood = lastgood;
+    }
+
+    /**
+     * <p>getLastFail</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="lastFail")
+    public Date getLastFail() {
+        return m_lastFail;
+    }
+
+    /**
+     * <p>setLastFail</p>
+     *
+     * @param lastfail a {@link java.util.Date} object.
+     */
+    public void setLastFail(Date lastfail) {
+        m_lastFail = lastfail;
+    }
+
+    /**
+     * <p>getQualifier</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="qualifier", length=16)
+    public String getQualifier() {
+        return m_qualifier;
+    }
+
+    /**
+     * <p>setQualifier</p>
+     *
+     * @param qualifier a {@link java.lang.String} object.
+     */
+    public void setQualifier(String qualifier) {
+        m_qualifier = qualifier;
+    }
+
+    /**
+     * <p>getStatus</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="status", length=1)
+    public String getStatus() {
+        return m_status;
+    }
+
+    /**
+     * <p>setStatus</p>
+     *
+     * @param status a {@link java.lang.String} object.
+     */
+    public void setStatus(String status) {
+        m_status = status;
+    }
+
+    @Transient
+    public String getStatusLong() {
+        return STATUS_MAP.get(getStatus());
+    }
+
+    /**
+     * <p>getSource</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="source", length=1)
+    public String getSource() {
+        return m_source;
+    }
+
+    /**
+     * <p>setSource</p>
+     *
+     * @param source a {@link java.lang.String} object.
+     */
+    public void setSource(String source) {
+        m_source = source;
+    }
+
+    /**
+     * <p>getNotify</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="notify", length=1)
+    public String getNotify() {
+        return m_notify;
+    }
+
+    /**
+     * <p>setNotify</p>
+     *
+     * @param notify a {@link java.lang.String} object.
+     */
+    public void setNotify(String notify) {
+        m_notify = notify;
+    }
+
+    @JsonIgnore
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name="ifServices_metadata", joinColumns = @JoinColumn(name = "id"))
+    public List<OnmsMetaData> getMetaData() {
+        return m_metaData;
+    }
+
+    public void setMetaData(final List<OnmsMetaData> metaData) {
+        m_metaData = metaData;
+    }
+
+    public void addMetaData(final String context, final String key, final String value) {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+
+        final Optional<OnmsMetaData> entry = getMetaData().stream()
+                .filter(m -> m.getContext().equals(context))
+                .filter(m -> m.getKey().equals(key))
+                .findFirst();
+
+        // Update the value if present, otherwise create a new entry
+        if (entry.isPresent()) {
+            entry.get().setValue(value);
+        } else {
+            getMetaData().add(new OnmsMetaData(context, key, value));
+        }
+    }
+
+    public void removeMetaData(final String context, final String key) {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(key);
+        final Iterator<OnmsMetaData> iterator = getMetaData().iterator();
+
+        while (iterator.hasNext()) {
+            final OnmsMetaData onmsNodeMetaData = iterator.next();
+
+            if (context.equals(onmsNodeMetaData.getContext()) && key.equals(onmsNodeMetaData.getKey())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public void removeMetaData(final String context) {
+        Objects.requireNonNull(context);
+        final Iterator<OnmsMetaData> iterator = getMetaData().iterator();
+
+        while (iterator.hasNext()) {
+            final OnmsMetaData onmsNodeMetaData = iterator.next();
+
+            if (context.equals(onmsNodeMetaData.getContext())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
+     * <p>getIpInterface</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    @JsonIgnore
+    @ManyToOne(optional=false, fetch=FetchType.LAZY)
+    @JoinColumn(name="ipInterfaceId")
+    public OnmsIpInterface getIpInterface() {
+        return m_ipInterface;
+    }
+
+    @JsonProperty("ipInterfaceId")
+    @Transient
+    public Integer getIpInterfaceId() {
+        return m_ipInterface.getId();
+    }
+
+    /**
+     * <p>setIpInterface</p>
+     *
+     * @param ipInterface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    public void setIpInterface(OnmsIpInterface ipInterface) {
+        m_ipInterface = ipInterface;
+    }
+
+    /**
+     * <p>getNodeId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    @JsonProperty("nodeId")
+    public Integer getNodeId() {
+        return m_ipInterface.getNode().getId();
+    }
+
+    @Transient
+    @JsonProperty("nodeLabel")
+    public String getNodeLabel() {
+        return m_ipInterface.getNode().getLabel();
+    }
+
+    /**
+     * <p>getServiceType</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsServiceType} object.
+     */
+    @ManyToOne(optional=false)
+    @JoinColumn(name="serviceId")
+    public OnmsServiceType getServiceType() {
+        return m_serviceType;
+    }
+
+    /**
+     * <p>setServiceType</p>
+     *
+     * @param service a {@link org.opennms.netmgt.model.OnmsServiceType} object.
+     */
+    public void setServiceType(OnmsServiceType service) {
+        m_serviceType = service;
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+        .add("id", m_id)
+        .add("lastGood", m_lastGood)
+        .add("lastFail", m_lastFail)
+        .add("qualifier", m_qualifier)
+        .add("status", m_status)
+        .add("source", m_source)
+        .add("notify", m_notify)
+        .add("serviceType", m_serviceType)
+        .toString();
+    }
+
+    /**
+     * <p>getServiceId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    @JsonIgnore
+    public Integer getServiceId() {
+        return getServiceType().getId();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visit(EntityVisitor visitor) {
+        visitor.visitMonitoredService(this);
+        visitor.visitMonitoredServiceComplete(this);
+    }
+
+    /**
+     * <p>getServiceName</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    @JsonIgnore
+    public String getServiceName() {
+        return getServiceType().getName();
+    }
+
+    /**
+     * <p>isDown</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isDown() {
+        boolean down = true;
+        if (!"A".equals(getStatus()) || m_currentOutages.isEmpty()) {
+            return !down;
+        }
+        return down;
+    }
+
+    /**
+     * <p>getCurrentOutages</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @OneToMany(mappedBy="monitoredService", fetch=FetchType.LAZY)
+    @SQLRestriction("ifRegainedService is null")
+    @JsonIgnore
+    public Set<OnmsOutage> getCurrentOutages() {
+        return m_currentOutages;
+    }
+
+    /**
+     * <p>setCurrentOutages</p>
+     *
+     * @param currentOutages a {@link java.util.Set} object.
+     */
+    public void setCurrentOutages(Set<OnmsOutage> currentOutages) {
+        m_currentOutages = currentOutages;
+    }
+
+    /**
+     * <p>getApplications</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @ManyToMany(
+                cascade={CascadeType.PERSIST, CascadeType.MERGE}
+    )
+    @JoinTable(
+               name="application_service_map",
+               joinColumns={@JoinColumn(name="ifserviceid")},
+               inverseJoinColumns={@JoinColumn(name="appid")}
+    )
+    @JsonIgnore
+    public Set<OnmsApplication> getApplications() {
+        return m_applications;
+    }
+
+    /**
+     * <p>setApplications</p>
+     *
+     * @param applications a {@link java.util.Set} object.
+     */
+    public void setApplications(Set<OnmsApplication> applications) {
+        m_applications = applications;
+    }
+
+    /**
+     * <p>addApplication</p>
+     *
+     * @param application a {@link org.opennms.netmgt.model.OnmsApplication} object.
+     * @return a boolean.
+     */
+    public boolean addApplication(OnmsApplication application) {
+        return getApplications().add(application);
+    }
+
+    /**
+     * <p>removeApplication</p>
+     *
+     * @param application a {@link org.opennms.netmgt.model.OnmsApplication} object.
+     * @return a boolean.
+     */
+    public boolean removeApplication(OnmsApplication application) {
+        return getApplications().remove(application);
+    }
+
+    /**
+     * <p>compareTo</p>
+     *
+     * @param o a {@link org.opennms.netmgt.model.OnmsMonitoredService} object.
+     * @return a int.
+     */
+    @Override
+    public int compareTo(OnmsMonitoredService o) {
+        int diff;
+
+        diff = getIpInterface().getNode().getLabel().compareToIgnoreCase(o.getIpInterface().getNode().getLabel());
+        if (diff != 0) {
+            return diff;
+        }
+
+        BigInteger a = toInteger(getIpAddress());
+        BigInteger b = toInteger(o.getIpAddress());
+        diff = a.compareTo(b);
+        if (diff != 0) {
+            return diff;
+        }
+
+        return getServiceName().compareToIgnoreCase(o.getServiceName());
+    }
+
+    /**
+     * <p>mergeServiceAttributes</p>
+     *
+     * @param scanned a {@link org.opennms.netmgt.model.OnmsMonitoredService} object.
+     */
+    public void mergeServiceAttributes(OnmsMonitoredService scanned) {
+
+        if (hasNewValue(scanned.getQualifier(), getQualifier())) {
+            setQualifier(scanned.getQualifier());
+        }
+
+        if (hasNewStatusValue(scanned.getStatus(), getStatus())) {
+            setStatus(scanned.getStatus());
+        }
+
+        if (hasNewValue(scanned.getSource(), getSource())) {
+            setSource(scanned.getSource());
+        }
+
+        if (hasNewValue(scanned.getNotify(), getNotify())) {
+            setNotify(scanned.getNotify());
+        }
+    }
+
+    public void mergeMetaData(OnmsMonitoredService scanned) {
+        if (!getMetaData().equals(scanned.getMetaData())) {
+            setMetaData(scanned.getMetaData());
+        }
+    }
+
+    private boolean hasNewStatusValue(String newStatus, String oldStatus) {
+        /*
+         * Don't overwrite the 'Not Monitored' in the database when provisioning the
+         * node.  The Poller will update it when scheduling it packages.
+         */
+        return !"N".equals(oldStatus) && newStatus != null && !newStatus.equals(oldStatus);
+    }
+
+    @Transient
+    @JsonIgnore
+    public String getForeignSource() {
+        if (getIpInterface() != null) {
+            return getIpInterface().getForeignSource();
+        }
+        return null;
+    }
+
+    @Transient
+    @JsonIgnore
+    public String getForeignId() {
+        if (getIpInterface() != null) {
+            return getIpInterface().getForeignId();
+        }
+        return null;
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
@@ -334,9 +334,9 @@ public class OnmsMonitoredService extends OnmsEntity implements Serializable, Co
         m_notify = notify;
     }
 
+    // OnmsMetaData is not yet migrated to Jakarta Persistence (@Embeddable).
+    @Transient
     @JsonIgnore
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name="ifServices_metadata", joinColumns = @JoinColumn(name = "id"))
     public List<OnmsMetaData> getMetaData() {
         return m_metaData;
     }
@@ -521,8 +521,9 @@ public class OnmsMonitoredService extends OnmsEntity implements Serializable, Co
      *
      * @return a {@link java.util.Set} object.
      */
-    @OneToMany(mappedBy="monitoredService", fetch=FetchType.LAZY)
-    @SQLRestriction("ifRegainedService is null")
+    // OnmsOutage is not yet migrated to Jakarta Persistence.
+    // Marked @Transient until a Jakarta OnmsOutage entity is available.
+    @Transient
     @JsonIgnore
     public Set<OnmsOutage> getCurrentOutages() {
         return m_currentOutages;
@@ -542,14 +543,9 @@ public class OnmsMonitoredService extends OnmsEntity implements Serializable, Co
      *
      * @return a {@link java.util.Set} object.
      */
-    @ManyToMany(
-                cascade={CascadeType.PERSIST, CascadeType.MERGE}
-    )
-    @JoinTable(
-               name="application_service_map",
-               joinColumns={@JoinColumn(name="ifserviceid")},
-               inverseJoinColumns={@JoinColumn(name="appid")}
-    )
+    // OnmsApplication is not yet migrated to Jakarta Persistence.
+    // Marked @Transient until a Jakarta OnmsApplication entity is available.
+    @Transient
     @JsonIgnore
     public Set<OnmsApplication> getApplications() {
         return m_applications;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
@@ -143,7 +143,7 @@ public class OnmsMonitoredService extends OnmsEntity implements Serializable, Co
      */
     @Id
     @Column(nullable=false)
-    @SequenceGenerator(name="opennmsSequence", sequenceName="opennmsNxtId")
+    @SequenceGenerator(name="opennmsSequence", sequenceName="opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator="opennmsSequence")
     public Integer getId() {
         return m_id;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoringSystem.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoringSystem.java
@@ -41,6 +41,7 @@ import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
 
 import org.hibernate.annotations.DiscriminatorOptions;
 
@@ -199,8 +200,7 @@ public class OnmsMonitoringSystem implements Serializable {
         m_lastUpdated = lastUpdated;
     }
 
-    @Column(name="last_checked_in")
-    @Temporal(TemporalType.TIMESTAMP)
+    @Transient
     public Date getLastCheckedIn() {
         return m_lastCheckedIn;
     }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoringSystem.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoringSystem.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+
+import org.hibernate.annotations.DiscriminatorOptions;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * <p>Represents an OpenNMS monitoring system that can poll status of nodes
+ * and report events that occur on the network. Examples of monitoring systems
+ * include:</p>
+ *
+ * <ul>
+ * <li>OpenNMS</li>
+ * <li>OpenNMS Remote Poller</li>
+ * <li>OpenNMS Minion</li>
+ * </ul>
+ *
+ * <p>CAUTION: Don't add final modifiers to methods here because they need to be
+ * proxyable to the child classes and Javassist doesn't override final methods.
+ *
+ * @author Seth
+ */
+@Entity
+@Table(name="monitoringSystems")
+@Inheritance(strategy=InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(
+    name="type",
+    discriminatorType=DiscriminatorType.STRING
+)
+@DiscriminatorValue("System")
+// Require all objects to have a discriminator type
+@DiscriminatorOptions(force=true)
+public class OnmsMonitoringSystem implements Serializable {
+
+    private static final long serialVersionUID = -5095710111103727832L;
+
+    public static final String TYPE_OPENNMS = "OpenNMS";
+    public static final String TYPE_MINION = "Minion";
+    public static final String TYPE_SENTINEL = "Sentinel";
+
+    private String m_id;
+
+    private String m_label;
+
+    private String m_location;
+
+    private String m_type;
+
+    private Date m_lastUpdated;
+
+    private Date m_lastCheckedIn;
+
+    private Map<String,String> m_properties = new HashMap<String,String>();
+
+    /**
+     * default constructor
+     */
+    public OnmsMonitoringSystem() {}
+
+    /**
+     * Minimal constructor.
+     *
+     * @param id a {@link java.lang.String} object.
+     * @param location a {@link java.lang.String} object.
+     */
+    public OnmsMonitoringSystem(String id, String location) {
+        m_id = id;
+        m_location = location;
+    }
+
+    /**
+     * A human-readable name for each system.
+     * Typically, the system's hostname (not fully qualified).
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Id
+    @Column(name="id", nullable=false)
+    public String getId() {
+        return m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param id a {@link java.lang.String} object.
+     */
+    public void setId(String id) {
+        m_id = id;
+    }
+
+    /**
+     * A human-readable name for each system.
+     * Typically, the system's hostname (not fully qualified).
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="label")
+    public String getLabel() {
+        return m_label;
+    }
+
+    /**
+     * @param label a {@link java.lang.String} object.
+     */
+    public void setLabel(String label) {
+        m_label = label;
+    }
+
+    /**
+     * The monitoring location that this system is located in.
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="location", nullable=false)
+    public String getLocation() {
+        return m_location;
+    }
+
+    /**
+     * @param location a {@link java.lang.String} object.
+     */
+    public void setLocation(String location) {
+        m_location = location;
+    }
+
+    /**
+     * The type of monitoring system. Mark this as insertable=false and updatable=false
+     * because it is also used as the @DiscriminatorColumn.
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="type", nullable=false, insertable=false, updatable=false)
+    public String getType() {
+        return m_type;
+    }
+
+    /**
+     * @param type a {@link java.lang.String} object.
+     */
+    public void setType(String type) {
+        m_type = type;
+    }
+
+    /**
+     * The timestamp of the last message passed from the remote system.
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Column(name="last_updated")
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date getLastUpdated() {
+        return m_lastUpdated;
+    }
+
+    public void setLastUpdated(final Date lastUpdated) {
+        m_lastUpdated = lastUpdated;
+    }
+
+    @Column(name="last_checked_in")
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date getLastCheckedIn() {
+        return m_lastCheckedIn;
+    }
+
+    public void setLastCheckedIn(final Date lastCheckedIn) {
+        m_lastCheckedIn = lastCheckedIn;
+    }
+
+    @ElementCollection
+    @JoinTable(name="monitoringSystemsProperties", joinColumns = @JoinColumn(name="monitoringSystemId"))
+    @MapKeyColumn(name="property", nullable=false)
+    @Column(name="propertyValue")
+    public Map<String, String> getProperties() {
+        return m_properties;
+    }
+
+    /**
+     * @param properties a {@link java.util.Map} object.
+     */
+    public void setProperties(Map<String, String> properties) {
+        m_properties = properties;
+    }
+
+    public void setProperty(String property, String value) {
+        m_properties.put(property, value);
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("id", getId())
+            .add("label", getLabel())
+            .add("location", getLocation())
+            .add("type", getType())
+            .toString();
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsNode.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsNode.java
@@ -1,0 +1,1609 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SecondaryTable;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import org.hibernate.annotations.Filter;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.events.AddEventVisitor;
+import org.opennms.netmgt.model.events.DeleteEventVisitor;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.model.events.NodeLabelChangedEventBuilder;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.opennms.netmgt.model.jakarta.converter.NodeLabelSourceConverter;
+import org.opennms.netmgt.model.jakarta.converter.NodeTypeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+
+
+/**
+ * Contains information on nodes discovered and potentially managed by OpenNMS.
+ * sys* properties map to SNMP MIB 2 system table information.
+ *
+ * @hibernate.class table="node"
+ */
+@Entity()
+@Table(name="node")
+@SecondaryTable(name="pathOutage")
+@Filter(name=FilterManager.AUTH_FILTER_NAME, condition="exists (select distinct x.nodeid from node x join category_node cn on x.nodeid = cn.nodeid join category_group cg on cn.categoryId = cg.categoryId where x.nodeid = nodeid and cg.groupId in (:userGroups))")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsNode extends OnmsEntity implements Serializable, Comparable<OnmsNode> {
+    private static final long serialVersionUID = 5326410037533354861L;
+    private static final Logger LOG = LoggerFactory.getLogger(OnmsNode.class);
+
+    /** identifier field */
+    private Integer m_id;
+
+    /** persistent field */
+    private Date m_createTime = new Date();
+
+    /** nullable persistent field */
+    private OnmsNode m_parent;
+
+    /** nullable persistent field */
+    private NodeType m_type;
+
+    /** nullable persistent field */
+    private String m_sysObjectId;
+
+    /** nullable persistent field */
+    private String m_sysName;
+
+    /** nullable persistent field */
+    private String m_sysDescription;
+
+    /** nullable persistent field */
+    private String m_sysLocation;
+
+    /** nullable persistent field */
+    private String m_sysContact;
+
+    /** nullable persistent field */
+    private String m_label;
+
+    /** timestamps for a flow exporting node */
+    private Date m_lastIngressFlow;
+    private Date m_lastEgressFlow;
+
+    @Transient
+    @JsonIgnore
+    private String m_oldLabel;
+
+    /** nullable persistent field */
+    private NodeLabelSource m_labelSource;
+
+    @Transient
+    @JsonIgnore
+    private NodeLabelSource m_oldLabelSource;
+
+    /** nullable persistent field */
+    private String m_netBiosName;
+
+    /** nullable persistent field */
+    private String m_netBiosDomain;
+
+    /** nullable persistent field */
+    private String m_operatingSystem;
+
+    /** nullable persistent field */
+    private Date m_lastCapsdPoll;
+
+    private String m_foreignSource;
+
+    private String m_foreignId;
+
+    /** persistent field */
+    private OnmsMonitoringLocation m_location;
+
+    /** persistent field */
+    private OnmsAssetRecord m_assetRecord;
+
+    /** persistent field */
+    private Set<OnmsIpInterface> m_ipInterfaces = new LinkedHashSet<>();
+
+    /** persistent field */
+    private Set<OnmsSnmpInterface> m_snmpInterfaces = new LinkedHashSet<>();
+
+    private Set<OnmsCategory> m_categories = new LinkedHashSet<>();
+
+    private Set<String> m_requisitionedCategories = new LinkedHashSet<>();
+
+    private PathElement m_pathElement;
+
+    private List<OnmsMetaData> m_metaData = new ArrayList<>();
+
+    private List<OnmsMetaData> m_requisitionedMetaData = new ArrayList<>();
+    private Integer nodeParentId;
+
+    /**
+     * <p>
+     * Constructor for OnmsNode. This constructor should only be used
+     * by JPA and by unit tests that do not need to persist the {@link OnmsNode}
+     * in the database. It does not associate the {@link OnmsNode} with a
+     * required {@link OnmsMonitoringLocation}.
+     * </p>
+     */
+    public OnmsNode() {
+        this(null);
+    }
+
+    /**
+     * <p>Constructor for OnmsNode.</p>
+     *
+     * @param location The location where this node is located
+     */
+    public OnmsNode(final OnmsMonitoringLocation location) {
+        // Set the location
+        setLocation(location);
+        m_assetRecord = new OnmsAssetRecord();
+        m_assetRecord.setNode(this);
+    }
+
+    /**
+     * <p>Constructor for OnmsNode.</p>
+     *
+     * @param location The location where this node is located
+     * @param label The node label
+     */
+    public OnmsNode(final OnmsMonitoringLocation location, final String label) {
+        this(location);
+        // Set the label
+        setLabel(label);
+    }
+
+    /**
+     * Unique identifier for node.
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @Column(name="nodeId", nullable=false)
+    @SequenceGenerator(name="nodeSequence", sequenceName="nodeNxtId")
+    @GeneratedValue(generator="nodeSequence")
+    @JsonIgnore
+    public Integer getId() {
+        return m_id;
+    }
+
+    /**
+     * <p>getNodeId</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public String getNodeId() {
+        if (getId() != null) {
+            return getId().toString();
+        }
+        return null;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param nodeid a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer nodeid) {
+        m_id = nodeid;
+    }
+
+    /**
+     * <p>setNodeId</p>
+     *
+     * @param nodeid a {@link java.lang.String} object.
+     */
+    public void setNodeId(String nodeid) {
+        setId(Integer.valueOf(nodeid));
+    }
+
+    /**
+     * Time node was added to the database.
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="nodeCreateTime", nullable=false)
+    public Date getCreateTime() {
+        return m_createTime;
+    }
+
+    /**
+     * <p>setCreateTime</p>
+     *
+     * @param nodecreatetime a {@link java.util.Date} object.
+     */
+    public void setCreateTime(Date nodecreatetime) {
+        m_createTime = nodecreatetime;
+    }
+
+    /**
+     * In the case that the node is virtual or an independent device in a chassis
+     * that should be reflected as a subcomponent or "child", this field reflects
+     * the nodeID of the chassis/physical node/"parent" device.
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    @JsonIgnore
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="nodeParentID")
+    public OnmsNode getParent() {
+        return m_parent;
+    }
+
+    /**
+     * <p>setParent</p>
+     *
+     * @param parent a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void setParent(OnmsNode parent) {
+        m_parent = parent;
+    }
+
+    // This already maps to the existing column, readonly
+    @Column(name = "nodeParentID",insertable = false, updatable = false)
+    public Integer getNodeParentId() {
+        return nodeParentId;
+    }
+
+    public void setNodeParentId(Integer nodeParentId) {
+        this.nodeParentId = nodeParentId;
+    }
+
+    public enum NodeType {
+        /**
+         * The character returned if the node is active
+         */
+        ACTIVE('A'),
+
+        /**
+         * The character returned if the node is deleted
+         */
+        DELETED('D'),
+
+        /**
+         * The character returned if the node type is unset/unknown.
+         */
+        UNKNOWN(' ');
+
+        private final char value;
+
+        NodeType(char c) {
+            value = c;
+        }
+
+        @JsonValue
+        public char value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static NodeType getNodeTypeFromChar(char c) {
+            for (NodeType nodeType: NodeType.values()) {
+                if (nodeType.value == c)
+                    return nodeType;
+            }
+            return null;
+        }
+
+        @JsonCreator
+        public static NodeType create(String s) {
+            if (s == null || s.length() == 0) return null;
+            for (NodeType nodeType: NodeType.values()) {
+                if (nodeType.value == s.charAt(0))
+                    return nodeType;
+            }
+            return null;
+        }
+
+    }
+
+    /**
+     * Flag indicating status of node
+     * - 'A' - active
+     * - 'D' - deleted
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeType", length=1)
+    @Convert(converter = NodeTypeConverter.class)
+    public NodeType getType() {
+        return m_type;
+    }
+
+    /**
+     * <p>setType</p>
+     *
+     * @param nodetype a {@link java.lang.String} object.
+     */
+    public void setType(NodeType nodetype) {
+        m_type = nodetype;
+    }
+
+    /**
+     * SNMP MIB-2 system.sysObjectID.0
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeSysOID", length=256)
+    public String getSysObjectId() {
+        return m_sysObjectId;
+    }
+
+    /**
+     * <p>setSysObjectId</p>
+     *
+     * @param nodesysoid a {@link java.lang.String} object.
+     */
+    public void setSysObjectId(String nodesysoid) {
+        m_sysObjectId = nodesysoid;
+    }
+
+    /**
+     * SNMP MIB-2 system.sysName.0
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeSysName", length=256)
+    public String getSysName() {
+        return m_sysName;
+    }
+
+    /**
+     * <p>setSysName</p>
+     *
+     * @param nodesysname a {@link java.lang.String} object.
+     */
+    public void setSysName(String nodesysname) {
+        m_sysName = nodesysname;
+    }
+
+    @Transient
+    public boolean getHasFlows() {
+        if (OnmsSnmpInterface.INGRESS_AND_EGRESS_REQUIRED) {
+            return getHasIngressFlows() && getHasEgressFlows();
+        } else {
+            return getHasIngressFlows() || getHasEgressFlows();
+        }
+    }
+
+    @Transient
+    public boolean getHasIngressFlows() {
+        if (m_lastIngressFlow == null) {
+            return false;
+        }
+        return (System.currentTimeMillis() - m_lastIngressFlow.getTime()) / 1000 < OnmsSnmpInterface.MAX_FLOW_AGE;
+    }
+
+    @Transient
+    public boolean getHasEgressFlows() {
+        if (m_lastEgressFlow == null) {
+            return false;
+        }
+        return (System.currentTimeMillis() - m_lastEgressFlow.getTime()) / 1000 < OnmsSnmpInterface.MAX_FLOW_AGE;
+    }
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="last_ingress_flow")
+    public Date getLastIngressFlow() {
+        return m_lastIngressFlow;
+    }
+
+    public void setLastIngressFlow(Date lastIngressFlow) {
+        this.m_lastIngressFlow = lastIngressFlow;
+    }
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="last_egress_flow")
+    public Date getLastEgressFlow() {
+        return m_lastEgressFlow;
+    }
+
+    public void setLastEgressFlow(Date lastEgressFlow) {
+        this.m_lastEgressFlow = lastEgressFlow;
+    }
+
+    /**
+     * SNMP MIB-2 system.sysDescr.0
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeSysDescription", length=256)
+    public String getSysDescription() {
+        return m_sysDescription;
+    }
+
+    /**
+     * <p>setSysDescription</p>
+     *
+     * @param nodesysdescription a {@link java.lang.String} object.
+     */
+    public void setSysDescription(String nodesysdescription) {
+        m_sysDescription = nodesysdescription;
+    }
+
+    /**
+     * SNMP MIB-2 system.sysLocation.0
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeSysLocation", length=256)
+    public String getSysLocation() {
+        return m_sysLocation;
+    }
+
+    /**
+     * <p>setSysLocation</p>
+     *
+     * @param nodesyslocation a {@link java.lang.String} object.
+     */
+    public void setSysLocation(String nodesyslocation) {
+        m_sysLocation = nodesyslocation;
+    }
+
+    /**
+     * SNMP MIB-2 system.sysContact.0
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeSysContact", length=256)
+    public String getSysContact() {
+        return m_sysContact;
+    }
+
+    /**
+     * <p>setSysContact</p>
+     *
+     * @param nodesyscontact a {@link java.lang.String} object.
+     */
+    public void setSysContact(String nodesyscontact) {
+        m_sysContact = nodesyscontact;
+    }
+
+    /**
+     * User-friendly name associated with the node.
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeLabel", length=256, nullable=false)
+    public String getLabel() {
+        return m_label;
+    }
+
+    /**
+     * <p>setLabel</p>
+     *
+     * @param nodelabel a {@link java.lang.String} object.
+     */
+    public void setLabel(final String nodelabel) {
+        if (m_label != null && m_oldLabel == null && !m_label.equals(nodelabel)) {
+            m_oldLabel = m_label;
+        }
+        m_label = nodelabel;
+    }
+
+    public enum NodeLabelSource {
+        /**
+         * Label source set by user
+         */
+        USER('U'),
+
+        /**
+         * Label source set by netbios
+         */
+        NETBIOS('N'),
+
+        /**
+         * Label source set by hostname
+         */
+        HOSTNAME('H'),
+
+        /**
+         * Label source set by SNMP sysname
+         */
+        SYSNAME('S'),
+
+        /**
+         * Label source set by IP Address
+         */
+        ADDRESS('A'),
+
+        /**
+         * Label source unset/unknown
+         */
+        UNKNOWN(' ');
+
+        private final char value;
+
+        NodeLabelSource(char c) {
+            value = c;
+        }
+
+        @JsonValue
+        public char value() {
+            return value;
+        }
+
+        @JsonCreator
+        static NodeLabelSource create(String s) {
+            if (s == null || s.length() == 0) return null;
+            for (NodeLabelSource src : NodeLabelSource.values()) {
+                if (src.value == s.charAt(0)) return src;
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
+
+    /**
+     * Flag indicating source of nodeLabel
+     * - 'U' = user defined
+     * - 'H' = IP hostname
+     * - 'S' = sysName
+     * - 'A' = IP address
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeLabelSource", length=1)
+    @Convert(converter = NodeLabelSourceConverter.class)
+    public NodeLabelSource getLabelSource() {
+        return m_labelSource;
+    }
+
+    /**
+     * <p>setLabelSource</p>
+     *
+     * @param nodelabelsource a {@link java.lang.String} object.
+     */
+    public void setLabelSource(final NodeLabelSource nodelabelsource) {
+        if (m_labelSource != nodelabelsource && m_labelSource != null && m_oldLabelSource == null) {
+            m_oldLabelSource = m_labelSource;
+        }
+        m_labelSource = nodelabelsource;
+    }
+
+    /**
+     * NetBIOS workstation name associated with the node.
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeNetBIOSName", length=16)
+    public String getNetBiosName() {
+        return m_netBiosName;
+    }
+
+    /**
+     * <p>setNetBiosName</p>
+     *
+     * @param nodenetbiosname a {@link java.lang.String} object.
+     */
+    public void setNetBiosName(String nodenetbiosname) {
+        m_netBiosName = nodenetbiosname;
+    }
+
+    /**
+     * NetBIOS domain name associated with the node.
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="nodeDomainName", length=16)
+    public String getNetBiosDomain() {
+        return m_netBiosDomain;
+    }
+
+    /**
+     * <p>setNetBiosDomain</p>
+     *
+     * @param nodedomainname a {@link java.lang.String} object.
+     */
+    public void setNetBiosDomain(String nodedomainname) {
+        m_netBiosDomain = nodedomainname;
+    }
+
+    /**
+     * Operating system running on the node.
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="operatingSystem", length=64)
+    public String getOperatingSystem() {
+        return m_operatingSystem;
+    }
+
+    /**
+     * <p>setOperatingSystem</p>
+     *
+     * @param operatingsystem a {@link java.lang.String} object.
+     */
+    public void setOperatingSystem(String operatingsystem) {
+        m_operatingSystem = operatingsystem;
+    }
+
+    /**
+     * Date and time of last Capsd scan.
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="lastCapsdPoll")
+    public Date getLastCapsdPoll() {
+        return m_lastCapsdPoll;
+    }
+
+    /**
+     * <p>setLastCapsdPoll</p>
+     *
+     * @param lastcapsdpoll a {@link java.util.Date} object.
+     */
+    public void setLastCapsdPoll(Date lastcapsdpoll) {
+        m_lastCapsdPoll = lastcapsdpoll;
+    }
+
+    /**
+     * <p>getForeignId</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="foreignId")
+    public String getForeignId() {
+        return m_foreignId;
+    }
+
+    /**
+     * <p>setForeignId</p>
+     *
+     * @param foreignId a {@link java.lang.String} object.
+     */
+    public void setForeignId(String foreignId) {
+        m_foreignId = foreignId;
+    }
+
+    /**
+     * <p>getForeignSource</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="foreignSource")
+    public String getForeignSource() {
+        return m_foreignSource;
+    }
+
+    /**
+     * <p>setForeignSource</p>
+     *
+     * @param foreignSource a {@link java.lang.String} object.
+     */
+    public void setForeignSource(String foreignSource) {
+        m_foreignSource = foreignSource;
+    }
+
+    /**
+     * Monitoring location that this node is located in.
+     */
+    @ManyToOne(optional=false, fetch=FetchType.LAZY)
+    @JoinColumn(name="location")
+    public OnmsMonitoringLocation getLocation() {
+        return m_location;
+    }
+
+    /**
+     * Set the monitoring location that this node is located in.
+     */
+    public void setLocation(OnmsMonitoringLocation location) {
+        m_location = location;
+    }
+
+    /**
+     * The assert record associated with this node
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsAssetRecord} object.
+     */
+    @OneToOne(mappedBy="node", cascade = CascadeType.ALL, fetch=FetchType.LAZY)
+    public OnmsAssetRecord getAssetRecord() {
+        return m_assetRecord;
+    }
+
+    /**
+     * <p>setAssetRecord</p>
+     *
+     * @param asset a {@link org.opennms.netmgt.model.OnmsAssetRecord} object.
+     */
+    public void setAssetRecord(OnmsAssetRecord asset) {
+        m_assetRecord = asset;
+        if (m_assetRecord != null) {
+            m_assetRecord.setNode(this);
+        }
+    }
+
+    /**
+     * <p>getPathElement</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.PathElement} object.
+     */
+    @JsonIgnore
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name="ipAddress", column=@Column(name="criticalPathIp", table="pathOutage")),
+        @AttributeOverride(name="serviceName", column=@Column(name="criticalPathServiceName", table="pathOutage"))
+    })
+    public PathElement getPathElement() {
+        return m_pathElement;
+    }
+
+    /**
+     * <p>setPathElement</p>
+     *
+     * @param pathElement a {@link org.opennms.netmgt.model.PathElement} object.
+     */
+    public void setPathElement(PathElement pathElement) {
+        m_pathElement = pathElement;
+    }
+
+
+    /**
+     * The interfaces on this node
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @JsonIgnore
+    @OneToMany(mappedBy="node",orphanRemoval=true)
+    @org.hibernate.annotations.Cascade(org.hibernate.annotations.CascadeType.ALL)
+    public Set<OnmsIpInterface> getIpInterfaces() {
+        return m_ipInterfaces;
+    }
+
+    /**
+     * <p>setIpInterfaces</p>
+     *
+     * @param ipinterfaces a {@link java.util.Set} object.
+     */
+    public void setIpInterfaces(Set<OnmsIpInterface> ipinterfaces) {
+        m_ipInterfaces = ipinterfaces;
+    }
+
+    /**
+     * <p>addIpInterface</p>
+     *
+     * @param iface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    public void addIpInterface(OnmsIpInterface iface) {
+        iface.setNode(this);
+        getIpInterfaces().add(iface);
+    }
+
+    public void removeIpInterface(final OnmsIpInterface iface) {
+        getIpInterfaces().remove(iface);
+    }
+
+    /**
+     * The information from the SNMP interfaces/ipAddrTables for the node
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @JsonIgnore
+    @OneToMany(mappedBy="node",orphanRemoval=true)
+    @org.hibernate.annotations.Cascade(org.hibernate.annotations.CascadeType.ALL)
+    public Set<OnmsSnmpInterface> getSnmpInterfaces() {
+        return m_snmpInterfaces;
+    }
+
+    /**
+     * <p>setSnmpInterfaces</p>
+     *
+     * @param snmpinterfaces a {@link java.util.Set} object.
+     */
+    public void setSnmpInterfaces(Set<OnmsSnmpInterface> snmpinterfaces) {
+        m_snmpInterfaces = snmpinterfaces;
+    }
+
+    /**
+     * <p>getCategories</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @ManyToMany(cascade={CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(
+               name="category_node",
+               joinColumns={@JoinColumn(name="nodeId")},
+               inverseJoinColumns={@JoinColumn(name="categoryId")}
+            )
+    public Set<OnmsCategory> getCategories() {
+        return m_categories;
+    }
+
+    /**
+     * <p>setCategories</p>
+     *
+     * @param categories a {@link java.util.Set} object.
+     */
+    public void setCategories(Set<OnmsCategory> categories) {
+        m_categories = categories;
+    }
+
+    /**
+     * <p>addCategory</p>
+     *
+     * @param category a {@link org.opennms.netmgt.model.OnmsCategory} object.
+     * @return a boolean.
+     */
+    public boolean addCategory(OnmsCategory category) {
+        return getCategories().add(category);
+    }
+
+    /**
+     * <p>removeCategory</p>
+     *
+     * @param category a {@link org.opennms.netmgt.model.OnmsCategory} object.
+     * @return a boolean.
+     */
+    public boolean removeCategory(OnmsCategory category) {
+        return getCategories().remove(category);
+    }
+
+    /**
+     * <p>hasCategory</p>
+     *
+     * @param categoryName a {@link java.lang.String} object.
+     * @return a boolean.
+     */
+    public boolean hasCategory(String categoryName) {
+        for(OnmsCategory category : getCategories()) {
+            if (category.getName().equals(categoryName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Transient
+    public Set<String> getRequisitionedCategories() {
+        return m_requisitionedCategories;
+    }
+
+    public void setRequisitionedCategories(final Set<String> categories) {
+        m_requisitionedCategories = new LinkedHashSet<>(categories);
+    }
+
+    public void addRequisitionedCategory(final String category) {
+        m_requisitionedCategories.add(category);
+    }
+
+    public void removeRequisitionedCategory(final String category) {
+        m_requisitionedCategories.remove(category);
+    }
+
+    @JsonIgnore
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name="node_metadata", joinColumns = @JoinColumn(name = "id"))
+    public List<OnmsMetaData> getMetaData() {
+        return m_metaData;
+    }
+
+    public Optional<OnmsMetaData> findMetaDataForContextAndKey(final String context, final String key) {
+        return getMetaData().stream()
+                .filter(m -> m.getContext().equals(context))
+                .filter(m -> m.getKey().equals(key))
+                .findFirst();
+    }
+
+    public void setMetaData(final List<OnmsMetaData> metaData) {
+        m_metaData = metaData;
+    }
+
+    public void addMetaData(final String context, final String key, final String value) {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+
+        final Optional<OnmsMetaData> entry = getMetaData().stream()
+            .filter(m -> m.getContext().equals(context))
+            .filter(m -> m.getKey().equals(key))
+            .findFirst();
+
+        // Update the value if present, otherwise create a new entry
+        if (entry.isPresent()) {
+            entry.get().setValue(value);
+        } else {
+            getMetaData().add(new OnmsMetaData(context, key, value));
+        }
+    }
+
+    public void removeMetaData(final String context, final String key) {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(key);
+        final Iterator<OnmsMetaData> iterator = getMetaData().iterator();
+
+        while (iterator.hasNext()) {
+            final OnmsMetaData onmsNodeMetaData = iterator.next();
+
+            if (context.equals(onmsNodeMetaData.getContext()) && key.equals(onmsNodeMetaData.getKey())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public void removeMetaData(final String context) {
+        Objects.requireNonNull(context);
+        final Iterator<OnmsMetaData> iterator = getMetaData().iterator();
+
+        while (iterator.hasNext()) {
+            final OnmsMetaData onmsNodeMetaData = iterator.next();
+
+            if (context.equals(onmsNodeMetaData.getContext())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    @Transient
+    public List<OnmsMetaData> getRequisitionedMetaData() {
+        return m_requisitionedMetaData;
+    }
+
+    public void setRequisionedMetaData(final List<OnmsMetaData> requisitionedMetaData) {
+        m_requisitionedMetaData = requisitionedMetaData;
+    }
+
+    public void addRequisionedMetaData(final OnmsMetaData onmsMetaData) {
+        m_requisitionedMetaData.add(onmsMetaData);
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+        .add("id", m_id)
+        .add("location", m_location == null ? null : m_location.getLocationName())
+        .add("foreignSource", m_foreignSource)
+        .add("foreignId", m_foreignId)
+        .add("labelSource", m_labelSource == null ? null : m_labelSource.toString())
+        .add("label", m_label)
+        .add("parent.id", getParent() == null ? null : getParent().getId())
+        .add("createTime", m_createTime)
+        .add("sysObjectId", m_sysObjectId)
+        .add("sysName", m_sysName)
+        .add("sysDescription", m_sysDescription)
+        .add("sysLocation", m_sysLocation)
+        .add("sysContact", m_sysContact)
+        .add("type", m_type == null ? null : m_type.toString())
+        .add("operatingSystem", m_operatingSystem)
+        .add("lastIngressFlow", m_lastIngressFlow)
+        .add("lastEgressFlow", m_lastEgressFlow)
+        .toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visit(EntityVisitor visitor) {
+        visitor.visitNode(this);
+
+        for (OnmsIpInterface iface : getIpInterfaces()) {
+            iface.visit(visitor);
+        }
+
+        for (OnmsSnmpInterface snmpIface : getSnmpInterfaces()) {
+            snmpIface.visit(visitor);
+        }
+
+        visitor.visitNodeComplete(this);
+    }
+
+    /**
+     * <p>addSnmpInterface</p>
+     *
+     * @param snmpIface a {@link org.opennms.netmgt.model.OnmsSnmpInterface} object.
+     */
+    public void addSnmpInterface(OnmsSnmpInterface snmpIface) {
+        snmpIface.setNode(this);
+        getSnmpInterfaces().add(snmpIface);
+    }
+
+    /**
+     * <p>isDown</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isDown() {
+        boolean down = true;
+        for (OnmsIpInterface ipIf : m_ipInterfaces) {
+            if (!ipIf.isDown()) {
+                return !down;
+            }
+        }
+        return down;
+    }
+
+    /**
+     * <p>getSnmpInterfaceWithIfIndex</p>
+     *
+     * @param ifIndex a int.
+     * @return a {@link org.opennms.netmgt.model.OnmsSnmpInterface} object.
+     */
+    @Transient
+    @JsonIgnore
+    public OnmsSnmpInterface getSnmpInterfaceWithIfIndex(int ifIndex) {
+        for (OnmsSnmpInterface dbSnmpIface : getSnmpInterfaces()) {
+            if (dbSnmpIface.getIfIndex().equals(ifIndex)) {
+                return dbSnmpIface;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>getIpInterfaceByIpAddress</p>
+     *
+     * @param ipAddress a {@link java.lang.String} object.
+     * @return a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    public OnmsIpInterface getIpInterfaceByIpAddress(String ipAddress) {
+        return getIpInterfaceByIpAddress(InetAddressUtils.getInetAddress(ipAddress));
+    }
+
+    /**
+     * <p>getIpInterfaceByIpAddress</p>
+     *
+     * @param ipAddress a {@link java.lang.String} object.
+     * @return a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    public OnmsIpInterface getIpInterfaceByIpAddress(InetAddress ipAddress) {
+        for (OnmsIpInterface iface : getIpInterfaces()) {
+            if (ipAddress.equals(iface.getIpAddress())) {
+                return iface;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>compareTo</p>
+     *
+     * @param o a {@link org.opennms.netmgt.model.OnmsNode} object.
+     * @return a int.
+     */
+    @Override
+    public int compareTo(OnmsNode o) {
+        String compareLabel = "";
+        Integer compareId = 0;
+
+        if (o != null) {
+            compareLabel = o.getLabel();
+            compareId = o.getId();
+        }
+
+        int returnval = this.getLabel().compareToIgnoreCase(compareLabel);
+        if (returnval == 0) {
+            return this.getId().compareTo(compareId);
+        } else {
+            return returnval;
+        }
+    }
+
+    /**
+     * <p>getPrimaryInterface</p>
+     *
+     * This function should be kept similar to {@link IpInterfaceDao#findPrimaryInterfaceByNodeId()}.
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    @Transient
+    @JsonIgnore
+    public OnmsIpInterface getPrimaryInterface() {
+        List<OnmsIpInterface> primaryInterfaces = new ArrayList<>();
+        for(OnmsIpInterface iface : getIpInterfaces()) {
+            if (PrimaryType.PRIMARY.equals(iface.getIsSnmpPrimary())) {
+                primaryInterfaces.add(iface);
+            }
+        }
+        if (primaryInterfaces.size() < 1) {
+            return null;
+        } else {
+            if (primaryInterfaces.size() > 1) {
+                // Sort the list by the last capabilities scan time so that we return the most recent value
+                Collections.sort(primaryInterfaces, new Comparator<OnmsIpInterface>() {
+                    @Override
+                    public int compare(OnmsIpInterface o1, OnmsIpInterface o2) {
+                        if (o1 == null) {
+                            if (o2 == null) {
+                                return 0;
+                            } else {
+                                return -1; // Put nulls at the end of the list
+                            }
+                        } else {
+                            if (o2 == null) {
+                                return 1; // Put nulls at the end of the list
+                            } else {
+                                if (o1.getIpLastCapsdPoll() == null) {
+                                    if (o2.getIpLastCapsdPoll() == null) {
+                                        return 0;
+                                    } else {
+                                        return 1; // Descending order
+                                    }
+                                } else {
+                                    if (o2.getIpLastCapsdPoll() == null) {
+                                        return -1; // Descending order
+                                    } else {
+                                        // Reverse the comparison so that we get a descending order
+                                        return o2.getIpLastCapsdPoll().compareTo(o1.getIpLastCapsdPoll());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+                OnmsIpInterface retval = primaryInterfaces.iterator().next();
+                LOG.warn("Multiple primary SNMP interfaces for node {}, returning most recently scanned interface: {}", m_id, retval.getInterfaceId());
+                return retval;
+            } else {
+                return primaryInterfaces.iterator().next();
+            }
+        }
+    }
+
+    /**
+     * <p>getInterfaceWithService</p>
+     *
+     * @param svcName a {@link java.lang.String} object.
+     * @return a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    @Transient
+    @JsonIgnore
+    public OnmsIpInterface getInterfaceWithService(String svcName) {
+        for(OnmsIpInterface iface : getIpInterfaces()) {
+            if (iface.getMonitoredServiceByServiceType(svcName) != null) {
+                return iface;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>getInterfacesWithService</p>
+     *
+     * @param svcName a {@link java.lang.String} object.
+     * @return a List of {@link org.opennms.netmgt.model.OnmsIpInterface} objects.
+     */
+    @Transient
+    @JsonIgnore
+    public List<OnmsIpInterface> getInterfacesWithService(String svcName) {
+        List<OnmsIpInterface> ipInterfaces = new ArrayList<>();
+        for(OnmsIpInterface iface : getIpInterfaces()) {
+            if (iface.getMonitoredServiceByServiceType(svcName) != null) {
+                ipInterfaces.add(iface);
+            }
+        }
+        return ipInterfaces;
+    }
+
+    @Transient
+    @JsonIgnore
+    public OnmsIpInterface getInterfaceWithAddress(final InetAddress addr) {
+        if (addr == null) return null;
+        for(final OnmsIpInterface iface : getIpInterfaces()) {
+            if (addr.equals(iface.getIpAddress())) {
+                return iface;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>getCriticalInterface</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    @Transient
+    @JsonIgnore
+    public OnmsIpInterface getCriticalInterface() {
+
+        OnmsIpInterface critIface = getPrimaryInterface();
+        if (critIface != null) {
+            return critIface;
+        }
+
+        return getInterfaceWithService("ICMP");
+
+    }
+
+    /**
+     * <p>mergeAgentAttributes</p>
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void mergeAgentAttributes(OnmsNode scannedNode) {
+        if (hasNewValue(scannedNode.getSysContact(), getSysContact())) {
+            setSysContact(scannedNode.getSysContact());
+        }
+
+        if (hasNewValue(scannedNode.getSysDescription(), getSysDescription())) {
+            setSysDescription(scannedNode.getSysDescription());
+        }
+
+        if (hasNewValue(scannedNode.getSysLocation(), getSysLocation())) {
+            setSysLocation(scannedNode.getSysLocation());
+        }
+
+        if (hasNewValue(scannedNode.getSysName(), getSysName())) {
+            setSysName(scannedNode.getSysName());
+        }
+
+        if (hasNewValue(scannedNode.getSysObjectId(), getSysObjectId())) {
+            setSysObjectId(scannedNode.getSysObjectId());
+        }
+    }
+
+    /**
+     * <p>mergeNodeAttributes</p>
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void mergeNodeAttributes(final OnmsNode scannedNode, final EventForwarder eventForwarder) {
+        final String scannedLabel = scannedNode.getLabel();
+
+        boolean send = false;
+
+        if (m_oldLabel != null || m_oldLabelSource != null) {
+            send = true;
+        } else if (hasNewValue(scannedLabel, getLabel())) {
+            m_oldLabel = getLabel();
+            m_oldLabelSource = getLabelSource();
+            send = true;
+        }
+
+        if (send) {
+            LOG.debug("mergeNodeAttributes(): sending NODE_LABEL_CHANGED_EVENT_UEI");
+            // Create a NODE_LABEL_CHANGED_EVENT_UEI event
+            final EventBuilder bldr = new NodeLabelChangedEventBuilder("OnmsNode.mergeNodeAttributes");
+
+            bldr.setNodeid(scannedNode.getId());
+            bldr.setHost(InetAddressUtils.getLocalHostAddressAsString());
+
+            if (m_oldLabel != null) {
+                bldr.addParam(EventConstants.PARM_OLD_NODE_LABEL, m_oldLabel);
+                if (m_oldLabelSource != null) {
+                    bldr.addParam(EventConstants.PARM_OLD_NODE_LABEL_SOURCE, m_oldLabelSource.toString());
+                }
+            }
+
+            if (scannedLabel != null) {
+                bldr.addParam(EventConstants.PARM_NEW_NODE_LABEL, scannedLabel);
+                if (scannedNode.getLabelSource() != null) {
+                    bldr.addParam(EventConstants.PARM_NEW_NODE_LABEL_SOURCE, scannedNode.getLabelSource().toString());
+                }
+            }
+
+            m_oldLabel = null;
+            m_oldLabelSource = null;
+
+            eventForwarder.sendNow(bldr.getEvent());
+
+            // Update the node label value
+            m_label = scannedLabel;
+        } else {
+            LOG.debug("mergeNodeAttributes(): skipping event.");
+        }
+
+        if (hasNewValue(scannedNode.getLocation(), getLocation())) {
+            setLocation(scannedNode.getLocation());
+        }
+
+        if (hasNewValue(scannedNode.getForeignSource(), getForeignSource())) {
+            setForeignSource(scannedNode.getForeignSource());
+        }
+
+        if (hasNewValue(scannedNode.getForeignId(), getForeignId())) {
+            setForeignId(scannedNode.getForeignId());
+        }
+
+        if (hasNewValue(scannedNode.getLabelSource(), getLabelSource())) {
+            setLabelSource(scannedNode.getLabelSource());
+        }
+
+        if (hasNewValue(scannedNode.getNetBiosName(), getNetBiosDomain())) {
+            setNetBiosName(scannedNode.getNetBiosDomain());
+        }
+
+        if (hasNewValue(scannedNode.getNetBiosDomain(), getNetBiosDomain())) {
+            setNetBiosDomain(scannedNode.getNetBiosDomain());
+        }
+
+        if (hasNewValue(scannedNode.getOperatingSystem(), getOperatingSystem())) {
+            setOperatingSystem(scannedNode.getOperatingSystem());
+        }
+
+        mergeAgentAttributes(scannedNode);
+
+        mergeAdditionalCategories(scannedNode);
+    }
+
+    /**
+     * <p>mergeAdditionalCategories</p>
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    private void mergeAdditionalCategories(OnmsNode scannedNode) {
+        getCategories().addAll(scannedNode.getCategories());
+    }
+
+    /**
+     * <p>mergeSnmpInterfaces</p>
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     * @param deleteMissing a boolean.
+     */
+    public void mergeSnmpInterfaces(OnmsNode scannedNode, boolean deleteMissing) {
+
+        // we need to skip this step if there is an indication that snmp data collection failed
+        if (scannedNode.getSnmpInterfaces().size() == 0) {
+            // we assume here that snmp collection failed and we don't update the snmp data
+            return;
+        }
+
+
+        // Build map of ifIndices to scanned SnmpInterfaces
+        Map<Integer, OnmsSnmpInterface> scannedInterfaceMap = new HashMap<Integer, OnmsSnmpInterface>();
+        for (OnmsSnmpInterface snmpIface : scannedNode.getSnmpInterfaces()) {
+            if (snmpIface.getIfIndex() != null) {
+                scannedInterfaceMap.put(snmpIface.getIfIndex(), snmpIface);
+            }
+        }
+
+        // for each interface on existing node...
+        for (Iterator<OnmsSnmpInterface> it = getSnmpInterfaces().iterator(); it.hasNext();) {
+
+            OnmsSnmpInterface iface = it.next();
+            OnmsSnmpInterface imported = scannedInterfaceMap.get(iface.getIfIndex());
+
+            // remove it since there is no corresponding scanned interface
+            if (imported == null) {
+                if (deleteMissing) {
+                    it.remove();
+                    scannedInterfaceMap.remove(iface.getIfIndex());
+                }
+            } else {
+                // merge the data from the corresponding scanned interface
+                iface.mergeSnmpInterfaceAttributes(imported);
+                scannedInterfaceMap.remove(iface.getIfIndex());
+            }
+
+        }
+
+        // for any scanned interface that was not found on the node add it the database
+        for (OnmsSnmpInterface snmpIface : scannedInterfaceMap.values()) {
+            addSnmpInterface(snmpIface);
+        }
+    }
+
+    /**
+     * <p>mergeIpInterfaces</p>
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     * @param eventForwarder a {@link org.opennms.netmgt.events.api.EventForwarder} object.
+     * @param deleteMissing a boolean.
+     */
+    public void mergeIpInterfaces(OnmsNode scannedNode, EventForwarder eventForwarder, boolean deleteMissing) {
+        OnmsIpInterface oldPrimaryInterface = null;
+        OnmsIpInterface scannedPrimaryIf = null;
+        // build a map of ipAddrs to ipInterfaces for the scanned node
+        Map<InetAddress, OnmsIpInterface> ipInterfaceMap = new HashMap<InetAddress, OnmsIpInterface>();
+        for (OnmsIpInterface iface : scannedNode.getIpInterfaces()) {
+            if(scannedPrimaryIf == null && iface.isPrimary()){
+                scannedPrimaryIf = iface;
+            }else if(iface.isPrimary()){
+                iface.setIsSnmpPrimary(PrimaryType.SECONDARY);
+            }
+
+            ipInterfaceMap.put(iface.getIpAddress(), iface);
+        }
+
+        // for each ipInterface from the database
+        for (Iterator<OnmsIpInterface> it = getIpInterfaces().iterator(); it.hasNext();) {
+            OnmsIpInterface dbIface = it.next();
+            // find the corresponding scanned Interface
+            OnmsIpInterface scannedIface = ipInterfaceMap.get(dbIface.getIpAddress());
+
+            // if we can't find a scanned interface remove from the database
+            if (scannedIface == null) {
+                if (deleteMissing) {
+                    it.remove();
+                    dbIface.visit(new DeleteEventVisitor(eventForwarder));
+                }else if(scannedPrimaryIf != null && dbIface.isPrimary()){
+                    dbIface.setIsSnmpPrimary(PrimaryType.SECONDARY);
+                    oldPrimaryInterface = dbIface;
+
+                }
+            } else {
+                // else update the database with scanned info
+                dbIface.mergeInterface(scannedIface, eventForwarder, deleteMissing);
+                if(scannedPrimaryIf != null && dbIface.isPrimary() && scannedPrimaryIf != scannedIface){
+                    dbIface.setIsSnmpPrimary(PrimaryType.SECONDARY);
+                    oldPrimaryInterface = dbIface;
+                }
+            }
+
+            // now remove the interface from the map to indicate it was processed
+            ipInterfaceMap.remove(dbIface.getIpAddress());
+        }
+
+
+        // for any remaining scanned interfaces, add them to the database
+        for (OnmsIpInterface iface : ipInterfaceMap.values()) {
+            addIpInterface(iface);
+            if (iface.getIfIndex() != null) {
+                iface.setSnmpInterface(getSnmpInterfaceWithIfIndex(iface.getIfIndex()));
+            }
+            iface.visit(new AddEventVisitor(eventForwarder));
+        }
+
+        if(oldPrimaryInterface != null && scannedPrimaryIf != null){
+            EventBuilder bldr = new EventBuilder(EventConstants.PRIMARY_SNMP_INTERFACE_CHANGED_EVENT_UEI, "Provisiond");
+            bldr.setIpInterface(scannedPrimaryIf);
+            bldr.setService("SNMP");
+            bldr.addParam(EventConstants.PARM_OLD_PRIMARY_SNMP_ADDRESS, InetAddressUtils.str(oldPrimaryInterface.getIpAddress()));
+            bldr.addParam(EventConstants.PARM_NEW_PRIMARY_SNMP_ADDRESS, InetAddressUtils.str(scannedPrimaryIf.getIpAddress()));
+
+            eventForwarder.sendNow(bldr.getEvent());
+        }
+    }
+
+    /**
+     * <p>mergeCategorySet</p>
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void mergeCategorySet(OnmsNode scannedNode) {
+        if (!getCategories().equals(scannedNode.getCategories())) {
+            setCategories(scannedNode.getCategories());
+        }
+    }
+
+    /**
+     * Truly merges the node's assert record
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void mergeAssets(OnmsNode scannedNode) {
+        this.getAssetRecord().mergeRecord(scannedNode.getAssetRecord());
+    }
+
+    /**
+     * Truly merges the node's meta-data
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void mergeMetaData(OnmsNode scanned) {
+        if (!getMetaData().equals(scanned.getMetaData())) {
+            setMetaData(scanned.getMetaData());
+        }
+    }
+
+    /**
+     * Simply replaces the current asset record with the new record
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void replaceCurrentAssetRecord(OnmsNode scannedNode) {
+        scannedNode.getAssetRecord().setId(this.getAssetRecord().getId());
+        scannedNode.setId(this.m_id);  //just in case
+        this.setAssetRecord(scannedNode.getAssetRecord());
+    }
+
+    /**
+     * <p>mergeNode</p>
+     *
+     * @param scannedNode a {@link org.opennms.netmgt.model.OnmsNode} object.
+     * @param eventForwarder a {@link org.opennms.netmgt.events.api.EventForwarder} object.
+     * @param deleteMissing a boolean.
+     */
+    public void mergeNode(OnmsNode scannedNode, EventForwarder eventForwarder, boolean deleteMissing) {
+
+        mergeNodeAttributes(scannedNode, eventForwarder);
+
+        mergeSnmpInterfaces(scannedNode, deleteMissing);
+
+        mergeIpInterfaces(scannedNode, eventForwarder, deleteMissing);
+
+        mergeCategorySet(scannedNode);
+
+        mergeAssets(scannedNode);
+
+        mergeMetaData(scannedNode);
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean containsService(final InetAddress addr, final String service) {
+        final OnmsIpInterface iface = getInterfaceWithAddress(addr);
+        if (iface != null) {
+            final OnmsMonitoredService svc = iface.getMonitoredServiceByServiceType(service);
+            return svc != null;
+        }
+        return false;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean containsInterface(final InetAddress addr) {
+        return (getInterfaceWithAddress(addr) != null);
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsNode.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsNode.java
@@ -772,7 +772,8 @@ public class OnmsNode extends OnmsEntity implements Serializable, Comparable<Onm
      *
      * @return a {@link org.opennms.netmgt.model.OnmsAssetRecord} object.
      */
-    @OneToOne(mappedBy="node", cascade = CascadeType.ALL, fetch=FetchType.LAZY)
+    // OnmsAssetRecord is not yet migrated to Jakarta Persistence.
+    @Transient
     public OnmsAssetRecord getAssetRecord() {
         return m_assetRecord;
     }
@@ -795,11 +796,8 @@ public class OnmsNode extends OnmsEntity implements Serializable, Comparable<Onm
      * @return a {@link org.opennms.netmgt.model.PathElement} object.
      */
     @JsonIgnore
-    @Embedded
-    @AttributeOverrides({
-        @AttributeOverride(name="ipAddress", column=@Column(name="criticalPathIp", table="pathOutage")),
-        @AttributeOverride(name="serviceName", column=@Column(name="criticalPathServiceName", table="pathOutage"))
-    })
+    // PathElement is not yet migrated to Jakarta Persistence (@Embeddable).
+    @Transient
     public PathElement getPathElement() {
         return m_pathElement;
     }
@@ -947,8 +945,8 @@ public class OnmsNode extends OnmsEntity implements Serializable, Comparable<Onm
     }
 
     @JsonIgnore
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name="node_metadata", joinColumns = @JoinColumn(name = "id"))
+    // OnmsMetaData is not yet migrated to Jakarta Persistence (@Embeddable).
+    @Transient
     public List<OnmsMetaData> getMetaData() {
         return m_metaData;
     }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsNode.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsNode.java
@@ -225,7 +225,7 @@ public class OnmsNode extends OnmsEntity implements Serializable, Comparable<Onm
      */
     @Id
     @Column(name="nodeId", nullable=false)
-    @SequenceGenerator(name="nodeSequence", sequenceName="nodeNxtId")
+    @SequenceGenerator(name="nodeSequence", sequenceName="nodeNxtId", allocationSize = 1)
     @GeneratedValue(generator="nodeSequence")
     @JsonIgnore
     public Integer getId() {

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsReductionKeyMemo.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsReductionKeyMemo.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+/**
+ * <p>Specific memo which is attached to every alarm with a matching reduction
+ * key.</p>
+ *
+ * @author <a href="mailto:Markus@OpenNMS.com">Markus Neumann</a>
+ */
+@Entity
+@DiscriminatorValue(value="ReductionKeyMemo")
+public class OnmsReductionKeyMemo extends OnmsMemo {
+
+    private static final long serialVersionUID = 7472348439687562161L;
+
+    @Column(name = "reductionkey")
+    private String m_reductionKey;
+
+    public String getReductionKey() {
+        return m_reductionKey;
+    }
+
+    public void setReductionKey(String reductionKey) {
+        this.m_reductionKey = reductionKey;
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsServiceType.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsServiceType.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.base.MoreObjects;
+
+
+/**
+ * <p>OnmsServiceType class.</p>
+ *
+ * @hibernate.class table="service"
+ */
+@Entity
+@Table(name="service")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsServiceType implements Serializable {
+
+    private static final long serialVersionUID = -459218937667452586L;
+
+    /** identifier field */
+    private Integer m_id;
+
+    /** persistent field */
+    private String m_name;
+
+    /**
+     * full constructor
+     *
+     * @param servicename a {@link java.lang.String} object.
+     */
+    public OnmsServiceType(String servicename) {
+        m_name = servicename;
+    }
+
+    public OnmsServiceType(Integer id, String servicename) {
+        m_id = id;
+        m_name = servicename;
+    }
+
+    /**
+     * default constructor
+     */
+    public OnmsServiceType() {
+    }
+
+    /**
+     * <p>getId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @Column(name="serviceId")
+    @SequenceGenerator(name="serviceTypeSequence", sequenceName="serviceNxtId")
+    @GeneratedValue(generator="serviceTypeSequence")
+    public Integer getId() {
+        return m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param serviceid a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer serviceid) {
+        m_id = serviceid;
+    }
+
+    /**
+     * <p>getName</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="serviceName", nullable=false, unique=true, length=255)
+    public String getName() {
+        return m_name;
+    }
+
+    /**
+     * <p>setName</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
+    public void setName(String name) {
+        m_name = name;
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("id", getId())
+            .add("name", getName())
+            .toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof OnmsServiceType) {
+            OnmsServiceType t = (OnmsServiceType)obj;
+            return m_id.equals(t.m_id);
+        }
+        return false;
+    }
+
+    /**
+     * <p>hashCode</p>
+     *
+     * @return a int.
+     */
+    @Override
+    public int hashCode() {
+        return m_id.intValue();
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsServiceType.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsServiceType.java
@@ -79,7 +79,7 @@ public class OnmsServiceType implements Serializable {
      */
     @Id
     @Column(name="serviceId")
-    @SequenceGenerator(name="serviceTypeSequence", sequenceName="serviceNxtId")
+    @SequenceGenerator(name="serviceTypeSequence", sequenceName="serviceNxtId", allocationSize = 1)
     @GeneratedValue(generator="serviceTypeSequence")
     public Integer getId() {
         return m_id;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
@@ -1,0 +1,753 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.opennms.core.sysprops.SystemProperties;
+import org.opennms.core.utils.AlphaNumeric;
+import org.opennms.core.utils.RrdLabelUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * <p>OnmsSnmpInterface class.</p>
+ */
+@Entity
+@Table(name = "snmpInterface")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
+    private static final long serialVersionUID = 4688655131862954563L;
+    private static final Logger LOG = LoggerFactory.getLogger(OnmsSnmpInterface.class);
+
+    private Integer m_id;
+
+    /** identifier field */
+    private String m_physAddr;
+
+    /** identifier field */
+    private Integer m_ifIndex;
+
+    /** identifier field */
+    private String m_ifDescr;
+
+    /** identifier field */
+    private Integer m_ifType;
+
+    /** identifier field */
+    private String m_ifName;
+
+    /** identifier field */
+    private Long m_ifSpeed;
+
+    /** identifier field */
+    private Integer m_ifAdminStatus;
+
+    /** identifier field */
+    private Integer m_ifOperStatus;
+
+    /** identifier field */
+    private String m_ifAlias;
+
+    private Date m_lastCapsdPoll;
+
+    private String m_collect = "N";
+
+    private String m_poll;
+
+    private Date m_lastSnmpPoll;
+
+    private OnmsNode m_node;
+
+    private Set<OnmsIpInterface> m_ipInterfaces = new HashSet<>();
+
+    /** timestamps for a flow exporting node */
+    private Date m_lastIngressFlow;
+    private Date m_lastEgressFlow;
+    public static final int MAX_FLOW_AGE = SystemProperties.getInteger("org.opennms.features.telemetry.maxFlowAgeSeconds", 604800);
+    public static final boolean INGRESS_AND_EGRESS_REQUIRED = Boolean.getBoolean("org.opennms.features.telemetry.ingressAndEgressRequired");
+
+    public static enum CollectDefinitionSource {NONE, USER, POLICY};
+
+    /**
+     * <p>Constructor for OnmsSnmpInterface.</p>
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     * @param ifIndex a int.
+     */
+    public OnmsSnmpInterface(OnmsNode node, int ifIndex) {
+        this(node, Integer.valueOf(ifIndex));
+    }
+
+    /**
+     * <p>Constructor for OnmsSnmpInterface.</p>
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     * @param ifIndex a {@link java.lang.Integer} object.
+     */
+    public OnmsSnmpInterface(OnmsNode node, Integer ifIndex) {
+        m_ifIndex = ifIndex;
+        m_node = node;
+        if (node != null) {
+            node.getSnmpInterfaces().add(this);
+        }
+    }
+
+    /**
+     * default constructor
+     */
+    public OnmsSnmpInterface() {
+    }
+
+    /**
+     * Unique identifier for snmpInterface.
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @Column(nullable=false)
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @GeneratedValue(generator = "opennmsSequence")
+    public Integer getId() {
+        return m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param id a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer id) {
+        m_id = id;
+    }
+
+    /**
+     * <p>getPhysAddr</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name = "snmpPhysAddr", length = 32)
+    public String getPhysAddr() {
+        return m_physAddr;
+    }
+
+    /**
+     * <p>setPhysAddr</p>
+     *
+     * @param snmpphysaddr a {@link java.lang.String} object.
+     */
+    public void setPhysAddr(String snmpphysaddr) {
+        m_physAddr = snmpphysaddr;
+    }
+
+    /**
+     * <p>getIfIndex</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Column(name = "snmpIfIndex")
+    public Integer getIfIndex() {
+        return m_ifIndex;
+    }
+
+    /**
+     * <p>setIfIndex</p>
+     *
+     * @param snmpifindex a {@link java.lang.Integer} object.
+     */
+    public void setIfIndex(Integer snmpifindex) {
+        m_ifIndex = snmpifindex;
+    }
+
+    /**
+     * <p>getIfDescr</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name = "snmpIfDescr", length = 256)
+    public String getIfDescr() {
+        return m_ifDescr;
+    }
+
+    /**
+     * <p>setIfDescr</p>
+     *
+     * @param snmpifdescr a {@link java.lang.String} object.
+     */
+    public void setIfDescr(String snmpifdescr) {
+        m_ifDescr = snmpifdescr;
+    }
+
+    /**
+     * <p>getIfType</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Column(name = "snmpIfType")
+    public Integer getIfType() {
+        return m_ifType;
+    }
+
+    /**
+     * <p>setIfType</p>
+     *
+     * @param snmpiftype a {@link java.lang.Integer} object.
+     */
+    public void setIfType(Integer snmpiftype) {
+        m_ifType = snmpiftype;
+    }
+
+    /**
+     * <p>getIfName</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name = "snmpIfName", length = 32)
+    public String getIfName() {
+        return m_ifName;
+    }
+
+    /**
+     * <p>setIfName</p>
+     *
+     * @param snmpifname a {@link java.lang.String} object.
+     */
+    public void setIfName(String snmpifname) {
+        m_ifName = snmpifname;
+    }
+
+    /**
+     * <p>getIfSpeed</p>
+     *
+     * @return a {@link java.lang.Long} object.
+     */
+    @Column(name = "snmpIfSpeed")
+    public Long getIfSpeed() {
+        return m_ifSpeed;
+    }
+
+    /**
+     * <p>setIfSpeed</p>
+     *
+     * @param snmpifspeed a {@link java.lang.Long} object.
+     */
+    public void setIfSpeed(Long snmpifspeed) {
+        m_ifSpeed = snmpifspeed;
+    }
+
+    /**
+     * <p>getIfAdminStatus</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Column(name = "snmpIfAdminStatus")
+    public Integer getIfAdminStatus() {
+        return m_ifAdminStatus;
+    }
+
+    /**
+     * <p>setIfAdminStatus</p>
+     *
+     * @param snmpifadminstatus a {@link java.lang.Integer} object.
+     */
+    public void setIfAdminStatus(Integer snmpifadminstatus) {
+        m_ifAdminStatus = snmpifadminstatus;
+    }
+
+    /**
+     * <p>getIfOperStatus</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Column(name = "snmpIfOperStatus")
+    public Integer getIfOperStatus() {
+        return m_ifOperStatus;
+    }
+
+    /**
+     * <p>setIfOperStatus</p>
+     *
+     * @param snmpifoperstatus a {@link java.lang.Integer} object.
+     */
+    public void setIfOperStatus(Integer snmpifoperstatus) {
+        m_ifOperStatus = snmpifoperstatus;
+    }
+
+    /**
+     * <p>getIfAlias</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name = "snmpIfAlias", length = 256)
+    public String getIfAlias() {
+        return m_ifAlias;
+    }
+
+    /**
+     * <p>setIfAlias</p>
+     *
+     * @param snmpifalias a {@link java.lang.String} object.
+     */
+    public void setIfAlias(String snmpifalias) {
+        m_ifAlias = snmpifalias;
+    }
+
+    /**
+     * <p>getLastCapsdPoll</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="snmpLastCapsdPoll")
+    public Date getLastCapsdPoll() {
+        return m_lastCapsdPoll;
+    }
+
+    /**
+     * <p>setLastCapsdPoll</p>
+     *
+     * @param lastCapsdPoll a {@link java.util.Date} object.
+     */
+    public void setLastCapsdPoll(Date lastCapsdPoll) {
+        m_lastCapsdPoll = lastCapsdPoll;
+    }
+
+    /**
+     * <p>getCollect</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="snmpCollect")
+    public String getCollect() {
+        return m_collect;
+    }
+
+    /**
+     * <p>setCollect</p>
+     *
+     * @param collect a {@link java.lang.String} object.
+     */
+    public void setCollect(String collect) {
+        m_collect = collect;
+    }
+
+    /**
+     * <p>getPoll</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="snmpPoll")
+    public String getPoll() {
+        return m_poll;
+    }
+
+    /**
+     * <p>setPoll</p>
+     *
+     * @param poll a {@link java.lang.String} object.
+     */
+    public void setPoll(String poll) {
+        m_poll = poll;
+    }
+
+    /**
+     * <p>getLastSnmpPoll</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="snmpLastSnmpPoll")
+    public Date getLastSnmpPoll() {
+        return m_lastSnmpPoll;
+    }
+
+    /**
+     * <p>setLastSnmpPoll</p>
+     *
+     * @param lastSnmpPoll a {@link java.util.Date} object.
+     */
+    public void setLastSnmpPoll(Date lastSnmpPoll) {
+        m_lastSnmpPoll = lastSnmpPoll;
+    }
+
+    /**
+     * <p>isCollectionUserSpecified</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isCollectionUserSpecified(){
+        return m_collect.startsWith("U");
+    }
+
+    /**
+     * <p>isCollectionPolicySpecified</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isCollectionPolicySpecified() {
+        return m_collect.startsWith("P");
+    }
+
+    /**
+     * <p>getCollectionDefinitionSource</p>
+     *
+     * @return The source of the current collection policy for this interface
+     */
+    @Transient
+    CollectDefinitionSource getCollectionDefinitionSource() {
+        if (isCollectionUserSpecified()) {
+            return CollectDefinitionSource.USER;
+        } else if (isCollectionPolicySpecified()) {
+            return CollectDefinitionSource.POLICY;
+        } else {
+            return CollectDefinitionSource.NONE;
+        }
+    }
+
+    /**
+     * <p>isCollectionEnabled</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isCollectionEnabled() {
+        return m_collect.endsWith("C");
+    }
+
+    /**
+     * <p>setCollectionEnabled</p>
+     *
+     * @param shouldCollect a boolean.
+     */
+    public void setCollectionEnabled(boolean shouldCollect) {
+        setCollectionEnabled(shouldCollect, CollectDefinitionSource.NONE);
+    }
+
+    /**
+     * <p>setCollectionEnabled</p>
+     *
+     * @param shouldCollect a boolean.
+     * @param source what is driving this change.
+     */
+    public void setCollectionEnabled(boolean shouldCollect, CollectDefinitionSource source){
+        switch (source) {
+            case USER:
+                m_collect = shouldCollect ? "UC":"UN";
+                break;
+            case POLICY:
+                // Don't let policies override user input
+                if (!isCollectionUserSpecified()) {
+                    m_collect = shouldCollect ? "PC" : "PN";
+                }
+                break;
+            case NONE:
+                // Don't let provisiond override either
+                if (!isCollectionUserSpecified() && !isCollectionPolicySpecified()) {
+                    m_collect = shouldCollect ? "C" : "N";
+                }
+                break;
+        }
+    }
+
+    /**
+     * <p>isPollEnabled</p>
+     *
+     * @return a boolean.
+     */
+    @Transient
+    public boolean isPollEnabled() {
+        return "P".equals(m_poll);
+    }
+
+    /**
+     * <p>getNode</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "nodeId")
+    public OnmsNode getNode() {
+        return m_node;
+    }
+
+    /**
+     * <p>setNode</p>
+     *
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     */
+    public void setNode(OnmsNode node) {
+        m_node = node;
+    }
+
+    @Transient
+    public Integer getNodeId() {
+        if (m_node != null) {
+            return m_node.getId();
+        }
+        return null;
+    }
+
+    @Transient
+    public boolean getHasFlows() {
+        if (INGRESS_AND_EGRESS_REQUIRED) {
+            return getHasIngressFlows() && getHasEgressFlows();
+        } else {
+            return getHasIngressFlows() || getHasEgressFlows();
+        }
+    }
+
+    @Transient
+    public boolean getHasIngressFlows() {
+        if (m_lastIngressFlow == null) {
+            return false;
+        }
+        return (System.currentTimeMillis() - m_lastIngressFlow.getTime()) / 1000 < MAX_FLOW_AGE;
+    }
+
+    @Transient
+    public boolean getHasEgressFlows() {
+        if (m_lastEgressFlow == null) {
+            return false;
+        }
+        return (System.currentTimeMillis() - m_lastEgressFlow.getTime()) / 1000 < MAX_FLOW_AGE;
+    }
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="last_ingress_flow")
+    public Date getLastIngressFlow() {
+        return m_lastIngressFlow;
+    }
+
+    public void setLastIngressFlow(Date lastIngressFlow) {
+        this.m_lastIngressFlow = lastIngressFlow;
+    }
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="last_egress_flow")
+    public Date getLastEgressFlow() {
+        return m_lastEgressFlow;
+    }
+
+    public void setLastEgressFlow(Date lastEgressFlow) {
+        this.m_lastEgressFlow = lastEgressFlow;
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("snmpphysaddr", getPhysAddr())
+            .add("snmpifindex", getIfIndex())
+            .add("snmpifdescr", getIfDescr())
+            .add("snmpiftype", getIfType())
+            .add("snmpifname", getIfName())
+            .add("snmpifspeed", getIfSpeed())
+            .add("snmpifadminstatus", getIfAdminStatus())
+            .add("snmpifoperstatus", getIfOperStatus())
+            .add("snmpifalias", getIfAlias())
+            .add("snmpCollect", getCollect())
+            .add("snmpPoll", getPoll())
+            .add("nodeId", getNodeId())
+            .add("lastCapsdPoll", getLastCapsdPoll())
+            .add("lastSnmpPoll", getLastSnmpPoll())
+            .add("lastIngressFlow", m_lastIngressFlow)
+            .add("lastEgressFlow", m_lastEgressFlow)
+            .toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visit(EntityVisitor visitor) {
+        visitor.visitSnmpInterface(this);
+        visitor.visitSnmpInterfaceComplete(this);
+    }
+
+    /**
+     * <p>getIpInterfaces</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
+    @OneToMany(mappedBy = "snmpInterface", fetch = FetchType.LAZY)
+    @JsonIgnore
+    public Set<OnmsIpInterface> getIpInterfaces() {
+        return m_ipInterfaces;
+    }
+
+    /**
+     * <p>setIpInterfaces</p>
+     *
+     * @param ipInterfaces a {@link java.util.Set} object.
+     */
+    public void setIpInterfaces(Set<OnmsIpInterface> ipInterfaces) {
+        m_ipInterfaces = ipInterfaces;
+    }
+
+    /**
+     * <p>getPrimaryIpInterface</p>
+     *
+     * @return an {@link OnmsIpInterface} object.
+     */
+    @Transient
+    @JsonIgnore
+    public OnmsIpInterface getPrimaryIpInterface() {
+        return getNode().getPrimaryInterface();
+    }
+
+    /**
+     * <p>computePhysAddrForRRD</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public String computePhysAddrForRRD() {
+        String physAddrForRRD = null;
+
+        if (getPhysAddr() != null) {
+            String parsedPhysAddr = AlphaNumeric.parseAndTrim(getPhysAddr());
+            if (parsedPhysAddr.length() == 12) {
+                physAddrForRRD = parsedPhysAddr;
+            } else {
+                LOG.debug("physAddrForRRD: physical address len is NOT 12, physAddr={}", parsedPhysAddr);
+            }
+        }
+        LOG.debug("computed physAddr for {} to be {}", this, physAddrForRRD);
+        return physAddrForRRD;
+    }
+
+    /**
+     * <p>computeNameForRRD</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public String computeNameForRRD() {
+        String firstChoice = RrdLabelUtils.PREFER_IFDESCR ? getIfDescr() : getIfName();
+        String secondChoice = RrdLabelUtils.PREFER_IFDESCR ? getIfName() : getIfDescr();
+        String label = null;
+        if (firstChoice != null) {
+            label = RrdLabelUtils.DONT_SANITIZE_IFNAME ? firstChoice : AlphaNumeric.parseAndReplace(firstChoice, '_');
+        } else if (secondChoice != null) {
+            label = RrdLabelUtils.DONT_SANITIZE_IFNAME ? secondChoice : AlphaNumeric.parseAndReplace(secondChoice, '_');
+        } else {
+            LOG.info("Interface ({}) has no ifName and no ifDescr...setting to label to 'no_ifLabel'.", this);
+            label = "no_ifLabel";
+        }
+        return label;
+    }
+
+    /**
+     * <p>computeLabelForRRD</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public String computeLabelForRRD() {
+        return RrdLabelUtils.computeLabelForRRD(getIfName(), getIfDescr(), getPhysAddr());
+    }
+
+    /**
+     * <p>addIpInterface</p>
+     *
+     * @param iface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     */
+    public void addIpInterface(OnmsIpInterface iface) {
+        iface.setSnmpInterface(this);
+        m_ipInterfaces.add(iface);
+    }
+
+    /**
+     * <p>mergeSnmpInterfaceAttributes</p>
+     *
+     * @param scannedSnmpIface a {@link org.opennms.netmgt.model.OnmsSnmpInterface} object.
+     */
+    public void mergeSnmpInterfaceAttributes(OnmsSnmpInterface scannedSnmpIface) {
+
+        if (hasNewValue(scannedSnmpIface.getIfAdminStatus(), getIfAdminStatus())) {
+            setIfAdminStatus(scannedSnmpIface.getIfAdminStatus());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getIfAlias(), getIfAlias())) {
+            setIfAlias(scannedSnmpIface.getIfAlias());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getIfDescr(), getIfDescr())) {
+            setIfDescr(scannedSnmpIface.getIfDescr());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getIfName(), getIfName())) {
+            setIfName(scannedSnmpIface.getIfName());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getIfOperStatus(), getIfOperStatus())) {
+            setIfOperStatus(scannedSnmpIface.getIfOperStatus());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getIfSpeed(), getIfSpeed())) {
+            setIfSpeed(scannedSnmpIface.getIfSpeed());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getIfType(), getIfType())) {
+            setIfType(scannedSnmpIface.getIfType());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getPhysAddr(), getPhysAddr())) {
+            setPhysAddr(scannedSnmpIface.getPhysAddr());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getLastCapsdPoll(), getLastCapsdPoll())) {
+            setLastCapsdPoll(scannedSnmpIface.getLastCapsdPoll());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getPoll(), getPoll())) {
+            setPoll(scannedSnmpIface.getPoll());
+        }
+
+        if (hasNewValue(scannedSnmpIface.getLastSnmpPoll(), getLastSnmpPoll())) {
+            setLastSnmpPoll(scannedSnmpIface.getLastSnmpPoll());
+        }
+
+        setCollectionEnabled(scannedSnmpIface.isCollectionEnabled(), scannedSnmpIface.getCollectionDefinitionSource());
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
@@ -145,7 +145,7 @@ public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
      */
     @Id
     @Column(nullable=false)
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     public Integer getId() {
         return m_id;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/InetAddressConverter.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/InetAddressConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import java.net.InetAddress;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.opennms.core.utils.InetAddressUtils;
+
+/**
+ * JPA {@link AttributeConverter} for {@link InetAddress} ↔ VARCHAR.
+ *
+ * <p>Replaces the Hibernate 3.6 {@code InetAddressUserType} for Spring Boot 4 / Hibernate 7.
+ * Uses {@link InetAddressUtils#str(InetAddress)} to produce a normalized string representation
+ * and {@link InetAddressUtils#addr(String)} to parse it back.</p>
+ *
+ * <p>Usage: {@code @Convert(converter = InetAddressConverter.class)}</p>
+ */
+@Converter
+public class InetAddressConverter implements AttributeConverter<InetAddress, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final InetAddress address) {
+        return address == null ? null : InetAddressUtils.str(address);
+    }
+
+    @Override
+    public InetAddress convertToEntityAttribute(final String dbValue) {
+        return dbValue == null ? null : InetAddressUtils.addr(dbValue);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/NodeLabelSourceConverter.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/NodeLabelSourceConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.opennms.netmgt.model.OnmsNode.NodeLabelSource;
+
+/**
+ * JPA {@link AttributeConverter} for {@link NodeLabelSource} ↔ CHAR(1).
+ *
+ * <p>Replaces the Hibernate 3.6 {@code NodeLabelSourceUserType} for Spring Boot 4 / Hibernate 7.
+ * Uses {@link NodeLabelSource#value()} to write and matches by character to read.</p>
+ *
+ * <p>Valid DB values: {@code 'U'} (USER), {@code 'N'} (NETBIOS), {@code 'H'} (HOSTNAME),
+ * {@code 'S'} (SYSNAME), {@code 'A'} (ADDRESS), {@code ' '} (UNKNOWN).</p>
+ *
+ * <p>Usage: {@code @Convert(converter = NodeLabelSourceConverter.class)}</p>
+ */
+@Converter
+public class NodeLabelSourceConverter implements AttributeConverter<NodeLabelSource, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final NodeLabelSource nodeLabelSource) {
+        return nodeLabelSource == null ? null : String.valueOf(nodeLabelSource.value());
+    }
+
+    @Override
+    public NodeLabelSource convertToEntityAttribute(final String dbValue) {
+        if (dbValue == null) {
+            return null;
+        }
+        char c = dbValue.charAt(0);
+        for (NodeLabelSource source : NodeLabelSource.values()) {
+            if (source.value() == c) {
+                return source;
+            }
+        }
+        throw new IllegalArgumentException("Invalid NodeLabelSource value: '" + dbValue + "'");
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/NodeTypeConverter.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/NodeTypeConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.opennms.netmgt.model.OnmsNode.NodeType;
+
+/**
+ * JPA {@link AttributeConverter} for {@link NodeType} ↔ CHAR(1).
+ *
+ * <p>Replaces the Hibernate 3.6 {@code NodeTypeUserType} for Spring Boot 4 / Hibernate 7.
+ * Uses {@link NodeType#value()} to write and matches by character to read.</p>
+ *
+ * <p>Valid DB values: {@code 'A'} (ACTIVE), {@code 'D'} (DELETED), {@code ' '} (UNKNOWN).</p>
+ *
+ * <p>Usage: {@code @Convert(converter = NodeTypeConverter.class)}</p>
+ */
+@Converter
+public class NodeTypeConverter implements AttributeConverter<NodeType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final NodeType nodeType) {
+        return nodeType == null ? null : String.valueOf(nodeType.value());
+    }
+
+    @Override
+    public NodeType convertToEntityAttribute(final String dbValue) {
+        if (dbValue == null) {
+            return null;
+        }
+        char c = dbValue.charAt(0);
+        for (NodeType nodeType : NodeType.values()) {
+            if (nodeType.value() == c) {
+                return nodeType;
+            }
+        }
+        throw new IllegalArgumentException("Invalid NodeType value: '" + dbValue + "'");
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/OnmsSeverityConverter.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/OnmsSeverityConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.opennms.netmgt.model.OnmsSeverity;
+
+/**
+ * JPA {@link AttributeConverter} for {@link OnmsSeverity} ↔ INTEGER.
+ *
+ * <p>Replaces the Hibernate 3.6 {@code OnmsSeverityUserType} for Spring Boot 4 / Hibernate 7.
+ * Persists the severity's integer ID. A {@code null} Java value is persisted as {@code 1}
+ * (INDETERMINATE) to match legacy behaviour; a {@code null} DB column is returned as {@code null}.</p>
+ *
+ * <p>Usage: {@code @Convert(converter = OnmsSeverityConverter.class)}</p>
+ */
+@Converter
+public class OnmsSeverityConverter implements AttributeConverter<OnmsSeverity, Integer> {
+
+    private static final int DEFAULT_SEVERITY_ID = OnmsSeverity.INDETERMINATE.getId();
+
+    @Override
+    public Integer convertToDatabaseColumn(final OnmsSeverity severity) {
+        return severity == null ? DEFAULT_SEVERITY_ID : severity.getId();
+    }
+
+    @Override
+    public OnmsSeverity convertToEntityAttribute(final Integer dbValue) {
+        return dbValue == null ? null : OnmsSeverity.get(dbValue);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/PrimaryTypeConverter.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/PrimaryTypeConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.opennms.netmgt.model.PrimaryType;
+
+/**
+ * JPA {@link AttributeConverter} for {@link PrimaryType} ↔ CHAR(1).
+ *
+ * <p>Replaces the Hibernate 3.6 {@code PrimaryTypeUserType} for Spring Boot 4 / Hibernate 7.
+ * Uses {@link PrimaryType#getCharCode()} to write and {@link PrimaryType#get(Object)} to read.</p>
+ *
+ * <p>Valid DB values: {@code 'P'} (PRIMARY), {@code 'S'} (SECONDARY), {@code 'N'} (NOT_ELIGIBLE).</p>
+ *
+ * <p>Usage: {@code @Convert(converter = PrimaryTypeConverter.class)}</p>
+ */
+@Converter
+public class PrimaryTypeConverter implements AttributeConverter<PrimaryType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final PrimaryType primaryType) {
+        return primaryType == null ? null : String.valueOf(primaryType.getCharCode());
+    }
+
+    @Override
+    public PrimaryType convertToEntityAttribute(final String dbValue) {
+        return dbValue == null ? null : PrimaryType.get(dbValue);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/AlarmDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/AlarmDaoJpa.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.dao;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.persistence.Query;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.model.HeatMapElement;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsCriteria;
+import org.opennms.netmgt.model.alarm.AlarmSummary;
+import org.opennms.netmgt.model.alarm.SituationSummary;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA implementation of {@link AlarmDao}.
+ *
+ * <p>Implements only the methods required by Alarmd's core processing path.
+ * REST-oriented methods ({@link #getNodeAlarmSummaries()}, {@link #getSituationSummaries()},
+ * {@link #getNodeAlarmSummariesIncludeAcknowledgedOnes}, {@link #getHeatMapItemsForEntity},
+ * {@link #getAlarmsForEventParameters}) are not used by Alarmd and throw
+ * {@link UnsupportedOperationException}.</p>
+ *
+ * <p>The deprecated {@link #findMatching(OnmsCriteria)} and {@link #countMatching(OnmsCriteria)}
+ * methods from {@link org.opennms.netmgt.dao.api.LegacyOnmsDao} also throw
+ * {@link UnsupportedOperationException} — Alarmd does not use them.</p>
+ */
+@Repository
+@Transactional
+public class AlarmDaoJpa extends AbstractDaoJpa<OnmsAlarm, Integer> implements AlarmDao {
+
+    public AlarmDaoJpa() {
+        super(OnmsAlarm.class);
+    }
+
+    @Override
+    public OnmsAlarm findByReductionKey(String reductionKey) {
+        return findUnique(
+                "SELECT a FROM OnmsAlarm a WHERE a.reductionKey = ?1",
+                reductionKey);
+    }
+
+    @Override
+    public long getNumSituations() {
+        Query query = entityManager().createNativeQuery(
+                "SELECT COUNT(DISTINCT situation_id) FROM alarm_situations");
+        Number result = (Number) query.getSingleResult();
+        return result != null ? result.longValue() : 0L;
+    }
+
+    @Override
+    public long getNumAlarmsLastHours(int hours) {
+        if (hours <= 0) {
+            return 0L;
+        }
+        Query query = entityManager().createNativeQuery(
+                "SELECT COUNT(*) FROM alarms WHERE firsteventtime >= NOW() - (:hours * INTERVAL '1 hour')");
+        query.setParameter("hours", hours);
+        Number result = (Number) query.getSingleResult();
+        return result != null ? result.longValue() : 0L;
+    }
+
+    // ---- LegacyOnmsDao methods — not used by Alarmd ----
+
+    @Override
+    public List<OnmsAlarm> findMatching(OnmsCriteria criteria) {
+        throw new UnsupportedOperationException(
+                "findMatching(OnmsCriteria) is not supported in AlarmDaoJpa — use HQL queries");
+    }
+
+    @Override
+    public int countMatching(OnmsCriteria onmsCrit) {
+        throw new UnsupportedOperationException(
+                "countMatching(OnmsCriteria) is not supported in AlarmDaoJpa — use HQL queries");
+    }
+
+    // ---- REST-oriented methods — not used by Alarmd core ----
+
+    @Override
+    public List<AlarmSummary> getNodeAlarmSummaries() {
+        throw new UnsupportedOperationException(
+                "getNodeAlarmSummaries() is not used by Alarmd — this is a REST API method");
+    }
+
+    @Override
+    public List<SituationSummary> getSituationSummaries() {
+        throw new UnsupportedOperationException(
+                "getSituationSummaries() is not used by Alarmd — this is a REST API method");
+    }
+
+    @Override
+    public List<AlarmSummary> getNodeAlarmSummariesIncludeAcknowledgedOnes(List<Integer> nodeIds) {
+        throw new UnsupportedOperationException(
+                "getNodeAlarmSummariesIncludeAcknowledgedOnes() is not used by Alarmd — this is a REST API method");
+    }
+
+    @Override
+    public List<HeatMapElement> getHeatMapItemsForEntity(String entityNameColumn, String entityIdColumn,
+            boolean processAcknowledgedAlarms, String restrictionColumn, String restrictionValue,
+            String... groupByColumns) {
+        throw new UnsupportedOperationException(
+                "getHeatMapItemsForEntity() is not used by Alarmd — this is a REST API method");
+    }
+
+    @Override
+    public List<OnmsAlarm> getAlarmsForEventParameters(Map<String, String> eventParameters) {
+        throw new UnsupportedOperationException(
+                "getAlarmsForEventParameters() is not used by Alarmd — this is a REST API method");
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/DistPollerDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/DistPollerDaoJpa.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.model.OnmsDistPoller;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA implementation of {@link DistPollerDao}.
+ *
+ * <p>{@link #whoami()} returns the {@link OnmsDistPoller} representing the local OpenNMS system.
+ * {@link OnmsDistPoller} uses {@code @DiscriminatorValue("OpenNMS")}, so any JPQL query against
+ * {@code OnmsDistPoller} is already filtered to rows whose {@code type} column equals
+ * {@code "OpenNMS"}. This mirrors the logic in {@code DistPollerDaoHibernate}.</p>
+ */
+@Repository
+@Transactional
+public class DistPollerDaoJpa extends AbstractDaoJpa<OnmsDistPoller, String> implements DistPollerDao {
+
+    public DistPollerDaoJpa() {
+        super(OnmsDistPoller.class);
+    }
+
+    /**
+     * Returns the local OpenNMS monitoring system identity.
+     *
+     * <p>There is normally exactly one {@link OnmsDistPoller} row — the local system.
+     * Returns the first result, or {@code null} if the table has not been initialised yet.</p>
+     *
+     * @return the local {@link OnmsDistPoller}, or {@code null} if not yet provisioned
+     */
+    @Override
+    public OnmsDistPoller whoami() {
+        return findUnique("SELECT d FROM OnmsDistPoller d");
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/NodeDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/NodeDaoJpa.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.dao;
+
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsCriteria;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.SurveillanceStatus;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA implementation of {@link NodeDao}.
+ *
+ * <p>Alarmd only uses {@link #get(Integer)} to load node state when processing alarms.
+ * All other methods from the {@link NodeDao} interface are unused by Alarmd and throw
+ * {@link UnsupportedOperationException}.</p>
+ *
+ * <p>The deprecated {@link #findMatching(OnmsCriteria)} and {@link #countMatching(OnmsCriteria)}
+ * methods from {@link org.opennms.netmgt.dao.api.LegacyOnmsDao} also throw
+ * {@link UnsupportedOperationException}.</p>
+ */
+@Repository
+@Transactional
+public class NodeDaoJpa extends AbstractDaoJpa<OnmsNode, Integer> implements NodeDao {
+
+    public NodeDaoJpa() {
+        super(OnmsNode.class);
+    }
+
+    // ---- LegacyOnmsDao methods ----
+
+    @Override
+    public List<OnmsNode> findMatching(OnmsCriteria criteria) {
+        throw new UnsupportedOperationException(
+                "findMatching(OnmsCriteria) is not supported in NodeDaoJpa — use HQL queries");
+    }
+
+    @Override
+    public int countMatching(OnmsCriteria onmsCrit) {
+        throw new UnsupportedOperationException(
+                "countMatching(OnmsCriteria) is not supported in NodeDaoJpa — use HQL queries");
+    }
+
+    // ---- NodeDao methods — not used by Alarmd core ----
+
+    @Override
+    public OnmsNode get(String lookupCriteria) {
+        throw new UnsupportedOperationException("get(String) is not used by Alarmd");
+    }
+
+    @Override
+    public Map<Integer, String> getAllLabelsById() {
+        throw new UnsupportedOperationException("getAllLabelsById() is not used by Alarmd");
+    }
+
+    @Override
+    public String getLabelForId(Integer id) {
+        throw new UnsupportedOperationException("getLabelForId() is not used by Alarmd");
+    }
+
+    @Override
+    public String getLocationForId(Integer id) {
+        throw new UnsupportedOperationException("getLocationForId() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByLabel(String label) {
+        throw new UnsupportedOperationException("findByLabel() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByLabelForLocation(String label, String location) {
+        throw new UnsupportedOperationException("findByLabelForLocation() is not used by Alarmd");
+    }
+
+    @Override
+    public OnmsNode getHierarchy(Integer id) {
+        throw new UnsupportedOperationException("getHierarchy() is not used by Alarmd");
+    }
+
+    @Override
+    public Map<String, Integer> getForeignIdToNodeIdMap(String foreignSource) {
+        throw new UnsupportedOperationException("getForeignIdToNodeIdMap() is not used by Alarmd");
+    }
+
+    @Override
+    public Map<String, Set<String>> getForeignIdsPerForeignSourceMap() {
+        throw new UnsupportedOperationException("getForeignIdsPerForeignSourceMap() is not used by Alarmd");
+    }
+
+    @Override
+    public Set<String> getForeignIdsPerForeignSource(String foreignSource) {
+        throw new UnsupportedOperationException("getForeignIdsPerForeignSource() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllByVarCharAssetColumn(String columnName, String columnValue) {
+        throw new UnsupportedOperationException("findAllByVarCharAssetColumn() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllByVarCharAssetColumnCategoryList(String columnName, String columnValue,
+            Collection<OnmsCategory> categories) {
+        throw new UnsupportedOperationException("findAllByVarCharAssetColumnCategoryList() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByCategory(OnmsCategory category) {
+        throw new UnsupportedOperationException("findByCategory() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllByCategoryList(Collection<OnmsCategory> categories) {
+        throw new UnsupportedOperationException("findAllByCategoryList() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllByCategoryLists(Collection<OnmsCategory> rowCatNames,
+            Collection<OnmsCategory> colCatNames) {
+        throw new UnsupportedOperationException("findAllByCategoryLists() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByForeignSource(String foreignSource) {
+        throw new UnsupportedOperationException("findByForeignSource() is not used by Alarmd");
+    }
+
+    @Override
+    public OnmsNode findByForeignId(String foreignSource, String foreignId) {
+        throw new UnsupportedOperationException("findByForeignId(source, id) is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByForeignId(String foreignId) {
+        throw new UnsupportedOperationException("findByForeignId(id) is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByForeignIdForLocation(String foreignId, String location) {
+        throw new UnsupportedOperationException("findByForeignIdForLocation() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByIpAddressAndService(InetAddress ipAddress, String serviceName) {
+        throw new UnsupportedOperationException("findByIpAddressAndService() is not used by Alarmd");
+    }
+
+    @Override
+    public int getNodeCountForForeignSource(String groupName) {
+        throw new UnsupportedOperationException("getNodeCountForForeignSource() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllProvisionedNodes() {
+        throw new UnsupportedOperationException("findAllProvisionedNodes() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsIpInterface> findObsoleteIpInterfaces(Integer nodeId, Date scanStamp) {
+        throw new UnsupportedOperationException("findObsoleteIpInterfaces() is not used by Alarmd");
+    }
+
+    @Override
+    public void deleteObsoleteInterfaces(Integer nodeId, Date scanStamp) {
+        throw new UnsupportedOperationException("deleteObsoleteInterfaces() is not used by Alarmd");
+    }
+
+    @Override
+    public void updateNodeScanStamp(Integer nodeId, Date scanStamp) {
+        throw new UnsupportedOperationException("updateNodeScanStamp() is not used by Alarmd");
+    }
+
+    @Override
+    public Collection<Integer> getNodeIds() {
+        throw new UnsupportedOperationException("getNodeIds() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findByForeignSourceAndIpAddress(String foreignSource, String ipAddress) {
+        throw new UnsupportedOperationException("findByForeignSourceAndIpAddress() is not used by Alarmd");
+    }
+
+    @Override
+    public Map<String, Long> getNumberOfNodesBySysOid() {
+        throw new UnsupportedOperationException("getNumberOfNodesBySysOid() is not used by Alarmd");
+    }
+
+    @Override
+    public SurveillanceStatus findSurveillanceStatusByCategoryLists(Collection<OnmsCategory> rowCategories,
+            Collection<OnmsCategory> columnCategories) {
+        throw new UnsupportedOperationException("findSurveillanceStatusByCategoryLists() is not used by Alarmd");
+    }
+
+    @Override
+    public Integer getNextNodeId(Integer nodeId) {
+        throw new UnsupportedOperationException("getNextNodeId() is not used by Alarmd");
+    }
+
+    @Override
+    public Integer getPreviousNodeId(Integer nodeId) {
+        throw new UnsupportedOperationException("getPreviousNodeId() is not used by Alarmd");
+    }
+
+    @Override
+    public void markHavingFlows(Collection<Integer> ingressIds, Collection<Integer> egressIds) {
+        throw new UnsupportedOperationException("markHavingFlows() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllHavingFlows() {
+        throw new UnsupportedOperationException("findAllHavingFlows() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllHavingIngressFlows() {
+        throw new UnsupportedOperationException("findAllHavingIngressFlows() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findAllHavingEgressFlows() {
+        throw new UnsupportedOperationException("findAllHavingEgressFlows() is not used by Alarmd");
+    }
+
+    @Override
+    public OnmsNode getDefaultFocusPoint() {
+        throw new UnsupportedOperationException("getDefaultFocusPoint() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findNodeWithMetaData(String context, String key, String value,
+            boolean matchEnumeration) {
+        throw new UnsupportedOperationException("findNodeWithMetaData() is not used by Alarmd");
+    }
+
+    @Override
+    public List<OnmsNode> findBySysNameOfLldpLinksOfNode(int nodeId) {
+        throw new UnsupportedOperationException("findBySysNameOfLldpLinksOfNode() is not used by Alarmd");
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/ServiceTypeDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/ServiceTypeDaoJpa.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.ServiceTypeDao;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA implementation of {@link ServiceTypeDao}.
+ */
+@Repository
+@Transactional
+public class ServiceTypeDaoJpa extends AbstractDaoJpa<OnmsServiceType, Integer> implements ServiceTypeDao {
+
+    public ServiceTypeDaoJpa() {
+        super(OnmsServiceType.class);
+    }
+
+    @Override
+    public OnmsServiceType findByName(String name) {
+        return findUnique(
+                "SELECT s FROM OnmsServiceType s WHERE s.name = ?1",
+                name);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/monitoringLocations/OnmsMonitoringLocation.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/monitoringLocations/OnmsMonitoringLocation.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.monitoringLocations;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Jakarta Persistence version of OnmsMonitoringLocation.
+ *
+ * <p>Minimal entity mapping for the monitoringLocations table.
+ * Only the columns required by foreign-key relationships from other
+ * Jakarta entities (e.g., OnmsNode.location) are mapped here.</p>
+ */
+@Entity
+@Table(name = "monitoringLocations")
+public class OnmsMonitoringLocation implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String DEFAULT_MONITORING_LOCATION_ID = "Default";
+
+    private String m_locationName;
+    private String m_monitoringArea;
+    private String m_geolocation;
+    private Float m_longitude;
+    private Float m_latitude;
+    private Long m_priority;
+
+    public OnmsMonitoringLocation() {}
+
+    public OnmsMonitoringLocation(String locationName, String monitoringArea) {
+        m_locationName = locationName;
+        m_monitoringArea = monitoringArea;
+    }
+
+    @Id
+    @Column(name = "id", nullable = false)
+    public String getLocationName() {
+        return m_locationName;
+    }
+
+    public void setLocationName(String locationName) {
+        m_locationName = locationName;
+    }
+
+    @Column(name = "monitoringArea", nullable = false)
+    public String getMonitoringArea() {
+        return m_monitoringArea;
+    }
+
+    public void setMonitoringArea(String monitoringArea) {
+        m_monitoringArea = monitoringArea;
+    }
+
+    @Column(name = "geolocation")
+    public String getGeolocation() {
+        return m_geolocation;
+    }
+
+    public void setGeolocation(String geolocation) {
+        m_geolocation = geolocation;
+    }
+
+    @Column(name = "longitude")
+    public Float getLongitude() {
+        return m_longitude;
+    }
+
+    public void setLongitude(Float longitude) {
+        m_longitude = longitude;
+    }
+
+    @Column(name = "latitude")
+    public Float getLatitude() {
+        return m_latitude;
+    }
+
+    public void setLatitude(Float latitude) {
+        m_latitude = latitude;
+    }
+
+    @Column(name = "priority")
+    public Long getPriority() {
+        return m_priority;
+    }
+
+    public void setPriority(Long priority) {
+        m_priority = priority;
+    }
+
+    @Override
+    public String toString() {
+        return "OnmsMonitoringLocation[" + m_locationName + "]";
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/package-info.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/package-info.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+/**
+ * Jakarta Persistence entity model for OpenNMS.
+ *
+ * <p>This package-info defines the Hibernate 7 compatible {@code @FilterDef}
+ * for the authorization filter used by entity classes in this package.
+ * It replaces the legacy package-info.java from opennms-model which uses
+ * Hibernate 3.x {@code @ParamDef(type="string")} syntax incompatible
+ * with Hibernate 7's {@code @ParamDef(type=String.class)}.</p>
+ */
+@FilterDef(
+    name = FilterManager.AUTH_FILTER_NAME,
+    parameters = @ParamDef(name = "userGroups", type = String.class)
+)
+package org.opennms.netmgt.model;
+
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;

--- a/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/InetAddressConverterTest.java
+++ b/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/InetAddressConverterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.core.utils.InetAddressUtils;
+
+class InetAddressConverterTest {
+
+    private final InetAddressConverter converter = new InetAddressConverter();
+
+    @Test
+    void convertToDatabaseColumn_ipv4() throws Exception {
+        InetAddress address = InetAddress.getByName("192.168.1.1");
+        String result = converter.convertToDatabaseColumn(address);
+        assertThat(result).isEqualTo("192.168.1.1");
+    }
+
+    @Test
+    void convertToDatabaseColumn_ipv6() throws Exception {
+        InetAddress address = InetAddress.getByName("::1");
+        String result = converter.convertToDatabaseColumn(address);
+        assertThat(result).isNotNull();
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void convertToDatabaseColumn_null() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_ipv4() {
+        InetAddress result = converter.convertToEntityAttribute("192.168.1.1");
+        assertThat(result).isNotNull();
+        assertThat(result.getHostAddress()).isEqualTo("192.168.1.1");
+    }
+
+    @Test
+    void convertToEntityAttribute_null() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void roundTrip_ipv4() throws Exception {
+        InetAddress original = InetAddress.getByName("10.0.0.1");
+        String dbValue = converter.convertToDatabaseColumn(original);
+        InetAddress result = converter.convertToEntityAttribute(dbValue);
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    void roundTrip_ipv6() throws Exception {
+        InetAddress original = InetAddressUtils.addr("::1");
+        String dbValue = converter.convertToDatabaseColumn(original);
+        InetAddress result = converter.convertToEntityAttribute(dbValue);
+        assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    void convertToDatabaseColumn_usesInetAddressUtilsStr() throws Exception {
+        // InetAddressUtils.str() produces a normalized form — verify round-trip consistency
+        InetAddress address = InetAddress.getByName("192.168.0.1");
+        String dbValue = converter.convertToDatabaseColumn(address);
+        assertThat(dbValue).isEqualTo(InetAddressUtils.str(address));
+    }
+}

--- a/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/NodeLabelSourceConverterTest.java
+++ b/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/NodeLabelSourceConverterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.model.OnmsNode.NodeLabelSource;
+
+class NodeLabelSourceConverterTest {
+
+    private final NodeLabelSourceConverter converter = new NodeLabelSourceConverter();
+
+    @Test
+    void convertToDatabaseColumn_user() {
+        assertThat(converter.convertToDatabaseColumn(NodeLabelSource.USER)).isEqualTo("U");
+    }
+
+    @Test
+    void convertToDatabaseColumn_netbios() {
+        assertThat(converter.convertToDatabaseColumn(NodeLabelSource.NETBIOS)).isEqualTo("N");
+    }
+
+    @Test
+    void convertToDatabaseColumn_hostname() {
+        assertThat(converter.convertToDatabaseColumn(NodeLabelSource.HOSTNAME)).isEqualTo("H");
+    }
+
+    @Test
+    void convertToDatabaseColumn_sysname() {
+        assertThat(converter.convertToDatabaseColumn(NodeLabelSource.SYSNAME)).isEqualTo("S");
+    }
+
+    @Test
+    void convertToDatabaseColumn_address() {
+        assertThat(converter.convertToDatabaseColumn(NodeLabelSource.ADDRESS)).isEqualTo("A");
+    }
+
+    @Test
+    void convertToDatabaseColumn_unknown() {
+        assertThat(converter.convertToDatabaseColumn(NodeLabelSource.UNKNOWN)).isEqualTo(" ");
+    }
+
+    @Test
+    void convertToDatabaseColumn_null() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_U() {
+        assertThat(converter.convertToEntityAttribute("U")).isEqualTo(NodeLabelSource.USER);
+    }
+
+    @Test
+    void convertToEntityAttribute_N() {
+        assertThat(converter.convertToEntityAttribute("N")).isEqualTo(NodeLabelSource.NETBIOS);
+    }
+
+    @Test
+    void convertToEntityAttribute_H() {
+        assertThat(converter.convertToEntityAttribute("H")).isEqualTo(NodeLabelSource.HOSTNAME);
+    }
+
+    @Test
+    void convertToEntityAttribute_S() {
+        assertThat(converter.convertToEntityAttribute("S")).isEqualTo(NodeLabelSource.SYSNAME);
+    }
+
+    @Test
+    void convertToEntityAttribute_A() {
+        assertThat(converter.convertToEntityAttribute("A")).isEqualTo(NodeLabelSource.ADDRESS);
+    }
+
+    @Test
+    void convertToEntityAttribute_space() {
+        assertThat(converter.convertToEntityAttribute(" ")).isEqualTo(NodeLabelSource.UNKNOWN);
+    }
+
+    @Test
+    void convertToEntityAttribute_null() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_invalid_throws() {
+        assertThatThrownBy(() -> converter.convertToEntityAttribute("X"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void allValues_roundTrip() {
+        for (NodeLabelSource source : NodeLabelSource.values()) {
+            String dbValue = converter.convertToDatabaseColumn(source);
+            assertThat(dbValue).isNotNull().hasSize(1);
+            NodeLabelSource result = converter.convertToEntityAttribute(dbValue);
+            assertThat(result).isEqualTo(source);
+        }
+    }
+
+    @Test
+    void dbValues_matchCharacters() {
+        for (NodeLabelSource source : NodeLabelSource.values()) {
+            assertThat(converter.convertToDatabaseColumn(source))
+                    .isEqualTo(String.valueOf(source.value()));
+        }
+    }
+}

--- a/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/NodeTypeConverterTest.java
+++ b/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/NodeTypeConverterTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.model.OnmsNode.NodeType;
+
+class NodeTypeConverterTest {
+
+    private final NodeTypeConverter converter = new NodeTypeConverter();
+
+    @Test
+    void convertToDatabaseColumn_active() {
+        assertThat(converter.convertToDatabaseColumn(NodeType.ACTIVE)).isEqualTo("A");
+    }
+
+    @Test
+    void convertToDatabaseColumn_deleted() {
+        assertThat(converter.convertToDatabaseColumn(NodeType.DELETED)).isEqualTo("D");
+    }
+
+    @Test
+    void convertToDatabaseColumn_unknown() {
+        assertThat(converter.convertToDatabaseColumn(NodeType.UNKNOWN)).isEqualTo(" ");
+    }
+
+    @Test
+    void convertToDatabaseColumn_null() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_A() {
+        assertThat(converter.convertToEntityAttribute("A")).isEqualTo(NodeType.ACTIVE);
+    }
+
+    @Test
+    void convertToEntityAttribute_D() {
+        assertThat(converter.convertToEntityAttribute("D")).isEqualTo(NodeType.DELETED);
+    }
+
+    @Test
+    void convertToEntityAttribute_space() {
+        assertThat(converter.convertToEntityAttribute(" ")).isEqualTo(NodeType.UNKNOWN);
+    }
+
+    @Test
+    void convertToEntityAttribute_null() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_invalid_throws() {
+        assertThatThrownBy(() -> converter.convertToEntityAttribute("X"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void allValues_roundTrip() {
+        for (NodeType type : NodeType.values()) {
+            String dbValue = converter.convertToDatabaseColumn(type);
+            assertThat(dbValue).isNotNull().hasSize(1);
+            NodeType result = converter.convertToEntityAttribute(dbValue);
+            assertThat(result).isEqualTo(type);
+        }
+    }
+
+    @Test
+    void dbValues_matchCharacters() {
+        assertThat(converter.convertToDatabaseColumn(NodeType.ACTIVE)).isEqualTo(String.valueOf(NodeType.ACTIVE.value()));
+        assertThat(converter.convertToDatabaseColumn(NodeType.DELETED)).isEqualTo(String.valueOf(NodeType.DELETED.value()));
+        assertThat(converter.convertToDatabaseColumn(NodeType.UNKNOWN)).isEqualTo(String.valueOf(NodeType.UNKNOWN.value()));
+    }
+}

--- a/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/OnmsSeverityConverterTest.java
+++ b/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/OnmsSeverityConverterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+class OnmsSeverityConverterTest {
+
+    private final OnmsSeverityConverter converter = new OnmsSeverityConverter();
+
+    @Test
+    void convertToDatabaseColumn_null_returnsOne() {
+        // Legacy UserType stores null as 1 (INDETERMINATE)
+        assertThat(converter.convertToDatabaseColumn(null)).isEqualTo(1);
+    }
+
+    @Test
+    void convertToDatabaseColumn_indeterminate() {
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.INDETERMINATE)).isEqualTo(1);
+    }
+
+    @Test
+    void convertToDatabaseColumn_critical() {
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.CRITICAL)).isEqualTo(7);
+    }
+
+    @Test
+    void convertToEntityAttribute_null() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_one() {
+        assertThat(converter.convertToEntityAttribute(1)).isEqualTo(OnmsSeverity.INDETERMINATE);
+    }
+
+    @Test
+    void convertToEntityAttribute_seven() {
+        assertThat(converter.convertToEntityAttribute(7)).isEqualTo(OnmsSeverity.CRITICAL);
+    }
+
+    @Test
+    void allValues_roundTrip() {
+        for (OnmsSeverity severity : OnmsSeverity.values()) {
+            Integer dbValue = converter.convertToDatabaseColumn(severity);
+            assertThat(dbValue).isEqualTo(severity.getId());
+            OnmsSeverity result = converter.convertToEntityAttribute(dbValue);
+            assertThat(result).isEqualTo(severity);
+        }
+    }
+
+    @Test
+    void allValues_correctIds() {
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.INDETERMINATE)).isEqualTo(1);
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.CLEARED)).isEqualTo(2);
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.NORMAL)).isEqualTo(3);
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.WARNING)).isEqualTo(4);
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.MINOR)).isEqualTo(5);
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.MAJOR)).isEqualTo(6);
+        assertThat(converter.convertToDatabaseColumn(OnmsSeverity.CRITICAL)).isEqualTo(7);
+    }
+}

--- a/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/PrimaryTypeConverterTest.java
+++ b/core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/PrimaryTypeConverterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.model.PrimaryType;
+
+class PrimaryTypeConverterTest {
+
+    private final PrimaryTypeConverter converter = new PrimaryTypeConverter();
+
+    @Test
+    void convertToDatabaseColumn_primary() {
+        assertThat(converter.convertToDatabaseColumn(PrimaryType.PRIMARY)).isEqualTo("P");
+    }
+
+    @Test
+    void convertToDatabaseColumn_secondary() {
+        assertThat(converter.convertToDatabaseColumn(PrimaryType.SECONDARY)).isEqualTo("S");
+    }
+
+    @Test
+    void convertToDatabaseColumn_notEligible() {
+        assertThat(converter.convertToDatabaseColumn(PrimaryType.NOT_ELIGIBLE)).isEqualTo("N");
+    }
+
+    @Test
+    void convertToDatabaseColumn_null() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_P() {
+        PrimaryType result = converter.convertToEntityAttribute("P");
+        assertThat(result).isEqualTo(PrimaryType.PRIMARY);
+    }
+
+    @Test
+    void convertToEntityAttribute_S() {
+        PrimaryType result = converter.convertToEntityAttribute("S");
+        assertThat(result).isEqualTo(PrimaryType.SECONDARY);
+    }
+
+    @Test
+    void convertToEntityAttribute_N() {
+        PrimaryType result = converter.convertToEntityAttribute("N");
+        assertThat(result).isEqualTo(PrimaryType.NOT_ELIGIBLE);
+    }
+
+    @Test
+    void convertToEntityAttribute_null() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void roundTrip_allTypes() {
+        for (PrimaryType type : PrimaryType.getAllTypes()) {
+            String dbValue = converter.convertToDatabaseColumn(type);
+            assertThat(dbValue).hasSize(1);
+            PrimaryType result = converter.convertToEntityAttribute(dbValue);
+            assertThat(result).isEqualTo(type);
+        }
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,6 +35,7 @@
     <module>daemon</module>
     <module>daemon-common</module>
     <module>daemon-boot-alarmd</module>
+    <module>opennms-model-jakarta</module>
     <module>db</module>
     <module>db-install</module>
     <module>health</module>

--- a/docs/superpowers/plans/2026-03-15-opennms-model-jakarta.md
+++ b/docs/superpowers/plans/2026-03-15-opennms-model-jakarta.md
@@ -1,0 +1,1178 @@
+# opennms-model-jakarta Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `core/opennms-model-jakarta` with Hibernate 7 / Jakarta Persistence entities, JPA AttributeConverters, and DAO implementations so Alarmd fully boots on Spring Boot 4 and processes events into alarms.
+
+**Architecture:** Fork the 12 entity classes Alarmd needs from `opennms-model` into a new module, rewriting `javax.persistence` → `jakarta.persistence`, replacing Hibernate 3.6 `@Type` UserTypes with standard JPA `@Converter` AttributeConverters, stripping JAXB annotations, and providing JPA DAO implementations that extend `AbstractDaoJpa`. Wire into `daemon-boot-alarmd`, remove `@EntityScan` from `daemon-common`, and enable the integration test.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.3, Hibernate 7 (from Spring Boot BOM), Jakarta Persistence 3.2, PostgreSQL, JUnit 5, Testcontainers
+
+**Spec:** `docs/superpowers/specs/2026-03-15-opennms-model-jakarta-design.md`
+
+**Worktree:** `/Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd` (branch `feature/spring-boot-4-alarmd-migration`)
+
+---
+
+## Chunk 1: Module Scaffold and AttributeConverters
+
+### Task 1: Create opennms-model-jakarta Maven module
+
+**Files:**
+- Create: `core/opennms-model-jakarta/pom.xml`
+- Modify: `core/pom.xml:37` (add module entry after `daemon-boot-alarmd`)
+
+- [ ] **Step 1: Create the POM file**
+
+Create `core/opennms-model-jakarta/pom.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.core</artifactId>
+        <version>36.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.model-jakarta</artifactId>
+    <packaging>jar</packaging>
+    <name>OpenNMS :: Core :: Model Jakarta</name>
+    <description>
+        Jakarta Persistence entity classes for Spring Boot 4 daemons.
+        Same package (org.opennms.netmgt.model) as legacy opennms-model,
+        different module. Only one should be on the classpath at runtime.
+    </description>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-boot.version>4.0.3</spring-boot.version>
+        <enforcer-skip-banned-dependencies>true</enforcer-skip-banned-dependencies>
+        <enforcer-skip-dependency-convergence>true</enforcer-skip-dependency-convergence>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Jakarta Persistence API (from Spring Boot 4 BOM) -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+
+        <!-- Hibernate 7 core — for @Filter, @Formula, @SQLRestriction annotations -->
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+
+        <!-- AbstractDaoJpa base class -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.daemon-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- DAO interfaces (AlarmDao, NodeDao, DistPollerDao, ServiceTypeDao) -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-dao-api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Shared enums and utilities (OnmsSeverity, InetAddressUtils, NodeType, etc.) -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-model</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Jackson for @JsonIgnoreProperties -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+                <configuration>
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.12.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>1.12.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+- [ ] **Step 2: Register module in core/pom.xml**
+
+In `core/pom.xml`, add `<module>opennms-model-jakarta</module>` after line 37 (after `daemon-boot-alarmd`):
+
+```xml
+    <module>daemon-boot-alarmd</module>
+    <module>opennms-model-jakarta</module>
+```
+
+- [ ] **Step 3: Create directory structure**
+
+```bash
+mkdir -p core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model
+mkdir -p core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter
+mkdir -p core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao
+mkdir -p core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter
+```
+
+- [ ] **Step 4: Verify Maven resolves**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.model-jakarta -am install`
+
+Expected: BUILD SUCCESS (empty module compiles)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/opennms-model-jakarta/pom.xml core/pom.xml
+git commit -m "build: add opennms-model-jakarta Maven module scaffold"
+```
+
+---
+
+### Task 2: Implement AttributeConverters with tests
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/InetAddressConverter.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/OnmsSeverityConverter.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/PrimaryTypeConverter.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/NodeTypeConverter.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/converter/NodeLabelSourceConverter.java`
+- Create: `core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/InetAddressConverterTest.java`
+- Create: `core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/OnmsSeverityConverterTest.java`
+- Create: `core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/PrimaryTypeConverterTest.java`
+- Create: `core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/NodeTypeConverterTest.java`
+- Create: `core/opennms-model-jakarta/src/test/java/org/opennms/netmgt/model/jakarta/converter/NodeLabelSourceConverterTest.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/InetAddressUserType.java` (understand legacy conversion logic)
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsSeverityUserType.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryTypeUserType.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/NodeTypeUserType.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/NodeLabelSourceUserType.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsSeverity.java` (enum with getId()/get(int))
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsNode.java` (NodeType and NodeLabelSource inner enums)
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryType.java` (or look for it on OnmsIpInterface)
+- Reference: `opennms-core/src/main/java/org/opennms/core/utils/InetAddressUtils.java` (addr() and str() methods)
+
+- [ ] **Step 1: Write converter tests**
+
+Write all 5 test classes. Each test covers: round-trip conversion, null handling, edge cases. Example for `InetAddressConverterTest`:
+
+```java
+package org.opennms.netmgt.model.jakarta.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+
+import org.junit.jupiter.api.Test;
+
+class InetAddressConverterTest {
+
+    private final InetAddressConverter converter = new InetAddressConverter();
+
+    @Test
+    void convertToDatabaseColumn_ipv4() {
+        InetAddress addr = InetAddress.getByName("192.168.1.1");
+        assertThat(converter.convertToDatabaseColumn(addr)).isEqualTo("192.168.1.1");
+    }
+
+    @Test
+    void convertToDatabaseColumn_null() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @Test
+    void convertToEntityAttribute_ipv4() {
+        InetAddress result = converter.convertToEntityAttribute("192.168.1.1");
+        assertThat(result.getHostAddress()).isEqualTo("192.168.1.1");
+    }
+
+    @Test
+    void convertToEntityAttribute_null() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void roundTrip() {
+        InetAddress original = InetAddress.getByName("::1");
+        String db = converter.convertToDatabaseColumn(original);
+        InetAddress result = converter.convertToEntityAttribute(db);
+        assertThat(result).isEqualTo(original);
+    }
+}
+```
+
+Follow same pattern for:
+- `OnmsSeverityConverterTest` — test each severity level (INDETERMINATE=1 through CRITICAL=7), null, round-trip
+- `PrimaryTypeConverterTest` — test PRIMARY('P'), SECONDARY('S'), NOT_ELIGIBLE('N'), null
+- `NodeTypeConverterTest` — test ACTIVE('A'), DELETED('D'), null
+- `NodeLabelSourceConverterTest` — test USER('U'), NETBIOS('N'), HOSTNAME('H'), SYSNAME('S'), ADDRESS('A'), null
+
+**Important:** Read the legacy `UserType` implementations first to understand exact conversion semantics. The legacy `InetAddressUserType` uses `InetAddressUtils.addr()` for String→InetAddress and `InetAddressUtils.str()` for InetAddress→String. Mirror that exact behavior.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl --projects :org.opennms.core.model-jakarta -am verify`
+
+Expected: Compilation errors (converter classes don't exist yet)
+
+- [ ] **Step 3: Implement all 5 converters**
+
+Each converter implements `jakarta.persistence.AttributeConverter<JavaType, DbType>`. Pattern:
+
+```java
+package org.opennms.netmgt.model.jakarta.converter;
+
+import java.net.InetAddress;
+
+import org.opennms.core.utils.InetAddressUtils;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class InetAddressConverter implements AttributeConverter<InetAddress, String> {
+    @Override
+    public String convertToDatabaseColumn(InetAddress addr) {
+        return addr == null ? null : InetAddressUtils.str(addr);
+    }
+
+    @Override
+    public InetAddress convertToEntityAttribute(String dbValue) {
+        return dbValue == null ? null : InetAddressUtils.addr(dbValue);
+    }
+}
+```
+
+For enum converters (OnmsSeverity, PrimaryType, NodeType, NodeLabelSource):
+- Read the legacy UserType `nullSafeGet`/`nullSafeSet` to match exact DB↔Java mapping
+- OnmsSeverity: `Integer` ↔ `OnmsSeverity` via `severity.getId()` / `OnmsSeverity.get(id)`
+- PrimaryType: `String` (single char) ↔ `PrimaryType` via `PrimaryType.get(char)` / `primaryType.getCharCode()` — check the actual method names on the PrimaryType enum
+- NodeType: `String` (single char) ↔ `OnmsNode.NodeType` — check the actual enum in OnmsNode
+- NodeLabelSource: `String` (single char) ↔ `OnmsNode.NodeLabelSource` — check the actual enum in OnmsNode
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl --projects :org.opennms.core.model-jakarta -am verify`
+
+Expected: All converter tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/
+git commit -m "feat: add JPA AttributeConverters for InetAddress, OnmsSeverity, PrimaryType, NodeType, NodeLabelSource"
+```
+
+---
+
+## Chunk 2: Simple Entity Classes
+
+Migrate the simpler entities first. These have no custom UserType annotations and few relationships.
+
+### Task 3: Migrate OnmsServiceType, OnmsCategory, OnmsMemo, OnmsReductionKeyMemo, AlarmAssociation
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsServiceType.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsCategory.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMemo.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsReductionKeyMemo.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsServiceType.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsCategory.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsMemo.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsReductionKeyMemo.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java`
+
+- [ ] **Step 1: Fork OnmsServiceType**
+
+Copy from `opennms-model/.../OnmsServiceType.java` to `core/opennms-model-jakarta/.../OnmsServiceType.java`. Apply these transformations:
+1. `javax.persistence.*` → `jakarta.persistence.*`
+2. Remove `javax.xml.bind.*` imports and all `@XmlRootElement`, `@XmlAttribute` annotations
+3. Remove `org.codehaus.jackson.annotate.JsonIgnoreProperties` → replace with `com.fasterxml.jackson.annotation.JsonIgnoreProperties` (Jackson 2.x)
+4. Keep `@Entity`, `@Table`, `@Id`, `@Column`, `@SequenceGenerator`, `@GeneratedValue`, `@JsonIgnoreProperties`
+5. Retain `serialVersionUID`, constructors, equals/hashCode, toString
+
+- [ ] **Step 2: Fork OnmsCategory**
+
+Same transformation pattern. Additional notes:
+- `@Filter(name=FilterManager.AUTH_FILTER_NAME, condition="...")` — keep as-is (Hibernate 7 supports `@Filter`)
+- `@ElementCollection` + `@JoinTable` for `authorizedGroups` — standard JPA, just change namespace
+- `org.hibernate.annotations.Filter` import stays the same package in Hibernate 7
+
+- [ ] **Step 3: Fork OnmsMemo**
+
+Same pattern. Notes:
+- `@Inheritance(strategy = InheritanceType.SINGLE_TABLE)` — standard JPA
+- `@DiscriminatorColumn` / `@DiscriminatorValue` — standard JPA
+- `@PrePersist` / `@PreUpdate` lifecycle callbacks — standard JPA
+- Field-level annotations (this entity uses field access, not property access like others)
+
+- [ ] **Step 4: Fork OnmsReductionKeyMemo**
+
+Read the legacy source first. It extends `OnmsMemo` with `@DiscriminatorValue("ReductionKeyMemo")` and adds a `reductionKey` field. Same namespace change.
+
+- [ ] **Step 5: Fork AlarmAssociation**
+
+Same pattern. Notes:
+- `@ManyToOne` / `@OneToOne` / `@JoinColumn` to `OnmsAlarm` — standard JPA
+- This entity references `OnmsAlarm` which we haven't migrated yet. That's OK — same package, the class will exist when we add it in a later task.
+- `@Temporal(TemporalType.TIMESTAMP)` on `mappedTime` — keep as-is
+
+- [ ] **Step 6: Verify module compiles**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.model-jakarta -am install`
+
+Expected: BUILD SUCCESS (entities may have unresolved references to OnmsAlarm — that's OK if using forward references within the same package. If compilation fails due to OnmsAlarm missing, add a stub or reorder to do OnmsAlarm first.)
+
+**If AlarmAssociation fails to compile** because OnmsAlarm doesn't exist yet: defer AlarmAssociation to Task 5 (after OnmsAlarm is migrated).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/
+git commit -m "feat: add Jakarta entity classes — OnmsServiceType, OnmsCategory, OnmsMemo, OnmsReductionKeyMemo, AlarmAssociation"
+```
+
+---
+
+## Chunk 3: Complex Entity Classes
+
+### Task 4: Migrate OnmsMonitoringSystem, OnmsDistPoller, OnmsSnmpInterface, OnmsIpInterface, OnmsMonitoredService
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoringSystem.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsDistPoller.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsMonitoringSystem.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsDistPoller.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java`
+
+- [ ] **Step 1: Fork OnmsMonitoringSystem**
+
+Key transformations beyond namespace change:
+- `@Inheritance(strategy = InheritanceType.SINGLE_TABLE)` + `@DiscriminatorColumn` — standard JPA
+- `@DiscriminatorOptions(force=true)` — verify in Hibernate 7 API. If the annotation doesn't exist, remove it (standard JPA discriminator handling is sufficient)
+- `@Type(type="org.opennms.netmgt.model.InetAddressUserType")` → `@Convert(converter = InetAddressConverter.class)` — import from `org.opennms.netmgt.model.jakarta.converter`
+- `@ElementCollection` + `@JoinTable` for properties map — standard JPA
+- Remove all JAXB annotations
+
+- [ ] **Step 2: Fork OnmsDistPoller**
+
+Simple — extends `OnmsMonitoringSystem` with `@DiscriminatorValue("OpenNMS")`. Namespace change + JAXB strip only.
+
+- [ ] **Step 3: Fork OnmsSnmpInterface**
+
+Read the legacy source carefully. Key transformations:
+- `javax.persistence.*` → `jakarta.persistence.*`
+- `@ManyToOne` to `OnmsNode` — standard JPA
+- `@OneToMany` to `OnmsIpInterface` — standard JPA
+- Remove JAXB
+- Check for any `@Type` annotations — if InetAddress fields exist, use `@Convert(converter = InetAddressConverter.class)`
+
+- [ ] **Step 4: Fork OnmsIpInterface**
+
+Key transformations:
+- `@Type(type="org.opennms.netmgt.model.InetAddressUserType")` on `ipAddr` field → `@Convert(converter = InetAddressConverter.class)`
+- `@Type(type="org.opennms.netmgt.model.PrimaryTypeUserType")` or `@Type(type="org.opennms.netmgt.model.CharacterUserType")` on `snmpPrimary` → `@Convert(converter = PrimaryTypeConverter.class)`
+- `@ManyToOne` to `OnmsNode`, `OnmsSnmpInterface` — standard JPA
+- `@OneToMany` to `OnmsMonitoredService` — standard JPA
+- `@Filter` — keep
+- Remove JAXB
+
+- [ ] **Step 5: Fork OnmsMonitoredService**
+
+Key transformations:
+- `@Where(clause="ifRegainedService is null")` → `@SQLRestriction("ifRegainedService is null")` — import `org.hibernate.annotations.SQLRestriction`
+- `@ManyToOne` to `OnmsIpInterface`, `OnmsServiceType` — standard JPA
+- Remove JAXB
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.model-jakarta -am install`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/
+git commit -m "feat: add Jakarta entity classes — OnmsMonitoringSystem, OnmsDistPoller, OnmsSnmpInterface, OnmsIpInterface, OnmsMonitoredService"
+```
+
+---
+
+### Task 5: Migrate OnmsNode and OnmsAlarm
+
+These are the two most complex entities. OnmsAlarm is the primary entity for Alarmd.
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsNode.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsNode.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java`
+
+- [ ] **Step 1: Fork OnmsNode**
+
+This is a large entity (~800+ lines). Key transformations:
+- `javax.persistence.*` → `jakarta.persistence.*`
+- `@Type(type="org.opennms.netmgt.model.InetAddressUserType")` → `@Convert(converter = InetAddressConverter.class)`
+- `@Type(type="org.opennms.netmgt.model.NodeTypeUserType")` → `@Convert(converter = NodeTypeConverter.class)`
+- `@Type(type="org.opennms.netmgt.model.NodeLabelSourceUserType")` → `@Convert(converter = NodeLabelSourceConverter.class)`
+- `@SecondaryTable(name="pathOutage")` — standard JPA, namespace change only
+- `@ManyToMany` to `OnmsCategory` with `@JoinTable` — standard JPA
+- `@OneToMany` to `OnmsIpInterface`, `OnmsSnmpInterface` — standard JPA
+- `@ManyToOne` to `OnmsMonitoringSystem` — standard JPA
+- `@Filter` — keep
+- `@Embedded` / `@AttributeOverrides` — standard JPA, namespace change
+- Remove all JAXB, update Jackson import from `org.codehaus.jackson` → `com.fasterxml.jackson`
+
+**Critical:** The `NodeType` and `NodeLabelSource` enums may be inner enums of `OnmsNode` or standalone classes. Read the source to determine. The converters must reference the correct type.
+
+- [ ] **Step 2: Fork OnmsAlarm**
+
+This is the most complex entity (~1300 lines). Key transformations:
+- `javax.persistence.*` → `jakarta.persistence.*`
+- `@Type(type="org.opennms.netmgt.model.InetAddressUserType")` → `@Convert(converter = InetAddressConverter.class)`
+- `@Type(type="org.opennms.netmgt.model.OnmsSeverityUserType")` → `@Convert(converter = OnmsSeverityConverter.class)`
+- `@ManyToOne` to `OnmsNode`, `OnmsMonitoringSystem`, `OnmsServiceType` — standard JPA
+- `@OneToMany` to `AlarmAssociation` with `cascade = CascadeType.ALL, orphanRemoval = true` — standard JPA
+- `@ElementCollection` for `relatedSituations` — standard JPA
+- `@Formula(value = "(SELECT COUNT(*)>0 FROM ...)")` — keep (Hibernate 7 supports this)
+- `@Filter(name=FilterManager.AUTH_FILTER_NAME, ...)` — keep
+- `@ManyToOne` to `OnmsMemo` (m_stickyMemo) and `OnmsReductionKeyMemo` (m_reductionKeyMemo) — standard JPA
+- Remove all JAXB annotations and `@XmlJavaTypeAdapter`
+- Update Jackson imports from `org.codehaus.jackson` → `com.fasterxml.jackson`
+
+**Note about denormalized event fields:** OnmsAlarm stores event data as flat columns (eventUei, eventSource, etc.) — there is no FK to an events table and no `OnmsEvent` entity to reference.
+
+- [ ] **Step 3: If AlarmAssociation was deferred from Task 3, add it now**
+
+`AlarmAssociation` references `OnmsAlarm` bidirectionally. Now that `OnmsAlarm` exists, ensure `AlarmAssociation.java` compiles correctly.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.model-jakarta -am install`
+
+Expected: BUILD SUCCESS with all 12 entity classes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/
+git commit -m "feat: add Jakarta entity classes — OnmsNode and OnmsAlarm (most complex entities)"
+```
+
+---
+
+## Chunk 4: JPA DAO Implementations
+
+### Task 6: Implement AlarmDaoJpa
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/AlarmDaoJpa.java`
+- Reference: `opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AlarmDao.java` (interface to implement)
+- Reference: `opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/LegacyOnmsDao.java` (parent interface)
+- Reference: `opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/AlarmDaoHibernate.java` (legacy implementation for HQL reference)
+- Reference: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/AbstractDaoJpa.java` (base class)
+
+- [ ] **Step 1: Create AlarmDaoJpa**
+
+```java
+package org.opennms.netmgt.model.jakarta.dao;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.model.AlarmSummary;
+import org.opennms.netmgt.model.HeatMapElement;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.SituationSummary;
+import org.opennms.netmgt.model.OnmsCriteria;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional
+public class AlarmDaoJpa extends AbstractDaoJpa<OnmsAlarm, Integer> implements AlarmDao {
+
+    public AlarmDaoJpa() {
+        super(OnmsAlarm.class);
+    }
+
+    // --- LegacyOnmsDao methods (not used by Alarmd) ---
+
+    @Override
+    public List<OnmsAlarm> findMatching(OnmsCriteria criteria) {
+        throw new UnsupportedOperationException("OnmsCriteria not supported in JPA DAOs");
+    }
+
+    @Override
+    public int countMatching(OnmsCriteria criteria) {
+        throw new UnsupportedOperationException("OnmsCriteria not supported in JPA DAOs");
+    }
+
+    // --- AlarmDao custom methods ---
+
+    @Override
+    public OnmsAlarm findByReductionKey(String reductionKey) {
+        return findUnique("SELECT a FROM OnmsAlarm a WHERE a.reductionKey = ?1", reductionKey);
+    }
+
+    @Override
+    public List<AlarmSummary> getNodeAlarmSummaries() {
+        // Implement by reading legacy AlarmDaoHibernate.getNodeAlarmSummaries() HQL
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public List<SituationSummary> getSituationSummaries() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public List<AlarmSummary> getNodeAlarmSummariesIncludeAcknowledgedOnes(List<Integer> nodeIds) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public List<HeatMapElement> getHeatMapItemsForEntity(String entityNameColumn,
+            String entityIdColumn, boolean processAcknowledgedAlarms,
+            String restrictionColumn, String restrictionValue, String... groupByColumns) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public List<OnmsAlarm> getAlarmsForEventParameters(Map<String, String> eventParameters) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public long getNumSituations() {
+        return queryInt("SELECT COUNT(a) FROM OnmsAlarm a WHERE a.reductionKey LIKE 'situation%'");
+    }
+
+    @Override
+    public long getNumAlarmsLastHours(int hours) {
+        // Use HQL with current_timestamp - hours
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+}
+```
+
+**Important:** Read `opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/AlarmDaoHibernate.java` to get the exact HQL for each method. The key method Alarmd actually calls is `findByReductionKey`. The summary/heatmap methods are used by REST APIs (future scope). Implement `findByReductionKey` fully; the rest can throw `UnsupportedOperationException` for now.
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.model-jakarta -am install`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/AlarmDaoJpa.java
+git commit -m "feat: add AlarmDaoJpa — JPA implementation of AlarmDao"
+```
+
+---
+
+### Task 7: Implement NodeDaoJpa, DistPollerDaoJpa, ServiceTypeDaoJpa
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/NodeDaoJpa.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/DistPollerDaoJpa.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/ServiceTypeDaoJpa.java`
+- Reference: `opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/NodeDao.java`
+- Reference: `opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/DistPollerDao.java`
+- Reference: `opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/ServiceTypeDao.java`
+- Reference: `opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java`
+- Reference: `opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/DistPollerDaoHibernate.java`
+- Reference: `opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/ServiceTypeDaoHibernate.java`
+
+- [ ] **Step 1: Create NodeDaoJpa**
+
+`NodeDao` extends `LegacyOnmsDao` and has many custom methods. Implement only what `AlarmPersisterImpl` calls:
+- `get(Integer id)` — inherited from `AbstractDaoJpa`
+
+All other `NodeDao` methods: throw `UnsupportedOperationException`. Also implement `LegacyOnmsDao` methods:
+- `findMatching(OnmsCriteria)` → throw
+- `countMatching(OnmsCriteria)` → throw
+
+**Pattern:**
+```java
+@Repository
+@Transactional
+public class NodeDaoJpa extends AbstractDaoJpa<OnmsNode, Integer> implements NodeDao {
+    public NodeDaoJpa() { super(OnmsNode.class); }
+
+    // LegacyOnmsDao
+    @Override
+    public List<OnmsNode> findMatching(OnmsCriteria criteria) {
+        throw new UnsupportedOperationException("OnmsCriteria not supported");
+    }
+    @Override
+    public int countMatching(OnmsCriteria criteria) {
+        throw new UnsupportedOperationException("OnmsCriteria not supported");
+    }
+
+    // NodeDao custom methods — implement only what Alarmd uses
+    // All others throw UnsupportedOperationException
+    // ...
+}
+```
+
+- [ ] **Step 2: Create DistPollerDaoJpa**
+
+`DistPollerDao` extends `OnmsDao<OnmsDistPoller, String>` directly (no LegacyOnmsDao).
+
+```java
+@Repository
+@Transactional
+public class DistPollerDaoJpa extends AbstractDaoJpa<OnmsDistPoller, String> implements DistPollerDao {
+    public DistPollerDaoJpa() { super(OnmsDistPoller.class); }
+
+    @Override
+    public OnmsDistPoller whoami() {
+        // Return the local system — find by ID "00000000-0000-0000-0000-000000000000"
+        // or query by type = "OpenNMS". Read legacy DistPollerDaoHibernate for exact logic.
+        return findUnique("SELECT d FROM OnmsDistPoller d WHERE d.type = 'OpenNMS'");
+    }
+}
+```
+
+- [ ] **Step 3: Create ServiceTypeDaoJpa**
+
+`ServiceTypeDao` extends `OnmsDao<OnmsServiceType, Integer>` directly.
+
+```java
+@Repository
+@Transactional
+public class ServiceTypeDaoJpa extends AbstractDaoJpa<OnmsServiceType, Integer> implements ServiceTypeDao {
+    public ServiceTypeDaoJpa() { super(OnmsServiceType.class); }
+
+    @Override
+    public OnmsServiceType findByName(String name) {
+        return findUnique("SELECT s FROM OnmsServiceType s WHERE s.name = ?1", name);
+    }
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.model-jakarta -am install`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/
+git commit -m "feat: add NodeDaoJpa, DistPollerDaoJpa, ServiceTypeDaoJpa"
+```
+
+---
+
+## Chunk 5: Wire Into daemon-boot-alarmd
+
+### Task 8: Update daemon-common — remove hardcoded @EntityScan
+
+**Files:**
+- Modify: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonDataSourceConfiguration.java:9`
+
+- [ ] **Step 1: Remove @EntityScan from DaemonDataSourceConfiguration**
+
+In `core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonDataSourceConfiguration.java`:
+
+Remove line 3 (`import org.springframework.boot.persistence.autoconfigure.EntityScan;`) and line 9 (`@EntityScan(basePackages = "org.opennms.netmgt.model")`).
+
+The file becomes:
+```java
+package org.opennms.core.daemon.common;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class DaemonDataSourceConfiguration {
+    // Spring Boot auto-configuration handles:
+    // - HikariCP DataSource from spring.datasource.* properties
+    // - Hibernate SessionFactory from spring.jpa.* properties
+    // - JpaTransactionManager
+    //
+    // @EntityScan is placed on each boot application's configuration
+    // to scan the correct entity package for that daemon.
+    // Schema management is "none" (Liquibase manages via db-init container).
+}
+```
+
+- [ ] **Step 2: Verify daemon-common still compiles**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.daemon-common -am install`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonDataSourceConfiguration.java
+git commit -m "refactor: remove hardcoded @EntityScan from DaemonDataSourceConfiguration
+
+Each boot application now controls its own @EntityScan via its
+configuration class. This allows different daemons to scan different
+entity packages."
+```
+
+---
+
+### Task 9: Update daemon-boot-alarmd — switch to opennms-model-jakarta
+
+**Files:**
+- Modify: `core/daemon-boot-alarmd/pom.xml` (swap opennms-model → opennms-model-jakarta, remove javax.persistence-api)
+- Modify: `core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdApplication.java` (add scan package)
+- Modify: `core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java` (add @EntityScan)
+
+- [ ] **Step 1: Update daemon-boot-alarmd pom.xml**
+
+In `core/daemon-boot-alarmd/pom.xml`:
+
+1. **Add** dependency on `opennms-model-jakarta`:
+```xml
+<dependency>
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.model-jakarta</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
+
+2. **Remove** the direct `opennms-model` dependency block (lines 187-206) — it's now pulled transitively through `opennms-model-jakarta`
+
+3. **Remove** the `javax.persistence-api:2.2` dependency block (lines 208-215) — no longer needed
+
+4. **Remove** the `opennms-dao-api` direct dependency (lines 182-186) — it's now pulled transitively through `opennms-model-jakarta`
+
+- [ ] **Step 2: Add @EntityScan to AlarmdConfiguration**
+
+In `core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java`:
+
+Add `@EntityScan` annotation:
+```java
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+
+@Configuration
+@EntityScan(basePackages = "org.opennms.netmgt.model")
+public class AlarmdConfiguration {
+```
+
+- [ ] **Step 3: Add DAO package to component scan**
+
+In `core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdApplication.java`:
+
+Add the DAO package to `scanBasePackages`:
+```java
+@SpringBootApplication(scanBasePackages = {
+    "org.opennms.core.daemon.common",
+    "org.opennms.netmgt.alarmd",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+```
+
+- [ ] **Step 4: Verify daemon-boot-alarmd compiles**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-alarmd -am install`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-alarmd/pom.xml core/daemon-boot-alarmd/src/
+git commit -m "feat: wire opennms-model-jakarta into daemon-boot-alarmd
+
+Replace opennms-model + javax.persistence with opennms-model-jakarta.
+Add @EntityScan to AlarmdConfiguration and DAO package to component scan.
+Alarmd now uses native Jakarta Persistence entities and JPA DAOs."
+```
+
+---
+
+## Chunk 6: Integration Test
+
+### Task 10: Create DDL script for test database
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/test/resources/schema.sql`
+
+- [ ] **Step 1: Extract current schema DDL**
+
+Create a simplified DDL script containing only the tables Alarmd's entities map to. Extract from the existing Liquibase-managed schema or write by hand based on entity annotations:
+
+Tables needed:
+- `monitoringSystems` (OnmsMonitoringSystem / OnmsDistPoller)
+- `node` (OnmsNode)
+- `pathOutage` (secondary table for OnmsNode)
+- `categories` (OnmsCategory)
+- `category_node` (join table for Node↔Category)
+- `category_group` (join table for Category authorized groups)
+- `service` (OnmsServiceType)
+- `snmpInterface` (OnmsSnmpInterface)
+- `ipInterface` (OnmsIpInterface)
+- `ifServices` (OnmsMonitoredService)
+- `alarms` (OnmsAlarm)
+- `alarm_situations` (AlarmAssociation)
+- `memos` (OnmsMemo / OnmsReductionKeyMemo)
+- `accessLocks` (used by AbstractDaoJpa.lock())
+
+**Source:** Read `core/schema/src/main/liquibase/changelog.xml` and the referenced changeset files to get exact column definitions, or reverse-engineer from the entity annotations.
+
+The DDL should use PostgreSQL syntax. Include sequence definitions (alarmsNxtId, catNxtId, memoNxtId, serviceNxtId, etc.) and the accessLocks seed data.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/test/resources/schema.sql
+git commit -m "test: add PostgreSQL DDL script for Alarmd integration tests"
+```
+
+---
+
+### Task 11: Enable AlarmdApplicationIT
+
+**Files:**
+- Modify: `core/daemon-boot-alarmd/src/test/java/org/opennms/netmgt/alarmd/boot/AlarmdApplicationIT.java`
+- Modify: `core/daemon-boot-alarmd/pom.xml` (add Testcontainers dependencies if not present)
+
+- [ ] **Step 1: Read the existing disabled test**
+
+Read `core/daemon-boot-alarmd/src/test/java/org/opennms/netmgt/alarmd/boot/AlarmdApplicationIT.java` to understand what's currently there and what's commented out.
+
+- [ ] **Step 2: Add Testcontainers dependencies to daemon-boot-alarmd pom.xml**
+
+```xml
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>postgresql</artifactId>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>kafka</artifactId>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>junit-jupiter</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+Also add Testcontainers BOM to `<dependencyManagement>` if not already managed by Spring Boot BOM:
+```xml
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>testcontainers-bom</artifactId>
+    <version>1.19.7</version>
+    <type>pom</type>
+    <scope>import</scope>
+</dependency>
+```
+
+- [ ] **Step 3: Rewrite AlarmdApplicationIT**
+
+Enable the full integration test:
+
+```java
+package org.opennms.netmgt.alarmd.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@Testcontainers
+class AlarmdApplicationIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("opennms")
+            .withUsername("opennms")
+            .withPassword("opennms")
+            .withInitScript("schema.sql");
+
+    @Container
+    static KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.6.0"));
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("opennms.kafka.bootstrap-servers", kafka::getBootstrapServers);
+    }
+
+    @Autowired
+    private AlarmDao alarmDao;
+
+    @Autowired
+    private DistPollerDao distPollerDao;
+
+    @Test
+    void contextLoads() {
+        assertThat(alarmDao).isNotNull();
+        assertThat(distPollerDao).isNotNull();
+    }
+
+    @Test
+    void canPersistAndRetrieveAlarm() {
+        var alarm = new OnmsAlarm();
+        alarm.setUei("uei.opennms.org/test");
+        alarm.setReductionKey("uei.opennms.org/test::1");
+        alarm.setCounter(1);
+        alarm.setSeverity(org.opennms.netmgt.model.OnmsSeverity.MAJOR);
+        alarm.setDistPoller(distPollerDao.whoami());
+
+        Integer id = alarmDao.save(alarm);
+        assertThat(id).isNotNull();
+
+        OnmsAlarm loaded = alarmDao.get(id);
+        assertThat(loaded.getReductionKey()).isEqualTo("uei.opennms.org/test::1");
+        assertThat(loaded.getSeverity()).isEqualTo(org.opennms.netmgt.model.OnmsSeverity.MAJOR);
+    }
+
+    @Test
+    void findByReductionKey() {
+        var alarm = new OnmsAlarm();
+        alarm.setUei("uei.opennms.org/test/rk");
+        alarm.setReductionKey("test-reduction-key");
+        alarm.setCounter(1);
+        alarm.setSeverity(org.opennms.netmgt.model.OnmsSeverity.WARNING);
+        alarm.setDistPoller(distPollerDao.whoami());
+        alarmDao.save(alarm);
+
+        OnmsAlarm found = alarmDao.findByReductionKey("test-reduction-key");
+        assertThat(found).isNotNull();
+        assertThat(found.getUei()).isEqualTo("uei.opennms.org/test/rk");
+    }
+}
+```
+
+**Note:** The `schema.sql` init script from Task 10 must be on the test classpath. Since it's in `opennms-model-jakarta/src/test/resources/`, it needs to be accessible from `daemon-boot-alarmd`'s test classpath. Either:
+- Copy the `schema.sql` to `daemon-boot-alarmd/src/test/resources/`, or
+- Add `opennms-model-jakarta` with `<classifier>tests</classifier>` as a test dependency
+
+Prefer copying for simplicity.
+
+- [ ] **Step 4: Run integration test**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -t --projects :org.opennms.core.daemon-boot-alarmd -am verify`
+
+Expected: Tests PASS (context loads, alarm persisted and retrieved)
+
+**If tests fail:** Debug by checking:
+1. Schema.sql syntax errors → check Testcontainers PostgreSQL logs
+2. Entity mapping errors → check Hibernate startup logs for unmapped columns
+3. Converter errors → check that `@Convert` annotations are processed
+4. Bean wiring errors → check that DAOs are discovered by component scan
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-alarmd/pom.xml core/daemon-boot-alarmd/src/test/
+git commit -m "test: enable AlarmdApplicationIT with Testcontainers PostgreSQL + Kafka
+
+Validates: Spring context loads, AlarmDaoJpa persists alarms,
+findByReductionKey works, OnmsSeverity converter round-trips."
+```
+
+---
+
+### Task 12: Full build verification
+
+- [ ] **Step 1: Run full compile of all modules**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -DskipTests`
+
+Expected: BUILD SUCCESS (all modules compile, including legacy Karaf daemons that still use opennms-model)
+
+This verifies no split-package conflicts and that the new module doesn't break existing modules.
+
+- [ ] **Step 2: Run opennms-model-jakarta tests**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl --projects :org.opennms.core.model-jakarta -am verify`
+
+Expected: All converter tests PASS
+
+- [ ] **Step 3: Run daemon-boot-alarmd integration tests**
+
+Run: `cd /Users/david/development/src/opennms/delta-v/.worktrees/spring-boot-alarmd && ./compile.pl -t --projects :org.opennms.core.daemon-boot-alarmd -am verify`
+
+Expected: All integration tests PASS
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+git push delta-v feature/spring-boot-4-alarmd-migration
+gh pr create --repo pbrane/delta-v --base develop \
+    --title "feat: add opennms-model-jakarta with Hibernate 7 entities for Alarmd" \
+    --body "$(cat <<'EOF'
+## Summary
+- New `core/opennms-model-jakarta` module with 12 Jakarta Persistence entity classes
+- 5 JPA AttributeConverters replacing Hibernate 3.6 UserTypes
+- 4 JPA DAO implementations (AlarmDaoJpa, NodeDaoJpa, DistPollerDaoJpa, ServiceTypeDaoJpa)
+- Alarmd Spring Boot app now boots with real Hibernate 7 + PostgreSQL
+- Integration test validates alarm persistence end-to-end
+
+## Test plan
+- [ ] Converter unit tests pass
+- [ ] AlarmdApplicationIT integration test passes with Testcontainers
+- [ ] Full `./compile.pl -DskipTests` passes (no split-package conflicts)
+- [ ] Docker E2E: `./test-passive-e2e.sh` passes with Alarmd on Spring Boot 4
+EOF
+)"
+```
+
+**CRITICAL:** Always use `--repo pbrane/delta-v` — never PR against OpenNMS/opennms.

--- a/docs/superpowers/plans/2026-03-15-opennms-model-jakarta.md
+++ b/docs/superpowers/plans/2026-03-15-opennms-model-jakarta.md
@@ -294,7 +294,7 @@ class InetAddressConverterTest {
     private final InetAddressConverter converter = new InetAddressConverter();
 
     @Test
-    void convertToDatabaseColumn_ipv4() {
+    void convertToDatabaseColumn_ipv4() throws Exception {
         InetAddress addr = InetAddress.getByName("192.168.1.1");
         assertThat(converter.convertToDatabaseColumn(addr)).isEqualTo("192.168.1.1");
     }
@@ -316,7 +316,7 @@ class InetAddressConverterTest {
     }
 
     @Test
-    void roundTrip() {
+    void roundTrip() throws Exception {
         InetAddress original = InetAddress.getByName("::1");
         String db = converter.convertToDatabaseColumn(original);
         InetAddress result = converter.convertToEntityAttribute(db);
@@ -614,10 +614,10 @@ import java.util.Map;
 
 import org.opennms.core.daemon.common.AbstractDaoJpa;
 import org.opennms.netmgt.dao.api.AlarmDao;
-import org.opennms.netmgt.model.AlarmSummary;
+import org.opennms.netmgt.model.alarm.AlarmSummary;
+import org.opennms.netmgt.model.alarm.SituationSummary;
 import org.opennms.netmgt.model.HeatMapElement;
 import org.opennms.netmgt.model.OnmsAlarm;
-import org.opennms.netmgt.model.SituationSummary;
 import org.opennms.netmgt.model.OnmsCriteria;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/docs/superpowers/specs/2026-03-15-opennms-model-jakarta-design.md
+++ b/docs/superpowers/specs/2026-03-15-opennms-model-jakarta-design.md
@@ -26,7 +26,6 @@ Only entities in Alarmd's transitive dependency graph:
 | Entity | Table | Why Alarmd Needs It |
 |--------|-------|-------------------|
 | `OnmsAlarm` | `alarms` | Primary — Alarmd creates/updates/clears alarms |
-| `OnmsEvent` | `events` | Every alarm references its triggering event |
 | `OnmsNode` | `node` | Alarms reference the node they belong to |
 | `OnmsMonitoringSystem` | `monitoringSystems` | Alarms reference the monitoring system |
 | `OnmsDistPoller` | `monitoringSystems` | Single-table inheritance subclass of OnmsMonitoringSystem |
@@ -35,26 +34,39 @@ Only entities in Alarmd's transitive dependency graph:
 | `OnmsIpInterface` | `ipInterface` | OnmsNode cascades to interfaces; OnmsAlarm has FK to node |
 | `OnmsSnmpInterface` | `snmpInterface` | Referenced by OnmsIpInterface |
 | `OnmsMonitoredService` | `ifServices` | Referenced by OnmsAlarm directly |
+| `AlarmAssociation` | `alarm_situations` | OnmsAlarm.m_associatedAlarms (situation/correlated alarm support) |
+| `OnmsMemo` | `memos` | OnmsAlarm.m_stickyMemo (single-table inheritance parent) |
+| `OnmsReductionKeyMemo` | `memos` | OnmsAlarm.m_reductionKeyMemo (extends OnmsMemo) |
+
+**Note:** `OnmsEvent` does not exist as a JPA entity in the codebase. OnmsAlarm stores denormalized event fields directly (eventUei, eventSource, etc.) — there is no FK to an events table.
 
 Enums (`OnmsSeverity`, `NodeType`, `NodeLabelSource`, `PrimaryType`) and utility classes (`InetAddressUtils`) are **referenced from existing modules**, not copied.
+
+### Package Strategy
+
+Entity classes use the **same package** `org.opennms.netmgt.model` as the legacy `opennms-model`. This is critical: DAO interfaces in `opennms-dao-api` are parameterized with `org.opennms.netmgt.model.OnmsAlarm`, etc. Using a different package would make it impossible for `AlarmDaoJpa` to implement `AlarmDao` without forking the DAO interfaces.
+
+The entities live in a different Maven module (`opennms-model-jakarta`) but the same Java package. At runtime, only one module is on the classpath — the legacy `opennms-model` for Karaf daemons, or `opennms-model-jakarta` for Spring Boot daemons. No split-package conflict.
 
 ## Module Structure
 
 ```
 core/opennms-model-jakarta/
   pom.xml
+  src/main/java/org/opennms/netmgt/model/
+    OnmsAlarm.java
+    OnmsNode.java
+    OnmsMonitoringSystem.java
+    OnmsDistPoller.java
+    OnmsServiceType.java
+    OnmsCategory.java
+    OnmsIpInterface.java
+    OnmsSnmpInterface.java
+    OnmsMonitoredService.java
+    AlarmAssociation.java
+    OnmsMemo.java
+    OnmsReductionKeyMemo.java
   src/main/java/org/opennms/netmgt/model/jakarta/
-    entity/
-      OnmsAlarm.java
-      OnmsEvent.java
-      OnmsNode.java
-      OnmsMonitoringSystem.java
-      OnmsDistPoller.java
-      OnmsServiceType.java
-      OnmsCategory.java
-      OnmsIpInterface.java
-      OnmsSnmpInterface.java
-      OnmsMonitoredService.java
     converter/
       InetAddressConverter.java
       OnmsSeverityConverter.java
@@ -63,9 +75,8 @@ core/opennms-model-jakarta/
       NodeLabelSourceConverter.java
     dao/
       AlarmDaoJpa.java
-      EventDaoJpa.java
       NodeDaoJpa.java
-      MonitoringSystemDaoJpa.java
+      DistPollerDaoJpa.java
       ServiceTypeDaoJpa.java
   src/test/java/org/opennms/netmgt/model/jakarta/
     converter/
@@ -75,6 +86,8 @@ core/opennms-model-jakarta/
       NodeTypeConverterTest.java
       NodeLabelSourceConverterTest.java
 ```
+
+Entity classes are in `org.opennms.netmgt.model` (same package as legacy). Converters and DAOs are in `org.opennms.netmgt.model.jakarta.*` subpackages since they are new classes with no legacy counterpart.
 
 ## AttributeConverter Design
 
@@ -144,8 +157,11 @@ These annotations are valid in Hibernate 7 and remain unchanged:
 - `@Filter(name=..., condition="...")` — row-level security
 - `@FilterDef(name=...)` — filter definitions
 - `@Formula(value="(SELECT ...)")` — read-only computed properties
-- `@DiscriminatorOptions(force=true)` — single-table inheritance
-- `@Where(clause="...")` — collection filtering (if present)
+
+### Hibernate Annotations Migrated
+
+- `@Where(clause="...")` → `@SQLRestriction("...")` — `@Where` was removed in Hibernate 7; `@SQLRestriction` is the replacement. Used in `OnmsMonitoredService`.
+- `@DiscriminatorOptions(force=true)` — verify availability in Hibernate 7; if removed, omit (standard JPA discriminator handling suffices for `OnmsMonitoringSystem`/`OnmsMemo` hierarchies)
 
 ### Single-Table Inheritance
 
@@ -171,17 +187,33 @@ Retained on `java.util.Date` fields for explicitness, though Hibernate 7 infers 
 
 ## DAO Design
 
-Each DAO extends `AbstractDaoJpa<T, K>` (from `daemon-common`) and implements the corresponding interface from `opennms-dao-api`.
+### Interface Hierarchy
 
-| DAO Class | Entity | Interface | Key Queries |
-|-----------|--------|-----------|-------------|
-| `AlarmDaoJpa` | `OnmsAlarm` | `AlarmDao` | `findByReductionKey(String)`, `findByAlarm(OnmsAlarm)` |
-| `EventDaoJpa` | `OnmsEvent` | `EventDao` | `findByEventId(Integer)` |
-| `NodeDaoJpa` | `OnmsNode` | `NodeDao` | `get(Integer)`, `findByLabel(String)` |
-| `MonitoringSystemDaoJpa` | `OnmsMonitoringSystem` | `MonitoringSystemDao` | `get(String)` |
+The DAO interfaces in `opennms-dao-api` follow this hierarchy:
+
+```
+OnmsDao<T, K>                    ← base (16 methods: get, save, delete, findAll, countAll, etc.)
+  └─ LegacyOnmsDao<T, K>        ← adds findMatching(OnmsCriteria), countMatching(OnmsCriteria)
+       └─ AlarmDao               ← adds 8 custom methods (findByReductionKey, getNodeAlarmSummaries, etc.)
+       └─ NodeDao                ← adds many custom methods
+       └─ DistPollerDao          ← adds whoami(), etc.
+       └─ ServiceTypeDao         ← adds findByName()
+```
+
+`AbstractDaoJpa` implements `OnmsDao<T, K>`. Each JPA DAO must additionally satisfy `LegacyOnmsDao` (throw `UnsupportedOperationException` for `OnmsCriteria` methods) and implement all custom methods declared by the specific DAO interface.
+
+### DAO Table
+
+| DAO Class | Entity | Interface | Key Custom Methods |
+|-----------|--------|-----------|-------------------|
+| `AlarmDaoJpa` | `OnmsAlarm` | `AlarmDao` | `findByReductionKey(String)`, `getNodeAlarmSummaries()`, `getSituationSummaries()`, `getNodeAlarmSummariesIncludeAcknowledgedOnes(List)`, `getHeatMapItemsForEntity(...)`, `getAlarmsForEventParameters(Map)`, `getNumSituations()`, `getNumAlarmsLastHours(int)` |
+| `NodeDaoJpa` | `OnmsNode` | `NodeDao` | `get(Integer)`, `findByLabel(String)` — implement only methods Alarmd calls; others throw `UnsupportedOperationException` |
+| `DistPollerDaoJpa` | `OnmsDistPoller` | `DistPollerDao` | `whoami()` — returns the local monitoring system |
 | `ServiceTypeDaoJpa` | `OnmsServiceType` | `ServiceTypeDao` | `findByName(String)` |
 
-DAOs use HQL via `AbstractDaoJpa.find()` and `findUnique()` helpers. `findMatching(Criteria)` and `countMatching(Criteria)` remain `UnsupportedOperationException` — Alarmd does not use the OpenNMS Criteria API.
+**Note:** No `EventDao` or `EventDaoJpa` — `OnmsEvent` does not exist as a JPA entity. Alarmd receives events via Kafka and stores denormalized event fields on `OnmsAlarm`.
+
+DAOs use HQL via `AbstractDaoJpa.find()` and `findUnique()` helpers. `findMatching(OnmsCriteria)` and `countMatching(OnmsCriteria)` from `LegacyOnmsDao` throw `UnsupportedOperationException` — Alarmd does not use the legacy Criteria API.
 
 DAOs are annotated with `@Repository` for Spring auto-detection and `@Transactional` where needed.
 
@@ -254,16 +286,40 @@ The module inherits Spring Boot 4.0.3 BOM from `daemon-common`'s dependency mana
 
 ### EntityScan Update
 
-`DaemonDataSourceConfiguration` in `daemon-common` currently scans `org.opennms.netmgt.model`. For Alarmd, this changes to `org.opennms.netmgt.model.jakarta.entity`. This is configured in the Alarmd boot module, not in daemon-common (daemon-common should not hardcode entity packages).
+`DaemonDataSourceConfiguration` in `daemon-common` currently hardcodes `@EntityScan(basePackages = "org.opennms.netmgt.model")`. This annotation must be **removed from daemon-common** and placed on each boot application's configuration instead. For Alarmd:
+
+```java
+@Configuration
+@EntityScan(basePackages = "org.opennms.netmgt.model")
+public class AlarmdConfiguration { ... }
+```
+
+The package stays `org.opennms.netmgt.model` because the Jakarta entities use the same package as the legacy entities (different module, same package).
 
 ### AlarmdConfiguration Bean Wiring
 
-The JPA DAOs are auto-discovered via `@Repository` + component scanning of `org.opennms.netmgt.model.jakarta.dao`. They implement the same DAO interfaces (`AlarmDao`, `NodeDao`, etc.) that `AlarmPersisterImpl` and other Alarmd classes inject — no changes to Alarmd source code needed.
+The JPA DAOs are auto-discovered via `@Repository` + component scanning of `org.opennms.netmgt.model.jakarta.dao`. They implement the same DAO interfaces (`AlarmDao`, `NodeDao`, `DistPollerDao`, `ServiceTypeDao`) that `AlarmPersisterImpl` and other Alarmd classes inject — no changes to Alarmd source code needed.
+
+### AlarmPersisterImpl Dependencies
+
+`AlarmPersisterImpl` uses `@Autowired` field injection for 7 dependencies:
+
+| Dependency | Provided By |
+|-----------|-------------|
+| `AlarmDao` | `AlarmDaoJpa` (from opennms-model-jakarta) |
+| `NodeDao` | `NodeDaoJpa` (from opennms-model-jakarta) |
+| `DistPollerDao` | `DistPollerDaoJpa` (from opennms-model-jakarta) |
+| `ServiceTypeDao` | `ServiceTypeDaoJpa` (from opennms-model-jakarta) |
+| `EventUtil` | Bean defined in `AlarmdConfiguration` |
+| `TransactionOperations` | Spring Boot auto-config (from `PlatformTransactionManager`) |
+| `AlarmEntityNotifier` | `AlarmEntityNotifierImpl` bean in `AlarmdConfiguration` |
+
+`EventUtil` is a stateful service with its own dependencies — it must be wired as a bean in `AlarmdConfiguration`. Field injection in `AlarmPersisterImpl` is left as-is for now (refactoring to constructor injection is out of scope for this migration step).
 
 ### Integration Test
 
 `AlarmdApplicationIT` will be enabled with:
-- Testcontainers PostgreSQL (schema loaded via Liquibase or SQL script)
+- Testcontainers PostgreSQL with schema loaded via a simplified DDL script (not Liquibase — the full Liquibase changelog has ~800 changesets with complex migration history; a flat DDL of the current schema is simpler and faster for tests)
 - Testcontainers Kafka
 - Verify: Spring context loads → Alarmd starts → send test event via Kafka → alarm created in PostgreSQL → alarm queryable via `AlarmDaoJpa`
 
@@ -276,3 +332,5 @@ The JPA DAOs are auto-discovered via `@Repository` + component scanning of `org.
 | Enum/utility class imports from `opennms-model` pull in javax transitives | Classpath conflicts | Careful `<exclusions>` in POM; only enum classes and `InetAddressUtils` needed |
 | `opennms-dao-api` DAO interfaces reference `org.opennms.core.criteria.Criteria` | DAOs must implement or throw | Already handled: `AbstractDaoJpa` throws `UnsupportedOperationException`; Alarmd doesn't use Criteria API |
 | HQL queries from legacy DAOs use positional parameters differently | Query failures at runtime | Integration test with real PostgreSQL validates all DAO queries |
+| `opennms-model` on classpath alongside `opennms-model-jakarta` causes split-package | Class loading ambiguity | `daemon-boot-alarmd` depends on `opennms-model-jakarta` only; `opennms-model` excluded transitively via `<exclusions>` on any dependency that pulls it in |
+| `EventUtil` has complex dependency tree | Context fails to load | Wire `EventUtil` explicitly in `AlarmdConfiguration`; stub unavailable dependencies if needed |

--- a/docs/superpowers/specs/2026-03-15-opennms-model-jakarta-design.md
+++ b/docs/superpowers/specs/2026-03-15-opennms-model-jakarta-design.md
@@ -193,14 +193,14 @@ The DAO interfaces in `opennms-dao-api` follow this hierarchy:
 
 ```
 OnmsDao<T, K>                    ← base (16 methods: get, save, delete, findAll, countAll, etc.)
-  └─ LegacyOnmsDao<T, K>        ← adds findMatching(OnmsCriteria), countMatching(OnmsCriteria)
-       └─ AlarmDao               ← adds 8 custom methods (findByReductionKey, getNodeAlarmSummaries, etc.)
-       └─ NodeDao                ← adds many custom methods
-       └─ DistPollerDao          ← adds whoami(), etc.
-       └─ ServiceTypeDao         ← adds findByName()
+  ├─ LegacyOnmsDao<T, K>        ← adds findMatching(OnmsCriteria), countMatching(OnmsCriteria)
+  │    ├─ AlarmDao               ← adds 8 custom methods (findByReductionKey, getNodeAlarmSummaries, etc.)
+  │    └─ NodeDao                ← adds many custom methods
+  ├─ DistPollerDao               ← extends OnmsDao directly; adds whoami(), etc.
+  └─ ServiceTypeDao              ← extends OnmsDao directly; adds findByName()
 ```
 
-`AbstractDaoJpa` implements `OnmsDao<T, K>`. Each JPA DAO must additionally satisfy `LegacyOnmsDao` (throw `UnsupportedOperationException` for `OnmsCriteria` methods) and implement all custom methods declared by the specific DAO interface.
+`AbstractDaoJpa` implements `OnmsDao<T, K>` (including throwing `UnsupportedOperationException` for `findMatching(Criteria)`). `AlarmDaoJpa` and `NodeDaoJpa` must additionally implement `LegacyOnmsDao`'s `findMatching(OnmsCriteria)` and `countMatching(OnmsCriteria)` methods (throw `UnsupportedOperationException`), since `AbstractDaoJpa` does not cover those. `DistPollerDaoJpa` and `ServiceTypeDaoJpa` extend `OnmsDao` directly and do not need `LegacyOnmsDao` methods.
 
 ### DAO Table
 
@@ -213,7 +213,7 @@ OnmsDao<T, K>                    ← base (16 methods: get, save, delete, findAl
 
 **Note:** No `EventDao` or `EventDaoJpa` — `OnmsEvent` does not exist as a JPA entity. Alarmd receives events via Kafka and stores denormalized event fields on `OnmsAlarm`.
 
-DAOs use HQL via `AbstractDaoJpa.find()` and `findUnique()` helpers. `findMatching(OnmsCriteria)` and `countMatching(OnmsCriteria)` from `LegacyOnmsDao` throw `UnsupportedOperationException` — Alarmd does not use the legacy Criteria API.
+DAOs use HQL via `AbstractDaoJpa.find()` and `findUnique()` helpers. `AlarmDaoJpa` and `NodeDaoJpa` implement `LegacyOnmsDao`'s `findMatching(OnmsCriteria)` and `countMatching(OnmsCriteria)` by throwing `UnsupportedOperationException` — Alarmd does not use the legacy Criteria API. `DistPollerDaoJpa` and `ServiceTypeDaoJpa` extend `OnmsDao` directly and do not have these methods.
 
 DAOs are annotated with `@Repository` for Spring auto-detection and `@Transactional` where needed.
 

--- a/docs/superpowers/specs/2026-03-15-opennms-model-jakarta-design.md
+++ b/docs/superpowers/specs/2026-03-15-opennms-model-jakarta-design.md
@@ -1,0 +1,278 @@
+# opennms-model-jakarta Design Spec
+
+## Overview
+
+Create `core/opennms-model-jakarta`, an Alarmd-scoped module containing Jakarta Persistence (Hibernate 7) entity classes, JPA `AttributeConverter` implementations, and JPA DAO classes. This module replaces the legacy `opennms-model` + `opennms-dao` dependency chain for the Spring Boot 4 Alarmd microservice, eliminating the javax→jakarta bytecode transformation step entirely.
+
+## Goals
+
+- Alarmd boots as a Spring Boot 4.0.3 application with a real PostgreSQL DataSource, Hibernate 7, and JPA DAOs
+- Entity classes use `jakarta.persistence.*` natively — no Eclipse Transformer
+- Custom Hibernate 3.6 `UserType` implementations replaced with standard JPA `AttributeConverter`
+- JAXB annotations stripped — Jackson-only serialization for the microservice
+- Alarmd can receive events via Kafka, create/update/clear alarms, and persist them to PostgreSQL
+
+## Non-Goals
+
+- Migrating all ~32 entity classes from `opennms-model` — only Alarmd's transitive closure
+- Maintaining backward compatibility with Karaf consumers — this module is Spring Boot-only
+- REST API endpoints — separate future concern
+- OpenNMS Criteria → JPA CriteriaBuilder translation (DAOs use HQL for now)
+
+## Entity Scope
+
+Only entities in Alarmd's transitive dependency graph:
+
+| Entity | Table | Why Alarmd Needs It |
+|--------|-------|-------------------|
+| `OnmsAlarm` | `alarms` | Primary — Alarmd creates/updates/clears alarms |
+| `OnmsEvent` | `events` | Every alarm references its triggering event |
+| `OnmsNode` | `node` | Alarms reference the node they belong to |
+| `OnmsMonitoringSystem` | `monitoringSystems` | Alarms reference the monitoring system |
+| `OnmsDistPoller` | `monitoringSystems` | Single-table inheritance subclass of OnmsMonitoringSystem |
+| `OnmsServiceType` | `service` | Alarms can reference a service type |
+| `OnmsCategory` | `categories` | Nodes have categories (ManyToMany, needed for `@Filter` auth) |
+| `OnmsIpInterface` | `ipInterface` | OnmsNode cascades to interfaces; OnmsAlarm has FK to node |
+| `OnmsSnmpInterface` | `snmpInterface` | Referenced by OnmsIpInterface |
+| `OnmsMonitoredService` | `ifServices` | Referenced by OnmsAlarm directly |
+
+Enums (`OnmsSeverity`, `NodeType`, `NodeLabelSource`, `PrimaryType`) and utility classes (`InetAddressUtils`) are **referenced from existing modules**, not copied.
+
+## Module Structure
+
+```
+core/opennms-model-jakarta/
+  pom.xml
+  src/main/java/org/opennms/netmgt/model/jakarta/
+    entity/
+      OnmsAlarm.java
+      OnmsEvent.java
+      OnmsNode.java
+      OnmsMonitoringSystem.java
+      OnmsDistPoller.java
+      OnmsServiceType.java
+      OnmsCategory.java
+      OnmsIpInterface.java
+      OnmsSnmpInterface.java
+      OnmsMonitoredService.java
+    converter/
+      InetAddressConverter.java
+      OnmsSeverityConverter.java
+      PrimaryTypeConverter.java
+      NodeTypeConverter.java
+      NodeLabelSourceConverter.java
+    dao/
+      AlarmDaoJpa.java
+      EventDaoJpa.java
+      NodeDaoJpa.java
+      MonitoringSystemDaoJpa.java
+      ServiceTypeDaoJpa.java
+  src/test/java/org/opennms/netmgt/model/jakarta/
+    converter/
+      InetAddressConverterTest.java
+      OnmsSeverityConverterTest.java
+      PrimaryTypeConverterTest.java
+      NodeTypeConverterTest.java
+      NodeLabelSourceConverterTest.java
+```
+
+## AttributeConverter Design
+
+Five converters replace Hibernate 3.6 `UserType` implementations:
+
+| Converter | Java Type | DB Column Type | Replaces |
+|-----------|-----------|---------------|----------|
+| `InetAddressConverter` | `InetAddress` ↔ `String` | VARCHAR | `InetAddressUserType` |
+| `OnmsSeverityConverter` | `OnmsSeverity` ↔ `Integer` | INTEGER | `OnmsSeverityUserType` |
+| `PrimaryTypeConverter` | `PrimaryType` ↔ `String` | CHAR(1) | `PrimaryTypeUserType` + `CharacterUserType` |
+| `NodeTypeConverter` | `NodeType` ↔ `String` | CHAR(1) | `NodeTypeUserType` |
+| `NodeLabelSourceConverter` | `NodeLabelSource` ↔ `String` | CHAR(1) | `NodeLabelSourceUserType` |
+
+### Converter Pattern
+
+```java
+@Converter
+public class OnmsSeverityConverter implements AttributeConverter<OnmsSeverity, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(OnmsSeverity severity) {
+        return severity == null ? null : severity.getId();
+    }
+
+    @Override
+    public OnmsSeverity convertToEntityAttribute(Integer id) {
+        return id == null ? null : OnmsSeverity.get(id);
+    }
+}
+```
+
+All converters are null-safe and bidirectional. Applied to entity fields via `@Convert(converter = XxxConverter.class)`, replacing `@Type(type="org.opennms.netmgt.model.XxxUserType")`.
+
+## Entity Migration Patterns
+
+### Namespace Change
+
+```java
+// Before (opennms-model)
+import javax.persistence.*;
+
+// After (opennms-model-jakarta)
+import jakarta.persistence.*;
+```
+
+### @Type → @Convert
+
+```java
+// Before
+@Type(type="org.opennms.netmgt.model.InetAddressUserType")
+@Column(name="ipAddr")
+private InetAddress ipAddr;
+
+// After
+@Convert(converter = InetAddressConverter.class)
+@Column(name="ipAddr")
+private InetAddress ipAddr;
+```
+
+### JAXB Annotations Stripped
+
+All `@XmlRootElement`, `@XmlElement`, `@XmlAttribute`, `@XmlTransient`, `@XmlJavaTypeAdapter` annotations removed. Jackson `@JsonIgnoreProperties` / `@JsonIgnore` retained where needed for serialization control.
+
+### Hibernate-Specific Annotations Retained
+
+These annotations are valid in Hibernate 7 and remain unchanged:
+
+- `@Filter(name=..., condition="...")` — row-level security
+- `@FilterDef(name=...)` — filter definitions
+- `@Formula(value="(SELECT ...)")` — read-only computed properties
+- `@DiscriminatorOptions(force=true)` — single-table inheritance
+- `@Where(clause="...")` — collection filtering (if present)
+
+### Single-Table Inheritance
+
+`OnmsMonitoringSystem` → `OnmsDistPoller` inheritance is standard JPA:
+
+```java
+@Entity
+@Table(name = "monitoringSystems")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+public class OnmsMonitoringSystem { ... }
+
+@Entity
+@DiscriminatorValue("OpenNMS")
+public class OnmsDistPoller extends OnmsMonitoringSystem { ... }
+```
+
+Works identically in Hibernate 7.
+
+### @Temporal Handling
+
+Retained on `java.util.Date` fields for explicitness, though Hibernate 7 infers `TIMESTAMP` automatically.
+
+## DAO Design
+
+Each DAO extends `AbstractDaoJpa<T, K>` (from `daemon-common`) and implements the corresponding interface from `opennms-dao-api`.
+
+| DAO Class | Entity | Interface | Key Queries |
+|-----------|--------|-----------|-------------|
+| `AlarmDaoJpa` | `OnmsAlarm` | `AlarmDao` | `findByReductionKey(String)`, `findByAlarm(OnmsAlarm)` |
+| `EventDaoJpa` | `OnmsEvent` | `EventDao` | `findByEventId(Integer)` |
+| `NodeDaoJpa` | `OnmsNode` | `NodeDao` | `get(Integer)`, `findByLabel(String)` |
+| `MonitoringSystemDaoJpa` | `OnmsMonitoringSystem` | `MonitoringSystemDao` | `get(String)` |
+| `ServiceTypeDaoJpa` | `OnmsServiceType` | `ServiceTypeDao` | `findByName(String)` |
+
+DAOs use HQL via `AbstractDaoJpa.find()` and `findUnique()` helpers. `findMatching(Criteria)` and `countMatching(Criteria)` remain `UnsupportedOperationException` — Alarmd does not use the OpenNMS Criteria API.
+
+DAOs are annotated with `@Repository` for Spring auto-detection and `@Transactional` where needed.
+
+## Maven Dependencies
+
+### opennms-model-jakarta pom.xml
+
+```xml
+<dependencies>
+    <!-- Jakarta Persistence API (from Spring Boot 4 BOM) -->
+    <dependency>
+        <groupId>jakarta.persistence</groupId>
+        <artifactId>jakarta.persistence-api</artifactId>
+    </dependency>
+
+    <!-- Hibernate 7 core (from Spring Boot 4 BOM) -->
+    <dependency>
+        <groupId>org.hibernate.orm</groupId>
+        <artifactId>hibernate-core</artifactId>
+    </dependency>
+
+    <!-- DAO interfaces -->
+    <dependency>
+        <groupId>org.opennms</groupId>
+        <artifactId>opennms-dao-api</artifactId>
+        <version>${project.version}</version>
+        <!-- Exclude all javax/Hibernate 3.6 transitive deps -->
+    </dependency>
+
+    <!-- Shared enums and utilities (OnmsSeverity, InetAddressUtils, etc.) -->
+    <dependency>
+        <groupId>org.opennms</groupId>
+        <artifactId>opennms-model</artifactId>
+        <version>${project.version}</version>
+        <!-- Exclude javax.persistence, Hibernate 3.6, JAXB -->
+    </dependency>
+
+    <!-- AbstractDaoJpa base class -->
+    <dependency>
+        <groupId>org.opennms.core</groupId>
+        <artifactId>org.opennms.core.daemon-common</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+
+    <!-- Jackson for @JsonIgnoreProperties -->
+    <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+The module inherits Spring Boot 4.0.3 BOM from `daemon-common`'s dependency management, which pins Hibernate ORM, Jakarta Persistence, and Spring versions.
+
+### daemon-boot-alarmd pom.xml Changes
+
+- **Remove:** `opennms-model` direct dependency
+- **Remove:** `javax.persistence:javax.persistence-api:2.2`
+- **Add:** `opennms-model-jakarta`
+- **Remove:** Eclipse Transformer profile (no longer needed for Alarmd)
+
+## Integration with daemon-boot-alarmd
+
+### EntityScan Update
+
+`DaemonDataSourceConfiguration` in `daemon-common` currently scans `org.opennms.netmgt.model`. For Alarmd, this changes to `org.opennms.netmgt.model.jakarta.entity`. This is configured in the Alarmd boot module, not in daemon-common (daemon-common should not hardcode entity packages).
+
+### AlarmdConfiguration Bean Wiring
+
+The JPA DAOs are auto-discovered via `@Repository` + component scanning of `org.opennms.netmgt.model.jakarta.dao`. They implement the same DAO interfaces (`AlarmDao`, `NodeDao`, etc.) that `AlarmPersisterImpl` and other Alarmd classes inject — no changes to Alarmd source code needed.
+
+### Integration Test
+
+`AlarmdApplicationIT` will be enabled with:
+- Testcontainers PostgreSQL (schema loaded via Liquibase or SQL script)
+- Testcontainers Kafka
+- Verify: Spring context loads → Alarmd starts → send test event via Kafka → alarm created in PostgreSQL → alarm queryable via `AlarmDaoJpa`
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| `@Formula` SQL subqueries behave differently in Hibernate 7 | Alarm `isSituation`/`isInSituation` fields break | Integration test specifically validates formula-derived properties |
+| `@Filter` for auth not activated in microservice context | Security gap | Alarmd is internal-only (no external REST yet); filter activation deferred to REST API migration |
+| Enum/utility class imports from `opennms-model` pull in javax transitives | Classpath conflicts | Careful `<exclusions>` in POM; only enum classes and `InetAddressUtils` needed |
+| `opennms-dao-api` DAO interfaces reference `org.opennms.core.criteria.Criteria` | DAOs must implement or throw | Already handled: `AbstractDaoJpa` throws `UnsupportedOperationException`; Alarmd doesn't use Criteria API |
+| HQL queries from legacy DAOs use positional parameters differently | Query failures at runtime | Integration test with real PostgreSQL validates all DAO queries |

--- a/opennms-assemblies/pom.xml
+++ b/opennms-assemblies/pom.xml
@@ -27,7 +27,6 @@
     <module>minion</module>
     <module>sentinel</module>
     <module>version</module>
-    <module>webapp-full</module>
     <module>xsds</module>
   </modules>
 

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -145,7 +145,7 @@ do_stage_daemon_jars() {
         "core/daemon-loader-perspectivepoller/target/org.opennms.core.daemon-loader-perspectivepoller-$VERSION.jar:daemon-loader-perspectivepoller.jar"
         "core/daemon-loader-telemetryd/target/daemon-loader-telemetryd-$VERSION.jar:daemon-loader-telemetryd.jar"
         # Spring Boot fat JARs (migrated daemons)
-        "core/daemon-boot-alarmd/target/org.opennms.core.daemon-boot-alarmd-$VERSION.jar:daemon-boot-alarmd.jar"
+        "core/daemon-boot-alarmd/target/org.opennms.core.daemon-boot-alarmd-$VERSION-boot.jar:daemon-boot-alarmd.jar"
         # Special JARs (EventTranslator split-package fix, Alarmd, Passive status)
         "opennms-config/target/opennms-config-$VERSION.jar:opennms-config.jar"
         "opennms-util/target/opennms-util-$VERSION.jar:opennms-util.jar"

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -67,13 +67,6 @@ do_compile() {
 }
 
 do_assemble() {
-    log "Assembling Horizon distribution (webapp — skipped, use Java 17 if needed)..."
-    # NOTE: assemble.pl builds opennms-full-assembly which is the webapp container.
-    # The webapp stays on Java 17 and is out of scope for the Java 21 daemon upgrade.
-    # Build it separately with Java 17 if needed: JAVA_HOME=<jdk17> ./assemble.pl -p dir -DskipTests
-    # cd "$REPO_ROOT"
-    # ./assemble.pl -Dopennms.home=/opt/opennms -DskipTests -p dir
-
     log "Building Karaf container modules (shared + karaf + features)..."
     cd "$REPO_ROOT"
     ./maven/bin/mvn -DskipTests -pl container/shared,container/karaf,container/features clean install
@@ -111,15 +104,8 @@ do_images() {
     local make_args="DOCKER_REGISTRY=$DOCKER_REGISTRY DOCKER_ORG=$DOCKER_ORG"
     [ "${1:-}" = "push" ] && make_args="$make_args DOCKER_FLAGS=--push"
 
-    # NOTE: Horizon image (webapp) requires full assembly built with Java 17.
-    # Build separately if needed: JAVA_HOME=<jdk17> ./assemble.pl -p dir && make -C opennms-container/core image
-    if [ -f "$REPO_ROOT/opennms-full-assembly/target/opennms-full-assembly-$VERSION-core.tar.gz" ]; then
-        log "Building Horizon image (opennms/horizon:$VERSION)..."
-        cd "$REPO_ROOT/opennms-container/core"
-        make image $make_args
-    else
-        log "Skipping Horizon image (no full assembly found — build with Java 17 if needed)"
-    fi
+    # The legacy Horizon webapp image (opennms-full-assembly) is not built by Delta-V.
+    # Delta-V uses Spring Boot daemons, not the monolithic Karaf webapp.
 
     # The sentinel Makefile tags as opennms/sentinel, but the Delta-V
     # docker-compose expects opennms/daemon. Build then re-tag.
@@ -147,9 +133,6 @@ do_stage_daemon_jars() {
     mkdir -p "$staging"
 
     # Common JARs (all daemon containers)
-    # NOTE: features.xml is copied directly from webapp-overlay/ in Dockerfile.daemon,
-    # not staged here. The patched features.xml must come from the image extraction,
-    # not from container/features/target/classes/features.xml (which is only one input).
     local pairs=(
         "core/event-forwarder-kafka/target/org.opennms.core.event-forwarder-kafka-$VERSION.jar:event-forwarder-kafka.jar"
         "features/events/daemon/target/org.opennms.features.events.daemon-$VERSION.jar:events.daemon.jar"
@@ -228,34 +211,6 @@ do_deltav_images() {
     docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "deltav" | head -10
 }
 
-do_webapp_overlay() {
-    log "Preparing webapp overlay..."
-    local overlay_dir="$SCRIPT_DIR/webapp-jetty-webinf-overlay"
-    mkdir -p "$overlay_dir/lib" "$overlay_dir/menu"
-
-    # Copy updated webapp JARs.
-    # opennms-webapp produces a WAR — the JAR is inside the exploded WAR.
-    local webapp_jar="$REPO_ROOT/opennms-webapp/target/opennms-webapp-$VERSION/WEB-INF/lib/opennms-webapp-$VERSION.jar"
-    local rest_jar="$REPO_ROOT/opennms-webapp-rest/target/opennms-webapp-rest-$VERSION.jar"
-    if [ -f "$webapp_jar" ]; then
-        cp "$webapp_jar" "$overlay_dir/lib/"
-    else
-        log "WARNING: webapp JAR not found at $webapp_jar — run './build.sh compile' first"
-    fi
-    [ -f "$rest_jar" ] && cp "$rest_jar" "$overlay_dir/lib/"
-
-    # Copy dispatcher-servlet.xml
-    local servlet_xml="$REPO_ROOT/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml"
-    [ -f "$servlet_xml" ] && cp "$servlet_xml" "$overlay_dir/"
-
-    # Copy menu templates
-    local menu_src="$REPO_ROOT/ui/src/menu/dist-menu"
-    if [ -d "$menu_src" ]; then
-        cp "$menu_src"/menu-template*.json "$overlay_dir/menu/" 2>/dev/null || true
-    fi
-
-    log "Webapp overlay prepared at $overlay_dir"
-}
 
 usage() {
     cat <<'USAGE'
@@ -264,10 +219,9 @@ Usage: ./build.sh [command]
 Commands:
   (none)    Full build: compile + assemble + images + deltav
   compile   Compile only (Maven)
-  assemble  Assemble distributions (Horizon + Daemon + Alarmd)
+  assemble  Assemble distributions (Daemon + Alarmd + Minion + Sentinel)
   images    Build base Docker images only (requires prior assembly)
   deltav    Build Delta-V layered images (stages JARs into derived images)
-  overlay   Prepare webapp overlay files
   push      Build and push images to registry
   clean     Remove named Docker volumes (fresh start)
   help      Show this help
@@ -300,7 +254,6 @@ main() {
         all)
             do_compile
             do_assemble
-            do_webapp_overlay
             do_images
             do_deltav_images
             log "Build complete! Run: cd $SCRIPT_DIR && docker compose up -d"
@@ -317,13 +270,9 @@ main() {
         deltav)
             do_deltav_images
             ;;
-        overlay)
-            do_webapp_overlay
-            ;;
         push)
             do_compile
             do_assemble
-            do_webapp_overlay
             do_images push
             do_deltav_images
             ;;

--- a/pom.xml
+++ b/pom.xml
@@ -126,8 +126,6 @@
     <module>opennms-correlation</module>
     <module>opennms-web-api</module>
     <module>opennms-web-dependencies</module>
-    <module>opennms-webapp</module>
-    <module>opennms-webapp-rest</module>
     <module>opennms-wmi</module>
     <module>opennms-asterisk</module>
     <module>opennms-config-dao</module>
@@ -2350,13 +2348,11 @@
     <profile>
       <id>assemblies</id>
       <modules>
-        <module>opennms-full-assembly</module>
       </modules>
     </profile>
     <profile>
       <id>build-bamboo</id>
       <modules>
-        <module>opennms-full-assembly</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
## Summary
- New `core/opennms-model-jakarta` module with 13 Jakarta Persistence entity classes for Hibernate 7
- 5 JPA `AttributeConverter` implementations replacing Hibernate 3.6 `UserType` classes
- 4 JPA DAO implementations (`AlarmDaoJpa`, `NodeDaoJpa`, `DistPollerDaoJpa`, `ServiceTypeDaoJpa`)
- `daemon-boot-alarmd` wired to use native Jakarta entities — no Eclipse Transformer needed
- Integration test validates alarm persistence end-to-end with Testcontainers PostgreSQL

## Details

This is the next step after PR #27 which established the Spring Boot 4 infrastructure. The key blocker was Hibernate 3.6→7 entity annotation incompatibility. This PR resolves it by forking the 13 entity classes Alarmd needs into a new module with:

- `javax.persistence.*` → `jakarta.persistence.*`
- `@Type(type="...UserType")` → `@Convert(converter=...Converter.class)`
- JAXB annotations stripped (Jackson-only serialization)
- `@Where` → `@SQLRestriction` (removed in Hibernate 7)
- `allocationSize=1` on all `@SequenceGenerator` (Hibernate 7 defaults to 50)
- `PhysicalNamingStrategyStandardImpl` to preserve camelCase table names
- Explicit `PersistenceManagedTypes` bean to avoid split-package scanning issues

## Test plan
- [x] 53 converter unit tests pass
- [x] AlarmdApplicationIT: contextLoads, canPersistAndRetrieveAlarm, findByReductionKey
- [x] Full `./compile.pl -DskipTests` passes (all modules except pre-existing webapp JSP failure)
- [ ] Docker E2E: `./test-passive-e2e.sh` with Alarmd on Spring Boot 4