### PR TITLE
fix: Pollerd config and Kafka event consumer lifecycle

### DIFF
--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -27,6 +27,7 @@ import org.opennms.core.event.forwarder.kafka.KafkaEventIpcManagerAdapter;
 import org.opennms.core.event.forwarder.kafka.KafkaEventSubscriptionService;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -72,7 +73,7 @@ public class KafkaEventTransportConfiguration {
         return forwarder;
     }
 
-    @Bean(initMethod = "start", destroyMethod = "stop")
+    @Bean(destroyMethod = "stop")
     public KafkaEventSubscriptionService kafkaEventSubscriptionService() {
         return KafkaEventSubscriptionService.create(
                 bootstrapServers,
@@ -86,5 +87,40 @@ public class KafkaEventTransportConfiguration {
     public EventIpcManager eventIpcManager(KafkaEventForwarder forwarder,
                                            KafkaEventSubscriptionService subscriptionService) {
         return new KafkaEventIpcManagerAdapter(forwarder, subscriptionService);
+    }
+
+    /**
+     * Starts the Kafka event consumer AFTER all InitializingBean callbacks
+     * have fired (i.e., after AnnotationBasedEventListenerAdapter has
+     * registered its listeners). SmartLifecycle runs after bean init but
+     * before the application is considered started. Phase -10 ensures this
+     * fires before daemon SmartLifecycles at the default phase (0).
+     */
+    @Bean
+    public SmartLifecycle kafkaEventSubscriptionLifecycle(KafkaEventSubscriptionService subscriptionService) {
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                subscriptionService.start();
+                running = true;
+            }
+
+            @Override
+            public void stop() {
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return -10;
+            }
+        };
     }
 }

