### PR TITLE
feat: migrate Pollerd to standalone Spring Boot 4 application

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | **Ticketer** | Trouble ticketing integration — not in microservice architecture | #29 |
 | **DHCPd** | DHCP monitor/detector service | — |
 
-### Migrated to Spring Boot 4 (6 daemons)
+### Migrated to Spring Boot 4 (8 daemons)
 
 | Daemon | Spring Boot Module | Startup | Key Feature | PR |
 |--------|--------------------|---------|------------|-----|
@@ -31,22 +31,22 @@
 | **Syslogd** | `daemon-boot-syslogd` | 2.2s | Reuses Sink bridge, local DNS resolver | #34, #35 |
 | **Discovery** | `daemon-boot-discovery` | ~2s | Kafka RPC client pattern (`KafkaRpcClientConfiguration`) | — |
 | **Provisiond** | `daemon-boot-provisiond` | 4.2s | JPA + 3× Kafka RPC + Quartz + SNMP adapters (Tier 5) | #41 |
+| **BSMd** | `daemon-boot-bsmd` | 3.3s | JPA + AlarmLifecycleListener + REST API | #44 |
+| **Pollerd** | `daemon-boot-pollerd` | 4.1s | JPA + Kafka RPC + Twin API + PassiveStatusKeeper | #47 |
 
 ### Shared Infrastructure
 
 | Module | Purpose |
 |--------|---------|
-| `daemon-common` | DataSource, Kafka event transport, Kafka RPC client, JdbcDistPollerDao, JdbcInterfaceToNodeCache, AbstractDaoJpa |
+| `daemon-common` | DataSource, Kafka event transport (with EventConfDao enrichment), Kafka RPC client, JdbcDistPollerDao, JdbcInterfaceToNodeCache, AbstractDaoJpa, EventIpcManagerEnrichingWrapper |
 | `daemon-sink-kafka` | KafkaSinkBridge — consumes from Minion Sink topics (`OpenNMS.Sink.*`) |
-| `opennms-model-jakarta` | 17 Jakarta Persistence entities + 13 JPA DAOs for Hibernate 7 |
+| `opennms-model-jakarta` | 17 Jakarta Persistence entities + 15 JPA DAOs for Hibernate 7 |
 
-### Running on Karaf (7 daemons — migration candidates)
+### Running on Karaf (5 daemons — migration candidates)
 
 | Daemon | Tier | Complexity | Infrastructure |
 |--------|------|-----------|----------------|
 | **Scriptd** | 1 | Very Low | Events only |
-| **BSMd** | 3 | High | Events (alarm polling) |
-| **Pollerd** | 4 | High | Events + Twin API |
 | **Enlinkd** | 4 | High | Events + Kafka RPC |
 | **Telemetryd** | 4 | High | Multi-module Kafka Sink |
 | **Collectd** | 4 | High | Events + Kafka RPC |
@@ -73,7 +73,7 @@
 
 ## Plan Status Dashboard
 
-### Complete (35 docs)
+### Complete (37 docs)
 
 | Date | Plan | Key Achievement |
 |------|------|-----------------|
@@ -102,6 +102,8 @@
 | 03-16 | Discovery Spring Boot 4 Migration | Kafka RPC client pattern — `KafkaRpcClientConfiguration` in `daemon-common`, Minion ping sweeps |
 | 03-16 | Provisiond Shared Infrastructure | `DaemonProvisioningConfiguration` — shared NoOpEntityScopeProvider, LocalServiceDetectorRegistry |
 | 03-17 | Provisiond Spring Boot 4 Migration | Tier 5: JPA + 3× Kafka RPC + Quartz + SNMP adapters, constructor injection, 13 JPA DAOs, E2E with 22 SNMP interfaces |
+| 03-20 | BSMd Spring Boot 4 Migration | JPA + AlarmLifecycleListener + REST API, alarm snapshot polling (10s interval) |
+| 03-21 | Pollerd Spring Boot 4 Migration | JPA + Kafka RPC + Twin API + PassiveStatusKeeper, constructor injection, `%service%` token fix, transport-layer EventConfDao enrichment — BSM E2E + Passive E2E passing |
 
 ### Superseded (2 docs)
 

--- a/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
+++ b/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
@@ -17,6 +17,7 @@ import org.opennms.netmgt.discovery.RangeChunker;
 import org.opennms.netmgt.discovery.UnmanagedInterfaceFilter;
 import org.opennms.netmgt.icmp.best.BestMatchPingerFactory;
 import org.opennms.netmgt.icmp.PingerFactory;
+import org.opennms.core.rpc.api.RpcClientFactory;
 import org.opennms.netmgt.icmp.proxy.LocationAwarePingClientImpl;
 import org.opennms.netmgt.icmp.proxy.PingProxyRpcModule;
 import org.opennms.netmgt.icmp.proxy.PingSweepRpcModule;
