### PR TITLE
feat: migrate BSMd to Spring Boot 4.0.3

### DIFF
--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -1,0 +1,529 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.core</artifactId>
+        <version>36.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.daemon-boot-bsmd</artifactId>
+    <packaging>jar</packaging>
+    <name>OpenNMS :: Core :: Daemon Boot :: BSMd</name>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-boot.version>4.0.3</spring-boot.version>
+        <!-- Skip enforcer: this module uses Spring Boot 4 / Spring 7
+             which the parent POM's banned-dependencies rules reject -->
+        <enforcer-skip-banned-dependencies>true</enforcer-skip-banned-dependencies>
+        <enforcer-skip-dependency-convergence>true</enforcer-skip-dependency-convergence>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import Spring Boot BOM for version management.
+                 Listed FIRST so it takes precedence over the parent POM's
+                 managed versions for JUnit, Spring, etc. -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Pin logback to match Spring Boot 4's requirements.
+                 Parent POM manages logback-classic at 1.2.13 which is
+                 incompatible with Spring Boot 4's Configurator API. -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <!-- Pin jboss-logging — Hibernate 7.2.4 requires 3.6+ for MethodHandles$Lookup API -->
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>3.6.1.Final</version>
+            </dependency>
+            <!-- Pin Jakarta XML Bind 4.x — parent POM manages 2.3.3, Hibernate 7 needs 4.0+ -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+            <!-- Pin SLF4J 2.x — parent POM manages 1.7.36 which is incompatible with logback 1.5 -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <!-- Pin Jackson 2.19.4 — parent POM manages 2.16.2 which lacks JsonFormat$Shape.POJO
+                 required by Spring Boot 4.0.3. Explicit entries here override the parent's
+                 managed versions even though the Spring Boot BOM is imported first. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <!-- Pin JUnit to 6.0.3 / Platform 6.0.3 which is the latest
+                 version supported by maven-surefire-plugin 3.5.5.
+                 Must be explicit entries (not BOM import) to override
+                 the parent POM's managed versions at 5.9.2 / 1.9.2. -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <!-- Testcontainers — use 2.0.3 to align with Spring Boot 4.0.3's managed version -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>2.0.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Jakarta entity classes — MUST be listed FIRST -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-jakarta</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Shared daemon infrastructure -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.daemon-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-scala_2.13</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- BSM daemon (Bsmd class) -->
+        <dependency>
+            <groupId>org.opennms.features.bsm</groupId>
+            <artifactId>org.opennms.features.bsm.daemon</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <!-- Exclude ALL ServiceMix Spring 4.2.x bundles — Spring Boot 4 provides Spring 7 -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <!-- Exclude old Spring Security that conflicts -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <!-- Exclude old Hibernate 3.x -->
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <!-- Exclude old SLF4J 1.7.x — Spring Boot 4 provides SLF4J 2.x -->
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <!-- Exclude old javax.persistence API — Spring Boot 4 uses jakarta.persistence -->
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <!-- Exclude Karaf/OSGi logging — not needed in Spring Boot -->
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <!-- Exclude commons-logging — Spring Boot uses jcl-over-slf4j -->
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <!-- Exclude config-model which contains legacy OnmsMonitoringLocation with
+                     javax.persistence annotations — not needed here (no JPA) -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- BSM service API + impl -->
+        <dependency>
+            <groupId>org.opennms.features.bsm</groupId>
+            <artifactId>org.opennms.features.bsm.service.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.features.bsm</groupId>
+            <artifactId>org.opennms.features.bsm.service.impl</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <!-- Exclude ALL ServiceMix Spring 4.2.x bundles — Spring Boot 4 provides Spring 7 -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <!-- Exclude old Spring Security that conflicts -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <!-- Exclude old Hibernate 3.x -->
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <!-- Exclude old SLF4J 1.7.x — Spring Boot 4 provides SLF4J 2.x -->
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <!-- Exclude old javax.persistence API — Spring Boot 4 uses jakarta.persistence -->
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <!-- Exclude Karaf/OSGi logging — not needed in Spring Boot -->
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <!-- Exclude commons-logging — Spring Boot uses jcl-over-slf4j -->
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <!-- Exclude config-model which contains legacy OnmsMonitoringLocation with
+                     javax.persistence annotations — not needed here (no JPA) -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Alarmd (AlarmLifecycleListenerManager) -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-alarmd</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <!-- Exclude ALL ServiceMix Spring 4.2.x bundles — Spring Boot 4 provides Spring 7 -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <!-- Exclude old Spring Security that conflicts -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <!-- Exclude old Hibernate 3.x -->
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <!-- Exclude old SLF4J 1.7.x — Spring Boot 4 provides SLF4J 2.x -->
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <!-- Exclude old javax.persistence API — Spring Boot 4 uses jakarta.persistence -->
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <!-- Exclude Karaf/OSGi logging — not needed in Spring Boot -->
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <!-- Exclude commons-logging — Spring Boot uses jcl-over-slf4j -->
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <!-- Exclude config-model which contains legacy OnmsMonitoringLocation with
+                     javax.persistence annotations — not needed here (no JPA) -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Alarm API -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-alarm-api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- javax.persistence API — needed at runtime so legacy opennms-model classes
+             on the classpath don't cause ClassNotFoundException when Spring's classpath
+             scanner encounters them. -->
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- javax.xml.bind API — needed at runtime for legacy Event XML unmarshalling -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Jakarta XML Bind — needed by Hibernate 7 for XML mapping support -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+
+        <!-- Jakarta Inject — needed by Hibernate 7 -->
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <!-- SLF4J 2.x — must be explicit to override old 1.7.x from transitive deps -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Exclude vintage engine to avoid classpath conflict
+                     with the JUnit 4 vintage engine from the parent POM -->
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- JUnit Platform Launcher — must be explicit test dep so that
+             surefire/failsafe pick up the correct version from the classpath
+             rather than resolving their own (older) transitive version -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers 2.x (artifact IDs have testcontainers- prefix) -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Use a classifier so the original JAR stays available
+                                 for failsafe integration tests (which need plain classes) -->
+                            <classifier>boot</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- Override to 3.5.5 which supports JUnit Platform 6.0.3
+                     required by Spring Boot 4 -->
+                <version>3.5.5</version>
+                <configuration>
+                    <!-- Only use JUnit Jupiter; the vintage engine from the parent
+                         is incompatible with JUnit Platform 1.12+ from Spring Boot 4 -->
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <!-- Override parent's vintage engine (5.9.2) to align versions -->
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <!-- Override parent's vintage engine (5.9.2) to align versions -->
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -360,6 +360,12 @@
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
 