--- a/docs/superpowers/plans/2026-03-20-pollerd-spring-boot-migration.md
+++ b/docs/superpowers/plans/2026-03-20-pollerd-spring-boot-migration.md
@@ -1,0 +1,426 @@
+# Pollerd Spring Boot 4 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate Pollerd from Karaf/OSGi to a standalone Spring Boot 4 application so it has deterministic bean initialization, direct Kafka event forwarding, and no OSGi service registry dependencies.
+
+**Architecture:** New Maven module `core/daemon-boot-pollerd` with four `@Configuration` classes (JPA, RPC, PassiveStatus, Daemon) following the established pattern from 7 prior daemon migrations. Pollerd delegates all poll execution to Minion via Kafka RPC. Events flow through `KafkaEventForwarder` to the `opennms-fault-events` Kafka topic.
+
+**Tech Stack:** Spring Boot 4.0.3, Hibernate 7 (Jakarta Persistence), Kafka (event transport + RPC + Twin API), PostgreSQL, Java 21.
+
+**Spec:** `docs/superpowers/specs/2026-03-20-pollerd-spring-boot-migration-design.md`
+
+---
+
+## File Map
+
+### New Files
+- `core/daemon-boot-pollerd/pom.xml` — Maven module with Spring Boot 4 + legacy dependency management
+- `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdApplication.java` — Entry point
+- `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java` — JPA entities, DAOs, no-ops
+- `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdRpcConfiguration.java` — Kafka RPC clients
+- `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java` — Twin API
+- `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java` — Core daemon wiring
+- `core/daemon-boot-pollerd/src/main/resources/application.yml` — Spring Boot config
+- `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java` — Jakarta entity port
+- `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java` — JPA DAO
+
+### Modified Files
+- `opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java` — Constructor injection (8 fields)
+- `opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java` — Constructor injection (5 fields)
+- `opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java` — Constructor injection (setters → constructor)
+- `core/daemon-loader-pollerd/src/main/java/org/opennms/core/daemon/loader/StandalonePollContext.java` — Move to daemon-boot-pollerd, update constructor
+- `features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/LocationAwarePollerClientImpl.java` — Constructor injection (5 fields)
+- `opennms-icmp/opennms-icmp-proxy-rpc-impl/src/main/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingClientImpl.java` — Constructor injection (3 fields)
+- `opennms-container/delta-v/docker-compose.yml` — Switch pollerd to Spring Boot JAR
+- `opennms-container/delta-v/build.sh` — Stage daemon-boot-pollerd JAR
+- `pom.xml` (root) — Add daemon-boot-pollerd module
+
+---
+
+### Task 1: Port OnmsOutage to Jakarta Persistence
+
+**Files:**
+- Reference: `opennms-model/src/main/java/org/opennms/netmgt/model/OnmsOutage.java` (493 lines)
+- Create: `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java`
+- Reference: Existing Jakarta entity `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java` for annotation patterns
+
+- [ ] **Step 1: Copy OnmsOutage to Jakarta module**
+
+Copy `opennms-model/.../OnmsOutage.java` to `core/opennms-model-jakarta/.../OnmsOutage.java`. Change package imports from `javax.persistence.*` to `jakarta.persistence.*`. Replace `org.hibernate.annotations.Type` with Hibernate 7 equivalents. Replace `@Filter` with Hibernate 7 `@Filter`. Remove `@Temporal` annotations (deprecated in Hibernate 7 — use `java.time` types or leave as-is if `java.util.Date` still compiles).
+
+- [ ] **Step 2: Verify Jakarta entity compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.model.jakarta -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Create OutageDaoJpa**
+
+Create `core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java` extending `AbstractDaoJpa<OnmsOutage, Integer>` with `@Repository`. Follow pattern from existing `AlarmDaoJpa` in same package. Must implement `OutageDao` interface from `opennms-dao-api`.
+
+- [ ] **Step 4: Verify DAO compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.model.jakarta -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```
+git add core/opennms-model-jakarta/
+git commit -m "feat: port OnmsOutage entity and OutageDaoJpa to Jakarta Persistence"
+```
+
+---
+
+### Task 2: Convert Poller, QueryManagerDaoImpl, DefaultPollContext to Constructor Injection
+
+**Files:**
+- Modify: `opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java`
+- Modify: `opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java`
+- Modify: `opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java`
+- Modify: `core/daemon-loader-pollerd/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-pollerd.xml` (update bean definitions to use constructor-arg)
+
+- [ ] **Step 1: Convert Poller to constructor injection**
+
+Replace 8 `@Autowired` fields with a constructor. Remove setter methods that only exist for injection. Keep setters needed by Spring XML (Karaf still uses XML wiring until the Karaf loader is removed). Add `final` to injected fields.
+
+- [ ] **Step 2: Convert QueryManagerDaoImpl to constructor injection**
+
+Replace 5 `@Autowired` fields (`m_nodeDao`, `m_outageDao`, `m_monitoredServiceDao`, `m_ipInterfaceDao`, `m_transcationOps`) with a constructor. Add `final` to fields.
+
+- [ ] **Step 3: Convert DefaultPollContext to constructor injection**
+
+Replace setter-injected fields with a constructor. `DefaultPollContext` has: `m_eventManager`, `m_pollerConfig`, `m_queryManager`, `m_nodeDao`, `m_tsidFactory`, `m_localHostName`, `m_name`. All currently set via `<property>` in the Spring XML context.
+
+**Important:** `StandalonePollContext` extends `DefaultPollContext` and must get a matching constructor that calls `super(...)`. Update `StandalonePollContext` in `core/daemon-loader-pollerd/` in this same step to keep the Karaf build compiling.
+
+- [ ] **Step 4: Convert LocationAwarePollerClientImpl to constructor injection**
+
+Replace 5 `@Autowired` fields with a constructor: `serviceMonitorRegistry`, `pollerClientRpcModule`, `rpcClientFactory`, `rpcTargetHelper`, `entityScopeProvider`. Remove `afterPropertiesSet()` call from old constructor. Add `final` to fields.
+
+- [ ] **Step 5: Convert LocationAwarePingClientImpl to constructor injection**
+
+Replace 3 `@Autowired` fields with a constructor: `rpcClientFactory`, `pingProxyRpcModule`, `pingSweepRpcModule`. Add `final` to fields.
+
+- [ ] **Step 6: Update Karaf Spring XML context**
+
+Update `applicationContext-daemon-loader-pollerd.xml` to use `<constructor-arg>` instead of `<property>` for the converted beans. This keeps the Karaf loader working during the transition.
+
+- [ ] **Step 7: Verify Karaf build still compiles**
+
+Run: `./compile.pl -DskipTests --projects :opennms-services,:org.opennms.core.daemon-loader-pollerd,:org.opennms.features.poller.client-rpc,:org.opennms.netmgt.icmp.proxy.rpc -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 8: Commit**
+
+```
+git add opennms-services/ core/daemon-loader-pollerd/ features/poller/client-rpc/ opennms-icmp/
+git commit -m "refactor: convert Poller, QueryManagerDaoImpl, DefaultPollContext, LocationAwarePollerClientImpl, LocationAwarePingClientImpl to constructor injection"
+```
+
+---
+
+### Task 3: Create daemon-boot-pollerd Maven Module (Skeleton)
+
+**Files:**
+- Create: `core/daemon-boot-pollerd/pom.xml`
+- Create: `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdApplication.java`
+- Create: `core/daemon-boot-pollerd/src/main/resources/application.yml`
+- Modify: `pom.xml` (root) — add module
+
+- [ ] **Step 1: Create pom.xml**
+
+Use `core/daemon-boot-provisiond/pom.xml` as the template. Key differences:
+- `artifactId`: `org.opennms.core.daemon-boot-pollerd`
+- Dependencies: `daemon-common`, `opennms-services`, `poller-client-rpc`, `opennms-model-jakarta`, `opennms-config`, `icmp-rpc-common`
+- Same Spring Boot 4.0.3 parent, same exclusion patterns for servicemix/OSGi bundles
+- Spring Boot Maven plugin with `boot` classifier for repackaging
+
+- [ ] **Step 2: Create PollerdApplication.java**
+
+```java
+@SpringBootApplication(scanBasePackages = {
+    "org.opennms.core.daemon.common",
+    "org.opennms.netmgt.poller.boot",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+public class PollerdApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PollerdApplication.class, args);
+    }
+}
+```
+
+- [ ] **Step 3: Create application.yml**
+
+Copy from spec section "application.yml". Includes datasource, JPA/Hibernate, Kafka event transport, Kafka RPC, and opennms.home configuration.
+
+- [ ] **Step 4: Add module to root pom.xml**
+
+Add `<module>core/daemon-boot-pollerd</module>` in the modules section, near the other daemon-boot modules.
+
+- [ ] **Step 5: Verify skeleton compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-pollerd -am install`
+Expected: BUILD SUCCESS (empty app with no config classes yet)
+
+- [ ] **Step 6: Commit**
+
+```
+git add core/daemon-boot-pollerd/ pom.xml
+git commit -m "feat: add daemon-boot-pollerd Maven module skeleton"
+```
+
+---
+
+### Task 4: PollerdJpaConfiguration
+
+**Files:**
+- Create: `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java`
+- Reference: `core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java` (JPA section)
+- Reference: `core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java` (JPA + FilterDao section)
+
+- [ ] **Step 1: Create PollerdJpaConfiguration with entity list**
+
+`PersistenceManagedTypes.of(...)` listing: OnmsNode, OnmsIpInterface, OnmsMonitoredService, OnmsServiceType, OnmsOutage, OnmsMonitoringSystem, OnmsMonitoringLocation, OnmsDistPoller, OnmsCategory. Add `PhysicalNamingStrategyStandardImpl` bean.
+
+- [ ] **Step 2: Add SessionUtils and TransactionTemplate beans**
+
+Follow Alarmd pattern: `SessionUtils` wrapping `TransactionTemplate` wrapping `PlatformTransactionManager`.
+
+- [ ] **Step 3: Add FilterDaoFactory initialization**
+
+Create a bean that initializes `FilterDaoFactory` with the Spring-managed `DataSource`. Use `@DependsOn` or bean ordering to ensure it runs before `PollerConfigFactory.init()`.
+
+Reference `ProvisiondBootConfiguration` for how Provisiond handles `FilterDaoFactory`.
+
+- [ ] **Step 4: Add QueryManagerDaoImpl bean**
+
+Wire with constructor args: `nodeDao`, `outageDao`, `monitoredServiceDao`, `ipInterfaceDao`, `transactionOperations`.
+
+- [ ] **Step 5: Add TsidFactory bean**
+
+```java
+@Bean
+public TsidFactory tsidFactory(@Value("${opennms.tsid.node-id:0}") long nodeId) {
+    return new TsidFactory(nodeId);
+}
+```
+
+- [ ] **Step 6: Add no-op stubs**
+
+- `PersisterFactory` — no-op implementation that discards metrics
+- `ThresholdingService` — no-op implementation
+- `EventUtil` — no-op implementation
+
+- [ ] **Step 7: Verify compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-pollerd -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 8: Commit**
+
+```
+git add core/daemon-boot-pollerd/
+git commit -m "feat: add PollerdJpaConfiguration — entities, DAOs, no-op stubs"
+```
+
+---
+
+### Task 5: PollerdRpcConfiguration
+
+**Files:**
+- Create: `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdRpcConfiguration.java`
+- Reference: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaRpcClientConfiguration.java`
+- Reference: `core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java` (RPC section)
+
+- [ ] **Step 1: Create PollerdRpcConfiguration**
+
+Beans:
+- `LocalServiceMonitorRegistry` — `new LocalServiceMonitorRegistry()` (ServiceLoader-based)
+- `PollerClientRpcModule` — stateless RPC protocol definition bean
+- `PingProxyRpcModule` — stateless ICMP ping RPC module
+- `PingSweepRpcModule` — stateless ICMP sweep RPC module
+- `LocationAwarePollerClientImpl` — constructor (after Task 2 conversion): `serviceMonitorRegistry`, `pollerClientRpcModule`, `rpcClientFactory`, `rpcTargetHelper`, `entityScopeProvider`
+- `LocationAwarePingClientImpl` — constructor (after Task 2 conversion): `rpcClientFactory`, `pingProxyRpcModule`, `pingSweepRpcModule`
+
+`KafkaRpcClientFactory`, `RpcTargetHelper`, and `NoOpEntityScopeProvider` are auto-wired from `KafkaRpcClientConfiguration` and `DaemonProvisioningConfiguration` in daemon-common (gated by `opennms.rpc.kafka.enabled=true`). Verify that `DaemonProvisioningConfiguration` provides `EntityScopeProvider` via `@ConditionalOnMissingBean`.
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-pollerd -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```
+git add core/daemon-boot-pollerd/
+git commit -m "feat: add PollerdRpcConfiguration — Kafka RPC clients for Minion"
+```
+
+---
+
+### Task 6: PollerdPassiveStatusConfiguration
+
+**Files:**
+- Create: `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java`
+- Reference: `core/daemon-loader-pollerd/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-pollerd.xml` (passive status section)
+- Reference: `opennms-services/src/main/java/org/opennms/netmgt/passive/PassiveStatusKeeper.java`
+- Reference: `opennms-services/src/main/java/org/opennms/netmgt/passive/PassiveStatusTwinPublisher.java`
+
+- [ ] **Step 1: Create PollerdPassiveStatusConfiguration**
+
+Beans:
+- `PassiveStatusKeeper` — create instance, call `PassiveStatusKeeper.setInstance(keeper)`, wire eventManager and dataSource
+- `InlineIdentity` — identity provider from `DistPollerDao.whoami()`
+- `MetricRegistry` — dedicated instance for Twin publisher metrics (qualified bean name to avoid conflicts)
+- `LocalTwinSubscriberImpl` — local Twin subscriber for same-JVM consumers. Constructor: `identity`
+- `KafkaTwinPublisher` — use 3-arg constructor: `localTwinSubscriber`, `identity`, `metricRegistry`. The publisher internally creates its own `OnmsKafkaConfigProvider` to read Kafka bootstrap servers from system properties. `TracerRegistry` comes from `NoOpTracerRegistry` in daemon-common's `KafkaRpcClientConfiguration`.
+- `PassiveStatusTwinPublisher` — constructor: `twinPublisher`, `passiveStatusKeeper`, `eventIpcManager`
+- `AnnotationBasedEventListenerAdapter` for `PassiveStatusTwinPublisher`
+
+Note: `TracerRegistry` and `NoOpTracerRegistry` are provided by daemon-common via component scanning of `org.opennms.core.daemon.common`.
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-pollerd -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```
+git add core/daemon-boot-pollerd/
+git commit -m "feat: add PollerdPassiveStatusConfiguration — Twin API for passive status"
+```
+
+---
+
+### Task 7: PollerdDaemonConfiguration
+
+**Files:**
+- Create: `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java`
+- Move: `core/daemon-loader-pollerd/.../StandalonePollContext.java` → `core/daemon-boot-pollerd/.../boot/StandalonePollContext.java`
+- Reference: `opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java`
+
+- [ ] **Step 1: Move StandalonePollContext to daemon-boot-pollerd**
+
+Copy `StandalonePollContext` from `core/daemon-loader-pollerd/` to `core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/`. Update package declaration. Update constructor to match `DefaultPollContext`'s new constructor injection signature.
+
+- [ ] **Step 2: Create PollerdDaemonConfiguration**
+
+Beans:
+- `PollerConfigFactory` — `PollerConfigFactory.init()` then `PollerConfigFactory.getInstance()` (singleton pattern). Must run after FilterDaoFactory init.
+- `PollOutagesConfigManager` — singleton init from `opennms.home`
+- `StandalonePollContext` — constructor: `eventIpcManager`, `pollerConfig`, `queryManager`, `nodeDao`, `tsidFactory`, `localHostName`, `name("OpenNMS.Poller.DefaultPollContext")`
+- `PollableNetwork` — `new PollableNetwork(pollContext)`
+- `Poller` — constructor: `queryManager`, `monitoredServiceDao`, `outageDao`, `transactionTemplate`, `persisterFactory`, `thresholdingService`, `locationAwarePollerClient`, `pollOutagesDao`. Then set pollerConfig, pollContext, pollableNetwork.
+- `DaemonSmartLifecycle` wrapping Poller
+
+- [ ] **Step 3: Verify compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-pollerd -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```
+git add core/daemon-boot-pollerd/
+git commit -m "feat: add PollerdDaemonConfiguration — core daemon, poll context, lifecycle"
+```
+
+---
+
+### Task 8: Docker Integration
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+- Modify: `opennms-container/delta-v/build.sh`
+- Remove/simplify: `opennms-container/delta-v/pollerd-daemon-overlay/etc/` (Karaf files)
+- Create: `opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml` (Spring Boot overlay)
+
+- [ ] **Step 1: Update docker-compose.yml**
+
+Change `pollerd` service:
+- `command: ["java", "-Xms512m", "-Xmx1g", "-jar", "/opt/daemon-boot-pollerd.jar"]`
+- `entrypoint: []`
+- Remove Sentinel volume mounts
+- Add Spring Boot environment variables (datasource, Kafka, RPC)
+- Add volume mount for poller-configuration.xml: `./pollerd-overlay/etc:/opt/deltav/etc:ro`
+
+- [ ] **Step 2: Create Spring Boot pollerd overlay**
+
+Move `poller-configuration.xml` from `pollerd-daemon-overlay/etc/` to `pollerd-overlay/etc/`. Keep only `poller-configuration.xml` and `poll-outages.xml` (if needed). Remove all Karaf-specific files.
+
+- [ ] **Step 3: Update build.sh**
+
+Add `daemon-boot-pollerd` JAR to the Delta-V staging directory:
+```bash
+cp core/daemon-boot-pollerd/target/org.opennms.core.daemon-boot-pollerd-*-boot.jar staging/daemon/daemon-boot-pollerd.jar
+```
+
+- [ ] **Step 4: Build and verify image**
+
+Run: `./build.sh deltav`
+Expected: Image builds, `daemon-boot-pollerd.jar` present in image.
+
+- [ ] **Step 5: Commit**
+
+```
+git add opennms-container/delta-v/
+git commit -m "feat: switch Pollerd Docker service to Spring Boot JAR"
+```
+
+---
+
+### Task 9: BSM E2E Verification
+
+**Files:**
+- Reference: `opennms-container/delta-v/scripts/setup-bsm-e2e.sh`
+
+- [ ] **Step 1: Full build**
+
+```bash
+./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-pollerd -am install
+cd opennms-container/delta-v && ./build.sh deltav
+```
+
+- [ ] **Step 2: Clean deploy**
+
+```bash
+docker compose --profile full down -v
+docker compose --profile full up -d
+sleep 180
+```
+
+- [ ] **Step 3: Verify Pollerd starts as Spring Boot app**
+
+```bash
+docker compose logs pollerd 2>&1 | grep "Started PollerdApplication"
+```
+Expected: `Started PollerdApplication in X seconds`
+
+- [ ] **Step 4: Verify services are polled — BSM status normal**
+
+```bash
+curl -sf http://localhost:8180/api/v3/business-services/.../status | jq '.operationalStatus'
+```
+Expected: `"normal"`
+
+- [ ] **Step 5: Run BSM E2E test**
+
+```bash
+./scripts/setup-bsm-e2e.sh --test
+```
+
+Expected output:
+- `PASS: BSM detected failure — status=major`
+- `PASS: BSM recovered — status=normal`
+- `=== BSM E2E test PASSED ===`
+
+- [ ] **Step 6: Commit any fixes needed during verification**
+
+- [ ] **Step 7: Final commit**
+
+```
+git commit -m "fix: Pollerd Spring Boot migration — verified with BSM E2E test"
+```

--- a/docs/superpowers/specs/2026-03-20-pollerd-spring-boot-migration-design.md
+++ b/docs/superpowers/specs/2026-03-20-pollerd-spring-boot-migration-design.md
@@ -1,0 +1,240 @@
+# Pollerd Spring Boot 4 Migration Design
+
+## Overview
+
+Migrate Pollerd from Karaf/OSGi to a standalone Spring Boot 4 application, following the established daemon-boot pattern used by Alarmd, Provisiond, Trapd, Syslogd, EventTranslator, Discovery, and BSMd.
+
+Pollerd is the polling daemon responsible for monitoring service availability. It schedules polls, delegates execution to Minion via Kafka RPC, processes results (outage creation/resolution), and publishes passive status to Minion via the Twin API.
+
+## Pre-requisites
+
+### OnmsOutage Jakarta Entity Port
+
+`OnmsOutage` in `opennms-model` uses `javax.persistence` annotations. A Jakarta-annotated version must be created in `core/opennms-model-jakarta/` before Pollerd can manage outages via JPA with Hibernate 7. The entity is relatively simple (no complex inheritance), but `@Filter` and Hibernate-specific `@Type` annotations need attention.
+
+A corresponding `OutageDaoJpa` is also needed in `core/opennms-model-jakarta/`.
+
+`QueryManagerDaoImpl` (in `opennms-services`) uses the Criteria API against `OnmsOutage` extensively. Its `@Autowired` fields will be converted to constructor injection during migration.
+
+### FilterDaoFactory Initialization
+
+`PollerConfigFactory.init()` validates filter rules via `FilterDaoFactory.getInstance()`. In Karaf, `FilterDao` was imported from OSGi. In Spring Boot, `FilterDaoFactory` must be explicitly initialized with a `DataSource` before `PollerConfigFactory.init()` is called.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Configuration structure | Sectioned classes (Approach B) | Four distinct subsystems map cleanly to separate configs; testable independently |
+| Monitor execution | Minion-only via Kafka RPC | Delta-V architecture: all I/O through Minion |
+| PersisterFactory | No-op stub | Followup: Kafka timeseries persister shared by Pollerd and Collectd |
+| ThresholdingService | No-op stub | Separate daemon concern |
+| LocationAwarePingClient | Included | For future node-outage/critical-path use |
+| Passive status | Included (publisher side only) | PassiveServiceMonitor executes on Minion; Pollerd receives events and publishes Twin updates |
+| Constructor injection | Convert during migration | Already touching all bean declarations; cheaper now than later |
+| Poll context | Use `StandalonePollContext` | Subclass of `DefaultPollContext` that skips `AsyncPollingEngine` creation in `afterPropertiesSet()` |
+
+## Module Structure
+
+New Maven module: `core/daemon-boot-pollerd`
+
+```
+core/daemon-boot-pollerd/
+  pom.xml
+  src/main/java/org/opennms/netmgt/poller/boot/
+    PollerdApplication.java
+    PollerdJpaConfiguration.java
+    PollerdRpcConfiguration.java
+    PollerdPassiveStatusConfiguration.java
+    PollerdDaemonConfiguration.java
+  src/main/resources/
+    application.yml
+```
+
+### PollerdApplication.java
+
+```java
+@SpringBootApplication(scanBasePackages = {
+    "org.opennms.core.daemon.common",
+    "org.opennms.netmgt.poller.boot",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+public class PollerdApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PollerdApplication.class, args);
+    }
+}
+```
+
+### Key Dependencies (pom.xml)
+
+- `daemon-common` — KafkaEventTransport, KafkaRpcClientConfiguration, DaemonSmartLifecycle
+- `opennms-services` — Poller, PollableServiceConfig, StandalonePollContext, QueryManagerDaoImpl
+- `poller-client-rpc` — LocationAwarePollerClientImpl, PollerRequestBuilderImpl
+- `opennms-model-jakarta` — Jakarta JPA entities and DAO implementations (NOT `opennms-dao` which has legacy javax.persistence DAOs)
+- `opennms-config` — PollerConfigManager, PollOutagesConfigManager
+- `icmp-rpc-common` — LocationAwarePingClient
+
+## Configuration Classes
+
+### PollerdJpaConfiguration
+
+JPA entities, DAOs, session/transaction management.
+
+**Entities** (explicit `PersistenceManagedTypes.of(...)`):
+- OnmsNode, OnmsIpInterface, OnmsMonitoredService, OnmsServiceType
+- OnmsOutage (requires Jakarta port — see Pre-requisites)
+- OnmsMonitoringSystem, OnmsMonitoringLocation, OnmsDistPoller
+- OnmsCategory
+
+**DAOs** (from `opennms-model-jakarta` component scan):
+- NodeDao, IpInterfaceDao, MonitoredServiceDao — service lookup
+- OutageDao (requires Jakarta port — see Pre-requisites)
+- MonitoringLocationDao, DistPollerDao — identity/location
+
+**Infrastructure:**
+- PhysicalNamingStrategyStandardImpl — no CamelCase conversion
+- SessionUtils wrapping TransactionTemplate
+- FilterDao — JDBC-based, initialized via `FilterDaoFactory.setInstance()` with DataSource before PollerConfigFactory.init()
+- QueryManager / QueryManagerDaoImpl — outage open/resolve interface
+- TsidFactory — generates outage/event TSIDs, used by StandalonePollContext
+
+**No-ops:**
+- PersisterFactory — stub (followup: Kafka timeseries)
+- ThresholdingService — stub
+- EventUtil — stub (token expansion handled by KafkaEventForwarder's EventConfEnrichmentService; Pollerd code does not call EventUtil directly)
+
+### PollerdRpcConfiguration
+
+Kafka RPC for delegating polls and pings to Minion.
+
+**Beans:**
+- KafkaRpcClientFactory — from daemon-common (gated by `opennms.rpc.kafka.enabled=true`)
+- LocationAwarePollerClientImpl — dispatches poll requests to Minion
+- LocationAwarePingClientImpl — ICMP proxy to Minion
+- LocalServiceMonitorRegistry — ServiceLoader-based (monitors not found locally, delegates to Minion)
+
+### PollerdPassiveStatusConfiguration
+
+Passive status event handling and Twin API publishing. Pollerd is the publisher side — it receives passive status events from Kafka and syncs the status map to Minion via Twin API. PassiveServiceMonitor executes on Minion only.
+
+**Beans:**
+- PassiveStatusKeeper — holds passive service status map, registered via `PassiveStatusKeeper.setInstance()`
+- KafkaTwinPublisher — publishes Twin updates to Kafka for Minion consumption
+- InlineIdentity — identity provider for Twin publisher (system ID + location)
+- MetricRegistry — for Twin publisher metrics
+- PassiveStatusTwinPublisher — event listener receiving passiveServiceStatus events, pushes through Twin
+- AnnotationBasedEventListenerAdapter for PassiveStatusTwinPublisher
+
+### PollerdDaemonConfiguration
+
+Core Poller daemon wiring.
+
+**Beans:**
+- PollerConfigFactory — loads poller-configuration.xml (singleton init with FilterDaoFactory)
+- PollOutagesConfigManager — loads poll-outages.xml
+- StandalonePollContext — poll context wired with EventIpcManager, QueryManager, DAOs, TsidFactory, localHostName (`InetAddressUtils.getLocalHostName()`)
+- PollableNetwork — in-memory tree of polled services
+- Poller — the daemon, wired with config, context, network, scheduler
+- DaemonSmartLifecycle — wraps Poller for Spring lifecycle
+
+**Event handling:** PollerEventProcessor is NOT wired via AnnotationBasedEventListenerAdapter. It implements EventListener directly and self-registers via `EventIpcManager.addEventListener()` inside `Poller.init()`. No adapter bean is needed.
+
+**Event flow:** StandalonePollContext.sendEvent() -> EventIpcManager.sendNow() -> KafkaEventForwarder -> enrichWithEventConf() -> Kafka `opennms-fault-events` topic. This produces nodeLostService/nodeRegainedService/interfaceDown/nodeDown events with alarm-data and expanded reduction keys.
+
+## application.yml
+
+```yaml
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
+    username: ${SPRING_DATASOURCE_USERNAME:opennms}
+    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+  jpa:
+    hibernate:
+      ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+      hibernate.archive.autodetection: none
+
+opennms:
+  home: ${OPENNMS_HOME:/opt/deltav}
+  instance:
+    id: ${OPENNMS_INSTANCE_ID:OpenNMS}
+  tsid:
+    node-id: ${OPENNMS_TSID_NODE_ID:0}
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
+    consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-pollerd}
+    poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
+  rpc:
+    kafka:
+      enabled: ${OPENNMS_RPC_KAFKA_ENABLED:true}
+      bootstrap-servers: ${OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+```
+
+## Docker Integration
+
+### docker-compose.yml changes
+
+```yaml
+pollerd:
+  profiles: [lite, full]
+  image: opennms/daemon-deltav:${VERSION}
+  entrypoint: []
+  command: ["java", "-Xms512m", "-Xmx1g", "-jar", "/opt/daemon-boot-pollerd.jar"]
+  container_name: delta-v-pollerd
+  hostname: pollerd
+  depends_on:
+    db-init:
+      condition: service_completed_successfully
+    kafka:
+      condition: service_healthy
+  environment:
+    SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
+    SPRING_DATASOURCE_USERNAME: opennms
+    SPRING_DATASOURCE_PASSWORD: opennms
+    KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    KAFKA_CONSUMER_GROUP: opennms-pollerd
+    OPENNMS_RPC_KAFKA_ENABLED: "true"
+    OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+```
+
+### Config overlay
+
+- `poller-configuration.xml` stays (loaded by PollerConfigFactory from `opennms.home` path)
+- Remove Karaf-specific files: `featuresBoot.d/`, `org.opennms.core.health.cfg.cfg`, `org.opennms.features.kafka.producer.client.cfg`, `org.opennms.core.event.forwarder.kafka.cfg`, `org.opennms.netmgt.distributed.datasource.cfg`
+
+### build.sh
+
+- Add `daemon-boot-pollerd` JAR to Delta-V staging/daemon directory
+- Remove `daemon-loader-pollerd` from Karaf feature set (if still referenced)
+
+## Constructor Injection
+
+All Poller classes with `@Autowired` field injection will be converted to constructor injection during this migration. This includes:
+- Poller daemon class (8 `@Autowired` fields)
+- StandalonePollContext (setter injection → constructor injection)
+- QueryManagerDaoImpl (6 `@Autowired` fields)
+- Any other classes touched during the wiring
+
+## Verification
+
+Run the BSM E2E test (`scripts/setup-bsm-e2e.sh --test`) to verify the full Pollerd→Alarmd→BSMd event chain:
+
+1. All 6 Delta-V services polled successfully through Minion via Kafka RPC — BSM status = normal
+2. Stop trapd container — Pollerd detects failure, sends `nodeLostService` to Kafka, Alarmd creates alarm, BSM status = major
+3. Start trapd container — Pollerd detects recovery, sends `nodeRegainedService` to Kafka, Alarmd clears alarm, BSM status = normal
+
+This test exercises the exact path that was broken under the Karaf Pollerd (PersisterFactory crash, event forwarding failures) and validates that the Spring Boot migration resolves those issues end-to-end.
+
+## Followup Tasks (Out of Scope)
+
+1. **Kafka timeseries persister** — Replace no-op PersisterFactory with implementation publishing response time and poll status metrics to Kafka. Shared by Pollerd and Collectd.
+2. **EventUtil/EventUtils consolidation** — Merge or clarify boundary between EventUtil (singleton token expander) and EventUtils (static parm reader). Code smell.

--- a/opennms-container/delta-v/pollerd-daemon-overlay/etc/poller-configuration.xml
+++ b/opennms-container/delta-v/pollerd-daemon-overlay/etc/poller-configuration.xml
@@ -1,5 +1,5 @@
 <poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller" threads="30" asyncPollingEngineEnabled="false" maxConcurrentAsyncPolls="200" nextOutageId="SELECT nextval('outageNxtId')" serviceUnresponsiveEnabled="false" pathOutageEnabled="false">
-   <node-outage status="on" pollAllIfNoCriticalServiceDefined="true">
+   <node-outage status="off" pollAllIfNoCriticalServiceDefined="true">
       <critical-service name="ICMP" />
    </node-outage>
    <package name="cassandra-via-jmx">
@@ -269,6 +269,9 @@
       <!-- Delta-V container health checks via PageSequenceMonitor -->
       <service name="Deltav-Health" interval="30000" user-defined="false" status="on">
         <parameter key="rrd-status" value="false"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
+        <parameter key="strict-timeout" value="true"/>
         <parameter key="page-sequence">
           <page-sequence>
             <page host="${nodeLabel}" path="/actuator/health" port="8080"
@@ -278,17 +281,28 @@
       </service>
       <service name="Minion-Health" interval="30000" user-defined="false" status="on">
         <parameter key="rrd-status" value="false"/>
-        <parameter key="port" value="8181"/>
-        <parameter key="hostname" value="${nodeLabel}"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
+        <parameter key="strict-timeout" value="true"/>
+        <parameter key="page-sequence">
+          <page-sequence>
+            <page host="${nodeLabel}" path="/minion/rest/health/probe" port="8181"
+                  response-range="200-299"/>
+          </page-sequence>
+        </parameter>
       </service>
       <!-- Delta-V infrastructure TCP monitors -->
       <service name="PostgreSQL" interval="30000" user-defined="false" status="on">
         <parameter key="rrd-status" value="false"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
         <parameter key="port" value="5432"/>
         <parameter key="hostname" value="${nodeLabel}"/>
       </service>
       <service name="Kafka" interval="30000" user-defined="false" status="on">
         <parameter key="rrd-status" value="false"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
         <parameter key="port" value="9092"/>
         <parameter key="hostname" value="${nodeLabel}"/>
       </service>


### PR DESCRIPTION
## Summary

- **Pollerd poller-configuration.xml**: Add `rrd-status="false"` to all Delta-V services to prevent `PersisterFactory` crash in decomposed Pollerd container. Disable `node-outage` mode (no ICMP critical service in Delta-V). Add explicit timeout/retry params.

- **KafkaEventTransportConfiguration**: Replace `initMethod="start"` with `SmartLifecycle` (phase -10) so the Kafka event consumer starts after `AnnotationBasedEventListenerAdapter.afterPropertiesSet()` registers listeners. Prevents events from being consumed and silently dropped before the daemon's event handler is wired.

## Context

Investigation of BSM E2E test failures revealed a chain of issues in the decomposed Pollerd→Alarmd event path:
1. `StatusStoringServiceMonitorAdaptor` crashed on missing `PersisterFactory` (fixed by `rrd-status=false`)
2. Node-outage ICMP critical path check caused false-down states (fixed by `status="off"`)
3. Kafka event consumer `initMethod="start"` fired during bean construction, before event listeners registered (fixed by SmartLifecycle)

## Test plan

- [ ] `docker compose --profile full up -d` with clean volumes
- [ ] Wait 3 minutes, verify BSM status = normal
- [ ] Stop trapd, verify `nodeLostService` events appear on `opennms-fault-events` Kafka topic
- [ ] Verify Alarmd creates alarms from those events
- [ ] Verify BSM detects failure