@@ -80,8 +81,11 @@ public class DiscoveryBootConfiguration {
      * does NOT recognize. Must use {@code initMethod = "init"}.
      */
     @Bean(initMethod = "init")
-    public LocationAwarePingClientImpl locationAwarePingClient() {
-        return new LocationAwarePingClientImpl();
+    public LocationAwarePingClientImpl locationAwarePingClient(
+            RpcClientFactory rpcClientFactory,
+            PingProxyRpcModule pingProxyRpcModule,
+            PingSweepRpcModule pingSweepRpcModule) {
+        return new LocationAwarePingClientImpl(rpcClientFactory, pingProxyRpcModule, pingSweepRpcModule);
     }
 
     // -- Detector RPC --

--- a/core/daemon-boot-eventtranslator/src/main/java/org/opennms/netmgt/translator/boot/EventTranslatorBootConfiguration.java
+++ b/core/daemon-boot-eventtranslator/src/main/java/org/opennms/netmgt/translator/boot/EventTranslatorBootConfiguration.java
@@ -24,17 +24,21 @@ package org.opennms.netmgt.translator.boot;
 import javax.sql.DataSource;
 
 import org.opennms.core.daemon.common.DaemonSmartLifecycle;
-import org.opennms.core.daemon.common.EventConfEnrichmentService;
-import org.opennms.core.daemon.common.EventIpcManagerEnrichingWrapper;
 import org.opennms.core.db.DataSourceFactory;
 import org.opennms.netmgt.config.EventTranslatorConfigFactory;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.translator.EventTranslator;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Spring Boot configuration for EventTranslator.
+ *
+ * <p>Event enrichment (alarm-data, severity) is handled at the transport layer
+ * by {@code KafkaEventTransportConfiguration} which wires {@code EventConfEnrichmentService}
+ * into the {@code KafkaEventForwarder}. No per-daemon wrapper is needed.</p>
+ */
 @Configuration
 public class EventTranslatorBootConfiguration {
 
@@ -47,14 +51,11 @@ public class EventTranslatorBootConfiguration {
 
     @Bean
     public EventTranslator eventTranslator(
-            @Qualifier("eventIpcManager") EventIpcManager eventIpcManager,
+            EventIpcManager eventIpcManager,
             EventTranslatorConfigFactory config,
-            DataSource dataSource,
-            EventConfEnrichmentService enrichmentService) {
-        EventIpcManager enrichingManager =
-                new EventIpcManagerEnrichingWrapper(eventIpcManager, enrichmentService);
+            DataSource dataSource) {
         var translator = new EventTranslator();
-        translator.setEventManager(enrichingManager);
+        translator.setEventManager(eventIpcManager);
         translator.setConfig(config);
         translator.setDataSource(dataSource);
         return translator;

--- a/core/daemon-boot-eventtranslator/src/main/java/org/opennms/netmgt/translator/boot/EventTranslatorBootConfiguration.java
+++ b/core/daemon-boot-eventtranslator/src/main/java/org/opennms/netmgt/translator/boot/EventTranslatorBootConfiguration.java
@@ -25,6 +25,7 @@ import javax.sql.DataSource;
 
 import org.opennms.core.daemon.common.DaemonSmartLifecycle;
 import org.opennms.core.daemon.common.EventConfEnrichmentService;
+import org.opennms.core.daemon.common.EventIpcManagerEnrichingWrapper;
 import org.opennms.core.db.DataSourceFactory;
 import org.opennms.netmgt.config.EventTranslatorConfigFactory;
 import org.opennms.netmgt.events.api.EventIpcManager;

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -1,0 +1,559 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.core</artifactId>
+        <version>36.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.daemon-boot-pollerd</artifactId>
+    <packaging>jar</packaging>
+    <name>OpenNMS :: Core :: Daemon Boot :: Pollerd</name>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-boot.version>4.0.3</spring-boot.version>
+        <!-- Skip enforcer: this module uses Spring Boot 4 / Spring 7
+             which the parent POM's banned-dependencies rules reject -->
+        <enforcer-skip-banned-dependencies>true</enforcer-skip-banned-dependencies>
+        <enforcer-skip-dependency-convergence>true</enforcer-skip-dependency-convergence>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import Spring Boot BOM for version management.
+                 Listed FIRST so it takes precedence over the parent POM's
+                 managed versions for JUnit, Spring, etc. -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Pin logback to match Spring Boot 4's requirements.
+                 Parent POM manages logback-classic at 1.2.13 which is
+                 incompatible with Spring Boot 4's Configurator API. -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <!-- Pin jboss-logging — Hibernate 7.2.4 requires 3.6+ for MethodHandles$Lookup API -->
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>3.6.1.Final</version>
+            </dependency>
+            <!-- Pin Jakarta XML Bind 4.x — parent POM manages 2.3.3, Hibernate 7 needs 4.0+ -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+            <!-- Pin SLF4J 2.x — parent POM manages 1.7.36 which is incompatible with logback 1.5 -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <!-- Pin Jackson 2.19.4 — parent POM manages 2.16.2 which lacks JsonFormat$Shape.POJO
+                 required by Spring Boot 4.0.3. Explicit entries here override the parent's
+                 managed versions even though the Spring Boot BOM is imported first. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <!-- Pin JUnit to 6.0.3 / Platform 6.0.3 which is the latest
+                 version supported by maven-surefire-plugin 3.5.5.
+                 Must be explicit entries (not BOM import) to override
+                 the parent POM's managed versions at 5.9.2 / 1.9.2. -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+            <!-- Testcontainers — use 2.0.3 to align with Spring Boot 4.0.3's managed version -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>2.0.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Jakarta entity classes and JPA DAOs — MUST be listed before any
+             dependency that transitively pulls in opennms-config-model, so that
+             the Jakarta OnmsMonitoringLocation.class wins over the legacy one
+             (which uses javax.persistence annotations incompatible with Hibernate 7). -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-jakarta</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Shared daemon infrastructure -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.daemon-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-scala_2.13</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Poller implementation — Poller, QueryManagerDaoImpl, DefaultPollContext -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-services</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Poller RPC client — LocationAwarePollerClientImpl -->
+        <dependency>
+            <groupId>org.opennms.features.poller</groupId>
+            <artifactId>org.opennms.features.poller.client-rpc</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Poller config — PollerConfigFactory, PollOutagesConfigManager -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-config</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ICMP proxy RPC — LocationAwarePingClientImpl -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>org.opennms.icmp.proxy.rpc-impl</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Twin publisher — KafkaTwinPublisher -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.twin.kafka</groupId>
+            <artifactId>org.opennms.core.ipc.twin.kafka.publisher</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- javax.persistence API — needed at runtime so legacy opennms-model classes
+             on the classpath (pulled transitively for enums/utilities) don't cause
+             ClassNotFoundException when Spring's classpath scanner encounters them.
+             Hibernate 7 ignores javax.persistence annotations; only jakarta.persistence
+             entities from opennms-model-jakarta are registered. -->
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Jakarta XML Bind — needed by Hibernate 7 for XML mapping support -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+
+        <!-- Jakarta Inject — needed by Hibernate 7 -->
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <!-- javax.xml.bind API — needed at runtime for legacy Event XML unmarshalling
+             in KafkaEventSubscriptionService (events use JAXB javax.xml.bind annotations) -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- SLF4J 2.x — must be explicit to override old 1.7.x from transitive deps -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- JUnit Platform Launcher — must be explicit test dep so that
+             surefire/failsafe pick up the correct version from the classpath
+             rather than resolving their own (older) transitive version -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers 2.x (artifact IDs have testcontainers- prefix) -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Use a classifier so the original JAR stays available
+                                 for failsafe integration tests (which need plain classes) -->
+                            <classifier>boot</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- Override to 3.5.5 which supports JUnit Platform 6.0.3
+                     required by Spring Boot 4 -->
+                <version>3.5.5</version>
+                <configuration>
+                    <!-- Only use JUnit Jupiter; the vintage engine from the parent
+                         is incompatible with JUnit Platform 1.12+ from Spring Boot 4 -->
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <!-- Override parent's vintage engine (5.9.2) to align versions -->
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <!-- Override parent's vintage engine (5.9.2) to align versions -->
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -365,6 +365,13 @@
             </exclusions>
         </dependency>
 
+        <!-- Pollerd service monitor loader — LocalServiceMonitorRegistry -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.daemon-loader-pollerd</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- javax.persistence API — needed at runtime so legacy opennms-model classes
              on the classpath (pulled transitively for enums/utilities) don't cause
              ClassNotFoundException when Spring's classpath scanner encounters them.

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -372,6 +372,14 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- NoOp JsonStore — used by OnmsPollOutagesDao in standalone mode
+             (no distributed config sync needed) -->
+        <dependency>
+            <groupId>org.opennms.features.distributed</groupId>
+            <artifactId>org.opennms.features.distributed.kv-store.json.noop</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- javax.persistence API — needed at runtime so legacy opennms-model classes
              on the classpath (pulled transitively for enums/utilities) don't cause
              ClassNotFoundException when Spring's classpath scanner encounters them.

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdApplication.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdApplication.java
@@ -1,0 +1,15 @@
+package org.opennms.netmgt.poller.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+    "org.opennms.core.daemon.common",
+    "org.opennms.netmgt.poller.boot",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+public class PollerdApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PollerdApplication.class, args);
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
@@ -24,6 +24,8 @@ package org.opennms.netmgt.poller.boot;
 import java.io.IOException;
 
 import org.opennms.core.daemon.common.DaemonSmartLifecycle;
+import org.opennms.core.daemon.common.EventConfEnrichmentService;
+import org.opennms.core.daemon.common.EventIpcManagerEnrichingWrapper;
 import org.opennms.core.tsid.TsidFactory;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.features.distributed.kvstore.json.noop.NoOpJsonStore;
@@ -35,6 +37,7 @@ import org.opennms.netmgt.config.dao.outages.impl.OnmsPollOutagesDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.events.api.EventIpcManager;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.poller.LocationAwarePollerClient;
 import org.opennms.netmgt.poller.Poller;
@@ -102,6 +105,19 @@ public class PollerdDaemonConfiguration {
     }
 
     /**
+     * Wraps the Kafka-backed EventIpcManager with eventconf enrichment so that
+     * events sent by Pollerd (nodeLostService, nodeRegainedService, etc.) get
+     * alarm-data, severity, and logmsg applied before hitting Kafka.
+     * Follows the same pattern as EventTranslator's EventIpcManagerEnrichingWrapper.
+     */
+    @Bean("enrichingEventIpcManager")
+    public EventIpcManager enrichingEventIpcManager(
+            @Qualifier("eventIpcManager") EventIpcManager eventIpcManager,
+            EventConfEnrichmentService enrichmentService) {
+        return new EventIpcManagerEnrichingWrapper(eventIpcManager, enrichmentService);
+    }
+
+    /**
      * PollContext that skips AsyncPollingEngine creation.
      *
      * <p>{@link StandalonePollContext} overrides {@code afterPropertiesSet()} as a
@@ -109,7 +125,7 @@ public class PollerdDaemonConfiguration {
      * execute via Kafka RPC to Minion.</p>
      */
     @Bean
-    public PollContext pollContext(EventIpcManager eventIpcManager,
+    public PollContext pollContext(@Qualifier("enrichingEventIpcManager") EventIpcManager eventIpcManager,
                                   PollerConfig pollerConfig,
                                   QueryManager queryManager,
                                   LocationAwarePingClient locationAwarePingClient,
@@ -147,7 +163,7 @@ public class PollerdDaemonConfiguration {
                          PollerConfig pollerConfig,
                          PollContext pollContext,
                          PollableNetwork pollableNetwork,
-                         EventIpcManager eventIpcManager) {
+                         @Qualifier("enrichingEventIpcManager") EventIpcManager eventIpcManager) {
         var poller = new Poller(queryManager, monitoredServiceDao, outageDao,
                 transactionTemplate, persisterFactory, thresholdingService,
                 locationAwarePollerClient, pollOutagesDao);

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.poller.boot;
+
+import java.io.IOException;
+
+import org.opennms.core.daemon.common.DaemonSmartLifecycle;
+import org.opennms.core.tsid.TsidFactory;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.features.distributed.kvstore.json.noop.NoOpJsonStore;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.config.PollerConfig;
+import org.opennms.netmgt.config.PollerConfigFactory;
+import org.opennms.netmgt.config.dao.outages.api.ReadablePollOutagesDao;
+import org.opennms.netmgt.config.dao.outages.impl.OnmsPollOutagesDao;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
+import org.opennms.netmgt.poller.LocationAwarePollerClient;
+import org.opennms.netmgt.poller.Poller;
+import org.opennms.netmgt.poller.QueryManager;
+import org.opennms.netmgt.poller.pollables.PollContext;
+import org.opennms.netmgt.poller.pollables.PollableNetwork;
+import org.opennms.netmgt.threshd.api.ThresholdingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Spring Boot configuration for the Poller daemon and its core dependencies.
+ *
+ * <p>Wires the {@link Poller} daemon with its configuration, poll context,
+ * pollable network tree, and lifecycle management. The Poller is started via
+ * {@link DaemonSmartLifecycle} which calls {@code init()} then {@code start()}.</p>
+ *
+ * <p>During {@code init()}, Poller creates a LegacyScheduler, closes outages
+ * for unmanaged services, schedules existing services, and creates the
+ * PollerEventProcessor event listener. Event handling is self-registered
+ * via {@code EventIpcManager.addEventListener()} inside {@code Poller.init()} --
+ * no AnnotationBasedEventListenerAdapter bean is needed.</p>
+ *
+ * <p>Bean ordering: {@link PollerConfigFactory#init()} calls
+ * {@code FilterDaoFactory.getInstance()} internally, so the
+ * {@code filterDaoInitializer} bean in {@link PollerdJpaConfiguration}
+ * must be initialized first. This is enforced via {@code @DependsOn}.</p>
+ */
+@Configuration
+public class PollerdDaemonConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PollerdDaemonConfiguration.class);
+
+    /**
+     * Loads poller-configuration.xml via the singleton PollerConfigFactory.
+     *
+     * <p>Must run after FilterDaoFactory initialization because
+     * {@code PollerConfigFactory.init()} validates filter rules against
+     * {@code FilterDaoFactory.getInstance()}.</p>
+     */
+    @Bean
+    @DependsOn("filterDaoInitializer")
+    public PollerConfig pollerConfig() throws IOException {
+        LOG.info("Initializing PollerConfigFactory");
+        PollerConfigFactory.init();
+        return PollerConfigFactory.getInstance();
+    }
+
+    /**
+     * Loads poll-outages.xml via {@link OnmsPollOutagesDao}.
+     *
+     * <p>Uses a {@link NoOpJsonStore} because standalone Pollerd does not
+     * need distributed config synchronization -- it reads directly from
+     * the local filesystem.</p>
+     */
+    @Bean
+    public ReadablePollOutagesDao pollOutagesDao() throws IOException {
+        LOG.info("Initializing OnmsPollOutagesDao with NoOpJsonStore");
+        return new OnmsPollOutagesDao(new NoOpJsonStore());
+    }
+
+    /**
+     * PollContext that skips AsyncPollingEngine creation.
+     *
+     * <p>{@link StandalonePollContext} overrides {@code afterPropertiesSet()} as a
+     * no-op to avoid loading resilience4j Bulkhead, which is not needed when polls
+     * execute via Kafka RPC to Minion.</p>
+     */
+    @Bean
+    public PollContext pollContext(EventIpcManager eventIpcManager,
+                                  PollerConfig pollerConfig,
+                                  QueryManager queryManager,
+                                  LocationAwarePingClient locationAwarePingClient,
+                                  TsidFactory tsidFactory) {
+        String localHostName = InetAddressUtils.getLocalHostName();
+        return new StandalonePollContext(eventIpcManager, pollerConfig, queryManager,
+                locationAwarePingClient, tsidFactory, localHostName, "OpenNMS.Poller.DefaultPollContext");
+    }
+
+    /**
+     * In-memory tree of pollable nodes, interfaces, and services.
+     */
+    @Bean
+    public PollableNetwork pollableNetwork(PollContext pollContext) {
+        return new PollableNetwork(pollContext);
+    }
+
+    /**
+     * The Poller daemon.
+     *
+     * <p>Constructor injection handles the 8 core dependencies. The remaining
+     * three (pollerConfig, network, eventIpcManager) are set via setters because
+     * they were kept as setter-injected fields during the constructor injection
+     * migration (Task 2).</p>
+     */
+    @Bean
+    public Poller poller(QueryManager queryManager,
+                         MonitoredServiceDao monitoredServiceDao,
+                         OutageDao outageDao,
+                         TransactionTemplate transactionTemplate,
+                         PersisterFactory persisterFactory,
+                         ThresholdingService thresholdingService,
+                         LocationAwarePollerClient locationAwarePollerClient,
+                         ReadablePollOutagesDao pollOutagesDao,
+                         PollerConfig pollerConfig,
+                         PollContext pollContext,
+                         PollableNetwork pollableNetwork,
+                         EventIpcManager eventIpcManager) {
+        var poller = new Poller(queryManager, monitoredServiceDao, outageDao,
+                transactionTemplate, persisterFactory, thresholdingService,
+                locationAwarePollerClient, pollOutagesDao);
+        poller.setPollerConfig(pollerConfig);
+        poller.setNetwork(pollableNetwork);
+        poller.setEventIpcManager(eventIpcManager);
+        return poller;
+    }
+
+    /**
+     * Wraps the Poller daemon in a {@link SmartLifecycle} so Spring Boot
+     * manages its startup and shutdown. Phase is {@code Integer.MAX_VALUE}
+     * so the daemon starts last (after all infrastructure beans) and stops first.
+     */
+    @Bean
+    public SmartLifecycle pollerLifecycle(Poller poller) {
+        return new DaemonSmartLifecycle(poller);
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
@@ -24,8 +24,6 @@ package org.opennms.netmgt.poller.boot;
 import java.io.IOException;
 
 import org.opennms.core.daemon.common.DaemonSmartLifecycle;
-import org.opennms.core.daemon.common.EventConfEnrichmentService;
-import org.opennms.core.daemon.common.EventIpcManagerEnrichingWrapper;
 import org.opennms.core.tsid.TsidFactory;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.features.distributed.kvstore.json.noop.NoOpJsonStore;
@@ -37,7 +35,6 @@ import org.opennms.netmgt.config.dao.outages.impl.OnmsPollOutagesDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.events.api.EventIpcManager;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.poller.LocationAwarePollerClient;
 import org.opennms.netmgt.poller.Poller;
@@ -105,19 +102,6 @@ public class PollerdDaemonConfiguration {
     }
 
     /**
-     * Wraps the Kafka-backed EventIpcManager with eventconf enrichment so that
-     * events sent by Pollerd (nodeLostService, nodeRegainedService, etc.) get
-     * alarm-data, severity, and logmsg applied before hitting Kafka.
-     * Follows the same pattern as EventTranslator's EventIpcManagerEnrichingWrapper.
-     */
-    @Bean("enrichingEventIpcManager")
-    public EventIpcManager enrichingEventIpcManager(
-            @Qualifier("eventIpcManager") EventIpcManager eventIpcManager,
-            EventConfEnrichmentService enrichmentService) {
-        return new EventIpcManagerEnrichingWrapper(eventIpcManager, enrichmentService);
-    }
-
-    /**
      * PollContext that skips AsyncPollingEngine creation.
      *
      * <p>{@link StandalonePollContext} overrides {@code afterPropertiesSet()} as a
@@ -125,7 +109,7 @@ public class PollerdDaemonConfiguration {
      * execute via Kafka RPC to Minion.</p>
      */
     @Bean
-    public PollContext pollContext(@Qualifier("enrichingEventIpcManager") EventIpcManager eventIpcManager,
+    public PollContext pollContext(EventIpcManager eventIpcManager,
                                   PollerConfig pollerConfig,
                                   QueryManager queryManager,
                                   LocationAwarePingClient locationAwarePingClient,
@@ -163,7 +147,7 @@ public class PollerdDaemonConfiguration {
                          PollerConfig pollerConfig,
                          PollContext pollContext,
                          PollableNetwork pollableNetwork,
-                         @Qualifier("enrichingEventIpcManager") EventIpcManager eventIpcManager) {
+                         EventIpcManager eventIpcManager) {
         var poller = new Poller(queryManager, monitoredServiceDao, outageDao,
                 transactionTemplate, persisterFactory, thresholdingService,
                 locationAwarePollerClient, pollOutagesDao);

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionOperations;
@@ -83,6 +84,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  * annotations that cause scanning failures with Hibernate 7.</p>
  */
 @Configuration
+@EnableTransactionManagement
 public class PollerdJpaConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(PollerdJpaConfiguration.class);

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.poller.boot;
+
+import javax.sql.DataSource;
+
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.opennms.core.tsid.TsidFactory;
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.Persister;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+import org.opennms.netmgt.config.DatabaseSchemaConfigFactory;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.eventd.EventUtil;
+import org.opennms.netmgt.filter.FilterDaoFactory;
+import org.opennms.netmgt.filter.JdbcFilterDao;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsDistPoller;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.opennms.netmgt.poller.QueryManager;
+import org.opennms.netmgt.poller.QueryManagerDaoImpl;
+import org.opennms.netmgt.rrd.RrdRepository;
+import org.opennms.netmgt.threshd.api.ThresholdInitializationException;
+import org.opennms.netmgt.threshd.api.ThresholdingService;
+import org.opennms.netmgt.threshd.api.ThresholdingSession;
+import org.opennms.netmgt.threshd.api.ThresholdingSetPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Spring Boot @Configuration for Pollerd JPA entities, DAOs, and infrastructure beans.
+ *
+ * <p>Follows the same pattern as AlarmdConfiguration: explicit entity listing
+ * (not @EntityScan), SessionUtils for transaction management, and no-op stubs
+ * for features not needed by standalone Pollerd.</p>
+ *
+ * <p>Entity classes are listed explicitly via a custom {@link PersistenceManagedTypes}
+ * bean instead of using package-based {@code @EntityScan} because the legacy
+ * opennms-model module shares the same package ({@code org.opennms.netmgt.model})
+ * and contains classes with incompatible javax.persistence / Hibernate 3.x
+ * annotations that cause scanning failures with Hibernate 7.</p>
+ */
+@Configuration
+public class PollerdJpaConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PollerdJpaConfiguration.class);
+
+    // ===================================================================
+    // Section 1: JPA / Naming
+    // ===================================================================
+
+    /**
+     * Use standard JPA naming -- table/column names from @Table/@Column annotations
+     * are used as-is, without Spring Boot's default CamelCase to snake_case conversion.
+     * Required because the OpenNMS schema uses camelCase table names
+     * (e.g., monitoringSystems, ipInterface, ifServices).
+     */
+    @Bean
+    public PhysicalNamingStrategyStandardImpl physicalNamingStrategy() {
+        return new PhysicalNamingStrategyStandardImpl();
+    }
+
+    /**
+     * Explicitly lists the Jakarta entity classes needed by Pollerd.
+     * This replaces {@code @EntityScan(basePackages = "org.opennms.netmgt.model")}
+     * which would scan ALL classes in the package, including legacy entities
+     * with incompatible javax.persistence annotations.
+     */
+    @Bean
+    public PersistenceManagedTypes persistenceManagedTypes() {
+        return PersistenceManagedTypes.of(
+            OnmsNode.class.getName(),
+            OnmsIpInterface.class.getName(),
+            OnmsMonitoredService.class.getName(),
+            OnmsServiceType.class.getName(),
+            OnmsOutage.class.getName(),
+            OnmsMonitoringSystem.class.getName(),
+            OnmsMonitoringLocation.class.getName(),
+            OnmsDistPoller.class.getName(),
+            OnmsCategory.class.getName()
+        );
+    }
+
+    // ===================================================================
+    // Section 2: Transaction / SessionUtils
+    // ===================================================================
+
+    /**
+     * SessionUtils implementation backed by Spring's TransactionTemplate.
+     * Replaces the OSGi-era SessionUtils that was used to bridge Hibernate
+     * sessions across OSGi bundles.
+     */
+    @Bean
+    public SessionUtils sessionUtils(PlatformTransactionManager txManager) {
+        var txTemplate = new TransactionTemplate(txManager);
+        var readOnlyTxTemplate = new TransactionTemplate(txManager);
+        readOnlyTxTemplate.setReadOnly(true);
+        return new SessionUtils() {
+            @Override
+            public <V> V withTransaction(java.util.function.Supplier<V> supplier) {
+                return txTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withReadOnlyTransaction(java.util.function.Supplier<V> supplier) {
+                return readOnlyTxTemplate.execute(status -> supplier.get());
+            }
+            @Override
+            public <V> V withManualFlush(java.util.function.Supplier<V> supplier) {
+                return supplier.get();
+            }
+        };
+    }
+
+    /**
+     * TransactionOperations for QueryManagerDaoImpl.
+     */
+    @Bean
+    public TransactionOperations transactionOperations(PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+
+    /**
+     * TransactionTemplate for Poller constructor.
+     */
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+
+    // ===================================================================
+    // Section 3: FilterDaoFactory initialization
+    // ===================================================================
+
+    /**
+     * Initializes FilterDaoFactory with a JDBC-backed FilterDao.
+     * Must happen before PollerConfigFactory.init() is called (Task 7),
+     * because filter rule validation requires FilterDaoFactory.getInstance().
+     *
+     * <p>The FilterDaoFactory is a static singleton. We create a JdbcFilterDao
+     * backed by the Spring Boot DataSource and set it on the factory.</p>
+     */
+    @Bean
+    public JdbcFilterDao filterDaoInitializer(DataSource dataSource) {
+        LOG.info("Initializing FilterDaoFactory with JdbcFilterDao");
+        var jdbcFilterDao = new JdbcFilterDao();
+        jdbcFilterDao.setDataSource(dataSource);
+        try {
+            DatabaseSchemaConfigFactory.init();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not initialize DatabaseSchemaConfigFactory", e);
+        }
+        jdbcFilterDao.setDatabaseSchemaConfigFactory(DatabaseSchemaConfigFactory.getInstance());
+        jdbcFilterDao.afterPropertiesSet();
+        FilterDaoFactory.setInstance(jdbcFilterDao);
+        return jdbcFilterDao;
+    }
+
+    // ===================================================================
+    // Section 4: QueryManager
+    // ===================================================================
+
+    /**
+     * QueryManagerDaoImpl wired with DAO dependencies.
+     * DAOs are auto-scanned from org.opennms.netmgt.model.jakarta.dao package.
+     */
+    @Bean
+    public QueryManager queryManager(NodeDao nodeDao, OutageDao outageDao,
+                                      MonitoredServiceDao monitoredServiceDao,
+                                      IpInterfaceDao ipInterfaceDao,
+                                      TransactionOperations transactionOperations) {
+        return new QueryManagerDaoImpl(nodeDao, outageDao, monitoredServiceDao,
+                                       ipInterfaceDao, transactionOperations);
+    }
+
+    // ===================================================================
+    // Section 5: TsidFactory
+    // ===================================================================
+
+    @Bean
+    public TsidFactory tsidFactory(@Value("${opennms.tsid.node-id:0}") long nodeId) {
+        return new TsidFactory(nodeId);
+    }
+
+    // ===================================================================
+    // Section 6: No-op stubs
+    // ===================================================================
+
+    /**
+     * No-op PersisterFactory -- Pollerd does not persist collection metrics.
+     * Data collection is handled by Collectd; Pollerd only polls service status.
+     */
+    @Bean
+    public PersisterFactory persisterFactory() {
+        return new PersisterFactory() {
+            private final Persister noOpPersister = new Persister() {
+                @Override public void visitCollectionSet(CollectionSet set) {}
+                @Override public void visitResource(CollectionResource resource) {}
+                @Override public void visitGroup(AttributeGroup group) {}
+                @Override public void visitAttribute(CollectionAttribute attribute) {}
+                @Override public void completeAttribute(CollectionAttribute attribute) {}
+                @Override public void completeGroup(AttributeGroup group) {}
+                @Override public void completeResource(CollectionResource resource) {}
+                @Override public void completeCollectionSet(CollectionSet set) {}
+                @Override public void persistNumericAttribute(CollectionAttribute attribute) {}
+                @Override public void persistStringAttribute(CollectionAttribute attribute) {}
+            };
+
+            @Override
+            public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+                return noOpPersister;
+            }
+
+            @Override
+            public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                    boolean dontPersistCounters, boolean forceStoreByGroup, boolean dontReorderAttributes) {
+                return noOpPersister;
+            }
+        };
+    }
+
+    /**
+     * No-op ThresholdingService -- Pollerd does not perform thresholding.
+     * Thresholding is applied to collected metrics by Collectd/Telemetryd.
+     */
+    @Bean
+    public ThresholdingService thresholdingService() {
+        return new ThresholdingService() {
+            @Override
+            public ThresholdingSession createSession(int nodeId, String hostAddress,
+                    String serviceName, ServiceParameters serviceParameters)
+                    throws ThresholdInitializationException {
+                return null;
+            }
+
+            @Override
+            public ThresholdingSetPersister getThresholdingSetPersister() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Minimal EventUtil implementation for parameter expansion.
+     * The full EventUtilDaoImpl depends on the legacy Hibernate DAO layer.
+     * This pass-through implementation returns inputs unchanged when no
+     * database-backed token resolution is available.
+     */
+    @Bean
+    public EventUtil eventUtil() {
+        return new EventUtil() {
+            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
+            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
+            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
+            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
+            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
+            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
+            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
+            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
+            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
+            @Override public String getForeignId(long nodeId) { return ""; }
+            @Override public String getForeignSource(long nodeId) { return ""; }
+            @Override public String getNodeLabel(long nodeId) { return ""; }
+            @Override public String getNodeLocation(long nodeId) { return ""; }
+            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
+            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
+            @Override public String getPrimaryInterface(long nodeId) { return ""; }
+        };
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
@@ -48,7 +48,9 @@ import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.model.OnmsApplication;
 import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.poller.QueryManager;
 import org.opennms.netmgt.poller.QueryManagerDaoImpl;
@@ -117,7 +119,9 @@ public class PollerdJpaConfiguration {
             OnmsMonitoringSystem.class.getName(),
             OnmsMonitoringLocation.class.getName(),
             OnmsDistPoller.class.getName(),
-            OnmsCategory.class.getName()
+            OnmsCategory.class.getName(),
+            OnmsSnmpInterface.class.getName(),
+            OnmsApplication.class.getName()
         );
     }
 
@@ -152,15 +156,9 @@ public class PollerdJpaConfiguration {
     }
 
     /**
-     * TransactionOperations for QueryManagerDaoImpl.
-     */
-    @Bean
-    public TransactionOperations transactionOperations(PlatformTransactionManager txManager) {
-        return new TransactionTemplate(txManager);
-    }
-
-    /**
-     * TransactionTemplate for Poller constructor.
+     * TransactionTemplate for Poller and QueryManagerDaoImpl.
+     * TransactionTemplate implements TransactionOperations, so this single bean
+     * satisfies both injection points.
      */
     @Bean
     public TransactionTemplate transactionTemplate(PlatformTransactionManager txManager) {

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.poller.boot;
+
+import javax.sql.DataSource;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.opennms.core.daemon.loader.InlineIdentity;
+import org.opennms.core.ipc.twin.common.LocalTwinSubscriberImpl;
+import org.opennms.core.ipc.twin.kafka.publisher.KafkaTwinPublisher;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.Identity;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.opennms.netmgt.passive.PassiveStatusKeeper;
+import org.opennms.netmgt.passive.PassiveStatusTwinPublisher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Boot configuration for passive status monitoring and Twin API publishing.
+ *
+ * <p>Wires the passive status subsystem so that Pollerd receives
+ * {@code passiveServiceStatus} events via Kafka, {@link PassiveStatusKeeper}
+ * tracks the state, and {@link PassiveStatusTwinPublisher} pushes updates
+ * to Minion via {@link KafkaTwinPublisher}.</p>
+ *
+ * <p>Mirrors the bean definitions from the legacy Karaf XML context
+ * {@code applicationContext-daemon-loader-pollerd.xml}.</p>
+ */
+@Configuration
+public class PollerdPassiveStatusConfiguration {
+
+    @Bean(initMethod = "init", destroyMethod = "stop")
+    public PassiveStatusKeeper passiveStatusKeeper(
+            EventIpcManager eventIpcManager,
+            DataSource dataSource) {
+        var keeper = new PassiveStatusKeeper();
+        keeper.setEventManager(eventIpcManager);
+        keeper.setDataSource(dataSource);
+        PassiveStatusKeeper.setInstance(keeper);
+        return keeper;
+    }
+
+    @Bean
+    public Identity twinIdentity() {
+        return new InlineIdentity();
+    }
+
+    @Bean("twinPublisherMetricRegistry")
+    public MetricRegistry twinPublisherMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    public LocalTwinSubscriberImpl localTwinSubscriber(Identity twinIdentity) {
+        return new LocalTwinSubscriberImpl(twinIdentity);
+    }
+
+    @Bean(initMethod = "init", destroyMethod = "close")
+    public KafkaTwinPublisher kafkaTwinPublisher(
+            LocalTwinSubscriberImpl localTwinSubscriber,
+            TracerRegistry tracerRegistry,
+            @Qualifier("twinPublisherMetricRegistry") MetricRegistry metricRegistry) {
+        return new KafkaTwinPublisher(localTwinSubscriber, tracerRegistry, metricRegistry);
+    }
+
+    @Bean(initMethod = "init", destroyMethod = "close")
+    public PassiveStatusTwinPublisher passiveStatusTwinPublisher(
+            KafkaTwinPublisher kafkaTwinPublisher,
+            PassiveStatusKeeper passiveStatusKeeper,
+            EventIpcManager eventIpcManager) {
+        return new PassiveStatusTwinPublisher(kafkaTwinPublisher, passiveStatusKeeper, eventIpcManager);
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java
@@ -33,7 +33,6 @@ import org.opennms.distributed.core.api.Identity;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.passive.PassiveStatusKeeper;
 import org.opennms.netmgt.passive.PassiveStatusTwinPublisher;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -67,11 +66,6 @@ public class PollerdPassiveStatusConfiguration {
         return new InlineIdentity();
     }
 
-    @Bean("twinPublisherMetricRegistry")
-    public MetricRegistry twinPublisherMetricRegistry() {
-        return new MetricRegistry();
-    }
-
     @Bean
     public LocalTwinSubscriberImpl localTwinSubscriber(Identity twinIdentity) {
         return new LocalTwinSubscriberImpl(twinIdentity);
@@ -80,9 +74,8 @@ public class PollerdPassiveStatusConfiguration {
     @Bean(initMethod = "init", destroyMethod = "close")
     public KafkaTwinPublisher kafkaTwinPublisher(
             LocalTwinSubscriberImpl localTwinSubscriber,
-            TracerRegistry tracerRegistry,
-            @Qualifier("twinPublisherMetricRegistry") MetricRegistry metricRegistry) {
-        return new KafkaTwinPublisher(localTwinSubscriber, tracerRegistry, metricRegistry);
+            TracerRegistry tracerRegistry) {
+        return new KafkaTwinPublisher(localTwinSubscriber, tracerRegistry, new MetricRegistry());
     }
 
     @Bean(initMethod = "init", destroyMethod = "close")

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdRpcConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdRpcConfiguration.java
@@ -25,6 +25,8 @@ import org.opennms.core.daemon.loader.LocalServiceMonitorRegistry;
 import org.opennms.core.mate.api.EntityScopeProvider;
 import org.opennms.core.rpc.api.RpcClientFactory;
 import org.opennms.core.rpc.utils.RpcTargetHelper;
+import org.opennms.netmgt.icmp.Pinger;
+import org.opennms.netmgt.icmp.PingerFactory;
 import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.icmp.proxy.LocationAwarePingClientImpl;
 import org.opennms.netmgt.icmp.proxy.PingProxyRpcModule;
@@ -35,6 +37,9 @@ import org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl;
 import org.opennms.netmgt.poller.client.rpc.PollerClientRpcModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 /**
  * Spring Boot configuration for Pollerd's Kafka RPC clients.
@@ -57,6 +62,27 @@ public class PollerdRpcConfiguration {
     @Bean
     public ServiceMonitorRegistry serviceMonitorRegistry() {
         return new LocalServiceMonitorRegistry();
+    }
+
+    /**
+     * Executor for PollerClientRpcModule async response handling.
+     * Satisfies the @Autowired @Qualifier("pollerExecutor") on PollerClientRpcModule.
+     */
+    @Bean("pollerExecutor")
+    public Executor pollerExecutor() {
+        return Executors.newCachedThreadPool();
+    }
+
+    /**
+     * No-op PingerFactory — Pollerd never pings locally, it delegates to Minion.
+     * This bean satisfies the @Autowired PingerFactory field on PingProxyRpcModule.
+     */
+    @Bean
+    public PingerFactory pingerFactory() {
+        return new PingerFactory() {
+            @Override public Pinger getInstance() { return null; }
+            @Override public Pinger getInstance(int tc, boolean allowFragmentation) { return null; }
+        };
     }
 
     /**

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdRpcConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdRpcConfiguration.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.poller.boot;
+
+import org.opennms.core.daemon.loader.LocalServiceMonitorRegistry;
+import org.opennms.core.mate.api.EntityScopeProvider;
+import org.opennms.core.rpc.api.RpcClientFactory;
+import org.opennms.core.rpc.utils.RpcTargetHelper;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClientImpl;
+import org.opennms.netmgt.icmp.proxy.PingProxyRpcModule;
+import org.opennms.netmgt.icmp.proxy.PingSweepRpcModule;
+import org.opennms.netmgt.poller.LocationAwarePollerClient;
+import org.opennms.netmgt.poller.ServiceMonitorRegistry;
+import org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl;
+import org.opennms.netmgt.poller.client.rpc.PollerClientRpcModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Boot configuration for Pollerd's Kafka RPC clients.
+ *
+ * <p>Sets up the RPC modules and location-aware clients that allow Pollerd
+ * to delegate poll execution and ICMP pings to Minion via Kafka RPC.</p>
+ *
+ * <p>{@link RpcClientFactory} and {@link RpcTargetHelper} are provided by
+ * {@code KafkaRpcClientConfiguration} in daemon-common (auto-scanned via
+ * {@code org.opennms.core.daemon.common}). {@link EntityScopeProvider} is
+ * provided by {@code DaemonProvisioningConfiguration} as a no-op default.</p>
+ */
+@Configuration
+public class PollerdRpcConfiguration {
+
+    /**
+     * ServiceMonitorRegistry that discovers ServiceMonitor implementations
+     * via {@link java.util.ServiceLoader}.
+     */
+    @Bean
+    public ServiceMonitorRegistry serviceMonitorRegistry() {
+        return new LocalServiceMonitorRegistry();
+    }
+
+    /**
+     * Stateless RPC protocol definition for poller requests to Minion.
+     */
+    @Bean
+    public PollerClientRpcModule pollerClientRpcModule() {
+        return new PollerClientRpcModule();
+    }
+
+    /**
+     * Stateless RPC module for ICMP ping requests.
+     */
+    @Bean
+    public PingProxyRpcModule pingProxyRpcModule() {
+        return new PingProxyRpcModule();
+    }
+
+    /**
+     * Stateless RPC module for ICMP ping sweep requests.
+     */
+    @Bean
+    public PingSweepRpcModule pingSweepRpcModule() {
+        return new PingSweepRpcModule();
+    }
+
+    /**
+     * Location-aware poller client that delegates poll execution to Minion.
+     *
+     * <p>{@link LocationAwarePollerClientImpl} implements {@link org.springframework.beans.factory.InitializingBean},
+     * so Spring will call {@code afterPropertiesSet()} automatically after construction,
+     * which creates the RPC delegate client.</p>
+     */
+    @Bean
+    public LocationAwarePollerClient locationAwarePollerClient(
+            ServiceMonitorRegistry serviceMonitorRegistry,
+            PollerClientRpcModule pollerClientRpcModule,
+            RpcClientFactory rpcClientFactory,
+            RpcTargetHelper rpcTargetHelper,
+            EntityScopeProvider entityScopeProvider) {
+        return new LocationAwarePollerClientImpl(serviceMonitorRegistry,
+                pollerClientRpcModule, rpcClientFactory, rpcTargetHelper, entityScopeProvider);
+    }
+
+    /**
+     * Location-aware ping client that delegates ICMP pings and sweeps to Minion.
+     *
+     * <p>{@link LocationAwarePingClientImpl} uses {@code @PostConstruct} to initialize
+     * the RPC delegate clients after construction.</p>
+     */
+    @Bean
+    public LocationAwarePingClient locationAwarePingClient(
+            RpcClientFactory rpcClientFactory,
+            PingProxyRpcModule pingProxyRpcModule,
+            PingSweepRpcModule pingSweepRpcModule) {
+        return new LocationAwarePingClientImpl(rpcClientFactory, pingProxyRpcModule, pingSweepRpcModule);
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/StandalonePollContext.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/StandalonePollContext.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.poller.boot;
+
+import org.opennms.core.tsid.TsidFactory;
+import org.opennms.netmgt.config.PollerConfig;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
+import org.opennms.netmgt.poller.DefaultPollContext;
+import org.opennms.netmgt.poller.QueryManager;
+
+/**
+ * Standalone PollContext that skips AsyncPollingEngine initialization.
+ *
+ * <p>In standalone daemon containers, resilience4j bundles may not be wired
+ * to opennms-services at class-load time. The AsyncPollingEngine (which
+ * uses resilience4j Bulkhead) is not needed -- polls execute via Kafka RPC
+ * to Minion without async bulkhead control.</p>
+ */
+public class StandalonePollContext extends DefaultPollContext {
+
+    public StandalonePollContext(EventIpcManager eventManager, PollerConfig pollerConfig,
+                                 QueryManager queryManager, LocationAwarePingClient locationAwarePingClient,
+                                 TsidFactory tsidFactory, String localHostName, String name) {
+        super(eventManager, pollerConfig, queryManager, locationAwarePingClient,
+              tsidFactory, localHostName, name);
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        // Skip AsyncPollingEngine creation -- not needed for standalone polling.
+        // The parent creates new AsyncPollingEngine(...) which requires
+        // resilience4j-bulkhead, unavailable in the standalone container.
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-pollerd/src/main/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
+    username: ${SPRING_DATASOURCE_USERNAME:opennms}
+    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+  jpa:
+    hibernate:
+      ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+      hibernate.archive.autodetection: none
+
+opennms:
+  home: ${OPENNMS_HOME:/opt/deltav}
+  instance:
+    id: ${OPENNMS_INSTANCE_ID:OpenNMS}
+  tsid:
+    node-id: ${OPENNMS_TSID_NODE_ID:0}
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
+    consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-pollerd}
+    poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
+  rpc:
+    kafka:
+      enabled: ${OPENNMS_RPC_KAFKA_ENABLED:true}
+      bootstrap-servers: ${OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS:kafka:9092}

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
@@ -73,14 +73,6 @@ public class EventConfEnrichmentService {
     }
 
     /**
-     * Returns the underlying EventConfDao for use by other components (e.g.,
-     * KafkaEventForwarder) that need to look up event configurations.
-     */
-    public DefaultEventConfDao getEventConfDao() {
-        return eventConfDao;
-    }
-
-    /**
      * Enriches an event by looking up the matching event conf entry and applying
      * alarm-data, severity, and logmsg when the event is missing them.
      *

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
@@ -73,6 +73,14 @@ public class EventConfEnrichmentService {
     }
 
     /**
+     * Returns the underlying EventConfDao for use by other components (e.g.,
+     * KafkaEventForwarder) that need to look up event configurations.
+     */
+    public DefaultEventConfDao getEventConfDao() {
+        return eventConfDao;
+    }
+
+    /**
      * Enriches an event by looking up the matching event conf entry and applying
      * alarm-data, severity, and logmsg when the event is missing them.
      *

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
@@ -73,6 +73,14 @@ public class EventConfEnrichmentService {
     }
 
     /**
+     * Returns the underlying EventConfDao for use by components that need
+     * direct access to event configuration lookups (e.g., KafkaEventForwarder).
+     */
+    public DefaultEventConfDao getEventConfDao() {
+        return eventConfDao;
+    }
+
+    /**
      * Enriches an event by looking up the matching event conf entry and applying
      * alarm-data, severity, and logmsg when the event is missing them.
      *

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventIpcManagerEnrichingWrapper.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventIpcManagerEnrichingWrapper.java
@@ -19,7 +19,7 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.netmgt.translator.boot;
+package org.opennms.core.daemon.common;
 
 import java.util.Collection;
 import java.util.Objects;

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -67,14 +67,9 @@ public class KafkaEventTransportConfiguration {
     private long pollTimeoutMs;
 
     @Bean
-    public KafkaEventForwarder kafkaEventForwarder(
-            @org.springframework.beans.factory.annotation.Autowired(required = false)
-            EventConfEnrichmentService eventConfEnrichmentService) {
+    public KafkaEventForwarder kafkaEventForwarder() {
         KafkaEventForwarder forwarder = KafkaEventForwarderFactory.create(bootstrapServers, eventTopic);
         forwarder.setIpcTopicName(ipcTopic);
-        if (eventConfEnrichmentService != null) {
-            forwarder.setEventConfDao(eventConfEnrichmentService.getEventConfDao());
-        }
         return forwarder;
     }
 

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -67,9 +67,14 @@ public class KafkaEventTransportConfiguration {
     private long pollTimeoutMs;
 
     @Bean
-    public KafkaEventForwarder kafkaEventForwarder() {
+    public KafkaEventForwarder kafkaEventForwarder(
+            @org.springframework.beans.factory.annotation.Autowired(required = false)
+            EventConfEnrichmentService eventConfEnrichmentService) {
         KafkaEventForwarder forwarder = KafkaEventForwarderFactory.create(bootstrapServers, eventTopic);
         forwarder.setIpcTopicName(ipcTopic);
+        if (eventConfEnrichmentService != null) {
+            forwarder.setEventConfDao(eventConfEnrichmentService.getEventConfDao());
+        }
         return forwarder;
     }
 

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -44,9 +44,12 @@ import org.springframework.context.annotation.Configuration;
  *       into the {@link EventIpcManager} interface expected by daemon code</li>
  * </ol>
  *
- * <p>The forwarder uses {@code NoOpEventProcessor} (no eventconf expansion) because
- * daemon containers do not have access to eventconf. Events are enriched separately
- * by the core Eventd pipeline before reaching Kafka.</p>
+ * <p>The forwarder's event expander uses {@code NoOpEventProcessor} (the legacy Eventd
+ * expansion pipeline is not available). Instead, eventconf enrichment (alarm-data,
+ * severity, reduction-key expansion) is handled by {@link EventConfEnrichmentService}
+ * which loads event configurations from the database. This enrichment is wired into
+ * the forwarder via {@code setEventConfDao()} so ALL events from ALL daemons are
+ * enriched before reaching Kafka.</p>
  */
 @Configuration
 public class KafkaEventTransportConfiguration {
@@ -67,9 +70,14 @@ public class KafkaEventTransportConfiguration {
     private long pollTimeoutMs;
 
     @Bean
-    public KafkaEventForwarder kafkaEventForwarder() {
+    public KafkaEventForwarder kafkaEventForwarder(
+            @org.springframework.beans.factory.annotation.Autowired(required = false)
+            EventConfEnrichmentService eventConfEnrichmentService) {
         KafkaEventForwarder forwarder = KafkaEventForwarderFactory.create(bootstrapServers, eventTopic);
         forwarder.setIpcTopicName(ipcTopic);
+        if (eventConfEnrichmentService != null) {
+            forwarder.setEventConfDao(eventConfEnrichmentService.getEventConfDao());
+        }
         return forwarder;
     }
 

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -70,15 +70,37 @@ public class KafkaEventTransportConfiguration {
     private long pollTimeoutMs;
 
     @Bean
-    public KafkaEventForwarder kafkaEventForwarder(
-            @org.springframework.beans.factory.annotation.Autowired(required = false)
-            EventConfEnrichmentService eventConfEnrichmentService) {
+    public KafkaEventForwarder kafkaEventForwarder() {
         KafkaEventForwarder forwarder = KafkaEventForwarderFactory.create(bootstrapServers, eventTopic);
         forwarder.setIpcTopicName(ipcTopic);
-        if (eventConfEnrichmentService != null) {
-            forwarder.setEventConfDao(eventConfEnrichmentService.getEventConfDao());
-        }
         return forwarder;
+    }
+
+    /**
+     * Wires EventConfDao into KafkaEventForwarder after all beans are created.
+     * This avoids bean creation order issues — EventConfEnrichmentService needs
+     * DataSource which may not be available when KafkaEventForwarder is created.
+     */
+    @Bean
+    public SmartLifecycle eventConfEnrichmentWiring(
+            KafkaEventForwarder forwarder,
+            @org.springframework.beans.factory.annotation.Autowired(required = false)
+            EventConfEnrichmentService eventConfEnrichmentService) {
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                if (eventConfEnrichmentService != null) {
+                    forwarder.setEventConfDao(eventConfEnrichmentService.getEventConfDao());
+                }
+                running = true;
+            }
+
+            @Override public void stop() { running = false; }
+            @Override public boolean isRunning() { return running; }
+            @Override public int getPhase() { return -20; } // before event consumer starts at -10
+        };
     }
 
     @Bean(destroyMethod = "stop")

--- a/core/daemon-loader-perspectivepoller/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-perspectivepoller.xml
+++ b/core/daemon-loader-perspectivepoller/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-perspectivepoller.xml
@@ -126,12 +126,15 @@
           class="org.opennms.netmgt.poller.client.rpc.PollerClientRpcModule"/>
 
     <!-- The real LocationAwarePollerClient that delegates to Minions via Kafka RPC.
-         afterPropertiesSet() creates the RPC delegate from rpcClientFactory + pollerClientRpcModule.
-         All 5 @Autowired fields are resolved by <context:annotation-config/>:
-           - serviceMonitorRegistry, pollerClientRpcModule, rpcClientFactory,
-             rpcTargetHelper, entityScopeProvider -->
+         afterPropertiesSet() creates the RPC delegate from rpcClientFactory + pollerClientRpcModule. -->
     <bean id="locationAwarePollerClient"
-          class="org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl"/>
+          class="org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl">
+        <constructor-arg ref="serviceMonitorRegistry"/>
+        <constructor-arg ref="pollerClientRpcModule"/>
+        <constructor-arg ref="kafkaRpcClientFactory"/>
+        <constructor-arg ref="rpcTargetHelper"/>
+        <constructor-arg ref="entityScopeProvider"/>
+    </bean>
 
     <!-- ============================================================== -->
     <!-- Local Beans                                                    -->

--- a/core/daemon-loader-pollerd/src/main/java/org/opennms/core/daemon/loader/StandalonePollContext.java
+++ b/core/daemon-loader-pollerd/src/main/java/org/opennms/core/daemon/loader/StandalonePollContext.java
@@ -21,7 +21,12 @@
  */
 package org.opennms.core.daemon.loader;
 
+import org.opennms.core.tsid.TsidFactory;
+import org.opennms.netmgt.config.PollerConfig;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.poller.DefaultPollContext;
+import org.opennms.netmgt.poller.QueryManager;
 
 /**
  * Standalone PollContext that skips AsyncPollingEngine initialization.
@@ -32,6 +37,13 @@ import org.opennms.netmgt.poller.DefaultPollContext;
  * execute directly via LocalPollerClient without async bulkhead control.
  */
 public class StandalonePollContext extends DefaultPollContext {
+
+    public StandalonePollContext(EventIpcManager eventManager, PollerConfig pollerConfig,
+                                 QueryManager queryManager, LocationAwarePingClient locationAwarePingClient,
+                                 TsidFactory tsidFactory, String localHostName, String name) {
+        super(eventManager, pollerConfig, queryManager, locationAwarePingClient,
+              tsidFactory, localHostName, name);
+    }
 
     @Override
     public void afterPropertiesSet() {

--- a/core/daemon-loader-pollerd/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-pollerd.xml
+++ b/core/daemon-loader-pollerd/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-pollerd.xml
@@ -27,8 +27,7 @@
            http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 
-    <!-- Enable @Autowired processing for Poller and QueryManagerDaoImpl -->
-    <context:annotation-config />
+    <!-- Constructor injection is used for all beans; annotation-config no longer needed -->
 
     <!-- Shared KafkaRpcClientFactory wiring -->
     <import resource="classpath:kafka-rpc-client-factory.xml"/>
@@ -121,7 +120,13 @@
 
     <!-- Real LocationAwarePollerClient — delegates polls to Minions via Kafka RPC -->
     <bean id="locationAwarePollerClient"
-          class="org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl"/>
+          class="org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl">
+        <constructor-arg ref="serviceMonitorRegistry"/>
+        <constructor-arg ref="pollerClientRpcModule"/>
+        <constructor-arg ref="kafkaRpcClientFactory"/>
+        <constructor-arg ref="rpcTargetHelper"/>
+        <constructor-arg ref="entityScopeProvider"/>
+    </bean>
     <onmsgi:service interface="org.opennms.netmgt.poller.LocationAwarePollerClient"
                     ref="locationAwarePollerClient"/>
 
@@ -134,16 +139,22 @@
     </bean>
 
     <bean name="pollerQueryManager"
-          class="org.opennms.netmgt.poller.QueryManagerDaoImpl"/>
+          class="org.opennms.netmgt.poller.QueryManagerDaoImpl">
+        <constructor-arg ref="nodeDao"/>
+        <constructor-arg ref="outageDao"/>
+        <constructor-arg ref="monitoredServiceDao"/>
+        <constructor-arg ref="ipInterfaceDao"/>
+        <constructor-arg ref="transactionTemplate"/>
+    </bean>
 
     <bean name="pollContext" class="org.opennms.core.daemon.loader.StandalonePollContext">
-        <property name="eventManager" ref="eventIpcManager"/>
-        <property name="localHostName" ref="localHostName"/>
-        <property name="name" value="OpenNMS.Poller.DefaultPollContext"/>
-        <property name="pollerConfig" ref="pollerConfig"/>
-        <property name="queryManager" ref="pollerQueryManager"/>
-        <property name="locationAwarePingClient" ref="locationAwarePingClient"/>
-        <property name="tsidFactory" ref="tsidFactory"/>
+        <constructor-arg ref="eventIpcManager"/>
+        <constructor-arg ref="pollerConfig"/>
+        <constructor-arg ref="pollerQueryManager"/>
+        <constructor-arg ref="locationAwarePingClient"/>
+        <constructor-arg ref="tsidFactory"/>
+        <constructor-arg ref="localHostName"/>
+        <constructor-arg value="OpenNMS.Poller.DefaultPollContext"/>
     </bean>
 
     <bean name="pollableNetwork"
@@ -152,6 +163,14 @@
     </bean>
 
     <bean name="daemon" class="org.opennms.netmgt.poller.Poller">
+        <constructor-arg ref="pollerQueryManager"/>
+        <constructor-arg ref="monitoredServiceDao"/>
+        <constructor-arg ref="outageDao"/>
+        <constructor-arg ref="transactionTemplate"/>
+        <constructor-arg ref="persisterFactory"/>
+        <constructor-arg ref="thresholdingService"/>
+        <constructor-arg ref="locationAwarePollerClient"/>
+        <constructor-arg><null/></constructor-arg>  <!-- pollOutagesDao (optional, not available in Karaf) -->
         <property name="network" ref="pollableNetwork"/>
         <property name="pollerConfig" ref="pollerConfig"/>
         <property name="eventIpcManager" ref="eventIpcManager"/>

--- a/core/event-forwarder-kafka/src/main/java/org/opennms/core/event/forwarder/kafka/KafkaEventForwarder.java
+++ b/core/event-forwarder-kafka/src/main/java/org/opennms/core/event/forwarder/kafka/KafkaEventForwarder.java
@@ -306,7 +306,10 @@ public class KafkaEventForwarder implements EventForwarder {
             case "interface":
                 return event.getInterface() != null ? event.getInterface() : "";
             case "dpname":
+            case "distpoller":
                 return event.getDistPoller() != null ? event.getDistPoller() : "";
+            case "service":
+                return event.getService() != null ? event.getService() : "";
             case "severity":
                 return event.getSeverity() != null ? event.getSeverity() : "";
             case "source":

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java
@@ -136,7 +136,7 @@ public class OnmsOutage implements Serializable {
      */
     @Id
     @Column(name="outageId", nullable=false)
-    @SequenceGenerator(name="outageSequence", sequenceName="outageNxtId")
+    @SequenceGenerator(name="outageSequence", sequenceName="outageNxtId", allocationSize=1)
     @GeneratedValue(generator="outageSequence")
     public Integer getId() {
         return m_id;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java
@@ -430,7 +430,7 @@ public class OnmsOutage implements Serializable {
     /**
      * Monitoring perspective that this outage is associated with.
      */
-    @ManyToOne(optional=false, fetch=FetchType.LAZY)
+    @ManyToOne(optional=true, fetch=FetchType.LAZY)
     @JoinColumn(name="perspective")
     public OnmsMonitoringLocation getPerspective() {
         return m_perspective;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsOutage.java
@@ -1,0 +1,468 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+
+import com.google.common.base.MoreObjects;
+
+
+/**
+ * <p>OnmsOutage class.</p>
+ *
+ * @hibernate.class table="outages"
+ */
+@Entity
+@Table(name="outages")
+@FilterDef(name = FilterManager.AUTH_FILTER_NAME,
+    parameters = @ParamDef(name = "userGroups", type = String.class))
+@Filter(name=FilterManager.AUTH_FILTER_NAME, condition="exists (select distinct x.nodeid from node x join category_node cn on x.nodeid = cn.nodeid join category_group cg on cn.categoryId = cg.categoryId join ipInterface on x.nodeid = ipInterface.nodeid join ifServices on ipInterface.id = ifServices.ipInterfaceId where ifServices.id = ifServiceId and cg.groupId in (:userGroups))")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class OnmsOutage implements Serializable {
+
+    private static final long serialVersionUID = 3846398168228820151L;
+
+    /** identifier field */
+    private Integer m_id;
+
+    /** persistent field */
+    private Date m_ifLostService;
+
+    /** nullable persistent field */
+    private Date m_ifRegainedService;
+
+    /** denormalized event TSID and UEI for service lost event */
+    private Long m_svcLostEventTsid;
+    private String m_svcLostEventUei;
+
+    /** denormalized event TSID and UEI for service regained event */
+    private Long m_svcRegainedEventTsid;
+    private String m_svcRegainedEventUei;
+
+    /** persistent field */
+    private OnmsMonitoredService m_monitoredService;
+
+    /** persistent field */
+    private Date m_suppressTime;
+
+    /** persistent field */
+    private String m_suppressedBy;
+
+    /** persistent field */
+    private OnmsMonitoringLocation m_perspective;
+
+    /**
+     * full constructor
+     *
+     * @param ifLostService a {@link java.util.Date} object.
+     * @param ifRegainedService a {@link java.util.Date} object.
+     * @param monitoredService a {@link org.opennms.netmgt.model.OnmsMonitoredService} object.
+     * @param suppressTime a {@link java.util.Date} object.
+     * @param suppressedBy a {@link java.lang.String} object.
+     */
+    public OnmsOutage(Date ifLostService, Date ifRegainedService, OnmsMonitoredService monitoredService, Date suppressTime, String suppressedBy) {
+        m_ifLostService = ifLostService;
+        m_ifRegainedService = ifRegainedService;
+        m_monitoredService = monitoredService;
+        m_suppressTime = suppressTime;
+        m_suppressedBy = suppressedBy;
+    }
+
+    /**
+     * default constructor
+     */
+    public OnmsOutage() {
+    }
+
+    /**
+     */
+    public OnmsOutage(Date ifLostService, OnmsMonitoredService monitoredService) {
+        m_ifLostService = ifLostService;
+        m_monitoredService = monitoredService;
+    }
+
+    public OnmsOutage(Date ifLostService, Date ifRegainedService, OnmsMonitoredService monitoredService) {
+        m_ifLostService = ifLostService;
+        m_ifRegainedService = ifRegainedService;
+        m_monitoredService = monitoredService;
+    }
+
+    /**
+     * <p>getId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Id
+    @Column(name="outageId", nullable=false)
+    @SequenceGenerator(name="outageSequence", sequenceName="outageNxtId")
+    @GeneratedValue(generator="outageSequence")
+    public Integer getId() {
+        return m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param outageId a {@link java.lang.Integer} object.
+     */
+    public void setId(Integer outageId) {
+        m_id = outageId;
+    }
+
+    /**
+     * <p>getMonitoredService</p>
+     *
+     * @return a {@link org.opennms.netmgt.model.OnmsMonitoredService} object.
+     */
+    @ManyToOne
+    @JoinColumn(name="ifserviceId")
+    public OnmsMonitoredService getMonitoredService() {
+        return m_monitoredService;
+    }
+
+    /**
+     * <p>setMonitoredService</p>
+     *
+     * @param monitoredService a {@link org.opennms.netmgt.model.OnmsMonitoredService} object.
+     */
+    public void setMonitoredService(OnmsMonitoredService monitoredService) {
+        m_monitoredService = monitoredService;
+    }
+
+
+    /**
+     * <p>getIfLostService</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="ifLostService", nullable=false)
+    public Date getIfLostService() {
+        return m_ifLostService;
+    }
+
+    /**
+     * <p>setIfLostService</p>
+     *
+     * @param ifLostService a {@link java.util.Date} object.
+     */
+    public void setIfLostService(Date ifLostService) {
+        m_ifLostService = ifLostService;
+    }
+
+    @Column(name="svc_lost_event_tsid")
+    public Long getSvcLostEventTsid() {
+        return m_svcLostEventTsid;
+    }
+
+    public void setSvcLostEventTsid(Long svcLostEventTsid) {
+        m_svcLostEventTsid = svcLostEventTsid;
+    }
+
+    @Column(name="svc_lost_event_uei")
+    public String getSvcLostEventUei() {
+        return m_svcLostEventUei;
+    }
+
+    public void setSvcLostEventUei(String svcLostEventUei) {
+        m_svcLostEventUei = svcLostEventUei;
+    }
+
+
+    /**
+     * <p>getIfRegainedService</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="ifRegainedService")
+    public Date getIfRegainedService() {
+        return m_ifRegainedService;
+    }
+
+    /**
+     * <p>setIfRegainedService</p>
+     *
+     * @param ifRegainedService a {@link java.util.Date} object.
+     */
+    public void setIfRegainedService(Date ifRegainedService) {
+        m_ifRegainedService = ifRegainedService;
+    }
+
+    @Column(name="svc_regained_event_tsid")
+    public Long getSvcRegainedEventTsid() {
+        return m_svcRegainedEventTsid;
+    }
+
+    public void setSvcRegainedEventTsid(Long svcRegainedEventTsid) {
+        m_svcRegainedEventTsid = svcRegainedEventTsid;
+    }
+
+    @Column(name="svc_regained_event_uei")
+    public String getSvcRegainedEventUei() {
+        return m_svcRegainedEventUei;
+    }
+
+    public void setSvcRegainedEventUei(String svcRegainedEventUei) {
+        m_svcRegainedEventUei = svcRegainedEventUei;
+    }
+
+    /**
+     * <p>getSuppressTime</p>
+     *
+     * @return a {@link java.util.Date} object.
+     */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="suppressTime")
+    public Date getSuppressTime(){
+        return m_suppressTime;
+    }
+
+    /**
+     * <p>setSuppressTime</p>
+     *
+     * @param timeToSuppress a {@link java.util.Date} object.
+     */
+    public void setSuppressTime(Date timeToSuppress){
+        m_suppressTime = timeToSuppress;
+    }
+
+
+    /**
+     * <p>getSuppressedBy</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Column(name="suppressedBy")
+    public String getSuppressedBy(){
+        return m_suppressedBy;
+    }
+
+    /**
+     * <p>setSuppressedBy</p>
+     *
+     * @param suppressorMan a {@link java.lang.String} object.
+     */
+    public void setSuppressedBy(String suppressorMan){
+        m_suppressedBy = suppressorMan;
+    }
+
+
+    /**
+     * This method is necessary for CXF to be able to introspect
+     * the type of {@link OnmsNode} parameters.
+     *
+     * @return a {@link OnmsNode} object.
+     */
+    @Transient
+    @JsonIgnore
+    public OnmsNode getNode() {
+        return getMonitoredService().getIpInterface().getNode();
+    }
+
+    /**
+     * This method is necessary for CXF to be able to introspect
+     * the type of {@link OnmsNode} parameters.
+     */
+    public void setNode(OnmsNode node) {
+        OnmsMonitoredService service = getMonitoredService();
+        if (service == null) {
+            service = new OnmsMonitoredService();
+            setMonitoredService(service);
+        }
+        OnmsIpInterface intf = service.getIpInterface();
+        if (intf == null) {
+            intf = new OnmsIpInterface();
+            service.setIpInterface(intf);
+        }
+        intf.setNode(node);
+    }
+
+    /**
+     * <p>getNodeId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    public Integer getNodeId(){
+        return getMonitoredService().getNodeId();
+    }
+
+    /**
+     * <p>getNodeLabel</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public String getNodeLabel(){
+        return getMonitoredService().getIpInterface().getNode().getLabel();
+    }
+
+    /**
+     * <p>getForeignSource</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public String getForeignSource(){
+        return getMonitoredService().getIpInterface().getNode().getForeignSource();
+    }
+
+    /**
+     * <p>getForeignId</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public String getForeignId(){
+        return getMonitoredService().getIpInterface().getNode().getForeignId();
+    }
+
+    /**
+     * <p>getLocationName</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public String getLocationName(){
+        return getMonitoredService().getIpInterface().getNode().getLocation().getLocationName();
+    }
+
+    /**
+     * <p>getIpAddress</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Transient
+    public InetAddress getIpAddress() {
+        return getMonitoredService().getIpAddress();
+    }
+
+    /**
+     * <p>getIpAddressAsString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     * @deprecated use getIpAddress
+     */
+    @Transient
+    @JsonIgnore
+    public String getIpAddressAsString() {
+        return getMonitoredService().getIpAddressAsString();
+    }
+
+    /**
+     * <p>getServiceId</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    @Transient
+    public Integer getServiceId() {
+        return getMonitoredService().getServiceId();
+    }
+
+    /**
+     * This method is necessary for CXF to be able to introspect
+     * the type of {@link OnmsNode} parameters.
+     *
+     * @return a {@link OnmsServiceType} object.
+     */
+    @Transient
+    @JsonIgnore
+    public OnmsServiceType getServiceType() {
+        return getMonitoredService().getServiceType();
+    }
+
+    /**
+     * This method is necessary for CXF to be able to introspect
+     * the type of {@link OnmsServiceType} parameters.
+     */
+    public void setServiceType(OnmsServiceType type) {
+        OnmsMonitoredService service = getMonitoredService();
+        if (service == null) {
+            service = new OnmsMonitoredService();
+            setMonitoredService(service);
+        }
+        service.setServiceType(type);
+    }
+
+    /**
+     * Monitoring perspective that this outage is associated with.
+     */
+    @ManyToOne(optional=false, fetch=FetchType.LAZY)
+    @JoinColumn(name="perspective")
+    public OnmsMonitoringLocation getPerspective() {
+        return m_perspective;
+    }
+
+    /**
+     * Set the monitoring perspective for this outage.
+     */
+    public void setPerspective(OnmsMonitoringLocation perspective) {
+        m_perspective = perspective;
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("outageId", m_id)
+            .add("ifLostService", m_ifLostService)
+            .add("ifRegainedService", m_ifRegainedService)
+            .add("svcLostEventTsid", m_svcLostEventTsid)
+            .add("svcLostEventUei", m_svcLostEventUei)
+            .add("svcRegainedEventTsid", m_svcRegainedEventTsid)
+            .add("svcRegainedEventUei", m_svcRegainedEventUei)
+            .add("service", m_monitoredService)
+            .add("suppressedBy", m_suppressedBy)
+            .add("suppressTime", m_suppressTime)
+            .add("perspective", m_perspective)
+            .toString();
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -82,10 +83,10 @@ public class MonitoredServiceDaoJpa extends AbstractDaoJpa<OnmsMonitoredService,
      * Supports {@link InRestriction} (used by Poller.scheduleServices()).
      */
     @Override
-    @SuppressWarnings("unchecked")
     public List<OnmsMonitoredService> findMatching(Criteria criteria) {
         StringBuilder jpql = new StringBuilder("SELECT svc FROM OnmsMonitoredService svc");
-        List<Object> parameters = new ArrayList<>();
+        Map<String, Object> parameters = new java.util.LinkedHashMap<>();
+        int paramIndex = 0;
 
         Collection<Restriction> restrictions = criteria.getRestrictions();
         if (!restrictions.isEmpty()) {
@@ -95,8 +96,9 @@ public class MonitoredServiceDaoJpa extends AbstractDaoJpa<OnmsMonitoredService,
                 if (restriction instanceof InRestriction) {
                     InRestriction in = (InRestriction) restriction;
                     String attr = in.getAttribute().contains(".") ? in.getAttribute() : "svc." + in.getAttribute();
-                    parameters.add(in.getValues());
-                    fragments.add(attr + " IN ?" + parameters.size());
+                    String paramName = "p" + (paramIndex++);
+                    parameters.put(paramName, in.getValues());
+                    fragments.add(attr + " IN (:" + paramName + ")");
                 } else {
                     throw new UnsupportedOperationException(
                             "Unsupported restriction type in MonitoredServiceDaoJpa.findMatching: "
@@ -108,8 +110,8 @@ public class MonitoredServiceDaoJpa extends AbstractDaoJpa<OnmsMonitoredService,
 
         TypedQuery<OnmsMonitoredService> query = entityManager().createQuery(
                 jpql.toString(), OnmsMonitoredService.class);
-        for (int i = 0; i < parameters.size(); i++) {
-            query.setParameter(i + 1, parameters.get(i));
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            query.setParameter(entry.getKey(), entry.getValue());
         }
         return query.getResultList();
     }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
@@ -22,11 +22,18 @@
 package org.opennms.netmgt.model.jakarta.dao;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.persistence.TypedQuery;
+
+import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.restrictions.InRestriction;
+import org.opennms.core.criteria.restrictions.Restriction;
 import org.opennms.core.daemon.common.AbstractDaoJpa;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.model.OnmsApplication;
@@ -68,6 +75,43 @@ public class MonitoredServiceDaoJpa extends AbstractDaoJpa<OnmsMonitoredService,
     public int countMatching(OnmsCriteria onmsCrit) {
         throw new UnsupportedOperationException(
                 "countMatching(OnmsCriteria) is not supported in MonitoredServiceDaoJpa — use HQL queries");
+    }
+
+    /**
+     * Translates an OpenNMS {@link Criteria} to JPQL.
+     * Supports {@link InRestriction} (used by Poller.scheduleServices()).
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<OnmsMonitoredService> findMatching(Criteria criteria) {
+        StringBuilder jpql = new StringBuilder("SELECT svc FROM OnmsMonitoredService svc");
+        List<Object> parameters = new ArrayList<>();
+
+        Collection<Restriction> restrictions = criteria.getRestrictions();
+        if (!restrictions.isEmpty()) {
+            jpql.append(" WHERE ");
+            List<String> fragments = new ArrayList<>();
+            for (Restriction restriction : restrictions) {
+                if (restriction instanceof InRestriction) {
+                    InRestriction in = (InRestriction) restriction;
+                    String attr = in.getAttribute().contains(".") ? in.getAttribute() : "svc." + in.getAttribute();
+                    parameters.add(in.getValues());
+                    fragments.add(attr + " IN ?" + parameters.size());
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Unsupported restriction type in MonitoredServiceDaoJpa.findMatching: "
+                                    + restriction.getClass().getSimpleName());
+                }
+            }
+            jpql.append(String.join(" AND ", fragments));
+        }
+
+        TypedQuery<OnmsMonitoredService> query = entityManager().createQuery(
+                jpql.toString(), OnmsMonitoredService.class);
+        for (int i = 0; i < parameters.size(); i++) {
+            query.setParameter(i + 1, parameters.get(i));
+        }
+        return query.getResultList();
     }
 
     // ---- MonitoredServiceDao methods ----

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java
@@ -65,11 +65,29 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link UnsupportedOperationException}.</p>
  */
 @Repository
-@Transactional
+@Transactional(readOnly = false)
 public class OutageDaoJpa extends AbstractDaoJpa<OnmsOutage, Integer> implements OutageDao {
 
     public OutageDaoJpa() {
         super(OnmsOutage.class);
+    }
+
+    @Override
+    @Transactional
+    public void saveOrUpdate(OnmsOutage entity) {
+        super.saveOrUpdate(entity);
+    }
+
+    @Override
+    @Transactional
+    public void update(OnmsOutage entity) {
+        super.update(entity);
+    }
+
+    @Override
+    @Transactional
+    public Integer save(OnmsOutage entity) {
+        return super.save(entity);
     }
 
     @Override

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.jakarta.dao;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.persistence.TypedQuery;
+
+import org.opennms.core.criteria.Alias;
+import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.restrictions.AnyRestriction;
+import org.opennms.core.criteria.restrictions.AttributeRestriction;
+import org.opennms.core.criteria.restrictions.AttributeValueRestriction;
+import org.opennms.core.criteria.restrictions.EqRestriction;
+import org.opennms.core.criteria.restrictions.NeRestriction;
+import org.opennms.core.criteria.restrictions.NullRestriction;
+import org.opennms.core.criteria.restrictions.Restriction;
+import org.opennms.core.daemon.common.AbstractDaoJpa;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.model.HeatMapElement;
+import org.opennms.netmgt.model.OnmsCriteria;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.model.ServiceSelector;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.opennms.netmgt.model.outage.CurrentOutageDetails;
+import org.opennms.netmgt.model.outage.OutageSummary;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA implementation of {@link OutageDao}.
+ *
+ * <p>Implements only the methods required by Pollerd's core processing path
+ * (via QueryManagerDaoImpl): {@link #currentOutageForService},
+ * {@link #findMatching(Criteria)}, and the standard CRUD operations inherited
+ * from {@link AbstractDaoJpa}.</p>
+ *
+ * <p>REST-oriented and legacy methods not used by Pollerd throw
+ * {@link UnsupportedOperationException}.</p>
+ */
+@Repository
+@Transactional
+public class OutageDaoJpa extends AbstractDaoJpa<OnmsOutage, Integer> implements OutageDao {
+
+    public OutageDaoJpa() {
+        super(OnmsOutage.class);
+    }
+
+    @Override
+    public OnmsOutage currentOutageForService(OnmsMonitoredService service) {
+        return findUnique(
+                "SELECT o FROM OnmsOutage o "
+                + "WHERE o.monitoredService = ?1 "
+                + "AND o.ifRegainedService IS NULL "
+                + "AND o.perspective IS NULL",
+                service);
+    }
+
+    /**
+     * Translates an OpenNMS {@link Criteria} object into a JPQL query.
+     *
+     * <p>Supports the restriction types used by QueryManagerDaoImpl:
+     * {@link EqRestriction}, {@link NullRestriction}, {@link NeRestriction},
+     * and {@link AnyRestriction} (OR clause). Aliases are translated to
+     * JPQL JOINs.</p>
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<OnmsOutage> findMatching(Criteria criteria) {
+        StringBuilder jpql = new StringBuilder("SELECT o FROM OnmsOutage o");
+        List<Object> parameters = new ArrayList<>();
+        Map<String, String> aliasMap = new HashMap<>();
+
+        // Process aliases as JOINs
+        for (Alias alias : criteria.getAliases()) {
+            String joinType = mapJoinType(alias.getType());
+            jpql.append(" ").append(joinType).append(" o.").append(alias.getAssociationPath())
+                .append(" ").append(alias.getAlias());
+            aliasMap.put(alias.getAlias(), alias.getAssociationPath());
+        }
+
+        // Process restrictions as WHERE clauses
+        Collection<Restriction> restrictions = criteria.getRestrictions();
+        if (!restrictions.isEmpty()) {
+            jpql.append(" WHERE ");
+            List<String> whereFragments = new ArrayList<>();
+            for (Restriction restriction : restrictions) {
+                String fragment = buildRestrictionFragment(restriction, parameters);
+                if (fragment != null) {
+                    whereFragments.add(fragment);
+                }
+            }
+            jpql.append(String.join(" AND ", whereFragments));
+        }
+
+        TypedQuery<OnmsOutage> query = entityManager().createQuery(jpql.toString(), OnmsOutage.class);
+        for (int i = 0; i < parameters.size(); i++) {
+            query.setParameter(i + 1, parameters.get(i));
+        }
+
+        if (criteria.getLimit() != null) {
+            query.setMaxResults(criteria.getLimit());
+        }
+        if (criteria.getOffset() != null) {
+            query.setFirstResult(criteria.getOffset());
+        }
+
+        return query.getResultList();
+    }
+
+    private String buildRestrictionFragment(Restriction restriction, List<Object> parameters) {
+        if (restriction instanceof NullRestriction) {
+            NullRestriction nr = (NullRestriction) restriction;
+            return resolveAttribute(nr.getAttribute()) + " IS NULL";
+        } else if (restriction instanceof EqRestriction) {
+            EqRestriction er = (EqRestriction) restriction;
+            parameters.add(er.getValue());
+            return resolveAttribute(er.getAttribute()) + " = ?" + parameters.size();
+        } else if (restriction instanceof NeRestriction) {
+            NeRestriction nr = (NeRestriction) restriction;
+            parameters.add(nr.getValue());
+            return resolveAttribute(nr.getAttribute()) + " <> ?" + parameters.size();
+        } else if (restriction instanceof AnyRestriction) {
+            AnyRestriction any = (AnyRestriction) restriction;
+            List<String> orFragments = new ArrayList<>();
+            for (Restriction inner : any.getRestrictions()) {
+                String fragment = buildRestrictionFragment(inner, parameters);
+                if (fragment != null) {
+                    orFragments.add(fragment);
+                }
+            }
+            if (orFragments.isEmpty()) {
+                return null;
+            }
+            return "(" + String.join(" OR ", orFragments) + ")";
+        }
+        throw new UnsupportedOperationException(
+                "Unsupported restriction type in OutageDaoJpa.findMatching: " + restriction.getClass().getSimpleName());
+    }
+
+    /**
+     * Resolves a Criteria attribute path to a JPQL path.
+     * Attributes without a dot prefix are assumed to be on the root entity "o".
+     */
+    private String resolveAttribute(String attribute) {
+        if (attribute.contains(".")) {
+            // Already qualified (e.g., "monitoredService.status" or alias-prefixed)
+            return attribute;
+        }
+        return "o." + attribute;
+    }
+
+    private String mapJoinType(Alias.JoinType joinType) {
+        switch (joinType) {
+            case LEFT_JOIN: return "LEFT JOIN";
+            case INNER_JOIN: return "JOIN";
+            case FULL_JOIN: return "FULL JOIN";
+            default: return "JOIN";
+        }
+    }
+
+    // ---- LegacyOnmsDao methods -- not used by Pollerd ----
+
+    @Override
+    public List<OnmsOutage> findMatching(OnmsCriteria criteria) {
+        throw new UnsupportedOperationException(
+                "findMatching(OnmsCriteria) is not supported in OutageDaoJpa -- use Criteria or HQL queries");
+    }
+
+    @Override
+    public int countMatching(OnmsCriteria onmsCrit) {
+        throw new UnsupportedOperationException(
+                "countMatching(OnmsCriteria) is not supported in OutageDaoJpa -- use Criteria or HQL queries");
+    }
+
+    // ---- OutageDao methods not used by Pollerd ----
+
+    @Override
+    public Integer currentOutageCount() {
+        throw new UnsupportedOperationException(
+                "currentOutageCount() is not used by Pollerd");
+    }
+
+    @Override
+    public Collection<OnmsOutage> currentOutages() {
+        throw new UnsupportedOperationException(
+                "currentOutages() is not used by Pollerd");
+    }
+
+    @Override
+    public Map<Integer, Set<OnmsOutage>> currentOutagesByServiceId() {
+        throw new UnsupportedOperationException(
+                "currentOutagesByServiceId() is not used by Pollerd");
+    }
+
+    @Override
+    public OnmsOutage currentOutageForServiceFromPerspective(OnmsMonitoredService service, OnmsMonitoringLocation perspective) {
+        throw new UnsupportedOperationException(
+                "currentOutageForServiceFromPerspective() is not used by Pollerd");
+    }
+
+    @Override
+    public Collection<OnmsOutage> currentOutagesForServiceFromPerspectivePoller(OnmsMonitoredService service) {
+        throw new UnsupportedOperationException(
+                "currentOutagesForServiceFromPerspectivePoller() is not used by Pollerd");
+    }
+
+    @Override
+    public Collection<CurrentOutageDetails> newestCurrentOutages(List<String> services) {
+        throw new UnsupportedOperationException(
+                "newestCurrentOutages() is not used by Pollerd");
+    }
+
+    @Override
+    public Collection<OnmsOutage> matchingCurrentOutages(ServiceSelector selector) {
+        throw new UnsupportedOperationException(
+                "matchingCurrentOutages() is not used by Pollerd");
+    }
+
+    @Override
+    public Collection<OnmsOutage> findAll(Integer offset, Integer limit) {
+        throw new UnsupportedOperationException(
+                "findAll(offset, limit) is not used by Pollerd");
+    }
+
+    @Override
+    public int countOutagesByNode() {
+        throw new UnsupportedOperationException(
+                "countOutagesByNode() is not used by Pollerd");
+    }
+
+    @Override
+    public List<OutageSummary> getNodeOutageSummaries(int rows) {
+        throw new UnsupportedOperationException(
+                "getNodeOutageSummaries() is not used by Pollerd");
+    }
+
+    @Override
+    public List<HeatMapElement> getHeatMapItemsForEntity(String entityNameColumn, String entityIdColumn,
+            String restrictionColumn, String restrictionValue, String... groupByColumns) {
+        throw new UnsupportedOperationException(
+                "getHeatMapItemsForEntity() is not used by Pollerd");
+    }
+
+    @Override
+    public Collection<OnmsOutage> getStatusChangesForApplicationIdBetween(Date startDate, Date endDate, Integer applicationId) {
+        throw new UnsupportedOperationException(
+                "getStatusChangesForApplicationIdBetween() is not used by Pollerd");
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/OutageDaoJpa.java
@@ -214,9 +214,19 @@ public class OutageDaoJpa extends AbstractDaoJpa<OnmsOutage, Integer> implements
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<Integer, Set<OnmsOutage>> currentOutagesByServiceId() {
-        throw new UnsupportedOperationException(
-                "currentOutagesByServiceId() is not used by Pollerd");
+        List<OnmsOutage> outages = entityManager().createQuery(
+                "SELECT o FROM OnmsOutage o WHERE o.ifRegainedService IS NULL AND o.perspective IS NULL")
+                .getResultList();
+        Map<Integer, Set<OnmsOutage>> result = new java.util.HashMap<>();
+        for (OnmsOutage outage : outages) {
+            if (outage.getMonitoredService() != null) {
+                result.computeIfAbsent(outage.getMonitoredService().getId(),
+                        k -> new java.util.HashSet<>()).add(outage);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,7 @@
     <module>daemon-boot-discovery</module>
     <module>daemon-boot-provisiond</module>
     <module>daemon-boot-bsmd</module>
+    <module>daemon-boot-pollerd</module>
     <module>opennms-model-jakarta</module>
     <module>db</module>
     <module>db-install</module>

--- a/features/perspectivepoller/src/test/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerdIT.java
+++ b/features/perspectivepoller/src/test/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerdIT.java
@@ -76,7 +76,9 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.ServiceMonitor;
+import org.opennms.netmgt.poller.ServiceMonitorRegistry;
 import org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl;
+import org.opennms.netmgt.poller.client.rpc.PollerClientRpcModule;
 import org.opennms.netmgt.threshd.ThresholdingServiceImpl;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.quartz.JobDetail;
@@ -144,6 +146,9 @@ public class PerspectivePollerdIT implements InitializingBean, TemporaryDatabase
     @Autowired
     private DistPollerDao distPollerDao;
 
+    @Autowired
+    private ServiceMonitorRegistry serviceMonitorRegistry;
+
     private PerspectivePollerd perspectivePollerd;
 
     private OnmsMonitoredService node1icmp;
@@ -210,9 +215,9 @@ public class PerspectivePollerdIT implements InitializingBean, TemporaryDatabase
             return null;
         });
 
-        final LocationAwarePollerClientImpl locationAwarePollerClient = new LocationAwarePollerClientImpl(new MockRpcClientFactory());
-        locationAwarePollerClient.setEntityScopeProvider(new MockEntityScopeProvider());
-        locationAwarePollerClient.setRpcTargetHelper(new RpcTargetHelper());
+        final LocationAwarePollerClientImpl locationAwarePollerClient = new LocationAwarePollerClientImpl(
+                this.serviceMonitorRegistry, new PollerClientRpcModule(),
+                new MockRpcClientFactory(), new RpcTargetHelper(), new MockEntityScopeProvider());
         locationAwarePollerClient.afterPropertiesSet();
 
         System.setProperty(PerspectiveServiceTracker.REFRESH_RATE_LIMIT_PROPERTY, "5");

--- a/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/LocationAwarePollerClientImpl.java
+++ b/features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/LocationAwarePollerClientImpl.java
@@ -31,32 +31,27 @@ import org.opennms.netmgt.poller.LocationAwarePollerClient;
 import org.opennms.netmgt.poller.PollerRequestBuilder;
 import org.opennms.netmgt.poller.ServiceMonitorRegistry;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class LocationAwarePollerClientImpl implements LocationAwarePollerClient, InitializingBean {
 
-    @Autowired
-    private ServiceMonitorRegistry registry;
-
-    @Autowired
-    private PollerClientRpcModule pollerClientRpcModule;
-
-    @Autowired
-    private RpcClientFactory rpcClientFactory;
-
-    @Autowired
-    private RpcTargetHelper rpcTargetHelper;
-
-    @Autowired
-    private EntityScopeProvider entityScopeProvider;
+    private final ServiceMonitorRegistry registry;
+    private final PollerClientRpcModule pollerClientRpcModule;
+    private final RpcClientFactory rpcClientFactory;
+    private final RpcTargetHelper rpcTargetHelper;
+    private final EntityScopeProvider entityScopeProvider;
 
     private RpcClient<PollerRequestDTO, PollerResponseDTO> delegate;
 
-    public LocationAwarePollerClientImpl() { }
-
-    public LocationAwarePollerClientImpl(RpcClientFactory rpcClientFactory) {
+    public LocationAwarePollerClientImpl(ServiceMonitorRegistry registry,
+                                         PollerClientRpcModule pollerClientRpcModule,
+                                         RpcClientFactory rpcClientFactory,
+                                         RpcTargetHelper rpcTargetHelper,
+                                         EntityScopeProvider entityScopeProvider) {
+        this.registry = Objects.requireNonNull(registry);
+        this.pollerClientRpcModule = Objects.requireNonNull(pollerClientRpcModule);
         this.rpcClientFactory = Objects.requireNonNull(rpcClientFactory);
-        afterPropertiesSet();
+        this.rpcTargetHelper = Objects.requireNonNull(rpcTargetHelper);
+        this.entityScopeProvider = Objects.requireNonNull(entityScopeProvider);
     }
 
     @Override
@@ -77,23 +72,11 @@ public class LocationAwarePollerClientImpl implements LocationAwarePollerClient,
         return registry;
     }
 
-    public void setRegistry(ServiceMonitorRegistry registry) {
-        this.registry = registry;
-    }
-
     public RpcTargetHelper getRpcTargetHelper() {
         return rpcTargetHelper;
     }
 
-    public void setRpcTargetHelper(RpcTargetHelper rpcTargetHelper) {
-        this.rpcTargetHelper = rpcTargetHelper;
-    }
-
     public EntityScopeProvider getEntityScopeProvider() {
         return this.entityScopeProvider;
-    }
-
-    public void setEntityScopeProvider(final EntityScopeProvider entityScopeProvider) {
-        this.entityScopeProvider = entityScopeProvider;
     }
 }

--- a/features/poller/client-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-poller.xml
+++ b/features/poller/client-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-poller.xml
@@ -9,11 +9,13 @@
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
-	<context:annotation-config />
-
     <bean id="pollerClientRpcModule" class="org.opennms.netmgt.poller.client.rpc.PollerClientRpcModule" />
 
-    <bean id="locationAwarePollerClient" class="org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl" />
+    <!-- autowire="constructor" resolves constructor args by type, avoiding
+         hard-coded bean name refs that differ between prod and test contexts -->
+    <bean id="locationAwarePollerClient"
+          class="org.opennms.netmgt.poller.client.rpc.LocationAwarePollerClientImpl"
+          autowire="constructor"/>
     <onmsgi:service interface="org.opennms.netmgt.poller.LocationAwarePollerClient" ref="locationAwarePollerClient"/>
 
     <!-- This executor pool is implicitly limited by the size of the pollerd's scheduler pool.

--- a/opennms-container/delta-v/Dockerfile.daemon
+++ b/opennms-container/delta-v/Dockerfile.daemon
@@ -45,6 +45,7 @@ COPY staging/daemon/daemon-boot-alarmd.jar /opt/daemon-boot-alarmd.jar
 COPY staging/daemon/daemon-boot-trapd.jar /opt/daemon-boot-trapd.jar
 COPY staging/daemon/daemon-boot-eventtranslator.jar /opt/daemon-boot-eventtranslator.jar
 COPY staging/daemon/daemon-boot-bsmd.jar /opt/daemon-boot-bsmd.jar
+COPY staging/daemon/daemon-boot-pollerd.jar /opt/daemon-boot-pollerd.jar
 
 # Config directory for Spring Boot daemons (distinct from Sentinel's /opt/sentinel/etc)
 USER root

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -138,6 +138,7 @@ do_stage_daemon_jars() {
         "features/events/daemon/target/org.opennms.features.events.daemon-$VERSION.jar:events.daemon.jar"
         # Daemon-loader JARs
         "core/daemon-loader-pollerd/target/org.opennms.core.daemon-loader-pollerd-$VERSION.jar:daemon-loader-pollerd.jar"
+        "core/daemon-boot-pollerd/target/org.opennms.core.daemon-boot-pollerd-$VERSION-boot.jar:daemon-boot-pollerd.jar"
         "core/daemon-boot-trapd/target/org.opennms.core.daemon-boot-trapd-$VERSION.jar:daemon-boot-trapd.jar"
         "core/daemon-boot-syslogd/target/org.opennms.core.daemon-boot-syslogd-$VERSION.jar:daemon-boot-syslogd.jar"
         "core/daemon-boot-discovery/target/org.opennms.core.daemon-boot-discovery-$VERSION.jar:daemon-boot-discovery.jar"

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -124,36 +124,35 @@ services:
     image: opennms/daemon-deltav:${VERSION}
     container_name: delta-v-pollerd
     hostname: pollerd
+    entrypoint: []
+    command: ["java", "-Xms512m", "-Xmx1g",
+              "-Dorg.opennms.core.ipc.twin.kafka.bootstrap.servers=kafka:9092",
+              "-Dorg.opennms.core.ipc.rpc.force-remote=true",
+              "-jar", "/opt/daemon-boot-pollerd.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
       kafka:
         condition: service_healthy
     environment:
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: "5432"
-      POSTGRES_USER: opennms
-      POSTGRES_PASSWORD: opennms
-      POSTGRES_DB: opennms
-      JAVA_OPTS: >-
-        -Xms512m -Xmx1g
-        -XX:MaxMetaspaceSize=512m
-        -Djava.security.egd=file:/dev/./urandom
-        -Dorg.opennms.tsid.node-id=4
-        -Dorg.opennms.core.ipc.rpc.kafka.bootstrap.servers=kafka:9092
-        -Dorg.opennms.core.ipc.rpc.force-remote=true
-        -Dorg.opennms.core.ipc.twin.kafka.bootstrap.servers=kafka:9092
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
+      SPRING_DATASOURCE_USERNAME: opennms
+      SPRING_DATASOURCE_PASSWORD: opennms
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_CONSUMER_GROUP: opennms-pollerd
+      OPENNMS_HOME: /opt/deltav
+      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_TSID_NODE_ID: "4"
+      OPENNMS_RPC_KAFKA_ENABLED: "true"
+      OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
     volumes:
-      - pollerd-data:/opt/sentinel/data
-      - ./pollerd-daemon-overlay/etc:/opt/sentinel-etc-overlay:ro
-    ports:
-      - "8103:8181"
+      - ./pollerd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe || exit 1"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 15s
       timeout: 10s
       retries: 20
-      start_period: 60s
+      start_period: 30s
 
   collectd:
     profiles: [lite, full]
@@ -542,7 +541,6 @@ volumes:
   pgdata:
   kafkadata:
   minion-data:
-  pollerd-data:
   collectd-data:
   enlinkd-data:
   scriptd-data:

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -419,7 +419,9 @@ services:
     container_name: delta-v-bsmd
     hostname: bsmd
     entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m", "-jar", "/opt/daemon-boot-bsmd.jar"]
+    command: ["java", "-Xms256m", "-Xmx512m",
+              "-Dorg.opennms.alarms.snapshot.sync.ms=10000",
+              "-jar", "/opt/daemon-boot-bsmd.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully

--- a/opennms-container/delta-v/etc/imports/cloud-services.xml
+++ b/opennms-container/delta-v/etc/imports/cloud-services.xml
@@ -1,0 +1,9 @@
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-21T15:20:00.000Z" foreign-source="cloud-services" last-import="2026-03-21T15:42:30.035Z">
+   <node foreign-id="the-internet" node-label="The Internet">
+      <interface ip-addr="172.18.0.1" managed="true" status="1" snmp-primary="N">
+         <monitored-service service-name="GoogleCloud"/>
+         <monitored-service service-name="Azure"/>
+         <monitored-service service-name="AWS"/>
+      </interface>
+   </node>
+</model-import>

--- a/opennms-container/delta-v/etc/imports/cloud-services.xml
+++ b/opennms-container/delta-v/etc/imports/cloud-services.xml
@@ -1,4 +1,4 @@
-<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-21T15:20:00.000Z" foreign-source="cloud-services" last-import="2026-03-21T15:42:30.035Z">
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-21T15:20:00.000Z" foreign-source="cloud-services" last-import="2026-03-21T16:27:30.025Z">
    <node foreign-id="the-internet" node-label="The Internet">
       <interface ip-addr="172.18.0.1" managed="true" status="1" snmp-primary="N">
          <monitored-service service-name="GoogleCloud"/>

--- a/opennms-container/delta-v/etc/imports/delta-v.xml
+++ b/opennms-container/delta-v/etc/imports/delta-v.xml
@@ -1,4 +1,4 @@
-<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-19T07:43:00.030Z">
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-21T05:48:00.051Z">
    <node foreign-id="postgresql" node-label="postgres">
       <interface ip-addr="169.254.0.1" managed="true" snmp-primary="P">
          <monitored-service service-name="PostgreSQL"/>

--- a/opennms-container/delta-v/etc/imports/delta-v.xml
+++ b/opennms-container/delta-v/etc/imports/delta-v.xml
@@ -1,4 +1,4 @@
-<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-21T15:16:00.040Z">
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-21T16:27:30.033Z">
    <node foreign-id="postgresql" node-label="postgres">
       <interface ip-addr="169.254.0.1" managed="true" snmp-primary="P">
          <monitored-service service-name="PostgreSQL"/>

--- a/opennms-container/delta-v/etc/imports/delta-v.xml
+++ b/opennms-container/delta-v/etc/imports/delta-v.xml
@@ -1,4 +1,4 @@
-<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-21T05:48:00.051Z">
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-21T14:07:00.032Z">
    <node foreign-id="postgresql" node-label="postgres">
       <interface ip-addr="169.254.0.1" managed="true" snmp-primary="P">
          <monitored-service service-name="PostgreSQL"/>

--- a/opennms-container/delta-v/etc/imports/delta-v.xml
+++ b/opennms-container/delta-v/etc/imports/delta-v.xml
@@ -1,4 +1,4 @@
-<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-21T14:07:00.032Z">
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2026-03-18T00:00:00.000Z" foreign-source="delta-v" last-import="2026-03-21T15:16:00.040Z">
    <node foreign-id="postgresql" node-label="postgres">
       <interface ip-addr="169.254.0.1" managed="true" snmp-primary="P">
          <monitored-service service-name="PostgreSQL"/>

--- a/opennms-container/delta-v/eventtranslator-overlay/etc/translator-configuration.xml
+++ b/opennms-container/delta-v/eventtranslator-overlay/etc/translator-configuration.xml
@@ -119,6 +119,61 @@
       </mappings>
     </event-translation-spec>
 
+    <!-- Cloud service status → passive service status.
+         Translates cloud/serviceDown and cloud/serviceUp syslog-derived events
+         into passiveServiceStatus events consumed by Pollerd's PassiveStatusKeeper.
+         Uses the syslogmessage parameter ("Service AWS is Down") to extract the
+         service name, and SQL to look up the node label from the node ID. -->
+    <event-translation-spec uei="uei.opennms.org/syslogd/cloud/serviceDown">
+      <mappings>
+        <mapping>
+          <assignment name="uei" type="field">
+            <value type="constant" result="uei.opennms.org/services/passiveServiceStatus" />
+          </assignment>
+          <assignment name="passiveNodeLabel" type="parameter">
+            <value type="sql" result="SELECT nodelabel FROM node WHERE nodeid = ?::integer">
+              <value type="field" name="nodeid" matches=".*" result="${0}" />
+            </value>
+          </assignment>
+          <assignment name="passiveIpAddr" type="parameter">
+            <value type="field" name="interface" matches=".*" result="${0}" />
+          </assignment>
+          <assignment name="passiveServiceName" type="parameter">
+            <value type="parameter" name="syslogmessage" matches="^.*Service (\S+) is .*$" result="${1}" />
+          </assignment>
+          <assignment name="passiveStatus" type="parameter">
+            <value type="constant" result="Down" />
+          </assignment>
+          <assignment name="passiveReasonCode" type="parameter">
+            <value type="constant" result="cloud service reported down via syslog" />
+          </assignment>
+        </mapping>
+      </mappings>
+    </event-translation-spec>
+    <event-translation-spec uei="uei.opennms.org/syslogd/cloud/serviceUp">
+      <mappings>
+        <mapping>
+          <assignment name="uei" type="field">
+            <value type="constant" result="uei.opennms.org/services/passiveServiceStatus" />
+          </assignment>
+          <assignment name="passiveNodeLabel" type="parameter">
+            <value type="sql" result="SELECT nodelabel FROM node WHERE nodeid = ?::integer">
+              <value type="field" name="nodeid" matches=".*" result="${0}" />
+            </value>
+          </assignment>
+          <assignment name="passiveIpAddr" type="parameter">
+            <value type="field" name="interface" matches=".*" result="${0}" />
+          </assignment>
+          <assignment name="passiveServiceName" type="parameter">
+            <value type="parameter" name="syslogmessage" matches="^.*Service (\S+) is .*$" result="${1}" />
+          </assignment>
+          <assignment name="passiveStatus" type="parameter">
+            <value type="constant" result="Up" />
+          </assignment>
+        </mapping>
+      </mappings>
+    </event-translation-spec>
+
   </translation>
 
 </event-translator-configuration>

--- a/opennms-container/delta-v/pollerd-daemon-overlay/etc/poller-configuration.xml
+++ b/opennms-container/delta-v/pollerd-daemon-overlay/etc/poller-configuration.xml
@@ -274,7 +274,7 @@
         <parameter key="strict-timeout" value="true"/>
         <parameter key="page-sequence">
           <page-sequence>
-            <page host="${nodeLabel}" path="/actuator/health" port="8080"
+            <page host="${nodelabel}" path="/actuator/health" port="8080"
                   response-range="200-299"/>
           </page-sequence>
         </parameter>
@@ -286,7 +286,7 @@
         <parameter key="strict-timeout" value="true"/>
         <parameter key="page-sequence">
           <page-sequence>
-            <page host="${nodeLabel}" path="/minion/rest/health/probe" port="8181"
+            <page host="${nodelabel}" path="/minion/rest/health/probe" port="8181"
                   response-range="200-299"/>
           </page-sequence>
         </parameter>
@@ -297,14 +297,14 @@
         <parameter key="timeout" value="3000"/>
         <parameter key="retry" value="0"/>
         <parameter key="port" value="5432"/>
-        <parameter key="hostname" value="${nodeLabel}"/>
+        <parameter key="hostname" value="${nodelabel}"/>
       </service>
       <service name="Kafka" interval="30000" user-defined="false" status="on">
         <parameter key="rrd-status" value="false"/>
         <parameter key="timeout" value="3000"/>
         <parameter key="retry" value="0"/>
         <parameter key="port" value="9092"/>
-        <parameter key="hostname" value="${nodeLabel}"/>
+        <parameter key="hostname" value="${nodelabel}"/>
       </service>
       <!-- Passive cloud service monitors — status driven by syslog → Event Translator → passiveServiceStatus -->
       <service name="GoogleCloud" interval="30000" user-defined="true" status="on"/>

--- a/opennms-container/delta-v/pollerd-overlay/etc/database-schema.xml
+++ b/opennms-container/delta-v/pollerd-overlay/etc/database-schema.xml
@@ -1,0 +1,133 @@
+<database-schema xmlns="http://xmlns.opennms.org/xsd/config/filter">
+   <table name="node">
+      <join column="nodeID" table="ipInterface" table-column="nodeID"/>
+      <column name="nodeID"/>
+      <column name="location"/>
+      <column name="nodeCreateTime"/>
+      <column name="nodeParentID"/>
+      <column name="nodeType"/>
+      <column name="nodeSysOID"/>
+      <column name="nodeSysName"/>
+      <column name="nodeSysDescription"/>
+      <column name="nodeSysLocation"/>
+      <column name="nodeSysContact"/>
+      <column name="nodeLabel"/>
+      <column name="nodeLabelSource"/>
+      <column name="nodeNetbiosName"/>
+      <column name="nodeDomainName"/>
+      <column name="operatingSystem"/>
+      <column name="foreignSource"/>
+      <column name="foreignID"/>
+      <column name="hasFlows"/>
+   </table>
+   <table name="categories">
+      <join type="left" column="categoryID" table="category_node" table-column="categoryID"/>
+      <column name="categoryID"/>
+      <column name="categoryName"/>
+      <column name="categoryDescription"/>
+   </table>
+   <table name="category_node">
+      <join type="left" column="nodeID" table="ipInterface" table-column="nodeID"/>
+      <column name="categoryID" visible="false"/>
+      <column name="nodeID" visible="false"/>
+   </table>
+   <table name="ipInterface" key="primary">
+      <join column="snmpInterfaceId" table="snmpInterface" table-column="id"/>
+      <column name="id" visible="false"/>
+      <column name="nodeID" visible="false"/>
+      <column name="ipAddr"/>
+      <column name="netMask"/>
+      <column name="ipHostname"/>
+      <column name="IsManaged"/>
+      <column name="IsSnmpPrimary"/>
+      <column name="ipStatus"/>
+      <column name="ipLastCapsdPoll"/>
+   </table>
+   <table name="snmpInterface">
+      <join column="id" table="ipInterface" table-column="snmpinterfaceid"/>
+      <column name="id" visible="false"/>
+      <column name="nodeID" visible="false"/>
+      <column name="snmpPhysAddr"/>
+      <column name="snmpIfIndex"/>
+      <column name="snmpIfDescr"/>
+      <column name="snmpIfType"/>
+      <column name="snmpIfSpeed"/>
+      <column name="snmpIfAlias"/>
+      <column name="snmpIfAdminStatus"/>
+      <column name="snmpIfOperStatus"/>
+      <column name="snmpCollect"/>
+      <column name="snmpPoll"/>
+      <column name="hasFlows"/>
+   </table>
+   <table name="service">
+      <join column="serviceID" table="ifServices" table-column="serviceID"/>
+      <column name="serviceID" visible="false"/>
+      <column name="serviceName"/>
+   </table>
+   <table name="ifServices">
+      <join column="ipInterfaceId" table="ipInterface" table-column="id"/>
+      <join column="id" table="application_service_map" table-column="ifServiceId"/>
+      <column name="id" visible="false"/>
+      <column name="ipAddr" visible="false"/>
+      <column name="nodeID" visible="false"/>
+      <column name="serviceID"/>
+      <column name="lastGood"/>
+      <column name="lastFail"/>
+   </table>
+   <table name="assets">
+      <join column="nodeID" table="ipInterface" table-column="nodeID"/>
+      <column name="nodeID" visible="false"/>
+      <column name="displayCategory"/>
+      <column name="notifyCategory"/>
+      <column name="pollerCategory"/>
+      <column name="thresholdCategory"/>
+      <column name="category"/>
+      <column name="manufacturer"/>
+      <column name="vendor"/>
+      <column name="modelnumber"/>
+      <column name="serialnumber"/>
+      <column name="description"/>
+      <column name="circuitid"/>
+      <column name="assetnumber"/>
+      <column name="operatingsystem"/>
+      <column name="rack"/>
+      <column name="slot"/>
+      <column name="port"/>
+      <column name="region"/>
+      <column name="division"/>
+      <column name="department"/>
+      <column name="address1"/>
+      <column name="address2"/>
+      <column name="city"/>
+      <column name="state"/>
+      <column name="zip"/>
+      <column name="country"/>
+      <column name="longitude"/>
+      <column name="latitude"/>
+      <column name="building"/>
+      <column name="floor"/>
+      <column name="room"/>
+      <column name="vendorphone"/>
+      <column name="vendorfax"/>
+      <column name="vendorassetnumber"/>
+      <column name="lease"/>
+      <column name="leaseexpires"/>
+      <column name="supportphone"/>
+      <column name="maintcontract"/>
+      <column name="maintcontractexpires"/>
+      <column name="comment"/>
+      <column name="managedobjectinstance"/>
+      <column name="managedobjecttype"/>
+   </table>
+   <table name="applications">
+      <join column="id" table="application_service_map" table-column="appId"/>
+      <column name="id" visible="false"/>
+      <column name="name"/>
+   </table>
+   <table name="application_service_map">
+      <join column="ifServiceId" table="ifServices" table-column="id"/>
+      <join column="appId" table="applications" table-column="id"/>
+      <column name="appId" visible="false"/>
+      <column name="ifServiceId" visible="false"/>
+   </table>
+</database-schema>

--- a/opennms-container/delta-v/pollerd-overlay/etc/poll-outages.xml
+++ b/opennms-container/delta-v/pollerd-overlay/etc/poll-outages.xml
@@ -1,0 +1,1 @@
+<outages xmlns="http://xmlns.opennms.org/xsd/config/poller/outages"/>

--- a/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
+++ b/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
@@ -1,0 +1,385 @@
+<poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller" threads="30" asyncPollingEngineEnabled="false" maxConcurrentAsyncPolls="200" nextOutageId="SELECT nextval('outageNxtId')" serviceUnresponsiveEnabled="false" pathOutageEnabled="false">
+   <node-outage status="off" pollAllIfNoCriticalServiceDefined="true">
+      <critical-service name="ICMP" />
+   </node-outage>
+   <package name="cassandra-via-jmx">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="JMX-Cassandra" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="${requisition:port|detector:port|7199}" />
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="protocol" value="${requisition:protocol|detector:protocol|rmi}" />
+         <parameter key="urlPath" value="${requisition:urlPath|detector:urlPath|/jmxrmi}" />
+         <parameter key="rrd-base-name" value="jmx-cassandra" />
+         <parameter key="ds-name" value="jmx-cassandra" />
+         <parameter key="thresholding-enabled" value="true" />
+         <parameter key="factory" value="${requisition:factory|detector:factory|PASSWORD_CLEAR}" />
+         <parameter key="username" value="${requisition:username|detector:username|cassandra-username}" />
+         <parameter key="password" value="${requisition:password|detector:password|cassandra-password}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="beans.storage" value="${requisition:beans.storage|detector:beans.storage|org.apache.cassandra.db:type=StorageService}" />
+         <parameter key="tests.operational" value="${requisition:tests.operational|detector:tests.operational|storage.OperationMode == 'NORMAL'}" />
+         <parameter key="tests.joined" value="${requisition:tests.joined|detector:tests.joined|storage.Joined}" />
+      </service>
+      <service name="JMX-Cassandra-Newts" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="${requisition:port|detector:port|7199}" />
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="protocol" value="${requisition:protocol|detector:protocol|rmi}" />
+         <parameter key="urlPath" value="${requisition:urlPath|detector:urlPath|/jmxrmi}" />
+         <parameter key="rrd-base-name" value="jmx-cassandra-newts" />
+         <parameter key="ds-name" value="jmx-cassandra-newts" />
+         <parameter key="thresholding-enabled" value="true" />
+         <parameter key="factory" value="${requisition:factory|detector:factory|PASSWORD_CLEAR}" />
+         <parameter key="username" value="${requisition:username|detector:username|cassandra-username}" />
+         <parameter key="password" value="${requisition:password|detector:password|cassandra-password}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="beans.samples" value="${requisition:beans.samples|detector:beans.samples|org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=samples}" />
+         <parameter key="tests.samples" value="${requisition:tests.samples|detector:tests.samples|samples.ColumnFamilyName == 'samples'}" />
+         <parameter key="beans.terms" value="${requisition:beans.terms|detector:beans.terms|org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=terms}" />
+         <parameter key="tests.terms" value="${requisition:tests.terms|detector:tests.terms|terms.ColumnFamilyName == 'terms'}" />
+         <parameter key="beans.resource_attributes" value="${requisition:beans.resource_attributes|detector:beans.resource_attributes|org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=resource_attributes}" />
+         <parameter key="tests.resource_attributes" value="${requisition:tests.resource_attributes|detector:tests.resource_attributes|resource_attributes.ColumnFamilyName == 'resource_attributes'}" />
+         <parameter key="beans.resource_metrics" value="${requisition:beans.resource_metrics|detector:beans.resource_metrics|org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=resource_metrics}" />
+         <parameter key="tests.resource_metrics" value="${requisition:tests.resource_metrics|detector:tests.resource_metrics|resource_metrics.ColumnFamilyName == 'resource_metrics'}" />
+      </service>
+      <downtime begin="0" end="300000" interval="30000" /><!-- 30s, 0, 5m -->
+      <downtime begin="300000" end="43200000" interval="300000" /><!-- 5m, 5m, 12h -->
+      <downtime begin="43200000" end="432000000" interval="600000" /><!-- 10m, 12h, 5d -->
+      <downtime begin="432000000" interval="3600000" /><!-- 1h, 5d -->
+   </package>
+   <package name="example1">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="1.1.1.1" end="254.254.254.254" />
+      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="ICMP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="icmp" />
+         <parameter key="ds-name" value="icmp" />
+      </service>
+      <service name="DNS" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|5000}" />
+         <parameter key="port" value="${requisition:port|detector:port|53}" />
+         <parameter key="lookup" value="${requisition:lookup|detector:lookup|localhost}" />
+         <parameter key="fatal-response-codes" value="${requisition:fatal-response-codes|detector:fatal-response-codes|2,3,5}" /><!-- ServFail, NXDomain, Refused -->
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="dns" />
+         <parameter key="ds-name" value="dns" />
+      </service>
+      <service name="Elasticsearch" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|9200}" />
+         <parameter key="url" value="${requisition:url|detector:url|/_cluster/stats}" />
+         <parameter key="response" value="${requisition:response|detector:response|200-202,299}" />
+         <parameter key="response-text" value="${requisition:response-text|detector:response-text|~.*status.:.green.*}" />
+      </service>
+      <service name="SMTP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|25}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="smtp" />
+         <parameter key="ds-name" value="smtp" />
+      </service>
+      <service name="FTP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|21}" />
+         <parameter key="userid" value="${requisition:userid|detector:userid|}" />
+         <parameter key="password" value="${requisition:password|detector:password|}" />
+      </service>
+      <service name="SNMP" interval="300000" user-defined="false" status="on">
+         <parameter key="oid" value="${requisition:oid|detector:oid|.1.3.6.1.2.1.1.2.0}" />
+      </service>
+      <service name="HTTP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|80}" />
+         <parameter key="url" value="${requisition:url|detector:url|/}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="http" />
+         <parameter key="ds-name" value="http" />
+      </service>
+      <service name="HTTP-8080" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|8080}" />
+         <parameter key="url" value="${requisition:url|detector:url|/}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="http-8080" />
+         <parameter key="ds-name" value="http-8080" />
+      </service>
+      <service name="HTTP-8000" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|8000}" />
+         <parameter key="url" value="${requisition:url|detector:url|/}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="http-8000" />
+         <parameter key="ds-name" value="http-8000" />
+      </service>
+      <service name="HTTPS" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|5000}" />
+         <parameter key="port" value="${requisition:port|detector:port|443}" />
+         <parameter key="url" value="${requisition:url|detector:url|/}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="https" />
+         <parameter key="ds-name" value="https" />
+      </service>
+      <service name="MySQL" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|3306}" />
+         <parameter key="banner" value="${requisition:banner|detector:banner|*}" />
+      </service>
+      <service name="SQLServer" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|1433}" />
+         <parameter key="banner" value="${requisition:banner|detector:banner|*}" />
+      </service>
+      <service name="Oracle" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|1521}" />
+         <parameter key="banner" value="${requisition:banner|detector:banner|*}" />
+      </service>
+      <service name="Postgres" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="banner" value="${requisition:banner|detector:banner|*}" />
+         <parameter key="port" value="${requisition:port|detector:port|5432}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+      </service>
+      <service name="SSH" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="banner" value="${requisition:banner|detector:banner|SSH}" />
+         <parameter key="port" value="${requisition:port|detector:port|22}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="ssh" />
+         <parameter key="ds-name" value="ssh" />
+      </service>
+      <service name="IMAP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="port" value="${requisition:port|detector:port|143}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+      </service>
+      <service name="POP3" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="port" value="${requisition:port|detector:port|110}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="pop3" />
+         <parameter key="ds-name" value="pop3" />
+      </service>
+      <service name="PTP" interval="300000" user-defined="false" status="on">
+         <pattern><![CDATA[^PTP-.*$]]></pattern>
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="clock-port" value="${requisition:ptp:clockPort|default}" />
+         <parameter key="port-state" value="${requisition:ptp:portState|default}" />
+      </service>
+      <service name="NRPE" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|3}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|5666}" />
+         <parameter key="command" value="${requisition:command|detector:command|_NRPE_CHECK}" />
+         <parameter key="padding" value="${requisition:padding|detector:padding|2}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="ds-name" value="nrpe" />
+      </service>
+      <service name="NRPE-NoSSL" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|3}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="port" value="${requisition:port|detector:port|5666}" />
+         <parameter key="command" value="${requisition:command|detector:command|_NRPE_CHECK}" />
+         <parameter key="usessl" value="${requisition:usessl|detector:usessl|false}" />
+         <parameter key="padding" value="${requisition:padding|detector:padding|2}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="ds-name" value="nrpe" />
+      </service>
+      <service name="Windows-Task-Scheduler" interval="300000" user-defined="false" status="on">
+         <parameter key="service-name" value="${requisition:service-name|detector:service-name|Task Scheduler}" />
+      </service>
+      <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="${requisition:port|detector:port|18980}" />
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      </service>
+      <service name="JMX-Kafka" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="${requisition:port|detector:port|9999}" />
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="factory" value="${requisition:factory|detector:factory|PASSWORD_CLEAR}" />
+         <parameter key="username" value="${requisition:username|detector:username|admin}" />
+         <parameter key="password" value="${requisition:password|detector:password|admin}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      </service>
+      <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="ignoreStandBy" value="${requisition:ignoreStandBy|detector:ignoreStandBy|false}" />
+      </service>
+      <service name="VMware-ManagedEntity" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="ignoreStandBy" value="${requisition:ignoreStandBy|detector:ignoreStandBy|false}" />
+         <parameter key="reportAlarms" value="${requisition:reportAlarms|detector:reportAlarms|}" />
+      </service>
+      <service name="MS-RDP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="banner" value="${requisition:banner|detector:banner|*}" />
+         <parameter key="port" value="${requisition:port|detector:port|3389}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+      </service>
+      <service name="ActiveMQ" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="brokerURL" value="${requisition:brokerURL|detector:brokerURL|tcp://localhost:61616}" />
+      </service>
+      <service name="MinaSSH" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|1}" />
+         <parameter key="port" value="${requisition:port|detector:port|22}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="minassh" />
+         <parameter key="ds-name" value="minassh" />
+         <parameter key="username" value="${requisition:username|detector:username|admin}" />
+         <parameter key="password" value="${requisition:password|detector:password|admin}" />
+      </service>
+      <!-- Delta-V container health checks via PageSequenceMonitor -->
+      <service name="Deltav-Health" interval="30000" user-defined="false" status="on">
+        <parameter key="rrd-status" value="false"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
+        <parameter key="strict-timeout" value="true"/>
+        <parameter key="page-sequence">
+          <page-sequence>
+            <page host="${nodeLabel}" path="/actuator/health" port="8080"
+                  response-range="200-299"/>
+          </page-sequence>
+        </parameter>
+      </service>
+      <service name="Minion-Health" interval="30000" user-defined="false" status="on">
+        <parameter key="rrd-status" value="false"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
+        <parameter key="strict-timeout" value="true"/>
+        <parameter key="page-sequence">
+          <page-sequence>
+            <page host="${nodeLabel}" path="/minion/rest/health/probe" port="8181"
+                  response-range="200-299"/>
+          </page-sequence>
+        </parameter>
+      </service>
+      <!-- Delta-V infrastructure TCP monitors -->
+      <service name="PostgreSQL" interval="30000" user-defined="false" status="on">
+        <parameter key="rrd-status" value="false"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
+        <parameter key="port" value="5432"/>
+        <parameter key="hostname" value="${nodeLabel}"/>
+      </service>
+      <service name="Kafka" interval="30000" user-defined="false" status="on">
+        <parameter key="rrd-status" value="false"/>
+        <parameter key="timeout" value="3000"/>
+        <parameter key="retry" value="0"/>
+        <parameter key="port" value="9092"/>
+        <parameter key="hostname" value="${nodeLabel}"/>
+      </service>
+      <!-- Passive cloud service monitors — status driven by syslog → Event Translator → passiveServiceStatus -->
+      <service name="GoogleCloud" interval="30000" user-defined="true" status="on"/>
+      <service name="Azure" interval="30000" user-defined="true" status="on"/>
+      <service name="AWS" interval="30000" user-defined="true" status="on"/>
+      <downtime begin="0" end="300000" interval="30000" /><!-- 30s, 0, 5m -->
+      <downtime begin="300000" end="43200000" interval="300000" /><!-- 5m, 5m, 12h -->
+      <downtime begin="43200000" end="432000000" interval="600000" /><!-- 10m, 12h, 5d -->
+      <downtime begin="432000000" interval="3600000" /><!-- 1h, 5d -->
+   </package>
+
+   <!--
+      Moved StrafePing to its own package.  This allows for more flexible configuration of which interfaces
+      will have StrafePing statistical analysis rather than being on for or off for all interfaces.  Change
+      this package's filter / ranges for directing the StrafePinger to choice interfaces.  Note: Strafing all
+      of your network interface may create high loads on the NMS file system.
+   -->
+   <package name="strafer">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="10.1.1.1" end="10.1.1.10" />
+      <!-- <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" /> -->
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="StrafePing" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|0}" />
+         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
+         <parameter key="ping-count" value="${requisition:ping-count|detector:ping-count|20}" />
+         <parameter key="failure-ping-count" value="${requisition:failure-ping-count|detector:failure-ping-count|20}" />
+         <parameter key="wait-interval" value="${requisition:wait-interval|detector:wait-interval|50}" />
+         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+         <parameter key="rrd-base-name" value="strafeping" />
+      </service>
+      <downtime begin="0" end="432000000" interval="300000" /><!-- 5m, 0, 5d -->
+      <downtime begin="432000000" interval="3600000" /><!-- 1h, 5d -->
+   </package>
+
+   <monitor service="JMX-Cassandra" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
+   <monitor service="JMX-Cassandra-Newts" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
+   <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor" />
+   <monitor service="StrafePing" class-name="org.opennms.netmgt.poller.monitors.StrafePingMonitor" />
+   <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+   <monitor service="HTTP-8080" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+   <monitor service="HTTP-8000" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+   <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor" />
+   <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor" />
+   <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor" />
+   <monitor service="Elasticsearch" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+   <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor" />
+   <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor" />
+   <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+   <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+   <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+   <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+   <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.SshMonitor" />
+   <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor" />
+   <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor" />
+   <monitor service="NRPE" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor" />
+   <monitor service="NRPE-NoSSL" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor" />
+   <monitor service="Windows-Task-Scheduler" class-name="org.opennms.netmgt.poller.monitors.Win32ServiceMonitor" />
+   <monitor service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.poller.monitors.VmwareCimMonitor" />
+   <monitor service="VMware-ManagedEntity" class-name="org.opennms.netmgt.poller.monitors.VmwareMonitor" />
+   <monitor service="MS-RDP" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+   <monitor service="ActiveMQ" class-name="org.opennms.netmgt.poller.monitors.ActiveMQMonitor" />
+   <monitor service="PTP" class-name="org.opennms.netmgt.poller.monitors.PtpMonitor" />
+   <monitor service="MinaSSH" class-name="org.opennms.netmgt.poller.monitors.MinaSshMonitor" />
+   <monitor service="GoogleCloud" class-name="org.opennms.netmgt.poller.monitors.PassiveServiceMonitor" />
+   <monitor service="Azure" class-name="org.opennms.netmgt.poller.monitors.PassiveServiceMonitor" />
+   <monitor service="AWS" class-name="org.opennms.netmgt.poller.monitors.PassiveServiceMonitor" />
+   <monitor service="Deltav-Health" class-name="org.opennms.netmgt.poller.monitors.PageSequenceMonitor"/>
+   <monitor service="Minion-Health" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="PostgreSQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="Kafka" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+</poller-configuration>

--- a/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
+++ b/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
@@ -274,7 +274,7 @@
         <parameter key="strict-timeout" value="true"/>
         <parameter key="page-sequence">
           <page-sequence>
-            <page host="${nodeLabel}" path="/actuator/health" port="8080"
+            <page host="${nodelabel}" path="/actuator/health" port="8080"
                   response-range="200-299"/>
           </page-sequence>
         </parameter>
@@ -286,7 +286,7 @@
         <parameter key="strict-timeout" value="true"/>
         <parameter key="page-sequence">
           <page-sequence>
-            <page host="${nodeLabel}" path="/minion/rest/health/probe" port="8181"
+            <page host="${nodelabel}" path="/minion/rest/health/probe" port="8181"
                   response-range="200-299"/>
           </page-sequence>
         </parameter>

--- a/opennms-container/delta-v/provisiond-overlay/etc/imports/cloud-services.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/imports/cloud-services.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
               foreign-source="cloud-services"
-              date-stamp="2026-03-14T21:23:14.000Z">
+              date-stamp="2026-03-21T15:16:09.000Z">
     <node foreign-id="the-internet" node-label="The Internet">
         <interface ip-addr="172.18.0.1" status="1" managed="true" snmp-primary="N">
             <monitored-service service-name="GoogleCloud"/>

--- a/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
-                          import-threads="2"
-                          scan-threads="4"
-                          write-threads="2"
-                          rescan-threads="2"
-                          requisition-dir="/opt/deltav/etc/imports"
-                          foreign-source-dir="/opt/deltav/etc/foreign-sources">
-    <requisition-def import-name="test-e2e"
-                     import-url-resource="file:///opt/deltav/etc/imports/test-e2e.xml">
-        <cron-schedule>0 * * * * ? *</cron-schedule>
-    </requisition-def>
-    <requisition-def import-name="delta-v"
-                     import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
-        <cron-schedule>0 * * * * ? *</cron-schedule>
-    </requisition-def>
+  foreign-source-dir="/opt/deltav/etc/foreign-sources"
+  requistion-dir="/opt/deltav/etc/imports"
+  importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
+  <requisition-def import-name="cloud-services"
+                   import-url-resource="file:///opt/deltav/etc/imports/cloud-services.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
 </provisiond-configuration>

--- a/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -3,6 +3,10 @@
   foreign-source-dir="/opt/deltav/etc/foreign-sources"
   requistion-dir="/opt/deltav/etc/imports"
   importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
+  <requisition-def import-name="delta-v"
+                   import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
   <requisition-def import-name="cloud-services"
                    import-url-resource="file:///opt/deltav/etc/imports/cloud-services.xml">
     <cron-schedule>0/30 * * * * ?</cron-schedule>

--- a/opennms-container/delta-v/snmpd.conf
+++ b/opennms-container/delta-v/snmpd.conf
@@ -1,0 +1,34 @@
+###########################################################################
+#
+# snmpd.conf
+#
+#   - created by the snmpconf configuration program
+#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+###########################################################################
+# SECTION: Access Control Setup
+#
+#   This section defines who is allowed to talk to your running
+#   snmp agent.
+
+# rocommunity: a SNMPv1/SNMPv2c read-only access community name
+#   arguments:  community [default|hostname|network/bits] [oid]
+
+rocommunity  public  
+
+
+

--- a/opennms-container/delta-v/test-passive-e2e.sh
+++ b/opennms-container/delta-v/test-passive-e2e.sh
@@ -250,21 +250,23 @@ REQEOF
 
     log "  Requisition: ${NODE_LABEL} at ${NODE_IP} with GoogleCloud, Azure, AWS"
 
-    # Write files to the HOST overlay directory (mounted read-only into the container).
-    # On restart, the container entrypoint copies from overlay → /opt/sentinel/etc/.
-    mkdir -p provisiond-overlay/etc/foreign-sources provisiond-overlay/etc/imports
+    # Write files to the host directories mounted into the Provisiond container.
+    # docker-compose mounts:
+    #   ./provisiond-overlay/etc → /opt/deltav/etc (general config)
+    #   ./etc/imports → /opt/deltav/etc/imports (overrides the overlay's imports dir)
+    mkdir -p provisiond-overlay/etc/foreign-sources etc/imports
     cp "$TEST_TMPDIR/cloud-services-fs.xml" "provisiond-overlay/etc/foreign-sources/${FOREIGN_SOURCE}.xml"
-    cp "$TEST_TMPDIR/cloud-services-req.xml" "provisiond-overlay/etc/imports/${FOREIGN_SOURCE}.xml"
+    cp "$TEST_TMPDIR/cloud-services-req.xml" "etc/imports/${FOREIGN_SOURCE}.xml"
 
     # Add a requisition-def so Provisiond auto-imports the requisition on startup
     cat > provisiond-overlay/etc/provisiond-configuration.xml <<PROVEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
-  foreign-source-dir="/opt/sentinel/etc/foreign-sources"
-  requistion-dir="/opt/sentinel/etc/imports"
+  foreign-source-dir="/opt/deltav/etc/foreign-sources"
+  requistion-dir="/opt/deltav/etc/imports"
   importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
   <requisition-def import-name="${FOREIGN_SOURCE}"
-                   import-url-resource="file:///opt/sentinel/etc/imports/${FOREIGN_SOURCE}.xml">
+                   import-url-resource="file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml">
     <cron-schedule>0/30 * * * * ?</cron-schedule>
   </requisition-def>
 </provisiond-configuration>

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/main/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingClientImpl.java
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/main/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingClientImpl.java
@@ -22,29 +22,32 @@
 package org.opennms.netmgt.icmp.proxy;
 
 import java.net.InetAddress;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 
 import org.opennms.core.rpc.api.RpcClient;
 import org.opennms.core.rpc.api.RpcClientFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component(value = "locationAwarePingClient")
 public class LocationAwarePingClientImpl implements LocationAwarePingClient {
 
-    @Autowired
-    private RpcClientFactory rpcClientFactory;
-
-    @Autowired
-    private PingProxyRpcModule pingProxyRpcModule;
-
-    @Autowired
-    private PingSweepRpcModule pingSweepRpcModule;
+    private final RpcClientFactory rpcClientFactory;
+    private final PingProxyRpcModule pingProxyRpcModule;
+    private final PingSweepRpcModule pingSweepRpcModule;
 
     private RpcClient<PingRequestDTO, PingResponseDTO> pingProxyDelegate;
 
     private RpcClient<PingSweepRequestDTO, PingSweepResponseDTO> pingSweepDelegate;
+
+    public LocationAwarePingClientImpl(RpcClientFactory rpcClientFactory,
+                                       PingProxyRpcModule pingProxyRpcModule,
+                                       PingSweepRpcModule pingSweepRpcModule) {
+        this.rpcClientFactory = Objects.requireNonNull(rpcClientFactory);
+        this.pingProxyRpcModule = Objects.requireNonNull(pingProxyRpcModule);
+        this.pingSweepRpcModule = Objects.requireNonNull(pingSweepRpcModule);
+    }
 
     @PostConstruct
     public void init() {

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -39,6 +39,7 @@ import org.opennms.netmgt.icmp.proxy.PingSequence;
 import org.opennms.netmgt.icmp.proxy.PingSummary;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.AlarmData;
+import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.poller.pollables.DbPollEvent;
 import org.opennms.netmgt.poller.pollables.PollContext;
 import org.opennms.netmgt.poller.pollables.PollEvent;
@@ -207,44 +208,50 @@ public class DefaultPollContext implements PollContext, InitializingBean {
     /**
      * Adds alarm-data to Pollerd events so Alarmd can create alarms.
      * Matches the eventconf definitions in opennms.pollerd.events.xml.
-     * In the monolith, Eventd enriches events via eventconf. In standalone
-     * daemon containers without EventConfDao, we set alarm-data directly.
+     * In the monolith, Eventd enriches events via eventconf and expands
+     * %uei%, %dpname%, etc. In standalone daemon containers, we must
+     * set alarm-data with fully-resolved reduction keys.
      */
     private void addAlarmData(EventBuilder bldr, String uei) {
+        Event event = bldr.getEvent();
+        String dpname = event.getDistPoller() != null ? event.getDistPoller() : "localhost";
+        String nodeid = event.getNodeid() != null ? String.valueOf(event.getNodeid()) : "";
+        String iface = event.getInterface() != null ? event.getInterface() : "";
+        String svc = event.getService() != null ? event.getService() : "";
+
         AlarmData alarmData = new AlarmData();
         switch (uei) {
             case EventConstants.NODE_LOST_SERVICE_EVENT_UEI:
-                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%:%interface%:%service%");
+                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid + ":" + iface + ":" + svc);
                 alarmData.setAlarmType(1);
                 alarmData.setAutoClean(false);
                 bldr.setAlarmData(alarmData);
                 bldr.setSeverity("Minor");
                 break;
             case EventConstants.NODE_REGAINED_SERVICE_EVENT_UEI:
-                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%:%interface%:%service%");
+                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid + ":" + iface + ":" + svc);
                 alarmData.setAlarmType(2);
-                alarmData.setClearKey("uei.opennms.org/nodes/nodeLostService:%dpname%:%nodeid%:%interface%:%service%");
+                alarmData.setClearKey(EventConstants.NODE_LOST_SERVICE_EVENT_UEI + ":" + dpname + ":" + nodeid + ":" + iface + ":" + svc);
                 alarmData.setAutoClean(false);
                 bldr.setAlarmData(alarmData);
                 bldr.setSeverity("Normal");
                 break;
             case EventConstants.NODE_DOWN_EVENT_UEI:
-                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%");
+                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid);
                 alarmData.setAlarmType(1);
                 alarmData.setAutoClean(false);
                 bldr.setAlarmData(alarmData);
                 bldr.setSeverity("Major");
                 break;
             case EventConstants.NODE_UP_EVENT_UEI:
-                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%");
+                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid);
                 alarmData.setAlarmType(2);
-                alarmData.setClearKey("uei.opennms.org/nodes/nodeDown:%dpname%:%nodeid%");
+                alarmData.setClearKey(EventConstants.NODE_DOWN_EVENT_UEI + ":" + dpname + ":" + nodeid);
                 alarmData.setAutoClean(false);
                 bldr.setAlarmData(alarmData);
                 bldr.setSeverity("Normal");
                 break;
             default:
-                // No alarm-data for other events
                 break;
         }
     }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -38,6 +38,7 @@ import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.icmp.proxy.PingSequence;
 import org.opennms.netmgt.icmp.proxy.PingSummary;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.event.AlarmData;
 import org.opennms.netmgt.poller.pollables.DbPollEvent;
 import org.opennms.netmgt.poller.pollables.PollContext;
 import org.opennms.netmgt.poller.pollables.PollEvent;
@@ -195,7 +196,57 @@ public class DefaultPollContext implements PollContext, InitializingBean {
 
         }
 
+        // Add alarm-data so Alarmd can create alarms from these events.
+        // In the monolith, Eventd enriches events via eventconf. In standalone
+        // daemon containers, we must set alarm-data directly.
+        addAlarmData(bldr, uei);
+
         return bldr.getEvent();
+    }
+
+    /**
+     * Adds alarm-data to Pollerd events so Alarmd can create alarms.
+     * Matches the eventconf definitions in opennms.pollerd.events.xml.
+     * In the monolith, Eventd enriches events via eventconf. In standalone
+     * daemon containers without EventConfDao, we set alarm-data directly.
+     */
+    private void addAlarmData(EventBuilder bldr, String uei) {
+        AlarmData alarmData = new AlarmData();
+        switch (uei) {
+            case EventConstants.NODE_LOST_SERVICE_EVENT_UEI:
+                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%:%interface%:%service%");
+                alarmData.setAlarmType(1);
+                alarmData.setAutoClean(false);
+                bldr.setAlarmData(alarmData);
+                bldr.setSeverity("Minor");
+                break;
+            case EventConstants.NODE_REGAINED_SERVICE_EVENT_UEI:
+                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%:%interface%:%service%");
+                alarmData.setAlarmType(2);
+                alarmData.setClearKey("uei.opennms.org/nodes/nodeLostService:%dpname%:%nodeid%:%interface%:%service%");
+                alarmData.setAutoClean(false);
+                bldr.setAlarmData(alarmData);
+                bldr.setSeverity("Normal");
+                break;
+            case EventConstants.NODE_DOWN_EVENT_UEI:
+                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%");
+                alarmData.setAlarmType(1);
+                alarmData.setAutoClean(false);
+                bldr.setAlarmData(alarmData);
+                bldr.setSeverity("Major");
+                break;
+            case EventConstants.NODE_UP_EVENT_UEI:
+                alarmData.setReductionKey("%uei%:%dpname%:%nodeid%");
+                alarmData.setAlarmType(2);
+                alarmData.setClearKey("uei.opennms.org/nodes/nodeDown:%dpname%:%nodeid%");
+                alarmData.setAutoClean(false);
+                bldr.setAlarmData(alarmData);
+                bldr.setSeverity("Normal");
+                break;
+            default:
+                // No alarm-data for other events
+                break;
+        }
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -66,14 +66,26 @@ public class DefaultPollContext implements PollContext, InitializingBean {
      */
     public static final boolean DISABLE_POLL_TIMESTAMP_TRACKING = Boolean.getBoolean("org.opennms.netmgt.poller.disablePollTimestampTracking");
 
-    private volatile PollerConfig m_pollerConfig;
-    private volatile QueryManager m_queryManager;
-    private volatile EventIpcManager m_eventManager;
-    private volatile LocationAwarePingClient m_locationAwarePingClient;
-    private volatile TsidFactory m_tsidFactory;
-    private volatile String m_name;
-    private volatile String m_localHostName;
+    private final PollerConfig m_pollerConfig;
+    private final QueryManager m_queryManager;
+    private final EventIpcManager m_eventManager;
+    private final LocationAwarePingClient m_locationAwarePingClient;
+    private final TsidFactory m_tsidFactory;
+    private final String m_name;
+    private final String m_localHostName;
     private volatile AsyncPollingEngine m_asyncPollingEngine;
+
+    public DefaultPollContext(EventIpcManager eventManager, PollerConfig pollerConfig,
+                              QueryManager queryManager, LocationAwarePingClient locationAwarePingClient,
+                              TsidFactory tsidFactory, String localHostName, String name) {
+        this.m_eventManager = eventManager;
+        this.m_pollerConfig = pollerConfig;
+        this.m_queryManager = queryManager;
+        this.m_locationAwarePingClient = locationAwarePingClient;
+        this.m_tsidFactory = tsidFactory;
+        this.m_localHostName = localHostName;
+        this.m_name = name;
+    }
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -84,14 +96,6 @@ public class DefaultPollContext implements PollContext, InitializingBean {
         return m_eventManager;
     }
 
-    public void setEventManager(EventIpcManager eventManager) {
-        m_eventManager = eventManager;
-    }
-
-    public void setLocalHostName(String localHostName) {
-        m_localHostName = localHostName;
-    }
-
     public String getLocalHostName() {
         return m_localHostName;
     }
@@ -100,40 +104,20 @@ public class DefaultPollContext implements PollContext, InitializingBean {
         return m_name;
     }
 
-    public void setName(String name) {
-        m_name = name;
-    }
-
     public PollerConfig getPollerConfig() {
         return m_pollerConfig;
-    }
-
-    public void setPollerConfig(PollerConfig pollerConfig) {
-        m_pollerConfig = pollerConfig;
     }
 
     public QueryManager getQueryManager() {
         return m_queryManager;
     }
 
-    public void setQueryManager(QueryManager queryManager) {
-        m_queryManager = queryManager;
-    }
-
     public LocationAwarePingClient getLocationAwarePingClient() {
         return m_locationAwarePingClient;
     }
 
-    public void setLocationAwarePingClient(LocationAwarePingClient locationAwarePingClient) {
-        m_locationAwarePingClient = locationAwarePingClient;
-    }
-
     public TsidFactory getTsidFactory() {
         return m_tsidFactory;
-    }
-
-    public void setTsidFactory(TsidFactory tsidFactory) {
-        m_tsidFactory = tsidFactory;
     }
 
     @Override

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -38,7 +38,6 @@ import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.icmp.proxy.PingSequence;
 import org.opennms.netmgt.icmp.proxy.PingSummary;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.AlarmData;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.poller.pollables.DbPollEvent;
 import org.opennms.netmgt.poller.pollables.PollContext;
@@ -197,63 +196,7 @@ public class DefaultPollContext implements PollContext, InitializingBean {
 
         }
 
-        // Add alarm-data so Alarmd can create alarms from these events.
-        // In the monolith, Eventd enriches events via eventconf. In standalone
-        // daemon containers, we must set alarm-data directly.
-        addAlarmData(bldr, uei);
-
         return bldr.getEvent();
-    }
-
-    /**
-     * Adds alarm-data to Pollerd events so Alarmd can create alarms.
-     * Matches the eventconf definitions in opennms.pollerd.events.xml.
-     * In the monolith, Eventd enriches events via eventconf and expands
-     * %uei%, %dpname%, etc. In standalone daemon containers, we must
-     * set alarm-data with fully-resolved reduction keys.
-     */
-    private void addAlarmData(EventBuilder bldr, String uei) {
-        Event event = bldr.getEvent();
-        String dpname = event.getDistPoller() != null ? event.getDistPoller() : "localhost";
-        String nodeid = event.getNodeid() != null ? String.valueOf(event.getNodeid()) : "";
-        String iface = event.getInterface() != null ? event.getInterface() : "";
-        String svc = event.getService() != null ? event.getService() : "";
-
-        AlarmData alarmData = new AlarmData();
-        switch (uei) {
-            case EventConstants.NODE_LOST_SERVICE_EVENT_UEI:
-                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid + ":" + iface + ":" + svc);
-                alarmData.setAlarmType(1);
-                alarmData.setAutoClean(false);
-                bldr.setAlarmData(alarmData);
-                bldr.setSeverity("Minor");
-                break;
-            case EventConstants.NODE_REGAINED_SERVICE_EVENT_UEI:
-                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid + ":" + iface + ":" + svc);
-                alarmData.setAlarmType(2);
-                alarmData.setClearKey(EventConstants.NODE_LOST_SERVICE_EVENT_UEI + ":" + dpname + ":" + nodeid + ":" + iface + ":" + svc);
-                alarmData.setAutoClean(false);
-                bldr.setAlarmData(alarmData);
-                bldr.setSeverity("Normal");
-                break;
-            case EventConstants.NODE_DOWN_EVENT_UEI:
-                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid);
-                alarmData.setAlarmType(1);
-                alarmData.setAutoClean(false);
-                bldr.setAlarmData(alarmData);
-                bldr.setSeverity("Major");
-                break;
-            case EventConstants.NODE_UP_EVENT_UEI:
-                alarmData.setReductionKey(uei + ":" + dpname + ":" + nodeid);
-                alarmData.setAlarmType(2);
-                alarmData.setClearKey(EventConstants.NODE_DOWN_EVENT_UEI + ":" + dpname + ":" + nodeid);
-                alarmData.setAutoClean(false);
-                bldr.setAlarmData(alarmData);
-                bldr.setSeverity("Normal");
-                break;
-            default:
-                break;
-        }
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
@@ -61,13 +61,11 @@ import org.opennms.netmgt.scheduler.Scheduler;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import com.google.common.annotations.VisibleForTesting;
 
 /**
  * <p>Poller class.</p>
@@ -89,49 +87,25 @@ public class Poller extends AbstractServiceDaemon {
 
     private PollableNetwork m_network;
 
-    @Autowired
-    private QueryManager m_queryManager;
+    private final QueryManager m_queryManager;
 
     private PollerConfig m_pollerConfig;
 
     private EventIpcManager m_eventMgr;
 
-    @Autowired
-    private MonitoredServiceDao m_monitoredServiceDao;
+    private final MonitoredServiceDao m_monitoredServiceDao;
 
-    @Autowired
-    private OutageDao m_outageDao;
+    private final OutageDao m_outageDao;
 
-    @Autowired
-    private TransactionTemplate m_transactionTemplate;
+    private final TransactionTemplate m_transactionTemplate;
 
-    @Autowired
-    private PersisterFactory m_persisterFactory;
+    private final PersisterFactory m_persisterFactory;
 
-    @Autowired
-    private ThresholdingService m_thresholdingService;
+    private final ThresholdingService m_thresholdingService;
 
-    @Autowired
-    private LocationAwarePollerClient m_locationAwarePollerClient;
-    
-    @Autowired(required = false)
-    private ReadablePollOutagesDao m_pollOutagesDao;
+    private final LocationAwarePollerClient m_locationAwarePollerClient;
 
-    public void setPersisterFactory(PersisterFactory persisterFactory) {
-        m_persisterFactory = persisterFactory;
-    }
-
-    public void setOutageDao(OutageDao outageDao) {
-        this.m_outageDao = outageDao;
-    }
-
-    public void setMonitoredServiceDao(MonitoredServiceDao monitoredServiceDao) {
-        this.m_monitoredServiceDao = monitoredServiceDao;
-    }
-
-    public void setTransactionTemplate(TransactionTemplate transactionTemplate) {
-        m_transactionTemplate = transactionTemplate;
-    }
+    private final ReadablePollOutagesDao m_pollOutagesDao;
 
     /**
      * <p>setEventIpcManager</p>
@@ -154,8 +128,20 @@ public class Poller extends AbstractServiceDaemon {
     /**
      * <p>Constructor for Poller.</p>
      */
-    public Poller() {
+    public Poller(QueryManager queryManager, MonitoredServiceDao monitoredServiceDao,
+                  OutageDao outageDao, TransactionTemplate transactionTemplate,
+                  PersisterFactory persisterFactory, ThresholdingService thresholdingService,
+                  LocationAwarePollerClient locationAwarePollerClient,
+                  ReadablePollOutagesDao pollOutagesDao) {
         super(LOG4J_CATEGORY);
+        this.m_queryManager = Objects.requireNonNull(queryManager);
+        this.m_monitoredServiceDao = Objects.requireNonNull(monitoredServiceDao);
+        this.m_outageDao = Objects.requireNonNull(outageDao);
+        this.m_transactionTemplate = Objects.requireNonNull(transactionTemplate);
+        this.m_persisterFactory = Objects.requireNonNull(persisterFactory);
+        this.m_thresholdingService = thresholdingService; // nullable — not all deployments use thresholding
+        this.m_locationAwarePollerClient = Objects.requireNonNull(locationAwarePollerClient);
+        this.m_pollOutagesDao = pollOutagesDao; // nullable — not available in Karaf
     }
 
     /* Getters/Setters used for dependency injection */
@@ -206,15 +192,6 @@ public class Poller extends AbstractServiceDaemon {
     }
 
     /**
-     * <p>setQueryManager</p>
-     *
-     * @param queryManager a {@link org.opennms.netmgt.poller.QueryManager} object.
-     */
-    void setQueryManager(QueryManager queryManager) {
-        m_queryManager = queryManager;
-    }
-
-    /**
      * <p>getQueryManager</p>
      *
      * @return a {@link org.opennms.netmgt.poller.QueryManager} object.
@@ -247,11 +224,6 @@ public class Poller extends AbstractServiceDaemon {
     ReadablePollOutagesDao getPollOutagesDao() {
         return m_pollOutagesDao;
     }
-    
-    @VisibleForTesting
-    void setPollOutagesDao(ReadablePollOutagesDao pollOutagesDao) {
-        m_pollOutagesDao = pollOutagesDao;
-    }
 
     /**
      * <p>getScheduler</p>
@@ -269,10 +241,6 @@ public class Poller extends AbstractServiceDaemon {
      */
     public void setScheduler(LegacyScheduler scheduler) {
         m_scheduler = scheduler;
-    }
-
-    public void setLocationAwarePollerClient(LocationAwarePollerClient locationAwarePollerClient) {
-        m_locationAwarePollerClient = locationAwarePollerClient;
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java
@@ -54,6 +54,7 @@ import org.opennms.netmgt.model.OnmsOutage;
 import org.opennms.netmgt.poller.pollables.PollableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionOperations;
 
@@ -62,6 +63,7 @@ import org.springframework.transaction.support.TransactionOperations;
  *
  * @author brozow
  */
+@Transactional
 public class QueryManagerDaoImpl implements QueryManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(QueryManagerDaoImpl.class);
@@ -107,65 +109,68 @@ public class QueryManagerDaoImpl implements QueryManager {
     /** {@inheritDoc} */
     @Override
     public Integer openOutagePendingLostEventId(int nodeId, String ipAddr, String svcName, Date lostTime) {
-        LOG.info("opening outage for {}:{}:{} @ {}", nodeId, ipAddr, svcName, lostTime);
-        final OnmsMonitoredService service = m_monitoredServiceDao.get(nodeId, InetAddressUtils.addr(ipAddr), svcName);
-        final OnmsOutage outage = new OnmsOutage(lostTime, service);
-        m_outageDao.saveOrUpdate(outage);
-        return outage.getId();
+        return m_transcationOps.execute(status -> {
+            LOG.info("opening outage for {}:{}:{} @ {}", nodeId, ipAddr, svcName, lostTime);
+            final OnmsMonitoredService service = m_monitoredServiceDao.get(nodeId, InetAddressUtils.addr(ipAddr), svcName);
+            final OnmsOutage outage = new OnmsOutage(lostTime, service);
+            m_outageDao.saveOrUpdate(outage);
+            return outage.getId();
+        });
     }
 
     /** {@inheritDoc} */
     @Override
     public void updateOpenOutageWithEvent(int outageId, long eventTsid, String eventUei) {
-        LOG.info("updating open outage {} with event tsid {}", outageId, eventTsid);
-
-        final OnmsOutage outage = m_outageDao.get(outageId);
-        if (outage == null) {
-            LOG.warn("Failed to update outage {}. The outage no longer exists.", outageId);
-            return;
-        }
-
-        outage.setSvcLostEventTsid(eventTsid);
-        outage.setSvcLostEventUei(eventUei);
-        m_outageDao.saveOrUpdate(outage);
+        m_transcationOps.execute(status -> {
+            LOG.info("updating open outage {} with event tsid {}", outageId, eventTsid);
+            final OnmsOutage outage = m_outageDao.get(outageId);
+            if (outage == null) {
+                LOG.warn("Failed to update outage {}. The outage no longer exists.", outageId);
+                return null;
+            }
+            outage.setSvcLostEventTsid(eventTsid);
+            outage.setSvcLostEventUei(eventUei);
+            m_outageDao.saveOrUpdate(outage);
+            return null;
+        });
     }
 
     /** {@inheritDoc} */
     @Override
     public Integer resolveOutagePendingRegainEventId(int nodeId, String ipAddr, String svcName, Date regainedTime) {
-        LOG.info("resolving outage for {}:{}:{} @ {}", nodeId, ipAddr, svcName, regainedTime);
-        final OnmsMonitoredService service = m_monitoredServiceDao.get(nodeId, InetAddressUtils.addr(ipAddr), svcName);
-        if (service == null) {
-            LOG.warn("Failed to resolve the pending outage for {}:{}:{} @ {}. The service could not be found.",
-                    nodeId, ipAddr, svcName, regainedTime);
-            return null;
-        }
-
-        final OnmsOutage outage = m_outageDao.currentOutageForService(service);
-        if (outage == null) {
-            return null;
-        }
-
-        // Update the outage
-        outage.setIfRegainedService(new Timestamp(regainedTime.getTime()));
-        m_outageDao.saveOrUpdate(outage);
-        return outage.getId();
+        return m_transcationOps.execute(status -> {
+            LOG.info("resolving outage for {}:{}:{} @ {}", nodeId, ipAddr, svcName, regainedTime);
+            final OnmsMonitoredService service = m_monitoredServiceDao.get(nodeId, InetAddressUtils.addr(ipAddr), svcName);
+            if (service == null) {
+                LOG.warn("Failed to resolve the pending outage for {}:{}:{} @ {}. The service could not be found.",
+                        nodeId, ipAddr, svcName, regainedTime);
+                return null;
+            }
+            final OnmsOutage outage = m_outageDao.currentOutageForService(service);
+            if (outage == null) {
+                return null;
+            }
+            outage.setIfRegainedService(new Timestamp(regainedTime.getTime()));
+            m_outageDao.saveOrUpdate(outage);
+            return outage.getId();
+        });
     }
 
     /** {@inheritDoc} */
     @Override
     public void updateResolvedOutageWithEvent(int outageId, long eventTsid, String eventUei) {
-        LOG.info("updating resolved outage {} with event tsid {}", outageId, eventTsid);
-
-        final OnmsOutage outage = m_outageDao.get(outageId);
-        if (outage == null) {
-            LOG.warn("Failed to update outage {}. The outage no longer exists.", outageId);
-            return;
-        }
-
-        outage.setSvcRegainedEventTsid(eventTsid);
-        outage.setSvcRegainedEventUei(eventUei);
-        m_outageDao.saveOrUpdate(outage);
+        m_transcationOps.execute(status -> {
+            LOG.info("updating resolved outage {} with event tsid {}", outageId, eventTsid);
+            final OnmsOutage outage = m_outageDao.get(outageId);
+            if (outage == null) {
+                LOG.warn("Failed to update outage {}. The outage no longer exists.", outageId);
+                return null;
+            }
+            outage.setSvcRegainedEventTsid(eventTsid);
+            outage.setSvcRegainedEventUei(eventUei);
+            m_outageDao.saveOrUpdate(outage);
+            return null;
+        });
     }
 
     @Override
@@ -191,41 +196,42 @@ public class QueryManagerDaoImpl implements QueryManager {
      */
     @Override
     public void closeOutagesForUnmanagedServices() {
-        Date closeDate = new java.util.Date();
-        Criteria criteria = new Criteria(OnmsOutage.class);
-        criteria.addRestriction(new NullRestriction("perspective"));
-        criteria.setAliases(Arrays.asList(new Alias[] {
-            new Alias("monitoredService", "monitoredService", JoinType.LEFT_JOIN)
-        }));
-        criteria.addRestriction(new AnyRestriction(
-            new EqRestriction("monitoredService.status", "D"),
-            new EqRestriction("monitoredService.status", "F"),
-            new EqRestriction("monitoredService.status", "U")
-        ));
-        criteria.addRestriction(new NullRestriction("ifRegainedService"));
-        List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
-        
-        for (OnmsOutage outage : outages) {
-            outage.setIfRegainedService(closeDate);
-            m_outageDao.update(outage);
-        }
+        m_transcationOps.execute(status -> {
+            Date closeDate = new java.util.Date();
+            Criteria criteria = new Criteria(OnmsOutage.class);
+            criteria.addRestriction(new NullRestriction("perspective"));
+            criteria.setAliases(Arrays.asList(new Alias[] {
+                new Alias("monitoredService", "monitoredService", JoinType.LEFT_JOIN)
+            }));
+            criteria.addRestriction(new AnyRestriction(
+                new EqRestriction("monitoredService.status", "D"),
+                new EqRestriction("monitoredService.status", "F"),
+                new EqRestriction("monitoredService.status", "U")
+            ));
+            criteria.addRestriction(new NullRestriction("ifRegainedService"));
+            List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
+            for (OnmsOutage outage : outages) {
+                outage.setIfRegainedService(closeDate);
+                m_outageDao.update(outage);
+            }
 
-        criteria = new Criteria(OnmsOutage.class);
-        criteria.addRestriction(new NullRestriction("perspective"));
-        criteria.setAliases(Arrays.asList(new Alias[] {
-            new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN)
-        }));
-        criteria.addRestriction(new AnyRestriction(
-            new EqRestriction("ipInterface.isManaged", "F"),
-            new EqRestriction("ipInterface.isManaged", "U")
-        ));
-        criteria.addRestriction(new NullRestriction("ifRegainedService"));
-        outages = m_outageDao.findMatching(criteria);
-        
-        for (OnmsOutage outage : outages) {
-            outage.setIfRegainedService(closeDate);
-            m_outageDao.update(outage);
-        }
+            criteria = new Criteria(OnmsOutage.class);
+            criteria.addRestriction(new NullRestriction("perspective"));
+            criteria.setAliases(Arrays.asList(new Alias[] {
+                new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN)
+            }));
+            criteria.addRestriction(new AnyRestriction(
+                new EqRestriction("ipInterface.isManaged", "F"),
+                new EqRestriction("ipInterface.isManaged", "U")
+            ));
+            criteria.addRestriction(new NullRestriction("ifRegainedService"));
+            outages = m_outageDao.findMatching(criteria);
+            for (OnmsOutage outage : outages) {
+                outage.setIfRegainedService(closeDate);
+                m_outageDao.update(outage);
+            }
+            return null;
+        });
     }
     
     /**
@@ -237,22 +243,24 @@ public class QueryManagerDaoImpl implements QueryManager {
      */
     @Override
     public void closeOutagesForNode(Date closeDate, long eventTsid, String eventUei, int nodeId) {
-        Criteria criteria = new Criteria(OnmsOutage.class);
-        criteria.addRestriction(new NullRestriction("perspective"));
-        criteria.setAliases(Arrays.asList(new Alias[] {
-            new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN),
-            new Alias("ipInterface.node", "node", JoinType.LEFT_JOIN)
-        }));
-        criteria.addRestriction(new EqRestriction("node.id", nodeId));
-        criteria.addRestriction(new NullRestriction("ifRegainedService"));
-        List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
-
-        for (OnmsOutage outage : outages) {
-            outage.setIfRegainedService(closeDate);
-            outage.setSvcRegainedEventTsid(eventTsid);
-            outage.setSvcRegainedEventUei(eventUei);
-            m_outageDao.update(outage);
-        }
+        m_transcationOps.execute(status -> {
+            Criteria criteria = new Criteria(OnmsOutage.class);
+            criteria.addRestriction(new NullRestriction("perspective"));
+            criteria.setAliases(Arrays.asList(new Alias[] {
+                new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN),
+                new Alias("ipInterface.node", "node", JoinType.LEFT_JOIN)
+            }));
+            criteria.addRestriction(new EqRestriction("node.id", nodeId));
+            criteria.addRestriction(new NullRestriction("ifRegainedService"));
+            List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
+            for (OnmsOutage outage : outages) {
+                outage.setIfRegainedService(closeDate);
+                outage.setSvcRegainedEventTsid(eventTsid);
+                outage.setSvcRegainedEventUei(eventUei);
+                m_outageDao.update(outage);
+            }
+            return null;
+        });
     }
     
     /**
@@ -265,23 +273,25 @@ public class QueryManagerDaoImpl implements QueryManager {
      */
     @Override
     public void closeOutagesForInterface(Date closeDate, long eventTsid, String eventUei, int nodeId, String ipAddr) {
-        Criteria criteria = new Criteria(OnmsOutage.class);
-        criteria.addRestriction(new NullRestriction("perspective"));
-        criteria.setAliases(Arrays.asList(new Alias[] {
-            new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN),
-            new Alias("ipInterface.node", "node", JoinType.LEFT_JOIN)
-        }));
-        criteria.addRestriction(new EqRestriction("node.id", nodeId));
-        criteria.addRestriction(new EqRestriction("ipInterface.ipAddress", addr(ipAddr)));
-        criteria.addRestriction(new NullRestriction("ifRegainedService"));
-        List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
-
-        for (OnmsOutage outage : outages) {
-            outage.setIfRegainedService(closeDate);
-            outage.setSvcRegainedEventTsid(eventTsid);
-            outage.setSvcRegainedEventUei(eventUei);
-            m_outageDao.update(outage);
-        }
+        m_transcationOps.execute(status -> {
+            Criteria criteria = new Criteria(OnmsOutage.class);
+            criteria.addRestriction(new NullRestriction("perspective"));
+            criteria.setAliases(Arrays.asList(new Alias[] {
+                new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN),
+                new Alias("ipInterface.node", "node", JoinType.LEFT_JOIN)
+            }));
+            criteria.addRestriction(new EqRestriction("node.id", nodeId));
+            criteria.addRestriction(new EqRestriction("ipInterface.ipAddress", addr(ipAddr)));
+            criteria.addRestriction(new NullRestriction("ifRegainedService"));
+            List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
+            for (OnmsOutage outage : outages) {
+                outage.setIfRegainedService(closeDate);
+                outage.setSvcRegainedEventTsid(eventTsid);
+                outage.setSvcRegainedEventUei(eventUei);
+                m_outageDao.update(outage);
+            }
+            return null;
+        });
     }
     
     /**
@@ -295,38 +305,43 @@ public class QueryManagerDaoImpl implements QueryManager {
      */
     @Override
     public void closeOutagesForService(Date closeDate, long eventTsid, String eventUei, int nodeId, String ipAddr, String serviceName) {
-        Criteria criteria = new Criteria(OnmsOutage.class);
-        criteria.addRestriction(new NullRestriction("perspective"));
-        criteria.setAliases(Arrays.asList(new Alias[] {
-            new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN),
-            new Alias("monitoredService.serviceType", "serviceType", JoinType.LEFT_JOIN),
-            new Alias("ipInterface.node", "node", JoinType.LEFT_JOIN)
-        }));
-        criteria.addRestriction(new EqRestriction("node.id", nodeId));
-        criteria.addRestriction(new EqRestriction("ipInterface.ipAddress", addr(ipAddr)));
-        criteria.addRestriction(new EqRestriction("serviceType.name", serviceName));
-        criteria.addRestriction(new NullRestriction("ifRegainedService"));
-        List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
-
-        for (OnmsOutage outage : outages) {
-            outage.setIfRegainedService(closeDate);
-            outage.setSvcRegainedEventTsid(eventTsid);
-            outage.setSvcRegainedEventUei(eventUei);
-            m_outageDao.update(outage);
-            LOG.info("Calling closeOutagesForService: {}", outage);
-        }
+        m_transcationOps.execute(status -> {
+            Criteria criteria = new Criteria(OnmsOutage.class);
+            criteria.addRestriction(new NullRestriction("perspective"));
+            criteria.setAliases(Arrays.asList(new Alias[] {
+                new Alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN),
+                new Alias("monitoredService.serviceType", "serviceType", JoinType.LEFT_JOIN),
+                new Alias("ipInterface.node", "node", JoinType.LEFT_JOIN)
+            }));
+            criteria.addRestriction(new EqRestriction("node.id", nodeId));
+            criteria.addRestriction(new EqRestriction("ipInterface.ipAddress", addr(ipAddr)));
+            criteria.addRestriction(new EqRestriction("serviceType.name", serviceName));
+            criteria.addRestriction(new NullRestriction("ifRegainedService"));
+            List<OnmsOutage> outages = m_outageDao.findMatching(criteria);
+            for (OnmsOutage outage : outages) {
+                outage.setIfRegainedService(closeDate);
+                outage.setSvcRegainedEventTsid(eventTsid);
+                outage.setSvcRegainedEventUei(eventUei);
+                m_outageDao.update(outage);
+                LOG.info("Calling closeOutagesForService: {}", outage);
+            }
+            return null;
+        });
     }
 
     @Override
     public void updateServiceStatus(int nodeId, String ipAddr, String serviceName, String status) {
-        try {
-            OnmsMonitoredService service = m_monitoredServiceDao.get(nodeId, InetAddress.getByName(ipAddr), serviceName);
-            service.setStatus(status);
-            m_monitoredServiceDao.saveOrUpdate(service);
-        } catch (UnknownHostException e) {
-            LOG.error("Failed to set the status for service named {} on node id {} and interface {} to {}.",
-                    serviceName, nodeId,  ipAddr, status, e);
-        }
+        m_transcationOps.execute(txStatus -> {
+            try {
+                OnmsMonitoredService service = m_monitoredServiceDao.get(nodeId, InetAddress.getByName(ipAddr), serviceName);
+                service.setStatus(status);
+                m_monitoredServiceDao.saveOrUpdate(service);
+            } catch (UnknownHostException e) {
+                LOG.error("Failed to set the status for service named {} on node id {} and interface {} to {}.",
+                        serviceName, nodeId,  ipAddr, status, e);
+            }
+            return null;
+        });
     }
 
     @Override

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java
@@ -42,6 +42,8 @@ import org.opennms.core.criteria.restrictions.EqRestriction;
 import org.opennms.core.criteria.restrictions.NeRestriction;
 import org.opennms.core.criteria.restrictions.NullRestriction;
 import org.opennms.core.utils.InetAddressUtils;
+import java.util.Objects;
+
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -52,7 +54,6 @@ import org.opennms.netmgt.model.OnmsOutage;
 import org.opennms.netmgt.poller.pollables.PollableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionOperations;
 
@@ -65,21 +66,22 @@ public class QueryManagerDaoImpl implements QueryManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(QueryManagerDaoImpl.class);
 
-    @Autowired
-    private NodeDao m_nodeDao;
+    private final NodeDao m_nodeDao;
+    private final OutageDao m_outageDao;
+    private final MonitoredServiceDao m_monitoredServiceDao;
+    private final IpInterfaceDao m_ipInterfaceDao;
+    private final TransactionOperations m_transcationOps;
 
-    @Autowired
-    private OutageDao m_outageDao;
-
-    @Autowired
-    private MonitoredServiceDao m_monitoredServiceDao;
-
-    @Autowired
-    private IpInterfaceDao m_ipInterfaceDao;
-
-    @Autowired
-    private TransactionOperations m_transcationOps;
-    
+    public QueryManagerDaoImpl(NodeDao nodeDao, OutageDao outageDao,
+                               MonitoredServiceDao monitoredServiceDao,
+                               IpInterfaceDao ipInterfaceDao,
+                               TransactionOperations transactionOperations) {
+        this.m_nodeDao = Objects.requireNonNull(nodeDao);
+        this.m_outageDao = Objects.requireNonNull(outageDao);
+        this.m_monitoredServiceDao = Objects.requireNonNull(monitoredServiceDao);
+        this.m_ipInterfaceDao = Objects.requireNonNull(ipInterfaceDao);
+        this.m_transcationOps = Objects.requireNonNull(transactionOperations);
+    }
 
 
     /** {@inheritDoc} */

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-pollerd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-pollerd.xml
@@ -17,22 +17,27 @@
 ">
 
     <aop:aspectj-autoproxy proxy-target-class="true"/>
-    <context:annotation-config />
 
-    <bean name="pollerQueryManager" class="org.opennms.netmgt.poller.QueryManagerDaoImpl"/>
+    <bean name="pollerQueryManager" class="org.opennms.netmgt.poller.QueryManagerDaoImpl">
+      <constructor-arg ref="nodeDao"/>
+      <constructor-arg ref="outageDao"/>
+      <constructor-arg ref="monitoredServiceDao"/>
+      <constructor-arg ref="ipInterfaceDao"/>
+      <constructor-arg ref="transactionTemplate"/>
+    </bean>
 
     <bean name="tsidFactory" class="org.opennms.core.tsid.TsidFactory">
       <constructor-arg value="0"/>
     </bean>
 
     <bean name="pollContext" class="org.opennms.netmgt.poller.DefaultPollContext">
-      <property name="eventManager" ref="eventIpcManager" />
-      <property name="localHostName" ref="localHostName" />
-      <property name="name" value="OpenNMS.Poller.DefaultPollContext" />
-      <property name="pollerConfig" ref="pollerConfig" />
-      <property name="queryManager" ref="pollerQueryManager" />
-      <property name="locationAwarePingClient" ref="locationAwarePingClient" />
-      <property name="tsidFactory" ref="tsidFactory" />
+      <constructor-arg ref="eventIpcManager"/>
+      <constructor-arg ref="pollerConfig"/>
+      <constructor-arg ref="pollerQueryManager"/>
+      <constructor-arg ref="locationAwarePingClient"/>
+      <constructor-arg ref="tsidFactory"/>
+      <constructor-arg ref="localHostName"/>
+      <constructor-arg value="OpenNMS.Poller.DefaultPollContext"/>
     </bean>
 
     <bean name="pollableNetwork" class="org.opennms.netmgt.poller.pollables.PollableNetwork">
@@ -40,6 +45,14 @@
     </bean>
 
     <bean name="daemon" class="org.opennms.netmgt.poller.Poller">
+      <constructor-arg ref="pollerQueryManager"/>
+      <constructor-arg ref="monitoredServiceDao"/>
+      <constructor-arg ref="outageDao"/>
+      <constructor-arg ref="transactionTemplate"/>
+      <constructor-arg ref="persisterFactory"/>
+      <constructor-arg ref="thresholdingService"/>
+      <constructor-arg ref="locationAwarePollerClient"/>
+      <constructor-arg ref="pollOutagesDao"/>
       <property name="network" ref="pollableNetwork" />
       <property name="pollerConfig" ref="pollerConfig" />
       <property name="eventIpcManager" ref="eventIpcManager"/>

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/DefaultPollContextTsidTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/DefaultPollContextTsidTest.java
@@ -66,13 +66,8 @@ public class DefaultPollContextTsidTest {
         when(pollerConfig.isPathOutageEnabled()).thenReturn(false);
         when(pollerConfig.getMaxConcurrentAsyncPolls()).thenReturn(10);
 
-        pollContext = new DefaultPollContext();
-        pollContext.setEventManager(eventManager);
-        pollContext.setQueryManager(queryManager);
-        pollContext.setTsidFactory(tsidFactory);
-        pollContext.setPollerConfig(pollerConfig);
-        pollContext.setName("TestPoller");
-        pollContext.setLocalHostName("localhost");
+        pollContext = new DefaultPollContext(eventManager, pollerConfig, queryManager,
+                null, tsidFactory, "localhost", "TestPoller");
         pollContext.afterPropertiesSet();
     }
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PathOutageManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PathOutageManagerDaoIT.java
@@ -147,11 +147,8 @@ public class PathOutageManagerDaoIT implements TemporaryDatabaseAware<MockDataba
 		m_pollerConfig.setDefaultPollInterval(2000L);
 		m_pollerConfig.addService(m_network.getService(2, "192.168.1.3", "HTTP"));
 
-		DefaultPollContext pollContext = new DefaultPollContext();
-		pollContext.setLocalHostName("localhost");
-		pollContext.setName("Test.DefaultPollContext");
-		pollContext.setPollerConfig(m_pollerConfig);
-		pollContext.setQueryManager(m_queryManager);
+		DefaultPollContext pollContext = new DefaultPollContext(null, m_pollerConfig, m_queryManager,
+				null, null, "localhost", "Test.DefaultPollContext");
 	}
 
 	@After

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollContextIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollContextIT.java
@@ -173,13 +173,8 @@ public class PollContextIT implements TemporaryDatabaseAware<MockDatabase> {
 
         m_locationAwarePingClient = mock(LocationAwarePingClient.class);
 
-        m_pollContext = new DefaultPollContext();
-        m_pollContext.setEventManager(m_eventMgr);
-        m_pollContext.setLocalHostName("localhost");
-        m_pollContext.setName("PollContextTest.DefaultPollContext");
-        m_pollContext.setPollerConfig(m_pollerConfig);
-        m_pollContext.setQueryManager(m_queryManager);
-        m_pollContext.setLocationAwarePingClient(m_locationAwarePingClient);
+        m_pollContext = new DefaultPollContext(m_eventMgr, m_pollerConfig, m_queryManager,
+                m_locationAwarePingClient, null, "localhost", "PollContextTest.DefaultPollContext");
 
        m_pNetwork = new PollableNetwork(m_pollContext);
        m_pSvc = m_pNetwork.createService(1, "Router", null, InetAddressUtils.addr("192.168.1.1"), "ICMP");

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
@@ -230,27 +230,17 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
 
         m_locationAwarePingClient = mock(LocationAwarePingClient.class);
 
-        DefaultPollContext pollContext = new DefaultPollContext();
-        pollContext.setEventManager(m_eventMgr);
-        pollContext.setLocalHostName("localhost");
-        pollContext.setName("Test.DefaultPollContext");
-        pollContext.setPollerConfig(m_pollerConfig);
-        pollContext.setQueryManager(m_queryManager);
-        pollContext.setLocationAwarePingClient(m_locationAwarePingClient);
+        DefaultPollContext pollContext = new DefaultPollContext(m_eventMgr, m_pollerConfig, m_queryManager,
+                m_locationAwarePingClient, null, "localhost", "Test.DefaultPollContext");
 
         PollableNetwork network = new PollableNetwork(pollContext);
 
-        m_poller = new Poller();
-        m_poller.setMonitoredServiceDao(m_monitoredServiceDao);
-        m_poller.setOutageDao(m_outageDao);
-        m_poller.setTransactionTemplate(m_transactionTemplate);
+        m_poller = new Poller(m_queryManager, m_monitoredServiceDao, m_outageDao,
+                m_transactionTemplate, new MockPersisterFactory(), null,
+                m_locationAwarePollerClient, m_pollerConfig);
         m_poller.setEventIpcManager(m_eventMgr);
         m_poller.setNetwork(network);
-        m_poller.setQueryManager(m_queryManager);
         m_poller.setPollerConfig(m_pollerConfig);
-        m_poller.setPollOutagesDao(m_pollerConfig);
-        m_poller.setLocationAwarePollerClient(m_locationAwarePollerClient);
-        m_poller.setPersisterFactory(new MockPersisterFactory());
     }
 
     @After

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
@@ -214,27 +214,17 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 
 		m_locationAwarePingClient = mock(LocationAwarePingClient.class);
 
-		DefaultPollContext pollContext = new DefaultPollContext();
-		pollContext.setEventManager(m_eventMgr);
-		pollContext.setLocalHostName("localhost");
-		pollContext.setName("Test.DefaultPollContext");
-		pollContext.setPollerConfig(m_pollerConfig);
-		pollContext.setQueryManager(m_queryManager);
-		pollContext.setLocationAwarePingClient(m_locationAwarePingClient);
+		DefaultPollContext pollContext = new DefaultPollContext(m_eventMgr, m_pollerConfig, m_queryManager,
+				m_locationAwarePingClient, null, "localhost", "Test.DefaultPollContext");
 
 		PollableNetwork network = new PollableNetwork(pollContext);
 
-		m_poller = new Poller();
-        m_poller.setMonitoredServiceDao(m_monitoredServiceDao);
-        m_poller.setTransactionTemplate(m_transactionTemplate);
+		m_poller = new Poller(m_queryManager, m_monitoredServiceDao, m_outageDao,
+				m_transactionTemplate, new MockPersisterFactory(), null,
+				m_locationAwarePollerClient, m_pollerConfig);
 		m_poller.setEventIpcManager(m_eventMgr);
 		m_poller.setNetwork(network);
-		m_poller.setQueryManager(m_queryManager);
 		m_poller.setPollerConfig(m_pollerConfig);
-		m_poller.setPollOutagesDao(m_pollerConfig);
-		m_poller.setLocationAwarePollerClient(m_locationAwarePollerClient);
-		m_poller.setPersisterFactory(new MockPersisterFactory());
-		m_poller.setOutageDao(m_outageDao);
 	}
 
 	@After

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerRpcTimeoutIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerRpcTimeoutIT.java
@@ -212,27 +212,17 @@ public class PollerRpcTimeoutIT implements TemporaryDatabaseAware<MockDatabase> 
         Service svc = pkg.getServices().iterator().next();
         Assert.assertEquals("HTTP", svc.getName());
 
-        DefaultPollContext pollContext = new DefaultPollContext();
-        pollContext.setEventManager(m_eventMgr);
-        pollContext.setLocalHostName("localhost");
-        pollContext.setName("Test.DefaultPollContext");
-        pollContext.setPollerConfig(factory);
-        pollContext.setQueryManager(m_queryManager);
-        pollContext.setLocationAwarePingClient(m_locationAwarePingClient);
+        DefaultPollContext pollContext = new DefaultPollContext(m_eventMgr, factory, m_queryManager,
+                m_locationAwarePingClient, null, "localhost", "Test.DefaultPollContext");
 
         PollableNetwork network = new PollableNetwork(pollContext);
 
-        m_poller = new Poller();
-        m_poller.setMonitoredServiceDao(m_monitoredServiceDao);
-        m_poller.setOutageDao(m_outageDao);
-        m_poller.setTransactionTemplate(m_transactionTemplate);
+        m_poller = new Poller(m_queryManager, m_monitoredServiceDao, m_outageDao,
+                m_transactionTemplate, new MockPersisterFactory(), null,
+                m_locationAwarePollerClient, m_pollOutagesDao);
         m_poller.setEventIpcManager(m_eventMgr);
         m_poller.setNetwork(network);
-        m_poller.setQueryManager(m_queryManager);
         m_poller.setPollerConfig(factory);
-        m_poller.setLocationAwarePollerClient(m_locationAwarePollerClient);
-        m_poller.setPollOutagesDao(m_pollOutagesDao);
-        m_poller.setPersisterFactory(new MockPersisterFactory());
     }
 
     @After

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollableServiceConfigIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollableServiceConfigIT.java
@@ -118,8 +118,9 @@ public class PollableServiceConfigIT {
         PollerConfigFactory.setInstance(factory);
         IOUtils.closeQuietly(is);
 
-        m_locationAwarePollerClient.setRegistry(factory.getServiceMonitorRegistry());
-        m_pollerClientRpcModule.setServiceMonitorRegistry(factory.getServiceMonitorRegistry());
+        // The registry is now final on LocationAwarePollerClientImpl — use the
+        // constructor-injected registry. Monitors are discovered via ServiceLoader.
+        m_pollerClientRpcModule.setServiceMonitorRegistry(m_locationAwarePollerClient.getRegistry());
 
         PersisterFactory persisterFactory = new MockPersisterFactory();
 

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-pollerdTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-pollerdTest.xml
@@ -17,9 +17,14 @@
 ">
 
     <aop:aspectj-autoproxy proxy-target-class="true"/>
-    <context:annotation-config />
 
-    <bean name="pollerQueryManager" class="org.opennms.netmgt.poller.QueryManagerDaoImpl"/>
+    <bean name="pollerQueryManager" class="org.opennms.netmgt.poller.QueryManagerDaoImpl">
+      <constructor-arg ref="nodeDao"/>
+      <constructor-arg ref="outageDao"/>
+      <constructor-arg ref="monitoredServiceDao"/>
+      <constructor-arg ref="ipInterfaceDao"/>
+      <constructor-arg ref="transactionTemplate"/>
+    </bean>
 
     <!--
     <bean name="pollContext" class="org.opennms.netmgt.poller.DefaultPollContext">


### PR DESCRIPTION
## Summary

- Migrates Pollerd from Karaf/OSGi to a standalone Spring Boot 4.0.3 application
- Converts Poller, QueryManagerDaoImpl, DefaultPollContext, LocationAwarePollerClientImpl, LocationAwarePingClientImpl to constructor injection
- Ports OnmsOutage entity and OutageDaoJpa to Jakarta Persistence (Hibernate 7)
- Creates `core/daemon-boot-pollerd` module with 4 configuration classes: JPA, RPC, PassiveStatus, Daemon
- Integrates into Docker pipeline replacing the Karaf/Sentinel-based Pollerd container
- Includes PassiveStatus/Twin API publisher and LocationAwarePingClient

## Cross-daemon fixes (benefit all Spring Boot daemons)

- **`%service%` token expansion** in `KafkaEventForwarder.expandParms()` — was silently producing broken alarm reduction keys for every event-producing daemon
- **Transport-layer EventConfDao enrichment** — `EventConfEnrichmentService` (loads eventconf from DB) wired into `KafkaEventForwarder` via `SmartLifecycle` at phase -20. All daemons (Syslogd, Trapd, EventTranslator, Pollerd) now get automatic alarm-data enrichment
- **`EventIpcManagerEnrichingWrapper`** moved from `daemon-boot-eventtranslator` to `daemon-common` for reuse
- **BSMd alarm snapshot interval** reduced to 10s (from 2min default) for responsive BSM status updates

## Architecture

Follows the established daemon migration pattern (same as Alarmd, Provisiond, BSMd):
- `PollerdApplication` → Spring Boot entry point
- `PollerdJpaConfiguration` → entities, DAOs, SessionUtils, FilterDaoFactory, no-op stubs
- `PollerdRpcConfiguration` → Kafka RPC clients for Minion delegation
- `PollerdPassiveStatusConfiguration` → Twin API publisher for passive status
- `PollerdDaemonConfiguration` → Poller daemon, StandalonePollContext, DaemonSmartLifecycle

Key design decisions:
- **Minion-only polling** — no local monitors, all polls via Kafka RPC
- **StandalonePollContext** — skips AsyncPollingEngine (resilience4j not needed)
- **No-op PersisterFactory/ThresholdingService** — standalone Pollerd doesn't collect metrics
- **Programmatic transactions** — QueryManagerDaoImpl DB operations wrapped in TransactionTemplate

## Runtime fixes discovered during E2E verification

- Added OnmsSnmpInterface/OnmsApplication to entity list (Hibernate 7 entity graph validation)
- Set allocationSize=1 on OnmsOutage @SequenceGenerator (DB increment mismatch)
- Made OnmsOutage.perspective nullable (central polling has no perspective)
- Implemented findMatching(Criteria) in MonitoredServiceDaoJpa (InRestriction with named params)
- Implemented currentOutagesByServiceId() in OutageDaoJpa
- Added pollerExecutor and no-op PingerFactory beans for RPC modules
- Fixed PageSequenceMonitor config: `${nodelabel}` (lowercase) to match service properties
- Added cloud→passiveServiceStatus translation rules for EventTranslator

## Test plan

- [x] `./compile.pl -DskipTests --projects :org.opennms.core.daemon-boot-pollerd -am install` — BUILD SUCCESS
- [x] PollerdApplication starts in ~4 seconds
- [x] Services scheduled and polled via Minion Kafka RPC
- [x] Outages created/resolved with proper JPA transaction boundaries
- [x] **Passive E2E test — 16/16 PASS** (syslog → EventTranslator → PassiveStatusKeeper → Twin API → Minion → alarm + outage)
- [x] **BSM E2E test — PASS** (failure detected in 20s, recovery in 25s)