### PR TITLE
fix: @Primary on eventIpcManager — resolves Syslogd EventForwarder ambiguity

### DIFF
--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -82,6 +82,7 @@ public class KafkaEventTransportConfiguration {
     }
 
     @Bean
+    @org.springframework.context.annotation.Primary
     public EventIpcManager eventIpcManager(KafkaEventForwarder forwarder,
                                            KafkaEventSubscriptionService subscriptionService) {
         return new KafkaEventIpcManagerAdapter(forwarder, subscriptionService);


### PR DESCRIPTION
## Summary

Fixes runtime startup failure in Syslogd Spring Boot container where `SyslogSinkConsumer`'s `@Autowired EventForwarder` field couldn't choose between `kafkaEventForwarder` and `eventIpcManager` beans (both implement `EventForwarder`).

Marks `eventIpcManager` as `@Primary` in `KafkaEventTransportConfiguration` since it's the composite adapter all consumers should use.

## Test plan

- [x] Syslogd starts in 2.15s, health UP
- [x] KafkaSinkBridge polling `OpenNMS.Sink.Syslog`
- [x] E2E: syslog → Minion → Kafka Sink → Syslogd (consumer offset advances)