### PR TITLE
refactor: system properties → Spring @Value + /opt/deltav identity

### DIFF
--- a/core/daemon-boot-alarmd/src/main/resources/application.yml
+++ b/core/daemon-boot-alarmd/src/main/resources/application.yml
@@ -31,7 +31,7 @@ management:
       show-details: always
 
 opennms:
-  home: ${OPENNMS_HOME:/opt/opennms}
+  home: ${OPENNMS_HOME:/opt/deltav}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}

--- a/core/daemon-boot-eventtranslator/src/main/java/org/opennms/netmgt/translator/boot/EventTranslatorBootConfiguration.java
+++ b/core/daemon-boot-eventtranslator/src/main/java/org/opennms/netmgt/translator/boot/EventTranslatorBootConfiguration.java
@@ -39,10 +39,6 @@ public class EventTranslatorBootConfiguration {
 
     @Bean
     public EventTranslatorConfigFactory eventTranslatorConfig(DataSource dataSource) throws Exception {
-        String opennmsHome = System.getProperty("opennms.home",
-                System.getenv().getOrDefault("OPENNMS_HOME", "/opt/sentinel"));
-        System.setProperty("opennms.home", opennmsHome);
-
         DataSourceFactory.setInstance(dataSource);
         EventTranslatorConfigFactory.init();
         return (EventTranslatorConfigFactory) EventTranslatorConfigFactory.getInstance();

--- a/core/daemon-boot-eventtranslator/src/main/resources/application.yml
+++ b/core/daemon-boot-eventtranslator/src/main/resources/application.yml
@@ -25,7 +25,7 @@ management:
       show-details: always
 
 opennms:
-  home: ${OPENNMS_HOME:/opt/sentinel}
+  home: ${OPENNMS_HOME:/opt/deltav}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}

--- a/core/daemon-boot-syslogd/src/main/resources/application.yml
+++ b/core/daemon-boot-syslogd/src/main/resources/application.yml
@@ -21,7 +21,7 @@ management:
       show-details: always
 
 opennms:
-  home: ${OPENNMS_HOME:/opt/opennms}
+  home: ${OPENNMS_HOME:/opt/deltav}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}

--- a/core/daemon-boot-trapd/src/main/resources/application.yml
+++ b/core/daemon-boot-trapd/src/main/resources/application.yml
@@ -21,7 +21,7 @@ management:
       show-details: always
 
 opennms:
-  home: ${OPENNMS_HOME:/opt/opennms}
+  home: ${OPENNMS_HOME:/opt/deltav}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
     event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/OpennmsHomeConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/OpennmsHomeConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Bridges the Spring Boot {@code opennms.home} property to the JVM system
+ * property expected by legacy classes such as {@code ConfigFileConstants}.
+ *
+ * <p>This replaces the previous pattern of passing {@code -Dopennms.home=...}
+ * on the Docker command line. The value is resolved from:
+ * <ol>
+ *   <li>The {@code OPENNMS_HOME} environment variable (via {@code application.yml})</li>
+ *   <li>The default {@code /opt/opennms}</li>
+ * </ol>
+ */
+@Configuration
+public class OpennmsHomeConfiguration implements InitializingBean {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpennmsHomeConfiguration.class);
+
+    @Value("${opennms.home:/opt/deltav}")
+    private String opennmsHome;
+
+    @Override
+    public void afterPropertiesSet() {
+        System.setProperty("opennms.home", opennmsHome);
+        LOG.info("Set opennms.home={}", opennmsHome);
+    }
+}

--- a/opennms-container/delta-v/Dockerfile.daemon
+++ b/opennms-container/delta-v/Dockerfile.daemon
@@ -45,6 +45,9 @@ COPY staging/daemon/daemon-boot-alarmd.jar /opt/daemon-boot-alarmd.jar
 COPY staging/daemon/daemon-boot-trapd.jar /opt/daemon-boot-trapd.jar
 COPY staging/daemon/daemon-boot-eventtranslator.jar /opt/daemon-boot-eventtranslator.jar
 
