### PR TITLE
fix: null-safe InterfaceToNodeCache for Discovery — null location handling

### DIFF
--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/JdbcInterfaceToNodeCache.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/JdbcInterfaceToNodeCache.java
@@ -70,6 +70,9 @@ public class JdbcInterfaceToNodeCache implements InterfaceToNodeCache {
 
     @Override
     public Optional<Entry> getFirst(String location, InetAddress addr) {
+        if (location == null || addr == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(cache.get(new LocationIpKey(location, addr)));
     }
 


### PR DESCRIPTION
## Summary

Discovery passes null location for IP ranges without an explicit location set in `discovery-configuration.xml`. The `JdbcInterfaceToNodeCache.getFirst()` method's `LocationIpKey` record threw NPE via `Objects.requireNonNull()`.

Returns `Optional.empty()` for null location/address instead of crashing.

## Test plan

- [x] Discovery starts, timer fires, ping sweep completes: "Discovery completed successfully"
- [x] Health endpoint UP
- [x] All 15 daemon-common tests still pass