+        <!-- Jakarta Validation — needed by BSM entity @Size annotations -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
         <!-- Jakarta Inject — needed by Hibernate 7 -->
         <dependency>
             <groupId>jakarta.inject</groupId>

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdApplication.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+    "org.opennms.core.daemon.common",
+    "org.opennms.netmgt.bsm.boot",
+    "org.opennms.netmgt.bsm.dao",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+public class BsmdApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BsmdApplication.class, args);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdConfiguration.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdConfiguration.java
@@ -74,7 +74,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
@@ -186,15 +185,8 @@ public class BsmdConfiguration {
     }
 
     /**
-     * Provides TransactionOperations for beans that need it.
-     */
-    @Bean
-    public TransactionOperations transactionOperations(PlatformTransactionManager txManager) {
-        return new TransactionTemplate(txManager);
-    }
-
-    /**
      * TransactionTemplate for Bsmd constructor injection.
+     * Also serves as TransactionOperations (TransactionTemplate implements it).
      */
     @Bean
     public TransactionTemplate transactionTemplate(PlatformTransactionManager txManager) {

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdConfiguration.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdConfiguration.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.boot;
+
+import java.util.HashMap;
+
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.opennms.core.daemon.common.SpringServiceDaemonSmartLifecycle;
+import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
+import org.opennms.netmgt.bsm.daemon.Bsmd;
+import org.opennms.netmgt.bsm.persistence.api.ApplicationEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceChildEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEntity;
+import org.opennms.netmgt.bsm.persistence.api.IPServiceEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.SingleReductionKeyEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.DecreaseEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.IdentityEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.IgnoreEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.IncreaseEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.SetToEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.AbstractReductionFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ExponentialPropagationEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.HighestSeverityAboveEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.HighestSeverityEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ThresholdEntity;
+import org.opennms.netmgt.bsm.service.BusinessServiceManager;
+import org.opennms.netmgt.bsm.service.BusinessServiceStateMachine;
+import org.opennms.netmgt.bsm.service.internal.BusinessServiceManagerImpl;
+import org.opennms.netmgt.bsm.service.internal.DefaultBusinessServiceStateMachine;
+import org.opennms.netmgt.config.DefaultEventConfDao;
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.opennms.netmgt.events.api.EventSubscriptionService;
+import org.opennms.netmgt.model.AlarmAssociation;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsApplication;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsDistPoller;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMemo;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsReductionKeyMemo;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Spring Boot @Configuration that wires all BSMd beans.
+ *
+ * <p>This replaces the Karaf-era BSMd blueprint XML and
+ * {@code applicationContext-daemon-loader-bsmd.xml}.
+ * Beans that depend on DAOs and other infrastructure services receive those
+ * dependencies via constructor injection or @Autowired field injection in the
+ * existing classes. The actual DAO beans are provided by JPA auto-config
+ * and the {@code @Repository}-annotated DAO classes scanned from
+ * {@code org.opennms.netmgt.bsm.dao}.</p>
+ *
+ * <p>Entity classes are listed explicitly via a custom {@link PersistenceManagedTypes}
+ * bean instead of using package-based {@code @EntityScan} because the legacy
+ * opennms-model module shares the same package ({@code org.opennms.netmgt.model})
+ * and contains classes with incompatible javax.persistence / Hibernate 3.x
+ * annotations that cause scanning failures with Hibernate 7.</p>
+ */
+@Configuration
+public class BsmdConfiguration {
+
+    /**
+     * Use standard JPA naming -- table/column names from @Table/@Column annotations
+     * are used as-is, without Spring Boot's default CamelCase-to-snake_case conversion.
+     * This is required because the OpenNMS schema uses camelCase table names
+     * (e.g., monitoringSystems, ipInterface, ifServices).
+     */
+    @Bean
+    public PhysicalNamingStrategyStandardImpl physicalNamingStrategy() {
+        return new PhysicalNamingStrategyStandardImpl();
+    }
+
+    /**
+     * Explicitly lists the Jakarta entity classes to register with Hibernate 7.
+     * This replaces {@code @EntityScan} which would scan ALL classes in the
+     * package, including legacy entities with incompatible javax.persistence
+     * annotations.
+     *
+     * <p>Includes both core model entities (OnmsAlarm, OnmsNode, etc.) and
+     * BSM-specific entities (BusinessServiceEntity, edge entities, reduction
+     * function entities, map function entities).</p>
+     */
+    @Bean
+    public PersistenceManagedTypes persistenceManagedTypes() {
+        return PersistenceManagedTypes.of(
+            // Core model entities
+            OnmsAlarm.class.getName(),
+            AlarmAssociation.class.getName(),
+            OnmsCategory.class.getName(),
+            OnmsDistPoller.class.getName(),
+            OnmsIpInterface.class.getName(),
+            OnmsMemo.class.getName(),
+            OnmsMonitoredService.class.getName(),
+            OnmsMonitoringSystem.class.getName(),
+            OnmsNode.class.getName(),
+            OnmsReductionKeyMemo.class.getName(),
+            OnmsServiceType.class.getName(),
+            OnmsSnmpInterface.class.getName(),
+            OnmsMonitoringLocation.class.getName(),
+            OnmsApplication.class.getName(),
+            // BSM entities
+            BusinessServiceEntity.class.getName(),
+            BusinessServiceEdgeEntity.class.getName(),
+            BusinessServiceChildEdgeEntity.class.getName(),
+            IPServiceEdgeEntity.class.getName(),
+            ApplicationEdgeEntity.class.getName(),
+            SingleReductionKeyEdgeEntity.class.getName(),
+            // Reduction function entities
+            AbstractReductionFunctionEntity.class.getName(),
+            HighestSeverityEntity.class.getName(),
+            HighestSeverityAboveEntity.class.getName(),
+            ThresholdEntity.class.getName(),
+            ExponentialPropagationEntity.class.getName(),
+            // Map function entities
+            AbstractMapFunctionEntity.class.getName(),
+            IdentityEntity.class.getName(),
+            IgnoreEntity.class.getName(),
+            DecreaseEntity.class.getName(),
+            IncreaseEntity.class.getName(),
+            SetToEntity.class.getName()
+        );
+    }
+
+    /**
+     * SessionUtils implementation backed by Spring's TransactionTemplate.
+     * Replaces the OSGi-era SessionUtils that was used to bridge Hibernate
+     * sessions across OSGi bundles.
+     */
+    @Bean
+    public org.opennms.netmgt.dao.api.SessionUtils sessionUtils(PlatformTransactionManager txManager) {
+        var txTemplate = new TransactionTemplate(txManager);
+        var readOnlyTxTemplate = new TransactionTemplate(txManager);
+        readOnlyTxTemplate.setReadOnly(true);
+        return new org.opennms.netmgt.dao.api.SessionUtils() {
+            @Override
+            public <V> V withTransaction(java.util.function.Supplier<V> supplier) {
+                return txTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withReadOnlyTransaction(java.util.function.Supplier<V> supplier) {
+                return readOnlyTxTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withManualFlush(java.util.function.Supplier<V> supplier) {
+                return supplier.get();
+            }
+        };
+    }
+
+    /**
+     * Provides TransactionOperations for beans that need it.
+     */
+    @Bean
+    public TransactionOperations transactionOperations(PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+
+    /**
+     * TransactionTemplate for Bsmd constructor injection.
+     */
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+
+    /**
+     * The Business Service state machine that evaluates alarm-to-BS severity
+     * propagation using the configured reduction and map functions.
+     */
+    @Bean
+    public BusinessServiceStateMachine businessServiceStateMachine() {
+        return new DefaultBusinessServiceStateMachine();
+    }
+
+    /**
+     * The Business Service manager that provides CRUD operations for
+     * Business Services and their edges.
+     */
+    @Bean
+    public BusinessServiceManager businessServiceManager() {
+        return new BusinessServiceManagerImpl();
+    }
+
+    /**
+     * Manages alarm lifecycle listeners. BSMd registers itself as a listener
+     * to receive alarm state change notifications.
+     */
+    @Bean
+    public AlarmLifecycleListenerManager alarmLifecycleListenerManager() {
+        return new AlarmLifecycleListenerManager();
+    }
+
+    /**
+     * Registers Bsmd as an alarm lifecycle listener after all beans are
+     * fully constructed, avoiding circular dependency issues during
+     * bean initialization.
+     */
+    @Bean
+    public SmartInitializingSingleton registerBsmdAsAlarmListener(
+            AlarmLifecycleListenerManager manager,
+            Bsmd bsmd) {
+        return () -> manager.onListenerRegistered(bsmd, new HashMap<>());
+    }
+
+    /**
+     * Default event configuration DAO that reads eventconf.xml from
+     * the OpenNMS configuration directory.
+     */
+    @Bean
+    public EventConfDao eventConfDao() {
+        return new DefaultEventConfDao();
+    }
+
+    /**
+     * The BSM daemon that drives the Business Service state machine by
+     * reacting to alarm lifecycle events and sending BS status change events.
+     */
+    @Bean
+    public Bsmd bsmd(
+            @Qualifier("eventIpcManager") EventIpcManager eventIpcManager,
+            EventConfDao eventConfDao,
+            TransactionTemplate transactionTemplate,
+            BusinessServiceStateMachine stateMachine,
+            BusinessServiceManager manager) {
+        return new Bsmd(eventIpcManager, eventConfDao, transactionTemplate, stateMachine, manager);
+    }
+
+    /**
+     * Bridges Bsmd's {@code @EventHandler}-annotated methods to the
+     * {@link EventSubscriptionService}, registering Bsmd as an event listener.
+     */
+    @Bean
+    public AnnotationBasedEventListenerAdapter bsmdEventListenerAdapter(
+            Bsmd bsmd,
+            @Qualifier("kafkaEventSubscriptionService") EventSubscriptionService eventSubscriptionService) {
+        var adapter = new AnnotationBasedEventListenerAdapter();
+        adapter.setAnnotatedListener(bsmd);
+        adapter.setEventSubscriptionService(eventSubscriptionService);
+        return adapter;
+    }
+
+    /**
+     * SmartLifecycle adapter that starts/stops Bsmd at the appropriate
+     * phase in the Spring application lifecycle.
+     */
+    @Bean
+    public SmartLifecycle bsmdLifecycle(Bsmd bsmd) {
+        return new SpringServiceDaemonSmartLifecycle(bsmd, Bsmd.NAME);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/BusinessServiceDaoJpa.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/BusinessServiceDaoJpa.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.dao;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceDao;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEntity;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BusinessServiceDaoJpa extends AbstractDaoJpa<BusinessServiceEntity, Long>
+        implements BusinessServiceDao {
+
+    public BusinessServiceDaoJpa() {
+        super(BusinessServiceEntity.class);
+    }
+
+    @Override
+    public Set<BusinessServiceEntity> findParents(BusinessServiceEntity child) {
+        List<BusinessServiceEdgeEntity> edges = entityManager()
+            .createQuery(
+                "SELECT edge FROM BusinessServiceEdgeEntity edge " +
+                "WHERE TYPE(edge) = BusinessServiceChildEdgeEntity " +
+                "AND edge.child.id = :childId",
+                BusinessServiceEdgeEntity.class)
+            .setParameter("childId", child.getId())
+            .getResultList();
+        return edges.stream()
+            .map(BusinessServiceEdgeEntity::getBusinessService)
+            .collect(Collectors.toSet());
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/BusinessServiceEdgeDaoJpa.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/BusinessServiceEdgeDaoJpa.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeDao;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeEntity;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BusinessServiceEdgeDaoJpa extends AbstractDaoJpa<BusinessServiceEdgeEntity, Long>
+        implements BusinessServiceEdgeDao {
+
+    public BusinessServiceEdgeDaoJpa() {
+        super(BusinessServiceEdgeEntity.class);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/MapFunctionDaoJpa.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/MapFunctionDaoJpa.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.MapFunctionDao;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MapFunctionDaoJpa extends AbstractDaoJpa<AbstractMapFunctionEntity, Long>
+        implements MapFunctionDao {
+
+    public MapFunctionDaoJpa() {
+        super(AbstractMapFunctionEntity.class);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/ReductionFunctionDaoJpa.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/ReductionFunctionDaoJpa.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.AbstractReductionFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ReductionFunctionDao;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReductionFunctionDaoJpa extends AbstractDaoJpa<AbstractReductionFunctionEntity, Long>
+        implements ReductionFunctionDao {
+
+    public ReductionFunctionDaoJpa() {
+        super(AbstractReductionFunctionEntity.class);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/ApplicationEdgeEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/ApplicationEdgeEntity.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import org.opennms.netmgt.dao.util.ReductionKeyHelper;
+import org.opennms.netmgt.model.OnmsApplication;
+
+import com.google.common.base.MoreObjects;
+
+@Entity
+@Table(name = "bsm_service_applications")
+@PrimaryKeyJoinColumn(name="id")
+@DiscriminatorValue("applications")
+public class ApplicationEdgeEntity extends BusinessServiceEdgeEntity {
+
+    private OnmsApplication m_application;
+
+    @ManyToOne(optional=false)
+    @JoinColumn(name="applicationid", nullable=false)
+    public OnmsApplication getApplication() {
+        return m_application;
+    }
+
+    public void setApplication(OnmsApplication application) {
+        m_application = application;
+    }
+
+    @Override
+    @Transient
+    public Set<String> getReductionKeys() {
+        return ReductionKeyHelper.getReductionKeys(m_application);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("m_application", m_application)
+                .toString();
+    }
+
+    @Override
+    public boolean equalsDefinition(BusinessServiceEdgeEntity other) {
+        boolean equalsSuper = super.equalsDefinition(other);
+        if (equalsSuper) {
+            return Objects.equals(m_application, ((ApplicationEdgeEntity) other).m_application);
+        }
+        return false;
+    }
+
+    @Override
+    public <T> T accept(EdgeEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceChildEdgeEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceChildEdgeEntity.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import com.google.common.collect.Sets;
+
+@Entity
+@Table(name = "bsm_service_children")
+@PrimaryKeyJoinColumn(name="id")
+@DiscriminatorValue(value="children")
+public class BusinessServiceChildEdgeEntity extends BusinessServiceEdgeEntity {
+
+    // The Business Service Entity where the parent points to (child relationship)
+    private BusinessServiceEntity child;
+
+    public void setChild(BusinessServiceEntity child) {
+        this.child = child;
+    }
+
+    @ManyToOne(optional=false)
+    @JoinColumn(name="bsm_service_child_id", nullable=false)
+    public BusinessServiceEntity getChild() {
+        return child;
+    }
+
+    @Transient
+    @Override
+    public Set<String> getReductionKeys() {
+        return Sets.newHashSet();
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("super", super.toString())
+                .add("child", child == null ? null : child.getId())
+                .toString();
+    }
+
+    @Override
+    public boolean equalsDefinition(BusinessServiceEdgeEntity other) {
+        boolean equalsSuper = super.equalsDefinition(other);
+        if (equalsSuper) {
+            return Objects.equals(child.getId(), ((BusinessServiceChildEdgeEntity) other).getChild().getId());
+        }
+        return false;
+    }
+
+    @Override
+    public <T> T accept(EdgeEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
@@ -75,7 +75,7 @@ public class BusinessServiceEdgeEntity implements EdgeEntity {
     private AbstractMapFunctionEntity m_mapFunction;
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+
+/**
+ * Base edges that includes properties common to all edge types.
+ *
+ * Ideally this class would be abstract, but in some cases Hibernate may
+ * try to instantiate this class.
+ *
+ * @author jwhite
+ */
+@Entity
+@Table(name = "bsm_service_edge")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name="type", discriminatorType= DiscriminatorType.STRING)
+@DiscriminatorValue(value="")
+public class BusinessServiceEdgeEntity implements EdgeEntity {
+
+    public static final int DEFAULT_WEIGHT = 1;
+
+    private Long m_id;
+
+    // The Business Service reference where this edge belongs to!
+    private BusinessServiceEntity m_businessService;
+
+    private boolean m_enabled = true;
+
+    private int m_weight = DEFAULT_WEIGHT;
+
+    private AbstractMapFunctionEntity m_mapFunction;
+
+    @Id
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @GeneratedValue(generator = "opennmsSequence")
+    @Column(name = "id", nullable = false)
+    public Long getId() {
+        return m_id;
+    }
+
+    public void setId(Long id) {
+        m_id = id;
+    }
+
+    @ManyToOne(optional=false)
+    @JoinColumn(name="bsm_service_id")
+    public BusinessServiceEntity getBusinessService() {
+        return m_businessService;
+    }
+
+    public void setBusinessService(BusinessServiceEntity service) {
+        m_businessService = Objects.requireNonNull(service);
+    }
+
+    @Column(name = "enabled", nullable = false)
+    public boolean isEnabled() {
+        return m_enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        m_enabled = enabled;
+    }
+
+    @Column(name = "weight", nullable = false)
+    public int getWeight() {
+        return m_weight;
+    }
+
+    @Override
+    @Transient
+    public Set<String> getReductionKeys() {
+        return Sets.newHashSet();
+    }
+
+    public void setWeight(int weight) {
+        Preconditions.checkArgument(weight > 0, "weight must be strictly positive.");
+        m_weight = weight;
+    }
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "bsm_map_id")
+    public AbstractMapFunctionEntity getMapFunction() {
+        return m_mapFunction;
+    }
+
+    public void setMapFunction(AbstractMapFunctionEntity mapFunction) {
+        m_mapFunction = Objects.requireNonNull(mapFunction);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (obj == this) return true;
+        if (!(obj instanceof BusinessServiceEdgeEntity)) return false;
+        final BusinessServiceEdgeEntity other = (BusinessServiceEdgeEntity) obj;
+        if (getId() != null) {
+            return getId().equals(other.getId());
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return 0; // HACK: always return 0, as otherwise Sets etc do not work.
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", m_id)
+                .add("businessService", m_businessService == null ? null : m_businessService.getId())
+                .add("enabled", m_enabled)
+                .add("weight", m_weight)
+                .add("mapFunction", m_mapFunction)
+                .toString();
+    }
+
+    /**
+     * Defines if the definition of the edge is equal to the given one.
+     * This is quite different than the equals method of the object itself.
+     *
+     * @return true if equal, otherwise false
+     */
+    public boolean equalsDefinition(BusinessServiceEdgeEntity other) {
+        if (other == null) return false;
+        if (!getClass().equals(other.getClass())) return false;
+        boolean equals = Objects.equals(getWeight(), other.getWeight())
+                && Objects.equals(getBusinessService().getId(), other.getBusinessService().getId())
+                && getMapFunction().equalsDefinition(other.getMapFunction());
+        return equals;
+    }
+
+    @Override
+    public <T> T accept(EdgeEntityVisitor<T> visitor) {
+        // ALl sub classes MUST overwrite this properly, as this class cannot be abstract.
+        // This is due to how hibernate deals with inheritance strategies.
+        throw new IllegalStateException("Class '" + getClass().getName() + "' did not overwrite accept(EdgeEntityVisitor) method properly");
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
@@ -79,7 +79,7 @@ public class BusinessServiceEntity {
     }
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.AbstractReductionFunctionEntity;
+import org.opennms.netmgt.model.OnmsApplication;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+@Entity
+@Table(name = "bsm_service")
+public class BusinessServiceEntity {
+
+    private Long m_id;
+
+    private String m_name;
+
+    private Map<String, String> m_attributes = Maps.newLinkedHashMap();
+
+    private Set<BusinessServiceEdgeEntity> m_edges = Sets.newLinkedHashSet();
+
+    private AbstractReductionFunctionEntity m_reductionFunction;
+
+    /** The level in the hierarchy.
+     * If 0 the business service should not have any parents.
+     * If -1 the business service level has not been initialized*/
+    private int level = -1;
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    @Transient
+    public int getLevel() {
+        return level;
+    }
+
+    @Id
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @GeneratedValue(generator = "opennmsSequence")
+    @Column(name = "id", nullable = false)
+    public Long getId() {
+        return m_id;
+    }
+
+    public void setId(Long id) {
+        m_id = id;
+    }
+
+    @Column(name = "name", nullable = false, unique = true)
+    public String getName() {
+        return m_name;
+    }
+
+    public void setName(String name) {
+        m_name = name;
+    }
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @JoinTable(name = "bsm_service_attributes", joinColumns = @JoinColumn(name = "bsm_service_id", referencedColumnName = "id"))
+    @MapKeyColumn(name = "key")
+    @Column(name = "value", nullable = false)
+    public Map<String, String> getAttributes() {
+        return m_attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        m_attributes = attributes;
+    }
+
+    public void setAttribute(String key, String value) {
+        m_attributes.put(key, value);
+    }
+
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy="businessService", orphanRemoval = true)
+    public Set<BusinessServiceEdgeEntity> getEdges() {
+        return m_edges;
+    }
+
+    public void setEdges(Set<BusinessServiceEdgeEntity> edges) {
+        m_edges = edges;
+    }
+
+    public void addEdge(BusinessServiceEdgeEntity edge) {
+        m_edges.add(edge);
+    }
+
+    public boolean removeEdge(BusinessServiceEdgeEntity edge) {
+        return m_edges.remove(edge);
+    }
+
+    @Transient
+    public Set<IPServiceEdgeEntity> getIpServiceEdges() {
+        return getEdges(IPServiceEdgeEntity.class);
+    }
+
+    @Transient
+    public Set<BusinessServiceChildEdgeEntity> getChildEdges() {
+        return getEdges(BusinessServiceChildEdgeEntity.class);
+    }
+
+    @Transient
+    public Set<SingleReductionKeyEdgeEntity> getReductionKeyEdges() {
+        return getEdges(SingleReductionKeyEdgeEntity.class);
+    }
+
+    @Transient
+    public Set<ApplicationEdgeEntity> getApplicationEdges() {
+        return getEdges(ApplicationEdgeEntity.class);
+    }
+
+    @Transient
+    @SuppressWarnings("unchecked")
+    private <T extends BusinessServiceEdgeEntity> Set<T> getEdges(Class<T> type) {
+        return getEdges().stream()
+                .filter(type::isInstance)
+                .map(e -> (T)e)
+                .collect(Collectors.toSet());
+    }
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "bsm_reduce_id")
+    public AbstractReductionFunctionEntity getReductionFunction() {
+        return m_reductionFunction;
+    }
+
+    public void setReductionFunction(AbstractReductionFunctionEntity reductionFunction) {
+        m_reductionFunction = Objects.requireNonNull(reductionFunction);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (obj == this) return true;
+        if (!(obj instanceof BusinessServiceEntity)) return false;
+        final BusinessServiceEntity other = (BusinessServiceEntity) obj;
+        if (getId() != null) {
+            return getId().equals(other.getId());
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return 0; // HACK: always return 0, as otherwise Sets etc do not work.
+    }
+
+    @Override
+    public String toString() {
+        // we do not include ip services here, otherwise we cannot use this object properly
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", m_id)
+                .add("name", m_name)
+                .add("attributes", m_attributes)
+                .add("edges", m_edges)
+                .toString();
+    }
+
+    // Convenient method to add a child edge
+    public BusinessServiceEntity addChildServiceEdge(BusinessServiceEntity child, AbstractMapFunctionEntity mapFunction) {
+        return addChildServiceEdge(child, mapFunction, 1);
+    }
+
+    // Convenient method to add a child edge
+    public BusinessServiceEntity addChildServiceEdge(BusinessServiceEntity child, AbstractMapFunctionEntity mapFunction, int weight) {
+        BusinessServiceChildEdgeEntity edge = new BusinessServiceChildEdgeEntity();
+        edge.setBusinessService(this);
+        edge.setChild(Objects.requireNonNull(child));
+        edge.setWeight(weight);
+        edge.setMapFunction(Objects.requireNonNull(mapFunction));
+        addEdge(edge);
+        return this;
+    }
+
+    public BusinessServiceEntity addApplicationEdge(OnmsApplication onmsApplication, AbstractMapFunctionEntity mapFunction) {
+        return addApplicationEdge(onmsApplication, mapFunction, 1);
+    }
+
+    public BusinessServiceEntity addApplicationEdge(OnmsApplication onmsApplication, AbstractMapFunctionEntity mapFunction, int weight) {
+        ApplicationEdgeEntity edge = new ApplicationEdgeEntity();
+        edge.setBusinessService(this);
+        edge.setApplication(Objects.requireNonNull(onmsApplication));
+        edge.setWeight(weight);
+        edge.setWeight(weight);
+        edge.setMapFunction(Objects.requireNonNull(mapFunction));
+        addEdge(edge);
+        return this;
+    }
+
+    // Convenient method to add an ipservice edge
+    public BusinessServiceEntity addIpServiceEdge(OnmsMonitoredService ipService, AbstractMapFunctionEntity mapFunction) {
+        return addIpServiceEdge(ipService, mapFunction, 1, null);
+    }
+
+    // Convenient method to add an ipservice edge
+    public BusinessServiceEntity addIpServiceEdge(OnmsMonitoredService ipService, AbstractMapFunctionEntity mapFunction, int weight, String friendlyName) {
+        IPServiceEdgeEntity edge = new IPServiceEdgeEntity();
+        edge.setBusinessService(this);
+        edge.setIpService(Objects.requireNonNull(ipService));
+        edge.setWeight(weight);
+        edge.setMapFunction(Objects.requireNonNull(mapFunction));
+        edge.setFriendlyName(friendlyName);
+        addEdge(edge);
+        return this;
+    }
+
+    // Convenient method to add a reduction key edge
+    public BusinessServiceEntity addReductionKeyEdge(String reductionKey, AbstractMapFunctionEntity mapFunction) {
+        return addReductionKeyEdge(reductionKey, mapFunction, 1, null);
+    }
+
+    // Convenient method to add a reduction key edge
+    public BusinessServiceEntity addReductionKeyEdge(String reductionKey, AbstractMapFunctionEntity mapFunction, int weight, String friendlyName) {
+        SingleReductionKeyEdgeEntity edge = new SingleReductionKeyEdgeEntity();
+        edge.setBusinessService(this);
+        edge.setReductionKey(Objects.requireNonNull(reductionKey));
+        edge.setWeight(weight);
+        edge.setMapFunction(Objects.requireNonNull(mapFunction));
+        edge.setFriendlyName(friendlyName);
+        addEdge(edge);
+        return this;
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/EdgeEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/EdgeEntity.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+import java.util.Set;
+
+import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
+
+public interface EdgeEntity {
+
+    boolean isEnabled();
+
+    int getWeight();
+
+    Set<String> getReductionKeys();
+
+    AbstractMapFunctionEntity getMapFunction();
+
+    <T> T accept(EdgeEntityVisitor<T> visitor);
+
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/EdgeEntityVisitor.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/EdgeEntityVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+public interface EdgeEntityVisitor<T> {
+
+    T visit(BusinessServiceChildEdgeEntity edgeEntity);
+
+    T visit(SingleReductionKeyEdgeEntity edgeEntity);
+
+    T visit(IPServiceEdgeEntity edgeEntity);
+
+    T visit(ApplicationEdgeEntity applicationEdgeEntity);
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/IPServiceEdgeEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/IPServiceEdgeEntity.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.validation.constraints.Size;
+
+import org.opennms.netmgt.dao.util.ReductionKeyHelper;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+
+@Entity
+@Table(name = "bsm_service_ifservices")
+@PrimaryKeyJoinColumn(name="id")
+@DiscriminatorValue("ipservices")
+public class IPServiceEdgeEntity extends BusinessServiceEdgeEntity {
+
+    private OnmsMonitoredService m_ipService;
+
+    private String m_friendlyName;
+
+    // NOTE: When we use @Column on this field, Hibernate attempts to serialize the objects as a byte array
+    // Instead, we resort to use @ManyToOne
+    @ManyToOne(optional=false)
+    @JoinColumn(name="ifserviceid", nullable=false)
+    public OnmsMonitoredService getIpService() {
+        return m_ipService;
+    }
+
+    public void setIpService(OnmsMonitoredService ipService) {
+        m_ipService = ipService;
+    }
+
+    @Column(name="friendlyname", nullable = true)
+    @Size(min = 0, max = 30)
+    public String getFriendlyName() {
+        return m_friendlyName;
+    }
+
+    public void setFriendlyName(String friendlyName) {
+        m_friendlyName = friendlyName;
+    }
+
+    @Override
+    @Transient
+    public Set<String> getReductionKeys() {
+        return ReductionKeyHelper.getReductionKeys(m_ipService);
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("super", super.toString())
+                .add("ipService", m_ipService)
+                .toString();
+    }
+
+    @Override
+    public boolean equalsDefinition(BusinessServiceEdgeEntity other) {
+        boolean equalsSuper = super.equalsDefinition(other);
+        if (equalsSuper) {
+            return Objects.equals(m_ipService, ((IPServiceEdgeEntity) other).m_ipService) &&
+                   Objects.equals(m_friendlyName, ((IPServiceEdgeEntity) other).m_friendlyName);
+        }
+        return false;
+    }
+
+    @Override
+    public <T> T accept(EdgeEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/SingleReductionKeyEdgeEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/SingleReductionKeyEdgeEntity.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api;
+
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Size;
+
+import com.google.common.collect.Sets;
+
+@Entity
+@Table(name = "bsm_service_reductionkeys",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"id", "reductionkey"}))
+@PrimaryKeyJoinColumn(name="id")
+@DiscriminatorValue("reductionkeys")
+public class SingleReductionKeyEdgeEntity extends BusinessServiceEdgeEntity {
+
+    private String reductionKey;
+    private String m_friendlyName;
+
+    public void setReductionKey(String reductionKey) {
+        this.reductionKey = reductionKey;
+    }
+
+    @Column(name = "reductionkey", nullable = false)
+    public String getReductionKey() {
+        return reductionKey;
+    }
+
+    @Override
+    @Transient
+    public Set<String> getReductionKeys() {
+        return Sets.newHashSet(reductionKey);
+    }
+
+    @Column(name="friendlyname", nullable = true)
+    @Size(min = 0, max = 30)
+    public String getFriendlyName() {
+        return m_friendlyName;
+    }
+
+    public void setFriendlyName(String friendlyName) {
+        m_friendlyName = friendlyName;
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("super", super.toString())
+                .add("reductionKey", reductionKey)
+                .toString();
+    }
+
+    @Override
+    public boolean equalsDefinition(BusinessServiceEdgeEntity other) {
+        boolean equalsSuper = super.equalsDefinition(other);
+        if (equalsSuper) {
+            return Objects.equals(reductionKey, ((SingleReductionKeyEdgeEntity) other).reductionKey) &&
+                   Objects.equals(m_friendlyName, ((SingleReductionKeyEdgeEntity) other).m_friendlyName);
+        }
+        return false;
+    }
+
+    @Override
+    public <T> T accept(EdgeEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/AbstractMapFunctionEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/AbstractMapFunctionEntity.java
@@ -43,7 +43,7 @@ public abstract class AbstractMapFunctionEntity {
     private Long m_id;
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/AbstractMapFunctionEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/AbstractMapFunctionEntity.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.map;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "bsm_map")
+@Inheritance(strategy=InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name="type", discriminatorType=DiscriminatorType.STRING)
+@DiscriminatorValue(value="")
+public abstract class AbstractMapFunctionEntity {
+
+    private Long m_id;
+
+    @Id
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @GeneratedValue(generator = "opennmsSequence")
+    @Column(name = "id", nullable = false)
+    public Long getId() {
+        return m_id;
+    }
+
+    public void setId(Long id) {
+        m_id = id;
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", m_id)
+                .toString();
+    }
+
+    /**
+     * Defines if the definition of the map function is equal to the given one.
+     *
+     * @return true if equal, otherwise false
+     */
+    public <T extends AbstractMapFunctionEntity> boolean equalsDefinition(T other) {
+        if (other == null) return false;
+        return other.getClass().equals(getClass());
+    }
+
+    public abstract <T> T accept(MapFunctionEntityVisitor<T> visitor);
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/DecreaseEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/DecreaseEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.map;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value="decrease")
+public class DecreaseEntity extends AbstractMapFunctionEntity {
+
+    @Override
+    public <T> T accept(MapFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IdentityEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IdentityEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.map;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value="identity")
+public class IdentityEntity extends AbstractMapFunctionEntity {
+
+    @Override
+    public <T> T accept(MapFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IgnoreEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IgnoreEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.map;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value="ignore")
+public class IgnoreEntity extends AbstractMapFunctionEntity {
+
+    @Override
+    public <T> T accept(MapFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IncreaseEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IncreaseEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.map;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value="increase")
+public class IncreaseEntity extends AbstractMapFunctionEntity {
+
+    @Override
+    public <T> T accept(MapFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/MapFunctionEntityVisitor.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/MapFunctionEntityVisitor.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.map;
+
+public interface MapFunctionEntityVisitor<T> {
+
+    T visit(DecreaseEntity decreaseEntity);
+
+    T visit(IdentityEntity identityEntity);
+
+    T visit(IgnoreEntity ignoreEntity);
+
+    T visit(IncreaseEntity increaseEntity);
+
+    T visit(SetToEntity setToEntity);
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/SetToEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/SetToEntity.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.map;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+import org.opennms.netmgt.model.OnmsSeverity;
+
+@Entity
+@DiscriminatorValue(value="set-to")
+public class SetToEntity extends AbstractMapFunctionEntity {
+
+    @Column(name="severity", nullable=false)    
+    private Integer m_severity;
+
+    public SetToEntity() {
+
+    }
+
+    public SetToEntity(Integer severity) {
+        m_severity = Objects.requireNonNull(severity);
+    }
+
+    public void setSeverity(OnmsSeverity severity) {
+        m_severity = Objects.requireNonNull(severity).getId();
+    }
+
+    public OnmsSeverity getSeverity() {
+        if (m_severity == null) {
+            return null;
+        } else {
+            return OnmsSeverity.get(m_severity);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", getId())
+                .add("severity", getSeverity())
+                .toString();
+    }
+
+    @Override
+    public <T extends AbstractMapFunctionEntity> boolean equalsDefinition(T other) {
+        boolean equalsSuper = super.equalsDefinition(other);
+        if (equalsSuper) {
+            return Objects.equals(m_severity, ((SetToEntity)other).m_severity);
+        }
+        return false;
+    }
+
+    @Override
+    public <T> T accept(MapFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/AbstractReductionFunctionEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/AbstractReductionFunctionEntity.java
@@ -43,7 +43,7 @@ public abstract class AbstractReductionFunctionEntity {
     private Long m_id;
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/AbstractReductionFunctionEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/AbstractReductionFunctionEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "bsm_reduce")
+@Inheritance(strategy=InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name="type", discriminatorType=DiscriminatorType.STRING)
+@DiscriminatorValue(value="")
+public abstract class AbstractReductionFunctionEntity {
+
+    private Long m_id;
+
+    @Id
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @GeneratedValue(generator = "opennmsSequence")
+    @Column(name = "id", nullable = false)
+    public Long getId() {
+        return m_id;
+    }
+
+    public void setId(Long id) {
+        m_id = id;
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", m_id)
+                .toString();
+    }
+
+    public abstract <T> T accept(ReductionFunctionEntityVisitor<T> visitor);
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ExponentialPropagationEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ExponentialPropagationEntity.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value="exponential-propagation")
+public class ExponentialPropagationEntity extends AbstractReductionFunctionEntity {
+
+    @Column(name="base", nullable=false)
+    private double m_base;
+
+    public ExponentialPropagationEntity() {
+    }
+
+    public ExponentialPropagationEntity(double base) {
+        setBase(base);
+    }
+
+    public void setBase(double base) {
+        m_base = base;
+    }
+
+    public double getBase() {
+        return m_base;
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", getId())
+                .add("base", m_base)
+                .toString();
+    }
+
+    @Override
+    public <T> T accept(ReductionFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityAboveEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityAboveEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value="highest-severity-above")
+public class HighestSeverityAboveEntity extends AbstractReductionFunctionEntity {
+
+    /**
+     * The ordinal number of the Status object.
+     */
+    @Column(name="threshold_severity", nullable=false)
+    private int m_threshold;
+
+    public HighestSeverityAboveEntity() {
+
+    }
+
+    public HighestSeverityAboveEntity(int threshold) {
+        setThreshold(threshold);
+    }
+
+    public void setThreshold(int threshold) {
+        m_threshold = threshold;
+    }
+
+    public int getThreshold() {
+        return m_threshold;
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", getId())
+                .add("threshold", m_threshold)
+                .toString();
+    }
+
+    @Override
+    public <T> T accept(ReductionFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value="highest-severity")
+public class HighestSeverityEntity extends AbstractReductionFunctionEntity {
+
+    @Override
+    public <T> T accept(ReductionFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ReductionFunctionEntityVisitor.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ReductionFunctionEntityVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
+
+public interface ReductionFunctionEntityVisitor<T> {
+
+    T visit(HighestSeverityAboveEntity highestSeverityAboveEntity);
+
+    T visit(HighestSeverityEntity highestSeverityEntity);
+
+    T visit(ThresholdEntity thresholdEntity);
+
+    T visit(ExponentialPropagationEntity exponentialPropagationEntity);
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ThresholdEntity.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ThresholdEntity.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+import com.google.common.base.Preconditions;
+
+@Entity
+@DiscriminatorValue("threshold")
+public class ThresholdEntity extends AbstractReductionFunctionEntity {
+
+    @Column(name="threshold", nullable=false)    
+    private float m_threshold;
+
+    public ThresholdEntity() {
+
+    }
+
+    public ThresholdEntity(float threshold) {
+        setThreshold(threshold);
+    }
+
+    public void setThreshold(float threshold) {
+        Preconditions.checkArgument(threshold > 0, "threshold must be strictly positive");
+        Preconditions.checkArgument(threshold <= 1, "threshold must be less or equal to 1");
+        m_threshold = threshold;
+    }
+
+    public float getThreshold() {
+        return m_threshold;
+    }
+
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", getId())
+                .add("threshold", m_threshold)
+                .toString();
+    }
+
+    @Override
+    public <T> T accept(ReductionFunctionEntityVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/resources/application.yml
+++ b/core/daemon-boot-bsmd/src/main/resources/application.yml
@@ -1,0 +1,49 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
+    username: ${SPRING_DATASOURCE_USERNAME:opennms}
+    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+  jpa:
+    hibernate:
+      ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+        implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
+    properties:
+      hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+      hibernate.archive.autodetection: none
+    open-in-view: false
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
+
+opennms:
+  home: ${OPENNMS_HOME:/opt/deltav}
+  instance:
+    id: ${OPENNMS_INSTANCE_ID:OpenNMS}
+  tsid:
+    node-id: ${OPENNMS_TSID_NODE_ID:0}
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-core}
+    poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
+
+logging:
+  level:
+    org.opennms: INFO
+    org.hibernate: WARN
+    org.hibernate.SQL: ${HIBERNATE_SQL_LOG_LEVEL:WARN}

--- a/core/daemon-boot-bsmd/src/test/java/org/opennms/netmgt/bsm/boot/BsmdApplicationIT.java
+++ b/core/daemon-boot-bsmd/src/test/java/org/opennms/netmgt/bsm/boot/BsmdApplicationIT.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.bsm.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.bsm.daemon.Bsmd;
+import org.opennms.netmgt.bsm.service.AlarmProvider;
+import org.opennms.netmgt.bsm.service.BusinessServiceManager;
+import org.opennms.netmgt.bsm.service.BusinessServiceStateMachine;
+import org.opennms.netmgt.events.api.EventSubscriptionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration test for the BSMd Spring Boot application.
+ *
+ * <p>Starts a full Spring Boot context backed by Testcontainers PostgreSQL
+ * (with schema.sql). Verifies that JPA DAOs are functional and that the
+ * BSMd daemon, state machine, and business service manager beans are
+ * properly wired.</p>
+ */
+@SpringBootTest(classes = BsmdApplication.class)
+@Testcontainers
+@Import(BsmdApplicationIT.TestConfig.class)
+@Transactional
+class BsmdApplicationIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("opennms")
+            .withUsername("opennms")
+            .withPassword("opennms")
+            .withInitScript("schema.sql");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("opennms.kafka.bootstrap-servers", () -> "localhost:9092");
+    }
+
+    /**
+     * Provides mock beans for services that BSMd requires but that are
+     * not part of the JPA/DAO layer being tested.
+     */
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        public EventSubscriptionService eventSubscriptionService() {
+            return mock(EventSubscriptionService.class);
+        }
+
+        @Bean
+        public AlarmProvider alarmProvider() {
+            return mock(AlarmProvider.class);
+        }
+    }
+
+    @Autowired
+    private Bsmd bsmd;
+
+    @Autowired
+    private BusinessServiceStateMachine stateMachine;
+
+    @Autowired
+    private BusinessServiceManager manager;
+
+    @Test
+    void contextLoads() {
+        assertThat(bsmd).isNotNull();
+        assertThat(stateMachine).isNotNull();
+        assertThat(manager).isNotNull();
+    }
+}

--- a/core/daemon-boot-bsmd/src/test/resources/schema.sql
+++ b/core/daemon-boot-bsmd/src/test/resources/schema.sql
@@ -1,0 +1,475 @@
+-- ============================================================================
+-- DDL for BSMd integration tests
+--
+-- Derived from Jakarta entity annotations in:
+--   core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/
+--   core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/
+--
+-- Tables cover only the entities mapped with jakarta.persistence annotations
+-- that Hibernate 7 will discover via PersistenceManagedTypes.
+-- ============================================================================
+
+-- -------------------------------------------------------
+-- Sequences
+-- -------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS alarmsNxtId    START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS catNxtId       START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS memoNxtId      START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS serviceNxtId   START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS nodeNxtId      START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS opennmsNxtId   START WITH 1 INCREMENT BY 1;
+
+-- -------------------------------------------------------
+-- monitoringLocations (referenced by node.location FK)
+-- Normally managed by the legacy model, but needed as a
+-- target for the foreign key from the node table.
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS monitoringLocations (
+    id              VARCHAR(255) NOT NULL,
+    monitoringArea  VARCHAR(255) NOT NULL,
+    geolocation     VARCHAR(255),
+    longitude       FLOAT,
+    latitude        FLOAT,
+    priority        BIGINT,
+    CONSTRAINT pk_monitoringLocations PRIMARY KEY (id)
+);
+
+-- -------------------------------------------------------
+-- monitoringSystems  (OnmsMonitoringSystem / OnmsDistPoller)
+-- Single-table inheritance: discriminator column = "type"
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS monitoringSystems (
+    id              VARCHAR(255) NOT NULL,
+    type            VARCHAR(31)  NOT NULL,
+    label           VARCHAR(255),
+    location        VARCHAR(255) NOT NULL,
+    last_updated    TIMESTAMP,
+    last_checked_in TIMESTAMP,
+    CONSTRAINT pk_monitoringSystems PRIMARY KEY (id)
+);
+
+-- Element collection for MonitoringSystem properties
+CREATE TABLE IF NOT EXISTS monitoringSystemsProperties (
+    monitoringSystemId VARCHAR(255) NOT NULL,
+    property           VARCHAR(255) NOT NULL,
+    propertyValue      VARCHAR(255),
+    CONSTRAINT fk_msp_system FOREIGN KEY (monitoringSystemId)
+        REFERENCES monitoringSystems(id) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- node  (OnmsNode)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS node (
+    nodeId            INTEGER      NOT NULL DEFAULT nextval('nodeNxtId'),
+    nodeCreateTime    TIMESTAMP    NOT NULL,
+    nodeParentID      INTEGER,
+    nodeType          VARCHAR(1),
+    nodeSysOID        VARCHAR(256),
+    nodeSysName       VARCHAR(256),
+    nodeSysDescription VARCHAR(256),
+    nodeSysLocation   VARCHAR(256),
+    nodeSysContact    VARCHAR(256),
+    nodeLabel         VARCHAR(256) NOT NULL,
+    nodeLabelSource   VARCHAR(1),
+    nodeNetBIOSName   VARCHAR(16),
+    nodeDomainName    VARCHAR(16),
+    operatingSystem   VARCHAR(64),
+    lastCapsdPoll     TIMESTAMP,
+    foreignId         VARCHAR(255),
+    foreignSource     VARCHAR(255),
+    location          VARCHAR(255) NOT NULL,
+    last_ingress_flow TIMESTAMP,
+    last_egress_flow  TIMESTAMP,
+    CONSTRAINT pk_node PRIMARY KEY (nodeId),
+    CONSTRAINT fk_node_parent FOREIGN KEY (nodeParentID)
+        REFERENCES node(nodeId) ON DELETE SET NULL,
+    CONSTRAINT fk_node_location FOREIGN KEY (location)
+        REFERENCES monitoringLocations(id)
+);
+
+-- pathOutage  (@SecondaryTable for OnmsNode)
+CREATE TABLE IF NOT EXISTS pathOutage (
+    nodeId                  INTEGER NOT NULL,
+    criticalPathIp          VARCHAR(255),
+    criticalPathServiceName VARCHAR(255),
+    CONSTRAINT pk_pathOutage PRIMARY KEY (nodeId),
+    CONSTRAINT fk_pathOutage_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE
+);
+
+-- node_metadata (ElementCollection for OnmsNode)
+CREATE TABLE IF NOT EXISTS node_metadata (
+    id      INTEGER      NOT NULL,
+    context VARCHAR(256) NOT NULL,
+    key     VARCHAR(256) NOT NULL,
+    value   TEXT,
+    CONSTRAINT fk_node_metadata FOREIGN KEY (id)
+        REFERENCES node(nodeId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- categories  (OnmsCategory)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS categories (
+    categoryid          INTEGER      NOT NULL DEFAULT nextval('catNxtId'),
+    categoryName        VARCHAR(255) NOT NULL UNIQUE,
+    categoryDescription VARCHAR(255),
+    CONSTRAINT pk_categories PRIMARY KEY (categoryid)
+);
+
+-- category_node  (ManyToMany join table: Node <-> Category)
+CREATE TABLE IF NOT EXISTS category_node (
+    nodeId      INTEGER NOT NULL,
+    categoryId  INTEGER NOT NULL,
+    CONSTRAINT pk_category_node PRIMARY KEY (nodeId, categoryId),
+    CONSTRAINT fk_cn_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE,
+    CONSTRAINT fk_cn_category FOREIGN KEY (categoryId)
+        REFERENCES categories(categoryid) ON DELETE CASCADE
+);
+
+-- category_group  (ElementCollection for OnmsCategory.authorizedGroups)
+CREATE TABLE IF NOT EXISTS category_group (
+    categoryId INTEGER      NOT NULL,
+    groupId    VARCHAR(64)  NOT NULL,
+    CONSTRAINT fk_cg_category FOREIGN KEY (categoryId)
+        REFERENCES categories(categoryid) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- service  (OnmsServiceType)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS service (
+    serviceId   INTEGER      NOT NULL DEFAULT nextval('serviceNxtId'),
+    serviceName VARCHAR(255) NOT NULL UNIQUE,
+    CONSTRAINT pk_service PRIMARY KEY (serviceId)
+);
+
+-- -------------------------------------------------------
+-- snmpInterface  (OnmsSnmpInterface)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS snmpInterface (
+    id                INTEGER NOT NULL DEFAULT nextval('opennmsNxtId'),
+    nodeId            INTEGER NOT NULL,
+    snmpPhysAddr      VARCHAR(32),
+    snmpIfIndex       INTEGER,
+    snmpIfDescr       VARCHAR(256),
+    snmpIfType        INTEGER,
+    snmpIfName        VARCHAR(32),
+    snmpIfSpeed       BIGINT,
+    snmpIfAdminStatus INTEGER,
+    snmpIfOperStatus  INTEGER,
+    snmpIfAlias       VARCHAR(256),
+    snmpLastCapsdPoll TIMESTAMP,
+    snmpCollect       VARCHAR(255),
+    snmpPoll          VARCHAR(255),
+    snmpLastSnmpPoll  TIMESTAMP,
+    last_ingress_flow TIMESTAMP,
+    last_egress_flow  TIMESTAMP,
+    CONSTRAINT pk_snmpInterface PRIMARY KEY (id),
+    CONSTRAINT fk_snmpIf_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- ipInterface  (OnmsIpInterface)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ipInterface (
+    id               INTEGER     NOT NULL DEFAULT nextval('opennmsNxtId'),
+    nodeId           INTEGER     NOT NULL,
+    ipAddr           VARCHAR(255),
+    netmask          VARCHAR(255),
+    ipHostName       VARCHAR(256),
+    isManaged        VARCHAR(1),
+    isSnmpPrimary    VARCHAR(1),
+    ipLastCapsdPoll  TIMESTAMP,
+    snmpInterfaceId  INTEGER,
+    CONSTRAINT pk_ipInterface PRIMARY KEY (id),
+    CONSTRAINT fk_ipIf_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE CASCADE,
+    CONSTRAINT fk_ipIf_snmpIf FOREIGN KEY (snmpInterfaceId)
+        REFERENCES snmpInterface(id) ON DELETE SET NULL
+);
+
+-- ipInterface_metadata (ElementCollection for OnmsIpInterface)
+CREATE TABLE IF NOT EXISTS ipInterface_metadata (
+    id      INTEGER      NOT NULL,
+    context VARCHAR(256) NOT NULL,
+    key     VARCHAR(256) NOT NULL,
+    value   TEXT,
+    CONSTRAINT fk_ipIf_metadata FOREIGN KEY (id)
+        REFERENCES ipInterface(id) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- ifServices  (OnmsMonitoredService)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ifServices (
+    id              INTEGER NOT NULL DEFAULT nextval('opennmsNxtId'),
+    ipInterfaceId   INTEGER NOT NULL,
+    serviceId       INTEGER NOT NULL,
+    lastGood        TIMESTAMP,
+    lastFail        TIMESTAMP,
+    qualifier       VARCHAR(16),
+    status          VARCHAR(1),
+    source          VARCHAR(1),
+    notify          VARCHAR(1),
+    CONSTRAINT pk_ifServices PRIMARY KEY (id),
+    CONSTRAINT fk_ifSvc_ipIf FOREIGN KEY (ipInterfaceId)
+        REFERENCES ipInterface(id) ON DELETE CASCADE,
+    CONSTRAINT fk_ifSvc_service FOREIGN KEY (serviceId)
+        REFERENCES service(serviceId)
+);
+
+-- ifServices_metadata (ElementCollection for OnmsMonitoredService)
+CREATE TABLE IF NOT EXISTS ifServices_metadata (
+    id      INTEGER      NOT NULL,
+    context VARCHAR(256) NOT NULL,
+    key     VARCHAR(256) NOT NULL,
+    value   TEXT,
+    CONSTRAINT fk_ifSvc_metadata FOREIGN KEY (id)
+        REFERENCES ifServices(id) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- memos  (OnmsMemo / OnmsReductionKeyMemo -- single-table inheritance)
+-- Discriminator column: "type"
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS memos (
+    id           INTEGER     NOT NULL DEFAULT nextval('memoNxtId'),
+    type         VARCHAR(31) NOT NULL,
+    body         TEXT,
+    author       VARCHAR(255),
+    updated      TIMESTAMP,
+    created      TIMESTAMP,
+    reductionkey VARCHAR(255),
+    CONSTRAINT pk_memos PRIMARY KEY (id)
+);
+
+-- -------------------------------------------------------
+-- alarms  (OnmsAlarm)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS alarms (
+    alarmId             INTEGER      NOT NULL DEFAULT nextval('alarmsNxtId'),
+    eventUEI            VARCHAR(256) NOT NULL,
+    systemId            VARCHAR(255) NOT NULL,
+    nodeId              INTEGER,
+    ipAddr              VARCHAR(255),
+    serviceid           INTEGER,
+    reductionKey        VARCHAR(255) UNIQUE,
+    alarmType           INTEGER,
+    ifIndex             INTEGER,
+    counter             INTEGER      NOT NULL,
+    severity            INTEGER      NOT NULL,
+    firstEventTime      TIMESTAMP,
+    lastEventTime       TIMESTAMP,
+    firstAutomationTime TIMESTAMP,
+    lastAutomationTime  TIMESTAMP,
+    description         VARCHAR(4000),
+    logmsg              VARCHAR(1024),
+    operinstruct        TEXT,
+    tticketId           VARCHAR(128),
+    tticketState        INTEGER,
+    mouseOverText       VARCHAR(64),
+    suppressedUntil     TIMESTAMP,
+    suppressedUser      VARCHAR(256),
+    suppressedTime      TIMESTAMP,
+    alarmAckUser        VARCHAR(256),
+    alarmAckTime        TIMESTAMP,
+    clearKey            VARCHAR(255),
+    stickymemo          INTEGER,
+    managedObjectInstance VARCHAR(512),
+    managedObjectType   VARCHAR(512),
+    applicationDN       VARCHAR(512),
+    ossPrimaryKey       VARCHAR(512),
+    x733AlarmType       VARCHAR(31),
+    x733ProbableCause   INTEGER      NOT NULL DEFAULT 0,
+    qosAlarmState       VARCHAR(31),
+    event_tsid          BIGINT,
+    event_uei           VARCHAR(256),
+    event_source        VARCHAR(256),
+    event_severity      INTEGER,
+    event_timestamp     TIMESTAMP,
+    event_node_id       BIGINT,
+    event_log_msg       TEXT,
+    last_event_data     TEXT,
+    CONSTRAINT pk_alarms PRIMARY KEY (alarmId),
+    CONSTRAINT fk_alarm_system FOREIGN KEY (systemId)
+        REFERENCES monitoringSystems(id),
+    CONSTRAINT fk_alarm_node FOREIGN KEY (nodeId)
+        REFERENCES node(nodeId) ON DELETE SET NULL,
+    CONSTRAINT fk_alarm_service FOREIGN KEY (serviceid)
+        REFERENCES service(serviceId),
+    CONSTRAINT fk_alarm_stickymemo FOREIGN KEY (stickymemo)
+        REFERENCES memos(id) ON DELETE SET NULL
+);
+
+-- alarm_attributes  (ElementCollection for OnmsAlarm.details)
+CREATE TABLE IF NOT EXISTS alarm_attributes (
+    alarmId        INTEGER      NOT NULL,
+    attributename  VARCHAR(255) NOT NULL,
+    attributeValue VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_alarm_attr FOREIGN KEY (alarmId)
+        REFERENCES alarms(alarmId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- alarm_situations  (AlarmAssociation entity)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS alarm_situations (
+    id               INTEGER NOT NULL DEFAULT nextval('alarmsNxtId'),
+    situation_id     INTEGER,
+    related_alarm_id INTEGER,
+    mapped_time      TIMESTAMP,
+    CONSTRAINT pk_alarm_situations PRIMARY KEY (id),
+    CONSTRAINT uk_alarm_situations UNIQUE (situation_id, related_alarm_id),
+    CONSTRAINT fk_as_situation FOREIGN KEY (situation_id)
+        REFERENCES alarms(alarmId) ON DELETE CASCADE,
+    CONSTRAINT fk_as_related FOREIGN KEY (related_alarm_id)
+        REFERENCES alarms(alarmId) ON DELETE CASCADE
+);
+
+-- -------------------------------------------------------
+-- accesslocks  (used by AbstractDaoJpa.lock())
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS accesslocks (
+    lockname VARCHAR(40) NOT NULL,
+    CONSTRAINT pk_accesslocks PRIMARY KEY (lockname)
+);
+
+-- -------------------------------------------------------
+-- applications  (OnmsApplication)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS applications (
+    id   INTEGER NOT NULL DEFAULT nextval('opennmsNxtId'),
+    name VARCHAR(32) NOT NULL UNIQUE,
+    CONSTRAINT pk_applications PRIMARY KEY (id)
+);
+
+-- application_service_map  (ManyToMany join: OnmsMonitoredService <-> OnmsApplication)
+CREATE TABLE IF NOT EXISTS application_service_map (
+    ifserviceid INTEGER NOT NULL,
+    appid       INTEGER NOT NULL
+);
+
+-- application_perspective_location_map  (ManyToMany join: OnmsApplication <-> OnmsMonitoringLocation)
+CREATE TABLE IF NOT EXISTS application_perspective_location_map (
+    appid                VARCHAR(255) NOT NULL,
+    monitoringlocationid VARCHAR(255) NOT NULL
+);
+
+-- -------------------------------------------------------
+-- BSM tables
+-- -------------------------------------------------------
+
+-- bsm_reduce  (AbstractReductionFunctionEntity -- single-table inheritance)
+-- Discriminator column: "type"
+-- Subclass columns: threshold (ThresholdEntity), threshold_severity (HighestSeverityAboveEntity),
+--                   base (ExponentialPropagationEntity)
+CREATE TABLE IF NOT EXISTS bsm_reduce (
+    id                 BIGINT NOT NULL DEFAULT nextval('opennmsNxtId'),
+    type               VARCHAR(255) NOT NULL,
+    threshold          FLOAT,
+    threshold_severity INTEGER,
+    base               DOUBLE PRECISION,
+    CONSTRAINT pk_bsm_reduce PRIMARY KEY (id)
+);
+
+-- bsm_map  (AbstractMapFunctionEntity -- single-table inheritance)
+-- Discriminator column: "type"
+-- Subclass columns: severity (SetToEntity)
+CREATE TABLE IF NOT EXISTS bsm_map (
+    id       BIGINT NOT NULL DEFAULT nextval('opennmsNxtId'),
+    type     VARCHAR(255) NOT NULL,
+    severity INTEGER,
+    CONSTRAINT pk_bsm_map PRIMARY KEY (id)
+);
+
+-- bsm_service  (BusinessServiceEntity)
+CREATE TABLE IF NOT EXISTS bsm_service (
+    id             BIGINT NOT NULL DEFAULT nextval('opennmsNxtId'),
+    name           VARCHAR(255) NOT NULL UNIQUE,
+    bsm_reduce_id  BIGINT,
+    CONSTRAINT pk_bsm_service PRIMARY KEY (id),
+    CONSTRAINT fk_bsm_service_reduce FOREIGN KEY (bsm_reduce_id) REFERENCES bsm_reduce(id)
+);
+
+-- bsm_service_attributes  (ElementCollection for BusinessServiceEntity.attributes)
+CREATE TABLE IF NOT EXISTS bsm_service_attributes (
+    bsm_service_id BIGINT NOT NULL,
+    key            VARCHAR(255) NOT NULL,
+    value          VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_bsm_service_attributes_service FOREIGN KEY (bsm_service_id) REFERENCES bsm_service(id)
+);
+
+-- bsm_service_edge  (BusinessServiceEdgeEntity -- joined inheritance base table)
+-- Discriminator column: "type"
+CREATE TABLE IF NOT EXISTS bsm_service_edge (
+    id             BIGINT NOT NULL DEFAULT nextval('opennmsNxtId'),
+    type           VARCHAR(255) NOT NULL,
+    bsm_service_id BIGINT NOT NULL,
+    enabled        BOOLEAN NOT NULL DEFAULT TRUE,
+    weight         INTEGER NOT NULL DEFAULT 1,
+    bsm_map_id     BIGINT,
+    CONSTRAINT pk_bsm_service_edge PRIMARY KEY (id),
+    CONSTRAINT fk_bsm_edge_service FOREIGN KEY (bsm_service_id) REFERENCES bsm_service(id),
+    CONSTRAINT fk_bsm_edge_map FOREIGN KEY (bsm_map_id) REFERENCES bsm_map(id)
+);
+
+-- bsm_service_children  (BusinessServiceChildEdgeEntity -- joined subclass)
+CREATE TABLE IF NOT EXISTS bsm_service_children (
+    id                   BIGINT NOT NULL,
+    bsm_service_child_id BIGINT NOT NULL,
+    CONSTRAINT pk_bsm_service_children PRIMARY KEY (id),
+    CONSTRAINT fk_bsm_children_edge FOREIGN KEY (id) REFERENCES bsm_service_edge(id),
+    CONSTRAINT fk_bsm_children_child FOREIGN KEY (bsm_service_child_id) REFERENCES bsm_service(id)
+);
+
+-- bsm_service_ifservices  (IPServiceEdgeEntity -- joined subclass)
+CREATE TABLE IF NOT EXISTS bsm_service_ifservices (
+    id           BIGINT NOT NULL,
+    ifserviceid  INTEGER NOT NULL,
+    friendlyname VARCHAR(30),
+    CONSTRAINT pk_bsm_service_ifservices PRIMARY KEY (id),
+    CONSTRAINT fk_bsm_ifservices_edge FOREIGN KEY (id) REFERENCES bsm_service_edge(id),
+    CONSTRAINT fk_bsm_ifservices_svc FOREIGN KEY (ifserviceid) REFERENCES ifservices(id)
+);
+
+-- bsm_service_reductionkeys  (SingleReductionKeyEdgeEntity -- joined subclass)
+CREATE TABLE IF NOT EXISTS bsm_service_reductionkeys (
+    id           BIGINT NOT NULL,
+    reductionkey VARCHAR(255) NOT NULL,
+    friendlyname VARCHAR(30),
+    CONSTRAINT pk_bsm_service_reductionkeys PRIMARY KEY (id),
+    CONSTRAINT fk_bsm_reductionkeys_edge FOREIGN KEY (id) REFERENCES bsm_service_edge(id),
+    CONSTRAINT uq_bsm_reductionkeys UNIQUE (id, reductionkey)
+);
+
+-- bsm_service_applications  (ApplicationEdgeEntity -- joined subclass)
+CREATE TABLE IF NOT EXISTS bsm_service_applications (
+    id            BIGINT NOT NULL,
+    applicationid INTEGER NOT NULL,
+    CONSTRAINT pk_bsm_service_applications PRIMARY KEY (id),
+    CONSTRAINT fk_bsm_applications_edge FOREIGN KEY (id) REFERENCES bsm_service_edge(id),
+    CONSTRAINT fk_bsm_applications_app FOREIGN KEY (applicationid) REFERENCES applications(id)
+);
+
+-- -------------------------------------------------------
+-- Seed data
+-- -------------------------------------------------------
+
+-- Default monitoring location (required by node FK)
+INSERT INTO monitoringLocations (id, monitoringArea)
+VALUES ('Default', 'Default')
+ON CONFLICT (id) DO NOTHING;
+
+-- Local OpenNMS system (required by alarm FK)
+INSERT INTO monitoringSystems (id, type, label, location)
+VALUES ('00000000-0000-0000-0000-000000000000', 'OpenNMS', 'localhost', 'Default')
+ON CONFLICT (id) DO NOTHING;
+
+-- Access lock for alarm DAO
+INSERT INTO accesslocks (lockname)
+VALUES ('ONMSALARM_ACCESS')
+ON CONFLICT (lockname) DO NOTHING;

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycle.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycle.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.common;
+
+import org.opennms.netmgt.daemon.SpringServiceDaemon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+
+/**
+ * Adapts a {@link SpringServiceDaemon} to Spring's {@link SmartLifecycle} interface.
+ *
+ * <p>{@code SpringServiceDaemon} extends {@code InitializingBean} and {@code DisposableBean},
+ * so this adapter calls {@link SpringServiceDaemon#afterPropertiesSet()} followed by
+ * {@link SpringServiceDaemon#start()} on startup, and {@link SpringServiceDaemon#destroy()}
+ * on shutdown.</p>
+ *
+ * <p>The phase is set to {@link Integer#MAX_VALUE} so daemons start last (after all
+ * infrastructure beans) and stop first during shutdown.</p>
+ */
+public class SpringServiceDaemonSmartLifecycle implements SmartLifecycle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringServiceDaemonSmartLifecycle.class);
+
+    private final SpringServiceDaemon daemon;
+    private final String name;
+    private volatile boolean running = false;
+
+    public SpringServiceDaemonSmartLifecycle(SpringServiceDaemon daemon, String name) {
+        this.daemon = daemon;
+        this.name = name;
+    }
+
+    @Override
+    public void start() {
+        LOG.info("Starting daemon: {}", name);
+        try {
+            daemon.afterPropertiesSet();
+            daemon.start();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to start daemon: " + name, e);
+        }
+        running = true;
+        LOG.info("Daemon started: {}", name);
+    }
+
+    @Override
+    public void stop() {
+        LOG.info("Stopping daemon: {}", name);
+        try {
+            daemon.destroy();
+        } catch (Exception e) {
+            LOG.error("Error stopping daemon: {}", name, e);
+        }
+        running = false;
+        LOG.info("Daemon stopped: {}", name);
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
+
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE;
+    }
+}

--- a/core/daemon-common/src/test/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycleTest.java
+++ b/core/daemon-common/src/test/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycleTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.daemon.SpringServiceDaemon;
+
+class SpringServiceDaemonSmartLifecycleTest {
+
+    private boolean initCalled = false;
+    private boolean startCalled = false;
+    private boolean destroyCalled = false;
+
+    private final SpringServiceDaemon mockDaemon = new SpringServiceDaemon() {
+        @Override
+        public void afterPropertiesSet() {
+            initCalled = true;
+        }
+
+        @Override
+        public void start() {
+            startCalled = true;
+        }
+
+        @Override
+        public void destroy() {
+            destroyCalled = true;
+        }
+    };
+
+    @Test
+    void startCallsAfterPropertiesSetThenStart() throws Exception {
+        var lifecycle = new SpringServiceDaemonSmartLifecycle(mockDaemon, "TestDaemon");
+        assertThat(lifecycle.isRunning()).isFalse();
+        lifecycle.start();
+        assertThat(initCalled).isTrue();
+        assertThat(startCalled).isTrue();
+        assertThat(lifecycle.isRunning()).isTrue();
+    }
+
+    @Test
+    void stopCallsDestroy() throws Exception {
+        var lifecycle = new SpringServiceDaemonSmartLifecycle(mockDaemon, "TestDaemon");
+        lifecycle.start();
+        lifecycle.stop();
+        assertThat(destroyCalled).isTrue();
+        assertThat(lifecycle.isRunning()).isFalse();
+    }
+
+    @Test
+    void phaseIsMaxValue() {
+        var lifecycle = new SpringServiceDaemonSmartLifecycle(mockDaemon, "TestDaemon");
+        assertThat(lifecycle.getPhase()).isEqualTo(Integer.MAX_VALUE);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsApplication.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsApplication.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * An Application is a grouping of services that belong together.
+ * They can run in different locations.
+ * An example would be "website", or "database".
+ */
+@Entity
+@Table(name = "applications")
+public class OnmsApplication implements Comparable<OnmsApplication> {
+
+    private Integer id;
+
+    private String name;
+
+    private Set<OnmsMonitoredService> monitoredServices = new LinkedHashSet<>();
+
+    /**
+     * These are locations from where the application is monitored.
+     */
+    private Set<OnmsMonitoringLocation> perspectiveLocations = new LinkedHashSet<>();
+
+    @Id
+    @Column(nullable=false)
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @GeneratedValue(generator = "opennmsSequence")
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @Column(name = "name", length=32, nullable=false, unique=true)
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @ManyToMany(
+                mappedBy="applications",
+                cascade={CascadeType.PERSIST, CascadeType.MERGE}
+    )
+    @JsonBackReference
+    public Set<OnmsMonitoredService> getMonitoredServices() {
+        return monitoredServices;
+    }
+
+    public void setMonitoredServices(Set<OnmsMonitoredService> services) {
+        monitoredServices = services;
+    }
+
+    public void addMonitoredService(OnmsMonitoredService service) {
+        getMonitoredServices().add(service);
+    }
+
+    public void removeMonitoredService(OnmsMonitoredService service) {
+        getMonitoredServices().remove(service);
+    }
+
+
+    @ManyToMany(cascade={CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(name="application_perspective_location_map",
+            joinColumns=@JoinColumn(name="appid", referencedColumnName = "id"),
+            inverseJoinColumns=@JoinColumn(name="monitoringlocationid", referencedColumnName = "id"))
+    @JsonIgnore
+    public Set<OnmsMonitoringLocation> getPerspectiveLocations() {
+        return this.perspectiveLocations;
+    }
+
+    public void setPerspectiveLocations(Set<OnmsMonitoringLocation> perspectiveLocations) {
+        this.perspectiveLocations = perspectiveLocations;
+    }
+
+    public void addPerspectiveLocation(OnmsMonitoringLocation perspectiveLocation) {
+        getPerspectiveLocations().add(perspectiveLocation);
+    }
+
+    @Override
+    public int compareTo(OnmsApplication o) {
+        return getName().compareTo(o.getName());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+        .add("id", getId())
+        .add("name", getName())
+        .toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof OnmsApplication) {
+            OnmsApplication app = (OnmsApplication)obj;
+            return getName().equals(app.getName());
+        }
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return getName().hashCode();
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsApplication.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsApplication.java
@@ -63,7 +63,7 @@ public class OnmsApplication implements Comparable<OnmsApplication> {
 
     @Id
     @Column(nullable=false)
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     public Integer getId() {
         return id;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsMonitoredService.java
@@ -543,9 +543,14 @@ public class OnmsMonitoredService extends OnmsEntity implements Serializable, Co
      *
      * @return a {@link java.util.Set} object.
      */
-    // OnmsApplication is not yet migrated to Jakarta Persistence.
-    // Marked @Transient until a Jakarta OnmsApplication entity is available.
-    @Transient
+    @ManyToMany(
+                cascade={CascadeType.PERSIST, CascadeType.MERGE}
+    )
+    @JoinTable(
+               name="application_service_map",
+               joinColumns={@JoinColumn(name="ifserviceid")},
+               inverseJoinColumns={@JoinColumn(name="appid")}
+    )
     @JsonIgnore
     public Set<OnmsApplication> getApplications() {
         return m_applications;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/ApplicationDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/ApplicationDaoJpa.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.dao;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.ApplicationDao;
+import org.opennms.netmgt.dao.api.ApplicationStatus;
+import org.opennms.netmgt.dao.api.MonitoredServiceStatusEntity;
+import org.opennms.netmgt.dao.api.ServicePerspective;
+import org.opennms.netmgt.model.OnmsApplication;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA implementation of {@link ApplicationDao}.
+ *
+ * <p>The {@link #findByName(String)} method uses HQL. The status and alarm
+ * methods ({@link #getApplicationStatus()}, {@link #getAlarmStatus()},
+ * {@link #getPerspectiveLocationsForService(int, InetAddress, String)},
+ * {@link #getServicePerspectives()}) return empty lists as they serve the
+ * REST API layer, not daemon use.</p>
+ */
+@Repository
+@Transactional
+public class ApplicationDaoJpa extends AbstractDaoJpa<OnmsApplication, Integer>
+        implements ApplicationDao {
+
+    public ApplicationDaoJpa() {
+        super(OnmsApplication.class);
+    }
+
+    // ---- ApplicationDao methods ----
+
+    @Override
+    public OnmsApplication findByName(String label) {
+        return findUnique(
+                "SELECT app FROM OnmsApplication app WHERE app.name = ?1",
+                label);
+    }
+
+    @Override
+    public List<ApplicationStatus> getApplicationStatus() {
+        // Application status calculation is for REST API, not daemon use.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ApplicationStatus> getApplicationStatus(List<OnmsApplication> applications) {
+        // Application status calculation is for REST API, not daemon use.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<MonitoredServiceStatusEntity> getAlarmStatus() {
+        // Alarm status retrieval is for REST API, not daemon use.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<MonitoredServiceStatusEntity> getAlarmStatus(List<OnmsApplication> applications) {
+        // Alarm status retrieval is for REST API, not daemon use.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<OnmsMonitoringLocation> getPerspectiveLocationsForService(int nodeId, InetAddress ipAddress,
+            String serviceName) {
+        // Perspective location lookup is for REST API, not daemon use.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ServicePerspective> getServicePerspectives() {
+        // Service perspectives are for REST API, not daemon use.
+        return Collections.emptyList();
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
@@ -22,6 +22,8 @@
 package org.opennms.netmgt.model.jakarta.dao;
 
 import java.net.InetAddress;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -37,8 +39,13 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * JPA implementation of {@link MonitoredServiceDao}.
  *
- * <p>Implements only the methods required by Provisiond. All other methods
- * throw {@link UnsupportedOperationException}.</p>
+ * <p>Implements all methods from the {@link MonitoredServiceDao} interface.
+ * The HQL-backed methods use the helper methods from {@link AbstractDaoJpa}.</p>
+ *
+ * <p>The deprecated {@link #findMatching(OnmsCriteria)} and
+ * {@link #countMatching(OnmsCriteria)} methods from
+ * {@link org.opennms.netmgt.dao.api.LegacyOnmsDao} throw
+ * {@link UnsupportedOperationException}.</p>
  */
 @Repository
 @Transactional
@@ -49,77 +56,102 @@ public class MonitoredServiceDaoJpa extends AbstractDaoJpa<OnmsMonitoredService,
         super(OnmsMonitoredService.class);
     }
 
-    // ---- Methods used by Provisiond ----
-
-    @Override
-    public OnmsMonitoredService get(Integer nodeId, InetAddress ipAddress, String svcName) {
-        return findUnique(
-                "from OnmsMonitoredService ms where ms.ipInterface.node.id = ?1 " +
-                "and ms.ipInterface.ipAddress = ?2 and ms.serviceType.name = ?3",
-                nodeId, ipAddress, svcName);
-    }
-
-    // ---- LegacyOnmsDao methods — not used by Provisiond ----
+    // ---- LegacyOnmsDao methods ----
 
     @Override
     public List<OnmsMonitoredService> findMatching(OnmsCriteria criteria) {
         throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.findMatching(OnmsCriteria) not implemented — not required by Provisiond");
+                "findMatching(OnmsCriteria) is not supported in MonitoredServiceDaoJpa — use HQL queries");
     }
 
     @Override
     public int countMatching(OnmsCriteria onmsCrit) {
         throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.countMatching(OnmsCriteria) not implemented — not required by Provisiond");
+                "countMatching(OnmsCriteria) is not supported in MonitoredServiceDaoJpa — use HQL queries");
     }
 
-    // ---- MonitoredServiceDao methods — not used by Provisiond ----
+    // ---- MonitoredServiceDao methods ----
 
     @Override
     public OnmsMonitoredService get(Integer nodeId, InetAddress ipAddress, Integer serviceId) {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.get(nodeId, ipAddress, serviceId) not implemented — not required by Provisiond");
+        return findUnique(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "JOIN svc.ipInterface ip "
+                + "JOIN ip.node n "
+                + "WHERE n.id = ?1 AND ip.ipAddress = ?2 AND svc.serviceType.id = ?3",
+                nodeId, ipAddress, serviceId);
     }
 
     @Override
     public OnmsMonitoredService get(Integer nodeId, InetAddress ipAddr, Integer ifIndex, Integer serviceId) {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.get(nodeId, ipAddr, ifIndex, serviceId) not implemented — not required by Provisiond");
+        return findUnique(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "JOIN svc.ipInterface ip "
+                + "JOIN ip.node n "
+                + "WHERE n.id = ?1 AND ip.ipAddress = ?2 AND ip.snmpInterface.ifIndex = ?3 AND svc.serviceType.id = ?4",
+                nodeId, ipAddr, ifIndex, serviceId);
+    }
+
+    @Override
+    public OnmsMonitoredService get(Integer nodeId, InetAddress ipAddress, String svcName) {
+        return findUnique(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "JOIN svc.ipInterface ip "
+                + "JOIN ip.node n "
+                + "WHERE n.id = ?1 AND ip.ipAddress = ?2 AND svc.serviceType.name = ?3",
+                nodeId, ipAddress, svcName);
     }
 
     @Override
     public List<OnmsMonitoredService> findByType(String typeName) {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.findByType not implemented — not required by Provisiond");
-    }
-
-    @Override
-    public List<OnmsMonitoredService> findMatchingServices(ServiceSelector serviceSelector) {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.findMatchingServices not implemented — not required by Provisiond");
+        return find(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "WHERE svc.serviceType.name = ?1",
+                typeName);
     }
 
     @Override
     public List<OnmsMonitoredService> findAllServices() {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.findAllServices not implemented — not required by Provisiond");
+        return find(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "JOIN FETCH svc.ipInterface ip "
+                + "JOIN FETCH ip.node");
     }
 
     @Override
     public Set<OnmsMonitoredService> findByApplication(OnmsApplication application) {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.findByApplication not implemented — not required by Provisiond");
+        List<OnmsMonitoredService> services = find(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "JOIN svc.applications app "
+                + "WHERE app.id = ?1",
+                application.getId());
+        return new LinkedHashSet<>(services);
     }
 
     @Override
     public OnmsMonitoredService getPrimaryService(Integer nodeId, String svcName) {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.getPrimaryService not implemented — not required by Provisiond");
+        return findUnique(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "JOIN svc.ipInterface ip "
+                + "JOIN ip.node n "
+                + "WHERE n.id = ?1 AND ip.isSnmpPrimary = 'P' AND svc.serviceType.name = ?2",
+                nodeId, svcName);
+    }
+
+    @Override
+    public List<OnmsMonitoredService> findMatchingServices(ServiceSelector serviceSelector) {
+        // ServiceSelector-based matching requires Hibernate Criteria translation
+        // which is not needed for daemon use. Return empty list.
+        return Collections.emptyList();
     }
 
     @Override
     public List<OnmsMonitoredService> findByNode(int nodeId) {
-        throw new UnsupportedOperationException(
-                "MonitoredServiceDaoJpa.findByNode not implemented — not required by Provisiond");
+        return find(
+                "SELECT svc FROM OnmsMonitoredService svc "
+                + "JOIN svc.ipInterface ip "
+                + "JOIN ip.node n "
+                + "WHERE n.id = ?1",
+                nodeId);
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,6 +41,7 @@
     <module>daemon-boot-eventtranslator</module>
     <module>daemon-boot-discovery</module>
     <module>daemon-boot-provisiond</module>
+    <module>daemon-boot-bsmd</module>
     <module>opennms-model-jakarta</module>
     <module>db</module>
     <module>db-install</module>

--- a/docs/superpowers/plans/2026-03-17-bsmd-spring-boot-4-migration.md
+++ b/docs/superpowers/plans/2026-03-17-bsmd-spring-boot-4-migration.md
@@ -1,0 +1,1069 @@
+# BSMd Spring Boot 4.0.3 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate BSMd from Karaf/OSGi to a standalone Spring Boot 4.0.3 fat JAR, including Jakarta entity conversion of 17 BSM entity classes.
+
+**Architecture:** Create `core/daemon-boot-bsmd/` with Jakarta BSM entities, JPA DAOs, and Spring Boot configuration that reuses the existing BSM service layer (`BusinessServiceManagerImpl`, `DefaultBusinessServiceStateMachine`) unchanged. Add `SpringServiceDaemonSmartLifecycle` to `daemon-common` for `SpringServiceDaemon` support. Add `OnmsApplication`, `MonitoredServiceDaoJpa`, and `ApplicationDaoJpa` to `model-jakarta`.
+
+**Tech Stack:** Spring Boot 4.0.3, Hibernate 7, Jakarta Persistence, Java 21, Kafka event transport, Testcontainers 2.0.3
+
+**Spec:** `docs/superpowers/specs/2026-03-17-bsmd-spring-boot-4-migration-design.md`
+
+---
+
+### Task 1: Add SpringServiceDaemonSmartLifecycle to daemon-common
+
+`Bsmd` implements `SpringServiceDaemon` (not `AbstractServiceDaemon`), so the existing `DaemonSmartLifecycle` doesn't accept it. Add a new adapter.
+
+**Files:**
+- Create: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycle.java`
+- Test: `core/daemon-common/src/test/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycleTest.java`
+
+- [ ] **Step 1: Write the test**
+
+```java
+package org.opennms.core.daemon.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.daemon.SpringServiceDaemon;
+
+class SpringServiceDaemonSmartLifecycleTest {
+
+    private boolean initCalled = false;
+    private boolean startCalled = false;
+    private boolean destroyCalled = false;
+
+    private final SpringServiceDaemon mockDaemon = new SpringServiceDaemon() {
+        @Override
+        public void afterPropertiesSet() { initCalled = true; }
+        @Override
+        public void start() { startCalled = true; }
+        @Override
+        public void destroy() { destroyCalled = true; }
+    };
+
+    @Test
+    void startCallsAfterPropertiesSetThenStart() throws Exception {
+        var lifecycle = new SpringServiceDaemonSmartLifecycle(mockDaemon, "TestDaemon");
+        assertThat(lifecycle.isRunning()).isFalse();
+
+        lifecycle.start();
+
+        assertThat(initCalled).isTrue();
+        assertThat(startCalled).isTrue();
+        assertThat(lifecycle.isRunning()).isTrue();
+    }
+
+    @Test
+    void stopCallsDestroy() throws Exception {
+        var lifecycle = new SpringServiceDaemonSmartLifecycle(mockDaemon, "TestDaemon");
+        lifecycle.start();
+
+        lifecycle.stop();
+
+        assertThat(destroyCalled).isTrue();
+        assertThat(lifecycle.isRunning()).isFalse();
+    }
+
+    @Test
+    void phaseIsMaxValue() {
+        var lifecycle = new SpringServiceDaemonSmartLifecycle(mockDaemon, "TestDaemon");
+        assertThat(lifecycle.getPhase()).isEqualTo(Integer.MAX_VALUE);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd core/daemon-common && ../../maven/bin/mvn test -pl . -Dtest=SpringServiceDaemonSmartLifecycleTest -DfailIfNoTests=false`
+Expected: Compilation failure — class does not exist yet.
+
+- [ ] **Step 3: Implement SpringServiceDaemonSmartLifecycle**
+
+```java
+package org.opennms.core.daemon.common;
+
+import org.opennms.netmgt.daemon.SpringServiceDaemon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+
+/**
+ * Adapts a {@link SpringServiceDaemon} to Spring's {@link SmartLifecycle} interface.
+ *
+ * <p>Unlike {@link DaemonSmartLifecycle} which accepts {@code AbstractServiceDaemon},
+ * this adapter works with daemons that implement {@code SpringServiceDaemon}
+ * ({@code InitializingBean + DisposableBean + start()}).</p>
+ */
+public class SpringServiceDaemonSmartLifecycle implements SmartLifecycle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringServiceDaemonSmartLifecycle.class);
+
+    private final SpringServiceDaemon daemon;
+    private final String name;
+    private volatile boolean running = false;
+
+    public SpringServiceDaemonSmartLifecycle(SpringServiceDaemon daemon, String name) {
+        this.daemon = daemon;
+        this.name = name;
+    }
+
+    @Override
+    public void start() {
+        LOG.info("Starting daemon: {}", name);
+        try {
+            daemon.afterPropertiesSet();
+            daemon.start();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to start daemon: " + name, e);
+        }
+        running = true;
+        LOG.info("Daemon started: {}", name);
+    }
+
+    @Override
+    public void stop() {
+        LOG.info("Stopping daemon: {}", name);
+        try {
+            daemon.destroy();
+        } catch (Exception e) {
+            LOG.error("Error stopping daemon: {}", name, e);
+        }
+        running = false;
+        LOG.info("Daemon stopped: {}", name);
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
+
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd core/daemon-common && ../../maven/bin/mvn test -pl . -Dtest=SpringServiceDaemonSmartLifecycleTest`
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-common/src/main/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycle.java \
+        core/daemon-common/src/test/java/org/opennms/core/daemon/common/SpringServiceDaemonSmartLifecycleTest.java
+git commit -m "feat: add SpringServiceDaemonSmartLifecycle for SpringServiceDaemon adaption"
+```
+
+---
+
+### Task 2: Add OnmsApplication, MonitoredServiceDaoJpa, and ApplicationDaoJpa to model-jakarta
+
+`BusinessServiceManagerImpl` has `@Autowired` fields for `MonitoredServiceDao`, `ApplicationDao`, and `NodeDao`. `NodeDaoJpa` already exists. We need the other two DAOs plus the `OnmsApplication` Jakarta entity.
+
+**Files:**
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsApplication.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java`
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/ApplicationDaoJpa.java`
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsApplication.java` (legacy source)
+- Reference: `opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoredServiceDao.java`
+- Reference: `opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/ApplicationDao.java`
+
+- [ ] **Step 1: Create Jakarta OnmsApplication entity**
+
+Copy `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsApplication.java` to `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsApplication.java`. Convert:
+- `javax.persistence.*` → `jakarta.persistence.*`
+- `javax.xml.bind.*` → `jakarta.xml.bind.*`
+- Remove `org.codehaus.jackson` import (legacy Jackson 1.x) — use `com.fasterxml.jackson` if needed
+- Ensure `OnmsMonitoredService` and `OnmsMonitoringLocation` references resolve to the Jakarta versions already in this module
+
+Key annotations to preserve:
+- `@Entity`, `@Table(name = "applications")`
+- `@ManyToMany(mappedBy="applications")` for monitoredServices
+- `@ManyToMany` with `@JoinTable(name="application_perspective_location_map")` for perspectiveLocations
+
+- [ ] **Step 2: Create MonitoredServiceDaoJpa**
+
+```java
+package org.opennms.netmgt.model.jakarta.dao;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.model.OnmsApplication;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.ServiceSelector;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MonitoredServiceDaoJpa extends AbstractDaoJpa<OnmsMonitoredService, Integer>
+        implements MonitoredServiceDao {
+
+    public MonitoredServiceDaoJpa() {
+        super(OnmsMonitoredService.class);
+    }
+
+    @Override
+    public OnmsMonitoredService get(Integer nodeId, InetAddress ipAddress, Integer serviceId) {
+        return findUnique(
+            "SELECT s FROM OnmsMonitoredService s WHERE s.ipInterface.node.id = ?1 AND s.ipInterface.ipAddress = ?2 AND s.serviceType.id = ?3",
+            nodeId, ipAddress, serviceId);
+    }
+
+    @Override
+    public OnmsMonitoredService get(Integer nodeId, InetAddress ipAddr, Integer ifIndex, Integer serviceId) {
+        return findUnique(
+            "SELECT s FROM OnmsMonitoredService s WHERE s.ipInterface.node.id = ?1 AND s.ipInterface.ipAddress = ?2 AND s.ipInterface.ifIndex = ?3 AND s.serviceType.id = ?4",
+            nodeId, ipAddr, ifIndex, serviceId);
+    }
+
+    @Override
+    public OnmsMonitoredService get(Integer nodeId, InetAddress ipAddr, String svcName) {
+        return findUnique(
+            "SELECT s FROM OnmsMonitoredService s WHERE s.ipInterface.node.id = ?1 AND s.ipInterface.ipAddress = ?2 AND s.serviceType.name = ?3",
+            nodeId, ipAddr, svcName);
+    }
+
+    @Override
+    public List<OnmsMonitoredService> findByType(String typeName) {
+        return find("SELECT s FROM OnmsMonitoredService s WHERE s.serviceType.name = ?1", typeName);
+    }
+
+    @Override
+    public List<OnmsMonitoredService> findAllServices() {
+        return findAll();
+    }
+
+    @Override
+    public Set<OnmsMonitoredService> findByApplication(OnmsApplication application) {
+        return Set.copyOf(find(
+            "SELECT s FROM OnmsMonitoredService s JOIN s.applications a WHERE a.id = ?1",
+            application.getId()));
+    }
+
+    @Override
+    public OnmsMonitoredService getPrimaryService(Integer nodeId, String svcName) {
+        return findUnique(
+            "SELECT s FROM OnmsMonitoredService s WHERE s.ipInterface.node.id = ?1 AND s.serviceType.name = ?2 AND s.ipInterface.isSnmpPrimary = 'P'",
+            nodeId, svcName);
+    }
+
+    @Override
+    public List<OnmsMonitoredService> findMatchingServices(ServiceSelector selector) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<OnmsMonitoredService> findByNode(int nodeId) {
+        return find("SELECT s FROM OnmsMonitoredService s WHERE s.ipInterface.node.id = ?1", nodeId);
+    }
+
+    // --- LegacyOnmsDao methods (deprecated, stub implementations) ---
+
+    @Override
+    public List<OnmsMonitoredService> findMatching(org.opennms.core.criteria.OnmsCriteria criteria) {
+        throw new UnsupportedOperationException("LegacyOnmsDao.findMatching(OnmsCriteria) not implemented — use findMatching(Criteria)");
+    }
+
+    @Override
+    public int countMatching(org.opennms.core.criteria.OnmsCriteria criteria) {
+        throw new UnsupportedOperationException("LegacyOnmsDao.countMatching(OnmsCriteria) not implemented — use countMatching(Criteria)");
+    }
+}
+```
+
+- [ ] **Step 3: Create ApplicationDaoJpa**
+
+```java
+package org.opennms.netmgt.model.jakarta.dao;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.ApplicationDao;
+import org.opennms.netmgt.dao.api.ApplicationStatus;
+import org.opennms.netmgt.dao.api.MonitoredServiceStatusEntity;
+import org.opennms.netmgt.dao.api.ServicePerspective;
+import org.opennms.netmgt.model.OnmsApplication;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ApplicationDaoJpa extends AbstractDaoJpa<OnmsApplication, Integer>
+        implements ApplicationDao {
+
+    public ApplicationDaoJpa() {
+        super(OnmsApplication.class);
+    }
+
+    @Override
+    public OnmsApplication findByName(String name) {
+        return findUnique("SELECT a FROM OnmsApplication a WHERE a.name = ?1", name);
+    }
+
+    @Override
+    public List<ApplicationStatus> getApplicationStatus() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ApplicationStatus> getApplicationStatus(List<OnmsApplication> applications) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<MonitoredServiceStatusEntity> getAlarmStatus() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<MonitoredServiceStatusEntity> getAlarmStatus(List<OnmsApplication> applications) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<OnmsMonitoringLocation> getPerspectiveLocationsForService(int nodeId, InetAddress ipAddress, String serviceName) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ServicePerspective> getServicePerspectives() {
+        return Collections.emptyList();
+    }
+}
+```
+
+- [ ] **Step 4: Verify model-jakarta compiles**
+
+Run: `cd core/opennms-model-jakarta && ../../maven/bin/mvn compile -pl . -DskipTests`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsApplication.java \
+        core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java \
+        core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/ApplicationDaoJpa.java
+git commit -m "feat: add OnmsApplication entity and MonitoredServiceDaoJpa/ApplicationDaoJpa to model-jakarta"
+```
+
+---
+
+### Task 3: Create daemon-boot-bsmd module skeleton (POM + application.yml + register in reactor)
+
+**Files:**
+- Create: `core/daemon-boot-bsmd/pom.xml`
+- Create: `core/daemon-boot-bsmd/src/main/resources/application.yml`
+- Modify: `core/pom.xml` (add module)
+
+- [ ] **Step 1: Create pom.xml**
+
+Use `core/daemon-boot-eventtranslator/pom.xml` as the template. Key changes:
+- ArtifactId: `org.opennms.core.daemon-boot-bsmd`
+- Name: `OpenNMS :: Core :: Daemon Boot :: BSMd`
+- Dependencies:
+  - `org.opennms.core:org.opennms.core.model-jakarta` (FIRST — Jakarta entities win classpath)
+  - `org.opennms.core:org.opennms.core.daemon-common` (with `jackson-module-scala_2.13` exclusion)
+  - `org.opennms.features.bsm:org.opennms.features.bsm.daemon` (Bsmd class, with standard ServiceMix/Hibernate/SLF4J/config-model exclusions)
+  - `org.opennms.features.bsm:org.opennms.features.bsm.service.api`
+  - `org.opennms.features.bsm:org.opennms.features.bsm.service.impl` (with same exclusions)
+  - `org.opennms:opennms-alarmd` (AlarmLifecycleListenerManager, with exclusions)
+  - `org.opennms:opennms-alarm-api`
+  - `javax.persistence:javax.persistence-api:2.2` (runtime)
+  - `javax.xml.bind:jaxb-api:2.3.1` (runtime)
+  - Jakarta XML Bind, Jakarta Inject, JAXB runtime
+  - SLF4J 2.x overrides
+  - `spring-boot-starter-web`, `spring-boot-starter-data-jpa`
+  - Test deps: `spring-boot-starter-test`, Testcontainers
+- Same `<dependencyManagement>` block as EventTranslator
+- Same build plugins (compiler, spring-boot-maven-plugin, surefire 3.5.5, failsafe 3.5.5)
+
+- [ ] **Step 2: Create application.yml**
+
+```yaml
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
+    username: ${SPRING_DATASOURCE_USERNAME:opennms}
+    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+  jpa:
+    hibernate:
+      ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+        implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
+    properties:
+      hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+      hibernate.archive.autodetection: none
+    open-in-view: false
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
+
+opennms:
+  home: ${OPENNMS_HOME:/opt/deltav}
+  instance:
+    id: ${OPENNMS_INSTANCE_ID:OpenNMS}
+  tsid:
+    node-id: ${OPENNMS_TSID_NODE_ID:0}
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-core}
+    poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
+
+logging:
+  level:
+    org.opennms: INFO
+    org.hibernate: WARN
+    org.hibernate.SQL: ${HIBERNATE_SQL_LOG_LEVEL:WARN}
+```
+
+- [ ] **Step 3: Register in core/pom.xml**
+
+Add `<module>daemon-boot-bsmd</module>` after `daemon-boot-discovery` in `core/pom.xml`.
+
+- [ ] **Step 4: Verify POM resolves dependencies**
+
+Run: `cd core/daemon-boot-bsmd && ../../maven/bin/mvn dependency:resolve -pl .`
+Expected: BUILD SUCCESS — all dependencies resolved.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-bsmd/pom.xml core/daemon-boot-bsmd/src/main/resources/application.yml core/pom.xml
+git commit -m "feat: create daemon-boot-bsmd module skeleton"
+```
+
+---
+
+### Task 4: Create Jakarta BSM entities (20 files — mechanical javax→jakarta conversion)
+
+Copy all 17 entity classes + 3 interfaces from `features/bsm/persistence/api/` to `core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/`. Convert `javax.persistence.*` → `jakarta.persistence.*` and `javax.validation.*` → `jakarta.validation.*`. Change `OnmsMonitoredService` and `OnmsApplication` imports to use the `model-jakarta` versions (same package, so no import changes needed — they're in the same `org.opennms.netmgt.model` package).
+
+**Files to create** (all under `core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/`):
+
+Entity classes (javax→jakarta conversion):
+- `BusinessServiceEntity.java`
+- `BusinessServiceEdgeEntity.java`
+- `BusinessServiceChildEdgeEntity.java`
+- `IPServiceEdgeEntity.java`
+- `ApplicationEdgeEntity.java`
+- `SingleReductionKeyEdgeEntity.java`
+- `functions/reduce/AbstractReductionFunctionEntity.java`
+- `functions/reduce/HighestSeverityEntity.java`
+- `functions/reduce/HighestSeverityAboveEntity.java`
+- `functions/reduce/ThresholdEntity.java`
+- `functions/reduce/ExponentialPropagationEntity.java`
+- `functions/map/AbstractMapFunctionEntity.java`
+- `functions/map/IdentityEntity.java`
+- `functions/map/IgnoreEntity.java`
+- `functions/map/DecreaseEntity.java`
+- `functions/map/IncreaseEntity.java`
+- `functions/map/SetToEntity.java`
+
+Interfaces (no JPA annotations — copy as-is):
+- `EdgeEntity.java`
+- `EdgeEntityVisitor.java`
+- `functions/map/MapFunctionEntityVisitor.java`
+- `functions/reduce/ReductionFunctionEntityVisitor.java`
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+mkdir -p core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map
+mkdir -p core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce
+```
+
+- [ ] **Step 2: Copy and convert all entity files**
+
+For each file, the conversion is mechanical:
+- Replace `import javax.persistence.` → `import jakarta.persistence.`
+- Replace `import javax.validation.` → `import jakarta.validation.`
+- All other code remains identical
+
+The 3 interface files (`EdgeEntity.java`, `EdgeEntityVisitor.java`, `MapFunctionEntityVisitor.java`, `ReductionFunctionEntityVisitor.java`) have no JPA imports — copy them unchanged.
+
+Reference the complete source of each file from `features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/` (all sources read during planning phase).
+
+- [ ] **Step 3: Verify entities compile**
+
+Run: `cd core/daemon-boot-bsmd && ../../maven/bin/mvn compile -pl . -DskipTests`
+Expected: BUILD SUCCESS — all 20 files compile with Jakarta imports.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/persistence/api/
+git commit -m "feat: add Jakarta BSM persistence entities for Spring Boot 4"
+```
+
+---
+
+### Task 5: Create BSM JPA DAOs
+
+**Files to create** (all under `core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/`):
+- `BusinessServiceDaoJpa.java`
+- `BusinessServiceEdgeDaoJpa.java`
+- `MapFunctionDaoJpa.java`
+- `ReductionFunctionDaoJpa.java`
+
+- [ ] **Step 1: Create BusinessServiceDaoJpa**
+
+```java
+package org.opennms.netmgt.bsm.dao;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceChildEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceDao;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEntity;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BusinessServiceDaoJpa extends AbstractDaoJpa<BusinessServiceEntity, Long>
+        implements BusinessServiceDao {
+
+    public BusinessServiceDaoJpa() {
+        super(BusinessServiceEntity.class);
+    }
+
+    @Override
+    public Set<BusinessServiceEntity> findParents(BusinessServiceEntity child) {
+        List<BusinessServiceEdgeEntity> edges = entityManager()
+            .createQuery(
+                "SELECT edge FROM BusinessServiceEdgeEntity edge " +
+                "WHERE TYPE(edge) = BusinessServiceChildEdgeEntity " +
+                "AND edge.child.id = :childId",
+                BusinessServiceEdgeEntity.class)
+            .setParameter("childId", child.getId())
+            .getResultList();
+        return edges.stream()
+            .map(BusinessServiceEdgeEntity::getBusinessService)
+            .collect(Collectors.toSet());
+    }
+}
+```
+
+Note: The `findParents()` HQL uses named parameter `:childId` with `entityManager()` directly because the inherited `find()` helper returns `List<T>` typed to `BusinessServiceEntity`, but this query returns edge entities.
+
+- [ ] **Step 2: Create BusinessServiceEdgeDaoJpa**
+
+```java
+package org.opennms.netmgt.bsm.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeDao;
+import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeEntity;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BusinessServiceEdgeDaoJpa extends AbstractDaoJpa<BusinessServiceEdgeEntity, Long>
+        implements BusinessServiceEdgeDao {
+
+    public BusinessServiceEdgeDaoJpa() {
+        super(BusinessServiceEdgeEntity.class);
+    }
+}
+```
+
+- [ ] **Step 3: Create MapFunctionDaoJpa**
+
+```java
+package org.opennms.netmgt.bsm.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.MapFunctionDao;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MapFunctionDaoJpa extends AbstractDaoJpa<AbstractMapFunctionEntity, Long>
+        implements MapFunctionDao {
+
+    public MapFunctionDaoJpa() {
+        super(AbstractMapFunctionEntity.class);
+    }
+}
+```
+
+- [ ] **Step 4: Create ReductionFunctionDaoJpa**
+
+```java
+package org.opennms.netmgt.bsm.dao;
+
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.AbstractReductionFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ReductionFunctionDao;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReductionFunctionDaoJpa extends AbstractDaoJpa<AbstractReductionFunctionEntity, Long>
+        implements ReductionFunctionDao {
+
+    public ReductionFunctionDaoJpa() {
+        super(AbstractReductionFunctionEntity.class);
+    }
+}
+```
+
+- [ ] **Step 5: Verify DAOs compile**
+
+Run: `cd core/daemon-boot-bsmd && ../../maven/bin/mvn compile -pl . -DskipTests`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/dao/
+git commit -m "feat: add BSM JPA DAOs for Spring Boot 4"
+```
+
+---
+
+### Task 6: Convert Bsmd to constructor injection
+
+Modify the `Bsmd` class in `features/bsm/daemon/` to use constructor injection instead of `@Autowired` field injection. This makes it explicit what dependencies the daemon requires.
+
+**Files:**
+- Modify: `features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java`
+
+- [ ] **Step 1: Convert Bsmd to constructor injection**
+
+Replace the 6 `@Autowired` fields with constructor parameters:
+
+```java
+// Remove these @Autowired fields:
+// @Autowired @Qualifier("eventIpcManager") private EventIpcManager m_eventIpcManager;
+// @Autowired(required = false) private MessageBus m_messageBus;
+// @Autowired private EventConfDao m_eventConfDao;
+// @Autowired private TransactionTemplate m_template;
+// @Autowired private BusinessServiceStateMachine m_stateMachine;
+// @Autowired private BusinessServiceManager m_manager;
+
+// Add constructor:
+public Bsmd(EventIpcManager eventIpcManager,
+            EventConfDao eventConfDao,
+            TransactionTemplate transactionTemplate,
+            BusinessServiceStateMachine stateMachine,
+            BusinessServiceManager manager,
+            @org.springframework.lang.Nullable MessageBus messageBus) {
+    m_eventIpcManager = Objects.requireNonNull(eventIpcManager);
+    m_eventConfDao = Objects.requireNonNull(eventConfDao);
+    m_template = Objects.requireNonNull(transactionTemplate);
+    m_stateMachine = Objects.requireNonNull(stateMachine);
+    m_manager = Objects.requireNonNull(manager);
+    m_messageBus = messageBus; // nullable — IPC reload optional
+}
+```
+
+Keep the existing setter methods for backward compatibility with the Karaf XML context (`applicationContext-daemon-loader-bsmd.xml`) which uses property injection.
+
+Remove `@Autowired` and `@Qualifier` annotations from the fields. Keep the fields as `private` (not `final` since setters exist).
+
+- [ ] **Step 2: Backward compatibility with Karaf XML context**
+
+Add `@Autowired` on the new constructor. Remove `@Autowired` from the fields. Spring will use the constructor in both Boot and Karaf contexts — the Karaf XML context uses `<context:annotation-config/>` which enables `@Autowired` constructor resolution. Keep the existing setter methods as-is for any remaining XML property injection.
+
+- [ ] **Step 3: Verify features/bsm/daemon compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.features.bsm.daemon -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java
+git commit -m "refactor: convert Bsmd to constructor injection"
+```
+
+---
+
+### Task 7: Create BsmdApplication and BsmdConfiguration
+
+**Files:**
+- Create: `core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdApplication.java`
+- Create: `core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdConfiguration.java`
+
+- [ ] **Step 1: Create BsmdApplication**
+
+```java
+package org.opennms.netmgt.bsm.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+    "org.opennms.core.daemon.common",
+    "org.opennms.netmgt.bsm.boot",
+    "org.opennms.netmgt.bsm.dao",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+public class BsmdApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BsmdApplication.class, args);
+    }
+}
+```
+
+- [ ] **Step 2: Create BsmdConfiguration**
+
+This is the central wiring class. Reference `core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java` for the pattern. Key beans:
+
+```java
+package org.opennms.netmgt.bsm.boot;
+
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.opennms.core.daemon.common.SpringServiceDaemonSmartLifecycle;
+import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
+import org.opennms.netmgt.alarmd.api.AlarmLifecycleListener;
+import org.opennms.netmgt.bsm.daemon.Bsmd;
+import org.opennms.netmgt.bsm.persistence.api.*;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.*;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.*;
+import org.opennms.netmgt.bsm.service.BusinessServiceManager;
+import org.opennms.netmgt.bsm.service.BusinessServiceStateMachine;
+import org.opennms.netmgt.bsm.service.internal.BusinessServiceManagerImpl;
+import org.opennms.netmgt.bsm.service.internal.DefaultBusinessServiceStateMachine;
+import org.opennms.netmgt.config.DefaultEventConfDao;
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.opennms.netmgt.events.api.EventSubscriptionService;
+import org.opennms.netmgt.model.*;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class BsmdConfiguration {
+
+    @Bean
+    public PhysicalNamingStrategyStandardImpl physicalNamingStrategy() {
+        return new PhysicalNamingStrategyStandardImpl();
+    }
+
+    @Bean
+    public PersistenceManagedTypes persistenceManagedTypes() {
+        return PersistenceManagedTypes.of(
+            // Core entities (from model-jakarta)
+            OnmsAlarm.class.getName(),
+            AlarmAssociation.class.getName(),
+            OnmsCategory.class.getName(),
+            OnmsDistPoller.class.getName(),
+            OnmsIpInterface.class.getName(),
+            OnmsMemo.class.getName(),
+            OnmsMonitoredService.class.getName(),
+            OnmsMonitoringSystem.class.getName(),
+            OnmsNode.class.getName(),
+            OnmsReductionKeyMemo.class.getName(),
+            OnmsServiceType.class.getName(),
+            OnmsSnmpInterface.class.getName(),
+            OnmsMonitoringLocation.class.getName(),
+            OnmsApplication.class.getName(),
+            // BSM entities (Jakarta versions in this module)
+            BusinessServiceEntity.class.getName(),
+            BusinessServiceEdgeEntity.class.getName(),
+            BusinessServiceChildEdgeEntity.class.getName(),
+            IPServiceEdgeEntity.class.getName(),
+            ApplicationEdgeEntity.class.getName(),
+            SingleReductionKeyEdgeEntity.class.getName(),
+            AbstractReductionFunctionEntity.class.getName(),
+            HighestSeverityEntity.class.getName(),
+            HighestSeverityAboveEntity.class.getName(),
+            ThresholdEntity.class.getName(),
+            ExponentialPropagationEntity.class.getName(),
+            AbstractMapFunctionEntity.class.getName(),
+            IdentityEntity.class.getName(),
+            IgnoreEntity.class.getName(),
+            DecreaseEntity.class.getName(),
+            IncreaseEntity.class.getName(),
+            SetToEntity.class.getName()
+        );
+    }
+
+    @Bean
+    public org.opennms.netmgt.dao.api.SessionUtils sessionUtils(PlatformTransactionManager txManager) {
+        var txTemplate = new TransactionTemplate(txManager);
+        var readOnlyTxTemplate = new TransactionTemplate(txManager);
+        readOnlyTxTemplate.setReadOnly(true);
+        return new org.opennms.netmgt.dao.api.SessionUtils() {
+            @Override
+            public <V> V withTransaction(java.util.function.Supplier<V> supplier) {
+                return txTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withReadOnlyTransaction(java.util.function.Supplier<V> supplier) {
+                return readOnlyTxTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withManualFlush(java.util.function.Supplier<V> supplier) {
+                return supplier.get();
+            }
+        };
+    }
+
+    @Bean
+    public TransactionOperations transactionOperations(PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+
+    // --- BSM Service Layer (reused unchanged) ---
+
+    @Bean
+    public BusinessServiceStateMachine businessServiceStateMachine() {
+        return new DefaultBusinessServiceStateMachine();
+    }
+
+    @Bean
+    public BusinessServiceManager businessServiceManager() {
+        // @Autowired field injection will wire DAOs, state machine, etc.
+        return new BusinessServiceManagerImpl();
+    }
+
+    // --- Alarm Lifecycle ---
+
+    @Bean
+    public AlarmLifecycleListenerManager alarmLifecycleListenerManager() {
+        return new AlarmLifecycleListenerManager();
+    }
+
+    /**
+     * Register Bsmd as an AlarmLifecycleListener so it receives alarm snapshots.
+     * Uses SmartInitializingSingleton to run after all beans are constructed,
+     * avoiding circular dependency between AlarmLifecycleListenerManager and Bsmd.
+     */
+    @Bean
+    public org.springframework.beans.factory.SmartInitializingSingleton registerBsmdAsAlarmListener(
+            AlarmLifecycleListenerManager manager, Bsmd bsmd) {
+        return () -> manager.onListenerRegistered(bsmd, new java.util.HashMap<>());
+    }
+
+    // --- EventConf ---
+
+    @Bean
+    public EventConfDao eventConfDao() {
+        return new DefaultEventConfDao();
+    }
+
+    // --- Bsmd Daemon ---
+
+    @Bean
+    public Bsmd bsmd(
+            @Qualifier("eventIpcManager") EventIpcManager eventIpcManager,
+            EventConfDao eventConfDao,
+            TransactionTemplate transactionTemplate,
+            BusinessServiceStateMachine stateMachine,
+            BusinessServiceManager manager) {
+        return new Bsmd(eventIpcManager, eventConfDao, transactionTemplate,
+                        stateMachine, manager, null /* MessageBus not available */);
+    }
+
+    @Bean
+    public AnnotationBasedEventListenerAdapter bsmdEventListenerAdapter(
+            Bsmd bsmd,
+            @Qualifier("kafkaEventSubscriptionService") EventSubscriptionService eventSubscriptionService) {
+        var adapter = new AnnotationBasedEventListenerAdapter();
+        adapter.setAnnotatedListener(bsmd);
+        adapter.setEventSubscriptionService(eventSubscriptionService);
+        return adapter;
+    }
+
+    @Bean
+    public SmartLifecycle bsmdLifecycle(Bsmd bsmd) {
+        return new SpringServiceDaemonSmartLifecycle(bsmd, Bsmd.NAME);
+    }
+}
+```
+
+- [ ] **Step 3: Verify module compiles**
+
+Run: `cd core/daemon-boot-bsmd && ../../maven/bin/mvn compile -pl . -DskipTests`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/
+git commit -m "feat: add BsmdApplication and BsmdConfiguration for Spring Boot 4"
+```
+
+---
+
+### Task 8: Build verification and dependency resolution
+
+Full build to verify everything compiles together and dependency conflicts are resolved.
+
+**Files:**
+- Possibly modify: `core/daemon-boot-bsmd/pom.xml` (exclusions to fix conflicts)
+
+- [ ] **Step 1: Build daemon-boot-bsmd with all upstream dependencies**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-bsmd -am install`
+Expected: BUILD SUCCESS. If not, resolve dependency conflicts by adding exclusions to `pom.xml`.
+
+Common issues to watch for:
+- `jackson-module-scala_2.13` version conflict — exclude from `daemon-common` dep
+- ServiceMix Spring bundles leaking through BSM dependencies — add exclusions
+- Duplicate `javax.persistence` / `jakarta.persistence` classes — ensure `model-jakarta` is listed FIRST
+- `opennms-config-model` pulling in legacy `OnmsMonitoringLocation` — exclude it
+
+- [ ] **Step 2: Run dependency:tree to verify no conflicts**
+
+Run: `cd core/daemon-boot-bsmd && ../../maven/bin/mvn dependency:tree -pl . | grep -i "conflict\|omitted"`
+Expected: No unexpected omissions or conflicts.
+
+- [ ] **Step 3: Fix any remaining exclusions and rebuild**
+
+Iterate on exclusions until the build is clean.
+
+- [ ] **Step 4: Commit any POM fixes**
+
+```bash
+git add core/daemon-boot-bsmd/pom.xml
+git commit -m "fix: resolve dependency conflicts in daemon-boot-bsmd"
+```
+
+---
+
+### Task 9: Context loads integration test
+
+Verify the Spring Boot application context starts with all beans wired correctly against a real PostgreSQL database.
+
+**Files:**
+- Create: `core/daemon-boot-bsmd/src/test/java/org/opennms/netmgt/bsm/boot/BsmdApplicationIT.java`
+
+- [ ] **Step 1: Write the integration test**
+
+```java
+package org.opennms.netmgt.bsm.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.bsm.daemon.Bsmd;
+import org.opennms.netmgt.bsm.service.BusinessServiceManager;
+import org.opennms.netmgt.bsm.service.BusinessServiceStateMachine;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(classes = BsmdApplication.class,
+    properties = {
+        "opennms.kafka.bootstrap-servers=localhost:9092",
+        "spring.jpa.hibernate.ddl-auto=none"
+    })
+@Testcontainers
+class BsmdApplicationIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
+        .withDatabaseName("opennms")
+        .withUsername("opennms")
+        .withPassword("opennms")
+        .withInitScript("schema/bsm-schema.sql");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private Bsmd bsmd;
+
+    @Autowired
+    private BusinessServiceStateMachine stateMachine;
+
+    @Autowired
+    private BusinessServiceManager manager;
+
+    @Autowired
+    private EventIpcManager eventIpcManager;
+
+    @Test
+    void contextLoads() {
+        assertThat(bsmd).isNotNull();
+        assertThat(stateMachine).isNotNull();
+        assertThat(manager).isNotNull();
+        assertThat(eventIpcManager).isNotNull();
+    }
+}
+```
+
+Note: The `schema/bsm-schema.sql` test resource will need to contain the BSM table DDL (`bsm_service`, `bsm_service_edge`, `bsm_service_children`, `bsm_service_ifservices`, `bsm_service_applications`, `bsm_service_reductionkeys`, `bsm_reduce`, `bsm_map`, `bsm_service_attributes`) plus the core tables needed by the alarm and model entities. Extract these from the Liquibase changelogs or from an existing test schema file.
+
+- [ ] **Step 2: Create test schema SQL**
+
+Create `core/daemon-boot-bsmd/src/test/resources/schema/bsm-schema.sql` containing the DDL for all required tables. Extract from `core/schema/src/main/liquibase/` changelogs or adapt from existing daemon-boot test schemas.
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `cd core/daemon-boot-bsmd && ../../maven/bin/mvn verify -pl . -Dit.test=BsmdApplicationIT`
+Expected: PASS — context loads successfully with all beans wired.
+
+- [ ] **Step 4: Fix any wiring issues and iterate**
+
+If the context fails to load:
+- Check for missing bean definitions (Spring will log which bean can't be satisfied)
+- Check for entity scanning issues (verify `PersistenceManagedTypes` lists all entities)
+- Check for Hibernate mapping errors (column name mismatches, missing sequences)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-bsmd/src/test/
+git commit -m "test: add BsmdApplicationIT context loads integration test"
+```

--- a/docs/superpowers/specs/2026-03-17-bsmd-spring-boot-4-migration-design.md
+++ b/docs/superpowers/specs/2026-03-17-bsmd-spring-boot-4-migration-design.md
@@ -18,6 +18,18 @@ We create Jakarta versions of all BSM entities and new JPA DAOs, but **reuse the
 
 **Note:** `BusinessServiceManagerImpl` uses `org.hibernate.Hibernate.initialize()` in two places (for lazy-loading `OnmsApplication.monitoredServices`). This resolves correctly against Hibernate 7 since `org.hibernate.Hibernate` exists at the same package path in both Hibernate 3.x and 7.x.
 
+### Bsmd: Convert to Constructor Injection
+
+As part of this migration, convert `Bsmd` from `@Autowired` field injection to constructor injection. The 6 fields to convert:
+- `EventIpcManager m_eventIpcManager`
+- `MessageBus m_messageBus` (optional — keep `@Nullable` or use `Optional`)
+- `EventConfDao m_eventConfDao`
+- `TransactionTemplate m_template`
+- `BusinessServiceStateMachine m_stateMachine`
+- `BusinessServiceManager m_manager`
+
+`BusinessServiceManagerImpl` retains `@Autowired` field injection for now since it lives in `features/bsm/service/impl/` and is shared with the Karaf deployment.
+
 ### Why not other approaches
 
 - **Option A (rewrite service layer too)**: No benefit — the service layer works through interfaces and doesn't touch `javax.persistence`.

--- a/docs/superpowers/specs/2026-03-17-bsmd-spring-boot-4-migration-design.md
+++ b/docs/superpowers/specs/2026-03-17-bsmd-spring-boot-4-migration-design.md
@@ -1,0 +1,314 @@
+# BSMd Spring Boot 4.0.3 Migration Design
+
+## Summary
+
+Migrate the Business Service Monitor daemon (BSMd) from its Karaf/OSGi container (`core/daemon-loader-bsmd`) to a standalone Spring Boot 4.0.3 fat JAR (`core/daemon-boot-bsmd`), following the established pattern from Alarmd, Trapd, Syslogd, EventTranslator, and Discovery.
+
+BSMd is the first daemon with its own entity model (17 JPA entity classes + 3 interfaces = 20 files in `features/bsm/persistence/api/`) that must be converted from `javax.persistence` to `jakarta.persistence` for Hibernate 7 compatibility.
+
+## Approach: Option C — Jakarta Entities + Reused Service Layer
+
+The BSM codebase has clean architectural layers:
+
+```
+Entities (javax → jakarta) → DAOs (new JPA impls) → Service interfaces → Service impls (unchanged)
+```
+
+We create Jakarta versions of all BSM entities and new JPA DAOs, but **reuse the existing service classes** (`BusinessServiceManagerImpl`, `DefaultBusinessServiceStateMachine`) unchanged. These service classes depend on DAO interfaces and domain model interfaces, not on `javax.persistence` directly.
+
+**Note:** `BusinessServiceManagerImpl` uses `org.hibernate.Hibernate.initialize()` in two places (for lazy-loading `OnmsApplication.monitoredServices`). This resolves correctly against Hibernate 7 since `org.hibernate.Hibernate` exists at the same package path in both Hibernate 3.x and 7.x.
+
+### Why not other approaches
+
+- **Option A (rewrite service layer too)**: No benefit — the service layer works through interfaces and doesn't touch `javax.persistence`.
+- **Option B (JDBC/no ORM)**: Diverges from the entity pattern established across the project; can't reuse `BusinessServiceManagerImpl` which expects DAO interfaces returning entity objects.
+
+## Module Structure
+
+### New Module: `core/daemon-boot-bsmd/`
+
+```
+core/daemon-boot-bsmd/
+├── pom.xml
+└── src/main/java/org/opennms/netmgt/bsm/
+    ├── boot/
+    │   ├── BsmdApplication.java          # @SpringBootApplication
+    │   └── BsmdConfiguration.java        # Bean wiring
+    ├── persistence/
+    │   └── api/                          # Jakarta BSM entities (same package as legacy)
+    │       ├── BusinessServiceEntity.java
+    │       ├── BusinessServiceEdgeEntity.java
+    │       ├── BusinessServiceChildEdgeEntity.java
+    │       ├── IPServiceEdgeEntity.java
+    │       ├── ApplicationEdgeEntity.java
+    │       ├── SingleReductionKeyEdgeEntity.java
+    │       ├── EdgeEntity.java                    # Interface (no JPA annotations)
+    │       ├── EdgeEntityVisitor.java             # Interface (no JPA annotations)
+    │       └── functions/
+    │           ├── map/
+    │           │   ├── AbstractMapFunctionEntity.java
+    │           │   ├── IdentityEntity.java
+    │           │   ├── IgnoreEntity.java
+    │           │   ├── DecreaseEntity.java
+    │           │   ├── IncreaseEntity.java
+    │           │   ├── SetToEntity.java
+    │           │   └── MapFunctionEntityVisitor.java    # Interface
+    │           └── reduce/
+    │               ├── AbstractReductionFunctionEntity.java
+    │               ├── HighestSeverityEntity.java
+    │               ├── HighestSeverityAboveEntity.java
+    │               ├── ThresholdEntity.java
+    │               ├── ExponentialPropagationEntity.java
+    │               └── ReductionFunctionEntityVisitor.java  # Interface
+    └── dao/
+        ├── BusinessServiceDaoJpa.java
+        ├── BusinessServiceEdgeDaoJpa.java
+        ├── MapFunctionDaoJpa.java
+        └── ReductionFunctionDaoJpa.java
+```
+
+### Addition to `core/opennms-model-jakarta/`
+
+Add `OnmsApplication.java` — Jakarta version of the core model entity. It has:
+- `@ManyToMany(mappedBy="applications")` relationship to `OnmsMonitoredService`
+- `@ManyToMany` relationship to `OnmsMonitoringLocation` via join table `application_perspective_location_map`
+- Both referenced entities already exist in `model-jakarta`
+
+### Registration in `core/pom.xml`
+
+Add `<module>daemon-boot-bsmd</module>` to the reactor.
+
+## Entity Migration
+
+All 17 BSM entity classes receive a mechanical `javax.persistence → jakarta.persistence` import conversion. The entity classes are placed in the `daemon-boot-bsmd` module under the **same package** (`org.opennms.netmgt.bsm.persistence.api`) so the service layer code that references these types by name works unchanged.
+
+### Cross-references to core model
+
+Two BSM entities reference core model classes:
+
+| BSM Entity | Core Model Reference | Resolution |
+|---|---|---|
+| `IPServiceEdgeEntity` | `OnmsMonitoredService` | Use Jakarta version from `model-jakarta` |
+| `ApplicationEdgeEntity` | `OnmsApplication` | Use new Jakarta version added to `model-jakarta` |
+
+`SetToEntity` references `OnmsSeverity` which is an enum (no JPA annotations) — works as-is.
+
+### Entity list for PersistenceManagedTypes
+
+```java
+PersistenceManagedTypes.of(
+    // Core entities (from model-jakarta)
+    OnmsAlarm.class.getName(),
+    OnmsNode.class.getName(),
+    OnmsIpInterface.class.getName(),
+    OnmsMonitoredService.class.getName(),
+    OnmsServiceType.class.getName(),
+    OnmsMonitoringLocation.class.getName(),
+    OnmsMonitoringSystem.class.getName(),
+    OnmsDistPoller.class.getName(),
+    OnmsCategory.class.getName(),
+    OnmsSnmpInterface.class.getName(),
+    OnmsApplication.class.getName(),
+    AlarmAssociation.class.getName(),
+    OnmsMemo.class.getName(),
+    OnmsReductionKeyMemo.class.getName(),
+    // BSM entities (Jakarta versions in this module)
+    BusinessServiceEntity.class.getName(),
+    BusinessServiceEdgeEntity.class.getName(),
+    BusinessServiceChildEdgeEntity.class.getName(),
+    IPServiceEdgeEntity.class.getName(),
+    ApplicationEdgeEntity.class.getName(),
+    SingleReductionKeyEdgeEntity.class.getName(),
+    AbstractReductionFunctionEntity.class.getName(),
+    HighestSeverityEntity.class.getName(),
+    HighestSeverityAboveEntity.class.getName(),
+    ThresholdEntity.class.getName(),
+    ExponentialPropagationEntity.class.getName(),
+    AbstractMapFunctionEntity.class.getName(),
+    IdentityEntity.class.getName(),
+    IgnoreEntity.class.getName(),
+    DecreaseEntity.class.getName(),
+    IncreaseEntity.class.getName(),
+    SetToEntity.class.getName()
+)
+```
+
+## DAO Layer
+
+Four JPA DAOs extending `AbstractDaoJpa` from `daemon-common`, implementing the existing DAO interfaces from `features/bsm/persistence/api/`:
+
+| New DAO | Extends | Implements | Custom Methods |
+|---|---|---|---|
+| `BusinessServiceDaoJpa` | `AbstractDaoJpa<BusinessServiceEntity, Long>` | `BusinessServiceDao` | `findParents()` via HQL |
+| `BusinessServiceEdgeDaoJpa` | `AbstractDaoJpa<BusinessServiceEdgeEntity, Long>` | `BusinessServiceEdgeDao` | None |
+| `MapFunctionDaoJpa` | `AbstractDaoJpa<AbstractMapFunctionEntity, Long>` | `MapFunctionDao` | None |
+| `ReductionFunctionDaoJpa` | `AbstractDaoJpa<AbstractReductionFunctionEntity, Long>` | `ReductionFunctionDao` | None |
+
+### BusinessServiceDaoJpa.findParents()
+
+The legacy `BusinessServiceDaoImpl.findParents()` uses HQL:
+```sql
+select edge from BusinessServiceEdgeEntity edge
+where type(edge) = BusinessServiceChildEdgeEntity and edge.child.id = :childId
+```
+
+The JPA version uses `entityManager().createQuery()` directly (not the inherited `find()` helper) because the HQL returns `BusinessServiceEdgeEntity` objects, not `BusinessServiceEntity`. The method collects the parent business service from each edge's `getBusinessService()` and returns `Set<BusinessServiceEntity>`.
+
+### findMatching() not needed
+
+`AbstractDaoJpa.findMatching()` throws `UnsupportedOperationException`. BSMd only calls `findAll()` via `BusinessServiceManager.getAllBusinessServices()`. The complex `findMatching()` override in the legacy `BusinessServiceDaoImpl` (for paginated Vaadin admin UI) is not needed in the daemon context.
+
+## Service Layer (Reused Unchanged)
+
+| Class | Source Module | Role |
+|---|---|---|
+| `BusinessServiceManagerImpl` | `features/bsm/service/impl` | Loads BS config from DB via DAOs, converts to domain model |
+| `DefaultBusinessServiceStateMachine` | `features/bsm/service/impl` | In-memory graph computation, alarm→status propagation |
+
+### BusinessServiceManagerImpl @Autowired dependencies
+
+`BusinessServiceManagerImpl` has 9 `@Autowired` fields. BSMd only calls `getAllBusinessServices()` at runtime (which uses `businessServiceDao.findAll()`), but Spring requires all `@Autowired` fields to be satisfied at startup:
+
+| Field | Type | Provided By |
+|---|---|---|
+| `businessServiceDao` | `BusinessServiceDao` | `BusinessServiceDaoJpa` (new) |
+| `edgeDao` | `BusinessServiceEdgeDao` | `BusinessServiceEdgeDaoJpa` (new) |
+| `mapFunctionDao` | `MapFunctionDao` | `MapFunctionDaoJpa` (new) |
+| `reductionFunctionDao` | `ReductionFunctionDao` | `ReductionFunctionDaoJpa` (new) |
+| `businessServiceStateMachine` | `BusinessServiceStateMachine` | `DefaultBusinessServiceStateMachine` bean |
+| `monitoredServiceDao` | `MonitoredServiceDao` | New `MonitoredServiceDaoJpa` in `model-jakarta` |
+| `nodeDao` | `NodeDao` | Existing `NodeDaoJpa` in `model-jakarta` |
+| `applicationDao` | `ApplicationDao` | New `ApplicationDaoJpa` in `model-jakarta` |
+| `eventForwarder` | `EventForwarder` | `KafkaEventForwarder` from `daemon-common` |
+
+**New DAOs needed in `model-jakarta`:** `MonitoredServiceDaoJpa` and `ApplicationDaoJpa`. These are primarily needed to satisfy Spring autowiring; BSMd's core path (`getAllBusinessServices()`) doesn't call them, but `getAllIpServices()`, `getAllApplications()`, and `getNodeById()` do use them and could be called by the state machine or service layer during graph building.
+
+## Alarm Lifecycle Integration
+
+`AlarmLifecycleListenerManager` (from `opennms-alarmd`) polls `AlarmDao.findAll()` on a configurable interval (default 2 minutes, overridable via `org.opennms.alarms.snapshot.sync.ms`). It pushes alarm snapshots to all registered `AlarmLifecycleListener` instances.
+
+Configuration:
+1. Wire `AlarmLifecycleListenerManager` as a `@Bean`
+2. Register `Bsmd` as an `AlarmLifecycleListener` programmatically
+3. `AlarmDaoJpa` from `model-jakarta` provides alarm data
+
+## Event Infrastructure
+
+### Outbound events (BSMd → Kafka)
+
+`KafkaEventForwarder` (from `daemon-common`'s `KafkaEventTransportConfiguration`) handles:
+- Eventconf enrichment via `enrichWithEventConf()` — applies severity and alarm-data from `EventConfDao`
+- Topic routing via `EventClassifier` — BSM events are fault events, routed to the fault topic
+- No full `EventUtil` needed — BSM events carry explicit params and don't need node label resolution
+
+### Inbound events (Kafka → BSMd)
+
+`KafkaEventSubscriptionService` (from `daemon-common`) polls the fault Kafka topic and dispatches to registered listeners. `AnnotationBasedEventListenerAdapter` bridges Bsmd's `@EventHandler` annotations to this subscription service.
+
+### EventConfDao
+
+`DefaultEventConfDao` loaded via `EventConfInitializer` from the database (same pattern as the Karaf loader context). Required for:
+- Bsmd's reduction key verification in `start()`
+- KafkaEventForwarder's eventconf enrichment of outbound events
+
+## New Infrastructure: SpringServiceDaemonSmartLifecycle
+
+`Bsmd` implements `SpringServiceDaemon` (which extends `InitializingBean` + `DisposableBean`), NOT `AbstractServiceDaemon`. The existing `DaemonSmartLifecycle` in `daemon-common` only accepts `AbstractServiceDaemon`.
+
+**Solution:** Add `SpringServiceDaemonSmartLifecycle` to `daemon-common`. This adapter:
+- On `start()`: calls `afterPropertiesSet()` then `start()` on the wrapped `SpringServiceDaemon`
+- On `stop()`: calls `destroy()` on the wrapped `SpringServiceDaemon`
+- Same phase (`Integer.MAX_VALUE`) as `DaemonSmartLifecycle`
+
+This is a reusable addition — any future daemon that implements `SpringServiceDaemon` instead of `AbstractServiceDaemon` can use it.
+
+## BsmdConfiguration Bean Wiring
+
+```
+BsmdConfiguration
+├── physicalNamingStrategy()          — PhysicalNamingStrategyStandardImpl (camelCase tables)
+├── persistenceManagedTypes()         — All core + BSM Jakarta entities
+├── sessionUtils(txManager)           — TransactionTemplate wrapper
+├── transactionOperations(txManager)  — TransactionTemplate for @Autowired fields
+│
+├── businessServiceDao()              — BusinessServiceDaoJpa
+├── businessServiceEdgeDao()          — BusinessServiceEdgeDaoJpa
+├── mapFunctionDao()                  — MapFunctionDaoJpa
+├── reductionFunctionDao()            — ReductionFunctionDaoJpa
+│
+├── businessServiceStateMachine()     — DefaultBusinessServiceStateMachine
+├── businessServiceManager()          — BusinessServiceManagerImpl (DAOs injected via @Autowired)
+│
+├── alarmLifecycleListenerManager()   — AlarmLifecycleListenerManager
+│
+├── eventConfDao()                    — DefaultEventConfDao (loaded via EventConfInitializer)
+│
+├── bsmd(stateMachine, manager, ...)  — Bsmd daemon instance
+├── bsmdEventListenerAdapter(...)     — AnnotationBasedEventListenerAdapter
+├── bsmdLifecycle(bsmd)              — SpringServiceDaemonSmartLifecycle (NEW)
+```
+
+## BsmdApplication
+
+```java
+@SpringBootApplication(scanBasePackages = {
+    "org.opennms.core.daemon.common",
+    "org.opennms.netmgt.bsm.boot",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+public class BsmdApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BsmdApplication.class, args);
+    }
+}
+```
+
+## application.yml
+
+Same template as other daemon-boot modules:
+- PostgreSQL datasource with HikariCP
+- Hibernate dialect, `ddl-auto: none`, `PhysicalNamingStrategyStandardImpl`
+- Actuator health endpoint on port 8080
+- `opennms.home`, Kafka bootstrap servers, event topic, consumer group
+- Logging levels: `org.opennms: INFO`, `org.hibernate: WARN`
+
+## Maven Dependencies
+
+Key dependencies for `daemon-boot-bsmd` (following `daemon-boot-alarmd` pattern):
+
+| Dependency | Purpose |
+|---|---|
+| `org.opennms.core:daemon-common` | Shared Spring Boot daemon infrastructure |
+| `org.opennms.core:model-jakarta` | Jakarta core entities + JPA DAOs |
+| `org.opennms.features.bsm:service.api` | BSM service interfaces |
+| `org.opennms.features.bsm:service.impl` | BusinessServiceManagerImpl, DefaultBusinessServiceStateMachine |
+| `org.opennms:opennms-alarmd` | AlarmLifecycleListenerManager |
+| `org.opennms:opennms-alarm-api` | AlarmLifecycleListener interface |
+| `javax.persistence:javax.persistence-api:2.2` | Runtime — prevents CNFE from legacy classes on classpath |
+| `jakarta.xml.bind:jakarta.xml.bind-api` | Hibernate 7 XML mapping support |
+| `jakarta.inject:jakarta.inject-api` | Hibernate 7 requirement |
+| `javax.xml.bind:jaxb-api:2.3.1` | Runtime — legacy Event XML unmarshalling |
+| `org.opennms:opennms-dao-api` | `ReductionKeyHelper` used by Jakarta BSM edge entities, plus `MonitoredServiceDao`, `NodeDao`, `ApplicationDao` interfaces |
+| Spring Boot starters | `spring-boot-starter-web`, `spring-boot-starter-test` |
+
+Standard exclusions: ServiceMix Spring 4.2.x bundles, old Hibernate 3.x, old SLF4J 1.7.x, Karaf/OSGi logging, `opennms-config-model`, `commons-logging`.
+
+## What We Skip
+
+- **MessageBus**: Bsmd handles `null` MessageBus gracefully (logs warning, falls back to event-based reload). Can be added later.
+- **EventUtil**: Not needed — BSM events carry explicit params.
+- **EventProxy**: Not needed — Bsmd uses `EventIpcManager.sendNow()` directly.
+- **findMatching() in BusinessServiceDaoJpa**: Not called by BSMd.
+- **AlarmEntityNotifier**: Not needed — BSMd is a consumer of alarm state, not a producer.
+
+## Known Risks
+
+- **Bsmd's scheduled executor in instance initializer**: `Bsmd` creates a `ScheduledExecutorService` in an instance initializer block (lines 118-132) that starts immediately upon construction, before `afterPropertiesSet()` or `start()`. It references `m_eventIpcManager` which may be null at that point. The reload check (`reloadConfigurationAt > 0L`) guards against premature execution, but this should be verified during integration testing.
+
+## Testing Strategy
+
+- **Unit tests**: Context loads test verifying Spring Boot application starts with all beans wired
+- **Integration tests**: Testcontainers PostgreSQL + Kafka verifying:
+  - BSM config loaded from database via JPA DAOs
+  - Alarm snapshot triggers state machine evaluation
+  - BSM status change events published to Kafka fault topic

--- a/features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java
+++ b/features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java
@@ -62,7 +62,6 @@ import org.opennms.netmgt.xml.eventconf.AlarmData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -92,24 +91,31 @@ public class Bsmd implements SpringServiceDaemon, BusinessServiceStateChangeHand
     /** MessageBus type derived from uei.opennms.org/internal/reloadDaemonConfig */
     private static final String MSG_TYPE_RELOAD_DAEMON_CONFIG = "reloadDaemonConfig";
 
-    @Autowired
-    @Qualifier("eventIpcManager")
     private EventIpcManager m_eventIpcManager;
 
     @Autowired(required = false)
     private MessageBus m_messageBus;
 
-    @Autowired
     private EventConfDao m_eventConfDao;
 
-    @Autowired
     private TransactionTemplate m_template;
 
-    @Autowired
     private BusinessServiceStateMachine m_stateMachine;
 
-    @Autowired
     private BusinessServiceManager m_manager;
+
+    @Autowired
+    public Bsmd(EventIpcManager eventIpcManager,
+                EventConfDao eventConfDao,
+                TransactionTemplate transactionTemplate,
+                BusinessServiceStateMachine stateMachine,
+                BusinessServiceManager manager) {
+        m_eventIpcManager = Objects.requireNonNull(eventIpcManager);
+        m_eventConfDao = Objects.requireNonNull(eventConfDao);
+        m_template = Objects.requireNonNull(transactionTemplate);
+        m_stateMachine = Objects.requireNonNull(stateMachine);
+        m_manager = Objects.requireNonNull(manager);
+    }
 
     private boolean m_verifyReductionKeys = true;
 


### PR DESCRIPTION
## Summary

- Migrate BSMd (Business Service Monitor daemon) from Karaf/OSGi to standalone Spring Boot 4.0.3 fat JAR
- Add `SpringServiceDaemonSmartLifecycle` to daemon-common for `SpringServiceDaemon` support
- Add `OnmsApplication` entity + `MonitoredServiceDaoJpa` + `ApplicationDaoJpa` to model-jakarta
- Create 21 Jakarta BSM persistence entities (mechanical javax→jakarta conversion)
- Create 4 BSM JPA DAOs extending `AbstractDaoJpa`
- Convert `Bsmd` from `@Autowired` field injection to constructor injection
- Integration test with Testcontainers PostgreSQL — passing

## Test plan

- [x] Full build passes (`compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-bsmd -am install`)
- [x] `SpringServiceDaemonSmartLifecycleTest` — 3/3 tests passing
- [x] `BsmdApplicationIT` — context loads against real PostgreSQL via Testcontainers
- [ ] Smoke test with Docker Compose (BSMd container + Kafka + PostgreSQL)