+# Config directory for Spring Boot daemons (distinct from Sentinel's /opt/sentinel/etc)
+RUN mkdir -p /opt/deltav/etc
+
 # ── Special JARs (service-specific but harmless to include in all) ──
 # EventTranslator: split-package fix for opennms-config + opennms-util
 COPY staging/daemon/opennms-config.jar \

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -216,7 +216,7 @@ services:
     container_name: delta-v-trapd
     hostname: trapd
     entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m", "-Dopennms.home=/opt/sentinel", "-jar", "/opt/daemon-boot-trapd.jar"]
+    command: ["java", "-Xms256m", "-Xmx512m", "-jar", "/opt/daemon-boot-trapd.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -229,10 +229,10 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-trapd
       KAFKA_SINK_CONSUMER_GROUP: opennms-trapd-sink
-      OPENNMS_HOME: /opt/sentinel
+      OPENNMS_HOME: /opt/deltav
       INTERFACE_NODE_CACHE_REFRESH_MS: "15000"
     volumes:
-      - ./trapd-overlay/etc:/opt/sentinel/etc:ro
+      - ./trapd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 15s
@@ -246,7 +246,7 @@ services:
     container_name: delta-v-syslogd
     hostname: syslogd
     entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m", "-Dopennms.home=/opt/sentinel", "-jar", "/opt/daemon-boot-syslogd.jar"]
+    command: ["java", "-Xms256m", "-Xmx512m", "-jar", "/opt/daemon-boot-syslogd.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -259,10 +259,10 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-syslogd
       KAFKA_SINK_CONSUMER_GROUP: opennms-syslogd-sink
-      OPENNMS_HOME: /opt/sentinel
+      OPENNMS_HOME: /opt/deltav
       INTERFACE_NODE_CACHE_REFRESH_MS: "15000"
     volumes:
-      - ./syslogd-overlay/etc:/opt/sentinel/etc:ro
+      - ./syslogd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 15s
@@ -289,9 +289,9 @@ services:
       SPRING_DATASOURCE_PASSWORD: opennms
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-eventtranslator
-      OPENNMS_HOME: /opt/sentinel
+      OPENNMS_HOME: /opt/deltav
     volumes:
-      - ./eventtranslator-overlay/etc:/opt/sentinel/etc:ro
+      - ./eventtranslator-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health || exit 1"]
       interval: 15s
@@ -479,7 +479,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: opennms
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-alarmd
-      OPENNMS_HOME: /opt/sentinel
+      OPENNMS_HOME: /opt/deltav
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health || exit 1"]
       interval: 15s


### PR DESCRIPTION
## Summary

- **Shared `OpennmsHomeConfiguration`** in `daemon-common` — bridges `@Value("${opennms.home}")` to `System.setProperty()` for legacy `ConfigFileConstants` compatibility. Replaces per-daemon inline hacks.
- **Removed `-Dopennms.home` JVM flags** from Trapd and Syslogd Docker command lines — `OPENNMS_HOME` env var now flows through Spring's property resolution hierarchy.
- **Renamed `/opt/sentinel` → `/opt/deltav`** for all 4 Spring Boot daemon config paths. Karaf-based daemons retain `/opt/sentinel` (base image filesystem). Creates a clean identity boundary as daemons migrate.
- **Unified `application.yml` defaults** to `/opt/deltav` across all 4 daemons.

Config resolution is now: `Docker env → application.yml → @Value → System.setProperty()` — testable via `@TestPropertySource`, self-documenting, single source of truth.

## Test plan

- [x] `daemon-common`, `daemon-boot-trapd`, `daemon-boot-syslogd`, `daemon-boot-eventtranslator`, `daemon-boot-alarmd` all compile cleanly
- [ ] Docker rebuild (`./build.sh deltav`) and verify all 4 Spring Boot daemons start with `/opt/deltav/etc` config path
- [ ] E2E: trap pipeline, syslog pipeline, event translation, alarm creation still functional