### PR TITLE
feat: lightweight Docker images — jlink JRE on Alpine for Spring Boot daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 > For the original OpenNMS Horizon project description, see [OPENNMS.md](OPENNMS.md).
 
+## Architectural Direction: Karaf Elimination
+
+Delta-V is systematically removing Apache Karaf/OSGi from the runtime architecture. Each service daemon is being migrated from a Karaf OSGi bundle to a standalone **Spring Boot 4 fat JAR** running on a **jlink custom JRE** built from `alpine:3.21`.
+
+**Why:** The monolithic Karaf container was a 4.75GB image carrying the full Sentinel runtime, OSGi framework, and ServiceMix-repackaged Spring 4.2.x — all dead weight for daemons that just need a JVM and a JAR. The Karaf deployment model also couples daemon lifecycles, prevents independent scaling, and makes dependency management painful (ServiceMix Spring 4.x conflicts with Spring Boot 4's Spring 7).
+
+**Where we are:** 9 of 13 daemons migrated. All run on `opennms/daemon-deltav-springboot` — a 143MB Alpine-based custom JRE with diagnostic tools (jcmd, jstack, curl, tcpdump) and the 9 fat JARs layered on top. Each daemon starts in 2–4 seconds.
+
+**Where we're going:** When the remaining 4 Karaf daemons (Collectd, Enlinkd, Scriptd, Telemetryd) are migrated, the Sentinel/Karaf image is retired entirely. At that point:
+- **Phase 2 (Layered JARs)** extracts shared dependencies (~80% overlap across daemons) into a common Docker layer, collapsing the current ~3.5GB of duplicated libraries down to one shared ~300MB layer
+- **The `opennms-services` monolith** is eliminated — each daemon's implementation lives in its own focused module
+- **ServiceMix Spring bundles** are removed from the dependency tree — no more exclusion blocks
+- **Final target:** each daemon runs as a ~200MB image (143MB JRE base + ~5MB application layer + shared dependency layer), starting in 2–4 seconds, independently deployable and scalable
+
+---
+
 ## Service Daemon Status
 
 ### Deleted (10 daemons)
@@ -21,7 +37,7 @@
 | **Ticketer** | Trouble ticketing integration — not in microservice architecture | #29 |
 | **DHCPd** | DHCP monitor/detector service | — |
 
-### Migrated to Spring Boot 4 (8 daemons)
+### Migrated to Spring Boot 4 (9 daemons)
 
 | Daemon | Spring Boot Module | Startup | Key Feature | PR |
 |--------|--------------------|---------|------------|-----|
@@ -35,6 +51,14 @@
 | **Pollerd** | `daemon-boot-pollerd` | 4.1s | JPA + Kafka RPC + Twin API + PassiveStatusKeeper | #47 |
 | **PerspectivePollerd** | `daemon-boot-perspectivepollerd` | 3.6s | JPA + Kafka RPC + perspective outages + event self-consumption | — |
 
+### Docker Images
+
+| Image | Base | Size | Contents |
+|-------|------|------|----------|
+| `opennms/jre-deltav:21` | `alpine:3.21` | 143MB | jlink custom JRE (22 modules) + diagnostic tools (jcmd, curl, tcpdump, htop, etc.) |
+| `opennms/daemon-deltav-springboot` | `jre-deltav:21` | 3.55GB | 9 Spring Boot fat JARs (Phase 2: layered JAR dedup will reduce significantly) |
+| `opennms/daemon-deltav` | `opennms/sentinel` | 4.75GB | 4 remaining Karaf daemons (Collectd, Enlinkd, Scriptd, Telemetryd) |
+
 ### Shared Infrastructure
 
 | Module | Purpose |
@@ -43,15 +67,14 @@
 | `daemon-sink-kafka` | KafkaSinkBridge — consumes from Minion Sink topics (`OpenNMS.Sink.*`) |
 | `opennms-model-jakarta` | 17 Jakarta Persistence entities + 15 JPA DAOs for Hibernate 7 |
 
-### Running on Karaf (5 daemons — migration candidates)
+### Running on Karaf (4 daemons — migration candidates)
 
 | Daemon | Tier | Complexity | Infrastructure |
 |--------|------|-----------|----------------|
 | **Scriptd** | 1 | Very Low | Events only |
+| **Collectd** | 4 | High | Events + Kafka RPC |
 | **Enlinkd** | 4 | High | Events + Kafka RPC |
 | **Telemetryd** | 4 | High | Multi-module Kafka Sink |
-| **Collectd** | 4 | High | Events + Kafka RPC |
-| **PerspectivePoller** | 5 | Very High | Events + Kafka RPC |
 
 ### Other Components Removed
 
@@ -106,6 +129,7 @@
 | 03-20 | BSMd Spring Boot 4 Migration | JPA + AlarmLifecycleListener + REST API, alarm snapshot polling (10s interval) |
 | 03-21 | Pollerd Spring Boot 4 Migration | JPA + Kafka RPC + Twin API + PassiveStatusKeeper, constructor injection, `%service%` token fix, transport-layer EventConfDao enrichment — BSM E2E + Passive E2E passing |
 | 03-21 | PerspectivePollerd Spring Boot 4 Migration | First daemon without opennms-services dep, JPA + Kafka RPC + perspective outages, ServiceMix exclusion cleanup, 0-arg event adapter pattern |
+| 03-22 | Lightweight Docker Images | jlink custom JRE on Alpine (143MB base), all 9 Spring Boot daemons on `daemon-deltav-springboot` image, `-XX:MaxMetaspaceSize=256m` cap |
 
 ### Superseded (2 docs)
 
@@ -132,7 +156,7 @@
 1. **Events table eliminated** — events never touch PostgreSQL
 2. **ActiveMQ eliminated** — all IPC via Kafka
 3. **Core container eliminated** — replaced by lightweight `db-init` Spring Boot app
-4. **Spring Boot 4 migration** — 6 daemons migrated (Alarmd, EventTranslator, Trapd, Syslogd, Discovery, Provisiond) as `java -jar` fat JARs with 2–4s startup
+4. **Spring Boot 4 migration** — 9 daemons migrated (+ BSMd, Pollerd, PerspectivePollerd) as `java -jar` fat JARs with 2–4s startup on jlink Alpine JRE
 5. **Kafka Sink bridge** — `daemon-sink-kafka` module consumes from Minion Sink topics (`OpenNMS.Sink.*`), reused by Trapd and Syslogd
 6a. **Kafka RPC client** — `KafkaRpcClientConfiguration` in `daemon-common` sends RPC requests to Minions, used by Discovery and Provisiond (3× RPC: SNMP, Detector, DNS)
 6. **opennms-model-jakarta** — 17 Jakarta Persistence entities with JPA AttributeConverters + 13 JPA DAOs replacing Hibernate 3.6 UserTypes
@@ -146,7 +170,7 @@
 
 ### Remaining Work
 
-**Spring Boot 4 migration** — 7 Karaf daemons remain. Three shared infrastructure patterns established: Kafka event transport (all daemons), Kafka Sink bridge (Trapd, Syslogd, Telemetryd), Kafka RPC client (Discovery, Provisiond, Pollerd, Collectd, Enlinkd, PerspectivePoller). Provisiond was the most complex migration (Tier 5) — constructor injection, 13 JPA DAOs, Quartz scheduling, 3× RPC, SNMP adapters. Deferred items: HW inventory adapter (Hibernate 7 entity issue), Minion echo probes, service detector RPC, MATE scopes.
+**Spring Boot 4 migration** — 4 Karaf daemons remain (Collectd, Enlinkd, Scriptd, Telemetryd). Three shared infrastructure patterns established: Kafka event transport (all daemons), Kafka Sink bridge (Trapd, Syslogd, Telemetryd), Kafka RPC client (Discovery, Provisiond, Pollerd, Collectd, Enlinkd, PerspectivePollerd). When all 4 are migrated: retire Karaf/Sentinel image, implement Phase 2 layered JAR deduplication, eliminate `opennms-services` monolith. Deferred items: HW inventory adapter (Hibernate 7 entity issue), Minion echo probes, service detector RPC, MATE scopes.
 
 **Deferred** — Minion-Mandatory Architecture requires prerequisite work on non-distributable ServiceMonitors and collector delegation.
 
@@ -161,8 +185,8 @@ OpenNMS Horizon is an enterprise-grade open-source network monitoring platform. 
 - **Each daemon runs in its own container** — independent scaling, isolation, and restartability
 - **Kafka-only event transport** — no ActiveMQ, no shared event bus
 - **Events never touch PostgreSQL** — only alarms are persisted to the database
-- **2 Docker images** serve all daemon roles — `opennms/daemon-deltav` (13 daemon types, JRE 21), `opennms/minion-deltav` (distributed collection, JRE 21)
-- **Spring Boot 4 migration underway** — 6 daemons migrated (Alarmd, EventTranslator, Trapd, Syslogd, Discovery, Provisiond) as fat JARs (2–4s startup); 7 daemons remain on Karaf
+- **Lightweight Docker images** — 9 Spring Boot daemons run on `opennms/daemon-deltav-springboot` (143MB jlink Alpine JRE + fat JARs); 4 Karaf daemons on `opennms/daemon-deltav`; Minion on `opennms/minion-deltav`
+- **Spring Boot 4 migration: 9 of 13 daemons done** — Alarmd, EventTranslator, Trapd, Syslogd, Discovery, Provisiond, BSMd, Pollerd, PerspectivePollerd run as fat JARs (2–4s startup); 4 Karaf daemons remain (Collectd, Enlinkd, Scriptd, Telemetryd)
 - **One-shot database initialization** — `opennms/db-init` (312 MB) replaces the Core container for schema setup
 
 ## Architecture
@@ -188,9 +212,9 @@ Minion → Kafka Sink → Trapd/Syslogd
 | Service | Runtime | TSID | Purpose |
 |---------|---------|------|---------|
 | alarmd | **Spring Boot 4** | 2 | Kafka → alarm creation/reduction → PostgreSQL |
-| pollerd | Karaf | 4 | Service availability polling |
+| pollerd | **Spring Boot 4** | 4 | Service availability polling |
 | collectd | Karaf | 5 | Performance data collection |
-| perspectivepollerd | Karaf | 7 | Perspective (remote location) polling |
+| perspectivepollerd | **Spring Boot 4** | 7 | Perspective (remote location) polling |
 | discovery | **Spring Boot 4** | 9 | Network discovery (via Minion Kafka RPC) |
 | trapd | **Spring Boot 4** | 10 | SNMP trap reception (via Minion Kafka Sink) |
 | syslogd | **Spring Boot 4** | 11 | Syslog reception (via Minion Kafka Sink) |
@@ -198,7 +222,7 @@ Minion → Kafka Sink → Trapd/Syslogd
 | enlinkd | Karaf | 14 | Enhanced link discovery |
 | scriptd | Karaf | 15 | Script-based event automation |
 | provisiond | **Spring Boot 4** | 25 | Node provisioning and scanning (via Minion 3× Kafka RPC) |
-| bsmd | Karaf | 17 | Business service monitoring |
+| bsmd | **Spring Boot 4** | 17 | Business service monitoring |
 | telemetryd | Karaf | 18 | Telemetry/flow reception (via Minion Kafka Sink) |
 | minion | Karaf | — | Distributed data collection agent |
 | db-init | Spring Boot 4 | — | One-shot Liquibase schema migration |
@@ -255,7 +279,8 @@ cd opennms-container/delta-v
 ./build.sh compile    # Maven compile with JDK 21
 ./build.sh assemble   # Build Karaf assemblies (sentinel, minion, daemon, alarmd)
 ./build.sh images     # Build base Docker images (sentinel, minion, db-init)
-./build.sh deltav     # Build Delta-V layered images (daemon-deltav, minion-deltav)
+./build.sh jre        # Build jlink custom JRE base image (rarely needed)
+./build.sh deltav     # Build Delta-V layered images (daemon-deltav-springboot, daemon-deltav, minion-deltav)
 ```
 
 See [BUILD.md](BUILD.md) for detailed build instructions.

--- a/docs/superpowers/plans/2026-03-22-lightweight-docker-images.md
+++ b/docs/superpowers/plans/2026-03-22-lightweight-docker-images.md
@@ -1,0 +1,578 @@
+# Lightweight Docker Images Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 4.75GB monolithic Docker image with a ~500MB lightweight image for all 9 Spring Boot daemons using a jlink custom JRE on Alpine Linux.
+
+**Architecture:** Three-image split — `opennms/jre-deltav:21` (base JRE + tools), `opennms/daemon-deltav-springboot:${VERSION}` (9 Spring Boot fat JARs), existing `opennms/daemon-deltav:${VERSION}` (4 Karaf daemons unchanged). Spring Boot services switch `image:` in docker-compose.
+
+**Tech Stack:** jlink, Alpine 3.21, Eclipse Temurin 21, Docker multi-stage build
+
+**Spec:** `docs/superpowers/specs/2026-03-22-lightweight-docker-images-design.md`
+
+---
+
+## File Structure
+
+### New files to create:
+- `opennms-container/delta-v/Dockerfile.jre` — Multi-stage build for `opennms/jre-deltav:21`
+- `opennms-container/delta-v/Dockerfile.springboot` — Spring Boot daemon image
+
+### Files to modify:
+- `opennms-container/delta-v/build.sh` — Add `jre` command, modify `deltav` to build springboot image
+- `opennms-container/delta-v/docker-compose.yml` — Switch 9 services to new image, add MaxMetaspaceSize, remove entrypoint overrides
+
+---
+
+## Task 1: Create Dockerfile.jre
+
+**Files:**
+- Create: `opennms-container/delta-v/Dockerfile.jre`
+
+- [ ] **Step 1: Create Dockerfile.jre**
+
+```dockerfile
+# JRE base image for Delta-V Spring Boot daemons.
+# Uses jlink to create a custom JRE with only the modules needed by
+# Spring Boot 4 + Hibernate 7 + Kafka + PostgreSQL JDBC.
+#
+# Build with: ./build.sh jre
+# Rebuild only when upgrading JDK version or changing diagnostic tools.
+
+FROM eclipse-temurin:21-jdk-alpine AS jre-builder
+
+RUN jlink \
+    --add-modules \
+      java.base,\
+      java.sql,\
+      java.sql.rowset,\
+      java.naming,\
+      java.management,\
+      java.xml,\
+      java.desktop,\
+      java.logging,\
+      java.security.jgss,\
+      java.instrument,\
+      java.net.http,\
+      java.compiler,\
+      java.transaction.xa,\
+      jdk.jcmd,\
+      jdk.management,\
+      jdk.management.agent,\
+      jdk.naming.dns,\
+      jdk.naming.rmi,\
+      jdk.crypto.ec,\
+      jdk.unsupported,\
+      jdk.zipfs \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=zip-6 \
+    --output /custom-jre
+
+FROM alpine:3.21
+LABEL org.opencontainers.image.title="Delta-V JRE Base" \
+      org.opencontainers.image.description="Custom JRE with diagnostic tools for Delta-V Spring Boot daemons"
+
+# Custom JRE
+COPY --from=jre-builder /custom-jre /opt/java/openjdk
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Diagnostic tools
+RUN apk add --no-cache \
+    curl \
+    bind-tools \
+    iproute2 \
+    procps \
+    htop \
+    lsof \
+    tcpdump \
+    busybox-extras \
+    nmap-ncat
+
+# Non-root user
+RUN addgroup -S opennms && adduser -S opennms -G opennms
+
+# Config directory for Spring Boot daemons
+RUN mkdir -p /opt/deltav/etc && chown opennms:opennms /opt/deltav/etc
+
+USER opennms
+WORKDIR /opt
+```
+
+- [ ] **Step 2: Build and verify the JRE image**
+
+```bash
+cd opennms-container/delta-v
+docker build -f Dockerfile.jre -t opennms/jre-deltav:21 -t opennms/jre-deltav:latest .
+```
+Expected: Successful build
+
+- [ ] **Step 3: Verify the image works**
+
+```bash
+# Check java
+docker run --rm opennms/jre-deltav:21 java -version
+
+# Check jcmd
+docker run --rm opennms/jre-deltav:21 jcmd -l
+
+# Check curl
+docker run --rm opennms/jre-deltav:21 curl --version
+
+# Check user
+docker run --rm opennms/jre-deltav:21 whoami
+```
+Expected: Java 21, jcmd runs, curl available, user is `opennms`
+
+- [ ] **Step 4: Check image size**
+
+```bash
+docker images opennms/jre-deltav --format "{{.Tag}}\t{{.Size}}"
+```
+Expected: ~150MB
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add opennms-container/delta-v/Dockerfile.jre
+git commit -m "feat: add Dockerfile.jre — jlink custom JRE base image for Spring Boot daemons"
+```
+
+---
+
+## Task 2: Create Dockerfile.springboot
+
+**Files:**
+- Create: `opennms-container/delta-v/Dockerfile.springboot`
+
+- [ ] **Step 1: Create Dockerfile.springboot**
+
+```dockerfile
+# Delta-V Spring Boot daemon image — all 9 migrated daemons in one lightweight image.
+# Each daemon is selected at runtime via docker-compose command:
+#   command: ["java", "-jar", "/opt/daemon-boot-xxx.jar"]
+#
+# Build with: ./build.sh deltav  (requires prior: ./build.sh jre)
+
+ARG JRE_IMAGE=opennms/jre-deltav:21
+FROM ${JRE_IMAGE}
+
+LABEL org.opencontainers.image.title="Delta-V Spring Boot Daemons" \
+      org.opencontainers.image.description="Lightweight image for all Spring Boot daemon services"
+
+# Spring Boot fat JARs
+COPY staging/daemon/daemon-boot-alarmd.jar /opt/daemon-boot-alarmd.jar
+COPY staging/daemon/daemon-boot-eventtranslator.jar /opt/daemon-boot-eventtranslator.jar
+COPY staging/daemon/daemon-boot-trapd.jar /opt/daemon-boot-trapd.jar
+COPY staging/daemon/daemon-boot-syslogd.jar /opt/daemon-boot-syslogd.jar
+COPY staging/daemon/daemon-boot-discovery.jar /opt/daemon-boot-discovery.jar
+COPY staging/daemon/daemon-boot-provisiond.jar /opt/daemon-boot-provisiond.jar
+COPY staging/daemon/daemon-boot-bsmd.jar /opt/daemon-boot-bsmd.jar
+COPY staging/daemon/daemon-boot-pollerd.jar /opt/daemon-boot-pollerd.jar
+COPY staging/daemon/daemon-boot-perspectivepollerd.jar /opt/daemon-boot-perspectivepollerd.jar
+```
+
+- [ ] **Step 2: Build and verify** (requires staging JARs)
+
+Note: You cannot `source build.sh` to call individual functions (the script calls `main` at the end). Instead, build the springboot image after Task 3 is done, using the full `./build.sh deltav` flow. For initial testing in Task 2, stage the JARs manually:
+
+```bash
+cd opennms-container/delta-v
+mkdir -p staging/daemon
+
+# Copy the 9 Spring Boot JARs to staging (adjust VERSION as needed)
+VERSION=36.0.0-SNAPSHOT
+for jar in alarmd eventtranslator trapd syslogd discovery provisiond bsmd pollerd perspectivepollerd; do
+    src="../../core/daemon-boot-$jar/target/org.opennms.core.daemon-boot-$jar-$VERSION-boot.jar"
+    [ ! -f "$src" ] && src="../../core/daemon-boot-$jar/target/org.opennms.core.daemon-boot-$jar-$VERSION.jar"
+    [ -f "$src" ] && cp "$src" "staging/daemon/daemon-boot-$jar.jar" && echo "Staged $jar" || echo "MISSING: $src"
+done
+
+# Build the image
+docker build -f Dockerfile.springboot \
+    -t "opennms/daemon-deltav-springboot:$VERSION" \
+    -t "opennms/daemon-deltav-springboot:latest" \
+    .
+
+# Clean up manual staging
+rm -rf staging
+```
+Expected: Successful build
+
+- [ ] **Step 3: Verify all 9 JARs are present**
+
+```bash
+docker run --rm opennms/daemon-deltav-springboot:36.0.0-SNAPSHOT ls -la /opt/daemon-boot-*.jar
+```
+Expected: 9 JAR files listed
+
+- [ ] **Step 4: Check image size**
+
+```bash
+docker images opennms/daemon-deltav-springboot --format "{{.Tag}}\t{{.Size}}"
+```
+Expected: Significantly smaller than 4.75GB
+
+- [ ] **Step 5: Quick smoke test — start PerspectivePollerd from new image**
+
+```bash
+docker run --rm --name test-perspectivepollerd \
+    -e SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/opennms \
+    opennms/daemon-deltav-springboot:36.0.0-SNAPSHOT \
+    java -version
+```
+Expected: Java 21 version output (just verifying the JAR can find Java)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add opennms-container/delta-v/Dockerfile.springboot
+git commit -m "feat: add Dockerfile.springboot — lightweight image for 9 Spring Boot daemons"
+```
+
+---
+
+## Task 3: Update build.sh
+
+**Files:**
+- Modify: `opennms-container/delta-v/build.sh`
+
+- [ ] **Step 1: Add `do_jre_image()` function**
+
+Add after `do_db_init_image()` function (around line 101):
+
+```bash
+do_jre_image() {
+    log "Building opennms/jre-deltav:21..."
+    cd "$SCRIPT_DIR"
+    docker build -f Dockerfile.jre \
+        -t "opennms/jre-deltav:21" \
+        -t "opennms/jre-deltav:latest" \
+        .
+    log "JRE image built:"
+    docker images opennms/jre-deltav --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}"
+}
+```
+
+- [ ] **Step 2: Modify `do_deltav_images()` to build springboot image**
+
+In `do_deltav_images()` (around line 190), add the springboot build BEFORE the existing Karaf image build:
+
+Replace the entire `do_deltav_images()` function (lines 190-219) with:
+
+```bash
+do_deltav_images() {
+    log "Building Delta-V layered images..."
+
+    # Check that JRE base image exists
+    if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+        err "opennms/jre-deltav:21 not found — run './build.sh jre' first"
+    fi
+
+    do_stage_daemon_jars
+
+    # Spring Boot daemons — lightweight image
+    log "Building opennms/daemon-deltav-springboot:$VERSION..."
+    cd "$SCRIPT_DIR"
+    docker build \
+        -f Dockerfile.springboot \
+        -t "opennms/daemon-deltav-springboot:$VERSION" \
+        -t "opennms/daemon-deltav-springboot:latest" \
+        .
+
+    # Karaf daemons — existing Sentinel-based image
+    log "Building opennms/daemon-deltav:$VERSION..."
+    cd "$SCRIPT_DIR"
+    docker build \
+        --build-arg "VERSION=$VERSION" \
+        -f Dockerfile.daemon \
+        -t "opennms/daemon-deltav:$VERSION" \
+        -t "opennms/daemon-deltav:latest" \
+        .
+
+    # Minion image
+    log "Building opennms/minion-deltav:$VERSION..."
+    docker build \
+        --build-arg "VERSION=$VERSION" \
+        -f Dockerfile.minion \
+        -t "opennms/minion-deltav:$VERSION" \
+        -t "opennms/minion-deltav:latest" \
+        .
+
+    # Clean up staging
+    rm -rf "$SCRIPT_DIR/staging"
+
+    log "Delta-V images built:"
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "deltav" | head -10
+}
+```
+
+- [ ] **Step 3: Add `jre` case to `main()` switch and update `all`/`push` cases**
+
+In the `main()` case statement (around line 260):
+
+Add new case:
+```bash
+        jre)
+            do_jre_image
+            ;;
+```
+
+Update the `all` case to build JRE if missing:
+```bash
+        all)
+            do_compile
+            do_assemble
+            do_images
+            # Build JRE base if not already present
+            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+                do_jre_image
+            fi
+            do_deltav_images
+            log "Build complete! Run: cd $SCRIPT_DIR && docker compose up -d"
+            ;;
+```
+
+Update the `push` case similarly:
+```bash
+        push)
+            do_compile
+            do_assemble
+            do_images push
+            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+                do_jre_image
+            fi
+            do_deltav_images
+            ;;
+```
+
+- [ ] **Step 4: Update usage text**
+
+Add `jre` to the usage help:
+
+```
+  jre       Build JRE base image (opennms/jre-deltav:21, rarely needed)
+```
+
+- [ ] **Step 5: Test the build flow**
+
+```bash
+cd opennms-container/delta-v
+
+# Build JRE base (first time)
+VERSION=36.0.0-SNAPSHOT bash build.sh jre
+
+# Build Delta-V images (should build both springboot and karaf)
+VERSION=36.0.0-SNAPSHOT bash build.sh deltav
+```
+Expected: Both images built successfully
+
+- [ ] **Step 6: Verify both images exist**
+
+```bash
+docker images --format "{{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-deltav|jre-deltav"
+```
+Expected: Three images — `jre-deltav:21`, `daemon-deltav-springboot:VERSION`, `daemon-deltav:VERSION`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add opennms-container/delta-v/build.sh
+git commit -m "feat: add jre build command and springboot image to build.sh"
+```
+
+---
+
+## Task 4: Update docker-compose.yml
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+
+This task switches all 9 Spring Boot services to the new image, adds `-XX:MaxMetaspaceSize=256m` to all commands, and removes `entrypoint: []` overrides.
+
+For each service: change `image:` to `opennms/daemon-deltav-springboot:${VERSION}`, remove `entrypoint: []`, add `-XX:MaxMetaspaceSize=256m` to command. Preserve ALL existing `-D` system properties and heap sizes.
+
+- [ ] **Step 1: Update pollerd** (line 124)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m",
+              "-Dorg.opennms.core.ipc.twin.kafka.bootstrap.servers=kafka:9092",
+              "-Dorg.opennms.core.ipc.rpc.force-remote=true",
+              "-jar", "/opt/daemon-boot-pollerd.jar"]
+```
+Remove `entrypoint: []` (line 127).
+
+- [ ] **Step 2: Update discovery** (line 194)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m",
+              "-jar", "/opt/daemon-boot-discovery.jar"]
+```
+Remove `entrypoint: []` (line 197).
+
+- [ ] **Step 3: Update trapd** (line 226)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m",
+              "-jar", "/opt/daemon-boot-trapd.jar"]
+```
+Remove `entrypoint: []` (line 229).
+
+- [ ] **Step 4: Update syslogd** (line 258)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m",
+              "-jar", "/opt/daemon-boot-syslogd.jar"]
+```
+Remove `entrypoint: []` (line 261).
+
+- [ ] **Step 5: Update eventtranslator** (line 291)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m",
+              "-jar", "/opt/daemon-boot-eventtranslator.jar"]
+```
+Remove `entrypoint: []` (line 294).
+
+- [ ] **Step 6: Update provisiond** (line 385)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m",
+              "-jar", "/opt/daemon-boot-provisiond.jar"]
+```
+Remove `entrypoint: []` (line 388).
+
+- [ ] **Step 7: Update bsmd** (line 418)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m",
+              "-Dorg.opennms.alarms.snapshot.sync.ms=10000",
+              "-jar", "/opt/daemon-boot-bsmd.jar"]
+```
+Remove `entrypoint: []` (line 421).
+
+- [ ] **Step 8: Update perspectivepollerd** (line 450)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m",
+              "-Dorg.opennms.core.ipc.rpc.force-remote=true",
+              "-jar", "/opt/daemon-boot-perspectivepollerd.jar"]
+```
+Remove `entrypoint: []` (line 451).
+
+- [ ] **Step 9: Update alarmd** (line 484)
+
+```yaml
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m",
+              "-jar", "/opt/daemon-boot-alarmd.jar"]
+```
+Remove `entrypoint: []` (line 485).
+
+- [ ] **Step 10: Verify docker-compose is valid**
+
+```bash
+cd opennms-container/delta-v
+VERSION=36.0.0-SNAPSHOT docker compose config --quiet
+```
+Expected: No errors (exit code 0)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add opennms-container/delta-v/docker-compose.yml
+git commit -m "feat: switch 9 Spring Boot daemons to lightweight springboot image"
+```
+
+---
+
+## Task 5: Full Stack Verification
+
+- [ ] **Step 1: Build everything**
+
+```bash
+cd opennms-container/delta-v
+VERSION=36.0.0-SNAPSHOT bash build.sh jre
+VERSION=36.0.0-SNAPSHOT bash build.sh deltav
+```
+
+- [ ] **Step 2: Compare image sizes**
+
+```bash
+docker images --format "{{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-deltav|jre-deltav"
+```
+Expected output like:
+```
+opennms/jre-deltav:21                              ~150MB
+opennms/daemon-deltav-springboot:36.0.0-SNAPSHOT   ~500-700MB
+opennms/daemon-deltav:36.0.0-SNAPSHOT              ~4.75GB
+```
+
+- [ ] **Step 3: Start the full stack**
+
+```bash
+cd opennms-container/delta-v
+VERSION=36.0.0-SNAPSHOT docker compose --profile full up -d
+```
+
+- [ ] **Step 4: Wait for health checks and verify all Spring Boot daemons**
+
+```bash
+sleep 30
+
+# Check each Spring Boot daemon
+for svc in pollerd alarmd bsmd provisiond perspectivepollerd trapd syslogd eventtranslator discovery; do
+    echo "=== $svc ==="
+    docker exec "delta-v-$svc" curl -sf http://localhost:8080/actuator/health 2>&1 || echo "FAILED"
+done
+```
+Expected: All 9 show `{"status":"UP"}`
+
+- [ ] **Step 5: Verify Karaf daemons still work**
+
+```bash
+for svc in collectd enlinkd telemetryd scriptd; do
+    echo "=== $svc ==="
+    docker exec "delta-v-$svc" curl -sf -u admin:admin http://localhost:8181/sentinel/rest/health/probe 2>&1 || echo "FAILED or not running"
+done
+```
+Expected: Karaf daemons healthy (or not running if their profile isn't active)
+
+- [ ] **Step 6: Verify jcmd works inside a container**
+
+```bash
+docker exec delta-v-perspectivepollerd jcmd 1 VM.version
+```
+Expected: JDK version output
+
+- [ ] **Step 7: Commit any fixes if needed**
+
+```bash
+git add <changed-files>
+git commit -m "fix: resolve lightweight image startup issues"
+```
+
+---
+
+## Task 6: Update Dashboard
+
+- [ ] **Step 1: Update README.md**
+
+Add a note about the lightweight Docker image to the README dashboard section.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: update dashboard — lightweight Docker images for Spring Boot daemons"
+```

--- a/docs/superpowers/specs/2026-03-22-lightweight-docker-images-design.md
+++ b/docs/superpowers/specs/2026-03-22-lightweight-docker-images-design.md
@@ -1,0 +1,224 @@
+# Lightweight Docker Images for Spring Boot Daemons
+
+## Overview
+
+Replace the 4.75GB monolithic `daemon-deltav` image (based on Sentinel/Karaf) with a ~350MB lightweight image for the 9 Spring Boot daemons. Uses a jlink custom JRE on Alpine Linux with diagnostic tools baked in.
+
+The 4 remaining Karaf daemons (Collectd, Enlinkd, Telemetryd, Scriptd) continue using the existing Sentinel-based image until migrated.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Image strategy | Two-image split | Spring Boot daemons get lightweight image; Karaf daemons keep existing Sentinel-based image |
+| JRE approach | jlink custom JRE | Smaller than full JDK, includes `jcmd`/`jstack` for diagnostics |
+| Base OS | `alpine:3.21` | Smallest stable base, widely used |
+| JRE base image | Separate `opennms/jre-deltav:21` | Built once, shared by all Spring Boot daemon images; changes rarely |
+| Diagnostic tools | Baked into base image | Avoid ephemeral container friction for `jcmd`/`jstack` (require same PID namespace + JDK version) |
+| Module discovery | Known-good list (not jdeps) | `jdeps` misses reflection-based usage (Hibernate, Spring, Kafka); manual list is reliable |
+| JAR layout | Fat JARs in `/opt/` | Phase 1 simplicity; Phase 2 will add layered JAR deduplication |
+| Dockerfile.daemon cleanup | Keep Spring Boot JARs during transition | Allows fallback to old image by changing one docker-compose line |
+
+## Image Architecture
+
+```
+alpine:3.21
+  └─ opennms/jre-deltav:21 (~150MB)
+       └─ opennms/daemon-deltav-springboot:${VERSION} (~350MB)
+
+opennms/sentinel:${VERSION} (1.33GB)
+  └─ opennms/daemon-deltav:${VERSION} (4.75GB, Karaf daemons only)
+```
+
+| Image | Base | Contents | Estimated Size |
+|-------|------|----------|----------------|
+| `opennms/jre-deltav:21` | `alpine:3.21` | jlink custom JRE + diagnostic tools + curl + non-root user | ~150MB |
+| `opennms/daemon-deltav-springboot:${VERSION}` | `opennms/jre-deltav:21` | 9 Spring Boot fat JARs in `/opt/` | ~500-700MB (to be validated; fat JARs total ~1.2GB uncompressed but Docker layer compression helps) |
+| `opennms/daemon-deltav:${VERSION}` | `opennms/daemon:${VERSION}` | Existing Sentinel-based, 4 Karaf daemons | ~4.75GB (unchanged) |
+
+## JRE Base Image: `opennms/jre-deltav:21`
+
+### Dockerfile.jre
+
+Multi-stage build:
+1. Stage 1 (`eclipse-temurin:21-jdk-alpine`): runs `jlink` to create custom JRE
+2. Stage 2 (`alpine:3.21`): copies custom JRE, installs tools, creates user
+
+### jlink Module List
+
+| Module | Reason |
+|--------|--------|
+| `java.base` | Always required |
+| `java.sql` | JDBC / PostgreSQL driver |
+| `java.naming` | JNDI (Kafka client internal usage) |
+| `java.management` | JMX (Spring Boot actuator, Kafka metrics) |
+| `java.xml` | JAXB, poller-configuration.xml parsing |
+| `java.desktop` | `java.beans.Introspector` (Spring property binding — mandatory); `ImageIO` (some monitors) |
+| `java.logging` | JUL-to-SLF4J bridge |
+| `java.security.jgss` | Kerberos (Kafka SASL authentication) |
+| `java.instrument` | Spring Boot agent attachment |
+| `java.net.http` | Java HTTP client |
+| `java.compiler` | Runtime annotation processing |
+| `jdk.jcmd` | `jcmd` diagnostic tool (thread dumps, heap info) |
+| `jdk.management` | Platform MBeans |
+| `jdk.management.agent` | Remote JMX agent |
+| `jdk.naming.dns` | DNS lookups |
+| `jdk.crypto.ec` | TLS with EC ciphers |
+| `java.transaction.xa` | XA transaction interfaces (Hibernate 7 / `jakarta.transaction.xa.XAResource`) |
+| `java.sql.rowset` | `javax.sql.rowset.serial.SerialBlob` (Hibernate BLOB/CLOB proxy internals) |
+| `jdk.unsupported` | `sun.misc.Unsafe` (Kafka, Netty) |
+| `jdk.zipfs` | Spring Boot JAR-in-JAR loading |
+| `jdk.naming.rmi` | RMI naming (avoids warnings when `jdk.management.agent` is present) |
+
+### Diagnostic Tools
+
+Installed via `apk add --no-cache`:
+- `curl` — actuator health checks
+- `bind-tools` — `dig`, `nslookup`
+- `iproute2` — `ip`, `ss`
+- `procps` — `ps`, `top`
+- `htop` — interactive process monitor
+- `lsof` — open file listing
+- `tcpdump` — packet capture (requires `cap_add: [NET_RAW]` in docker-compose or `--privileged` for `docker exec`)
+- `busybox-extras` — `telnet`
+- `nmap-ncat` — `ncat` (netcat replacement)
+
+### User and Directories
+
+- Non-root user: `opennms:opennms` (note: existing `daemon-deltav` image uses `sentinel:sentinel` — this is safe because all overlays are mounted `:ro` so file ownership doesn't matter for reads)
+- Config directory: `/opt/deltav/etc` (owned by opennms, bind-mounted from overlay)
+- No entrypoint — daemons specify full `command` in docker-compose
+
+**Alpine musl libc note:** Alpine uses musl libc, not glibc. The Eclipse Temurin Alpine JDK handles this natively. JNI-based native libraries (unlikely in this stack) would need musl-compatible builds.
+
+**This image changes rarely** — only on JDK version upgrade or tool changes.
+
+## Spring Boot Daemon Image: `opennms/daemon-deltav-springboot:${VERSION}`
+
+### Dockerfile.springboot
+
+```dockerfile
+ARG JRE_IMAGE=opennms/jre-deltav:21
+FROM ${JRE_IMAGE}
+
+COPY staging/daemon/daemon-boot-alarmd.jar /opt/daemon-boot-alarmd.jar
+COPY staging/daemon/daemon-boot-eventtranslator.jar /opt/daemon-boot-eventtranslator.jar
+COPY staging/daemon/daemon-boot-trapd.jar /opt/daemon-boot-trapd.jar
+COPY staging/daemon/daemon-boot-syslogd.jar /opt/daemon-boot-syslogd.jar
+COPY staging/daemon/daemon-boot-discovery.jar /opt/daemon-boot-discovery.jar
+COPY staging/daemon/daemon-boot-provisiond.jar /opt/daemon-boot-provisiond.jar
+COPY staging/daemon/daemon-boot-bsmd.jar /opt/daemon-boot-bsmd.jar
+COPY staging/daemon/daemon-boot-pollerd.jar /opt/daemon-boot-pollerd.jar
+COPY staging/daemon/daemon-boot-perspectivepollerd.jar /opt/daemon-boot-perspectivepollerd.jar
+```
+
+### Spring Boot Daemons Included
+
+1. `daemon-boot-alarmd.jar`
+2. `daemon-boot-eventtranslator.jar`
+3. `daemon-boot-trapd.jar`
+4. `daemon-boot-syslogd.jar`
+5. `daemon-boot-discovery.jar`
+6. `daemon-boot-provisiond.jar`
+7. `daemon-boot-bsmd.jar`
+8. `daemon-boot-pollerd.jar`
+9. `daemon-boot-perspectivepollerd.jar`
+
+Each daemon is selected at runtime via docker-compose `command`:
+```yaml
+image: opennms/daemon-deltav-springboot:${VERSION}
+command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m", ..., "-jar", "/opt/daemon-boot-xxx.jar"]
+```
+
+### Standard JVM Flags
+
+All Spring Boot daemons should use these flags:
+- `-Xms512m -Xmx1g` — heap bounds
+- `-XX:MaxMetaspaceSize=256m` — cap Metaspace per JVM (measured range: 76-137MB across daemons; 256MB provides headroom without allowing unbounded growth across 9+ JVMs)
+
+## docker-compose.yml Changes
+
+### Spring Boot daemons (9 services)
+
+The following services switch from `opennms/daemon-deltav:${VERSION}` to `opennms/daemon-deltav-springboot:${VERSION}`:
+
+1. `alarmd`
+2. `eventtranslator`
+3. `trapd`
+4. `syslogd`
+5. `discovery`
+6. `provisiond`
+7. `bsmd`
+8. `pollerd`
+9. `perspectivepollerd`
+
+For each service:
+```yaml
+# Before:
+image: opennms/daemon-deltav:${VERSION}
+entrypoint: []
+command: ["java", ..., "-jar", "/opt/daemon-boot-xxx.jar"]
+
+# After:
+image: opennms/daemon-deltav-springboot:${VERSION}
+command: ["java", ..., "-jar", "/opt/daemon-boot-xxx.jar"]
+```
+
+The `entrypoint: []` override is no longer needed — `jre-deltav` has no entrypoint (unlike the Sentinel image). Remove the `entrypoint: []` line from all 9 services.
+
+### Karaf daemons (4 services: Collectd, Enlinkd, Telemetryd, Scriptd)
+
+Unchanged — continue using `opennms/daemon-deltav:${VERSION}`.
+
+## Build Integration
+
+### build.sh Changes
+
+All of these are NEW code to add to `build.sh`:
+
+**New function: `do_jre_image()`**
+```bash
+do_jre_image() {
+    log "Building opennms/jre-deltav:21..."
+    cd "$SCRIPT_DIR"
+    docker build -f Dockerfile.jre \
+        -t "opennms/jre-deltav:21" \
+        -t "opennms/jre-deltav:latest" \
+        .
+}
+```
+
+**New command:** `./build.sh jre` — calls `do_jre_image()` (run manually, rarely needed)
+
+**Modified: `do_deltav_images()`** — add springboot image build before existing Karaf image build:
+```bash
+# Check prerequisite
+if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+    err "opennms/jre-deltav:21 not found — run './build.sh jre' first"
+fi
+
+# Spring Boot daemons — lightweight image
+log "Building opennms/daemon-deltav-springboot:$VERSION..."
+docker build \
+    -f Dockerfile.springboot \
+    -t "opennms/daemon-deltav-springboot:$VERSION" \
+    -t "opennms/daemon-deltav-springboot:latest" \
+    .
+```
+
+**Staging:** `do_stage_daemon_jars()` is unchanged — stages all JARs. `Dockerfile.springboot` COPYs only the 9 Spring Boot JARs; `Dockerfile.daemon` COPYs everything.
+
+## Verification
+
+1. Build `jre-deltav:21` — verify `java -version`, `jcmd`, `curl` work
+2. Build `daemon-deltav-springboot:${VERSION}` — verify all 9 JARs in `/opt/`
+3. Start PerspectivePollerd from new image — verify actuator health UP
+4. Start all 9 Spring Boot daemons — verify all healthy
+5. Compare sizes — expect significant reduction from 4.75GB (exact size to be validated during build)
+6. Verify Karaf daemons still work on existing `daemon-deltav` image
+
+## Followup Tasks (Out of Scope)
+
+1. **Phase 2: Layered JAR deduplication** — extract and share common dependency layer across daemons (after all Karaf daemons migrated)
+2. **Remove Spring Boot JARs from Dockerfile.daemon** — after springboot image proven stable
+3. **Retire `daemon-deltav` entirely** — after all 4 Karaf daemons migrated to Spring Boot

--- a/opennms-container/delta-v/Dockerfile.jre
+++ b/opennms-container/delta-v/Dockerfile.jre
@@ -9,7 +9,7 @@ FROM eclipse-temurin:21-jdk-alpine AS jre-builder
 
 RUN jlink \
     --add-modules \
-      java.base,java.sql,java.sql.rowset,java.naming,java.management,java.xml,java.desktop,java.logging,java.security.jgss,java.instrument,java.net.http,java.compiler,java.transaction.xa,jdk.jcmd,jdk.management,jdk.management.agent,jdk.naming.dns,jdk.naming.rmi,jdk.crypto.ec,jdk.unsupported,jdk.zipfs \
+      java.base,java.sql,java.sql.rowset,java.naming,java.management,java.xml,java.desktop,java.logging,java.security.jgss,java.instrument,java.net.http,java.compiler,java.transaction.xa,java.scripting,jdk.jcmd,jdk.management,jdk.management.agent,jdk.naming.dns,jdk.naming.rmi,jdk.crypto.ec,jdk.unsupported,jdk.zipfs \
     --strip-debug \
     --no-man-pages \
     --no-header-files \

--- a/opennms-container/delta-v/Dockerfile.jre
+++ b/opennms-container/delta-v/Dockerfile.jre
@@ -1,0 +1,47 @@
+# JRE base image for Delta-V Spring Boot daemons.
+# Uses jlink to create a custom JRE with only the modules needed by
+# Spring Boot 4 + Hibernate 7 + Kafka + PostgreSQL JDBC.
+#
+# Build with: ./build.sh jre
+# Rebuild only when upgrading JDK version or changing diagnostic tools.
+
+FROM eclipse-temurin:21-jdk-alpine AS jre-builder
+
+RUN jlink \
+    --add-modules \
+      java.base,java.sql,java.sql.rowset,java.naming,java.management,java.xml,java.desktop,java.logging,java.security.jgss,java.instrument,java.net.http,java.compiler,java.transaction.xa,jdk.jcmd,jdk.management,jdk.management.agent,jdk.naming.dns,jdk.naming.rmi,jdk.crypto.ec,jdk.unsupported,jdk.zipfs \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=zip-6 \
+    --output /custom-jre
+
+FROM alpine:3.21
+LABEL org.opencontainers.image.title="Delta-V JRE Base" \
+      org.opencontainers.image.description="Custom JRE with diagnostic tools for Delta-V Spring Boot daemons"
+
+# Custom JRE
+COPY --from=jre-builder /custom-jre /opt/java/openjdk
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Diagnostic tools
+RUN apk add --no-cache \
+    curl \
+    bind-tools \
+    iproute2 \
+    procps \
+    htop \
+    lsof \
+    tcpdump \
+    busybox-extras \
+    nmap-ncat
+
+# Non-root user
+RUN addgroup -S opennms && adduser -S opennms -G opennms
+
+# Config directory for Spring Boot daemons
+RUN mkdir -p /opt/deltav/etc && chown opennms:opennms /opt/deltav/etc
+
+USER opennms
+WORKDIR /opt

--- a/opennms-container/delta-v/Dockerfile.springboot
+++ b/opennms-container/delta-v/Dockerfile.springboot
@@ -1,0 +1,22 @@
+# Delta-V Spring Boot daemon image — all 9 migrated daemons in one lightweight image.
+# Each daemon is selected at runtime via docker-compose command:
+#   command: ["java", "-jar", "/opt/daemon-boot-xxx.jar"]
+#
+# Build with: ./build.sh deltav  (requires prior: ./build.sh jre)
+
+ARG JRE_IMAGE=opennms/jre-deltav:21
+FROM ${JRE_IMAGE}
+
+LABEL org.opencontainers.image.title="Delta-V Spring Boot Daemons" \
+      org.opencontainers.image.description="Lightweight image for all Spring Boot daemon services"
+
+# Spring Boot fat JARs
+COPY staging/daemon/daemon-boot-alarmd.jar /opt/daemon-boot-alarmd.jar
+COPY staging/daemon/daemon-boot-eventtranslator.jar /opt/daemon-boot-eventtranslator.jar
+COPY staging/daemon/daemon-boot-trapd.jar /opt/daemon-boot-trapd.jar
+COPY staging/daemon/daemon-boot-syslogd.jar /opt/daemon-boot-syslogd.jar
+COPY staging/daemon/daemon-boot-discovery.jar /opt/daemon-boot-discovery.jar
+COPY staging/daemon/daemon-boot-provisiond.jar /opt/daemon-boot-provisiond.jar
+COPY staging/daemon/daemon-boot-bsmd.jar /opt/daemon-boot-bsmd.jar
+COPY staging/daemon/daemon-boot-pollerd.jar /opt/daemon-boot-pollerd.jar
+COPY staging/daemon/daemon-boot-perspectivepollerd.jar /opt/daemon-boot-perspectivepollerd.jar

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -100,6 +100,17 @@ do_db_init_image() {
     docker build -t "opennms/db-init:$VERSION" -t "opennms/db-init:latest" .
 }
 
+do_jre_image() {
+    log "Building opennms/jre-deltav:21..."
+    cd "$SCRIPT_DIR"
+    docker build -f Dockerfile.jre \
+        -t "opennms/jre-deltav:21" \
+        -t "opennms/jre-deltav:latest" \
+        .
+    log "JRE image built:"
+    docker images opennms/jre-deltav --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}"
+}
+
 do_images() {
     local make_args="DOCKER_REGISTRY=$DOCKER_REGISTRY DOCKER_ORG=$DOCKER_ORG"
     [ "${1:-}" = "push" ] && make_args="$make_args DOCKER_FLAGS=--push"
@@ -190,9 +201,23 @@ do_stage_daemon_jars() {
 do_deltav_images() {
     log "Building Delta-V layered images..."
 
+    # Check that JRE base image exists
+    if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+        err "opennms/jre-deltav:21 not found — run './build.sh jre' first"
+    fi
+
     do_stage_daemon_jars
 
-    # Daemon image (all 15 daemon services share one image)
+    # Spring Boot daemons — lightweight image
+    log "Building opennms/daemon-deltav-springboot:$VERSION..."
+    cd "$SCRIPT_DIR"
+    docker build \
+        -f Dockerfile.springboot \
+        -t "opennms/daemon-deltav-springboot:$VERSION" \
+        -t "opennms/daemon-deltav-springboot:latest" \
+        .
+
+    # Karaf daemons — existing Sentinel-based image
     log "Building opennms/daemon-deltav:$VERSION..."
     cd "$SCRIPT_DIR"
     docker build \
@@ -228,6 +253,7 @@ Commands:
   compile   Compile only (Maven)
   assemble  Assemble distributions (Daemon + Alarmd + Minion + Sentinel)
   images    Build base Docker images only (requires prior assembly)
+  jre       Build JRE base image (opennms/jre-deltav:21, rarely needed)
   deltav    Build Delta-V layered images (stages JARs into derived images)
   push      Build and push images to registry
   clean     Remove named Docker volumes (fresh start)
@@ -262,6 +288,9 @@ main() {
             do_compile
             do_assemble
             do_images
+            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+                do_jre_image
+            fi
             do_deltav_images
             log "Build complete! Run: cd $SCRIPT_DIR && docker compose up -d"
             ;;
@@ -274,6 +303,9 @@ main() {
         images)
             do_images
             ;;
+        jre)
+            do_jre_image
+            ;;
         deltav)
             do_deltav_images
             ;;
@@ -281,6 +313,9 @@ main() {
             do_compile
             do_assemble
             do_images push
+            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+                do_jre_image
+            fi
             do_deltav_images
             ;;
         clean)

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -121,11 +121,10 @@ services:
 
   pollerd:
     profiles: [lite, full]
-    image: opennms/daemon-deltav:${VERSION}
+    image: opennms/daemon-deltav-springboot:${VERSION}
     container_name: delta-v-pollerd
     hostname: pollerd
-    entrypoint: []
-    command: ["java", "-Xms512m", "-Xmx1g",
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m",
               "-Dorg.opennms.core.ipc.twin.kafka.bootstrap.servers=kafka:9092",
               "-Dorg.opennms.core.ipc.rpc.force-remote=true",
               "-jar", "/opt/daemon-boot-pollerd.jar"]
@@ -191,11 +190,10 @@ services:
 
   discovery:
     profiles: [passive, full]
-    image: opennms/daemon-deltav:${VERSION}
+    image: opennms/daemon-deltav-springboot:${VERSION}
     container_name: delta-v-discovery
     hostname: discovery
-    entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m", "-jar", "/opt/daemon-boot-discovery.jar"]
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m", "-jar", "/opt/daemon-boot-discovery.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -223,11 +221,10 @@ services:
 
   trapd:
     profiles: [passive, full]
-    image: opennms/daemon-deltav:${VERSION}
+    image: opennms/daemon-deltav-springboot:${VERSION}
     container_name: delta-v-trapd
     hostname: trapd
-    entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m", "-jar", "/opt/daemon-boot-trapd.jar"]
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m", "-jar", "/opt/daemon-boot-trapd.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -255,11 +252,10 @@ services:
 
   syslogd:
     profiles: [passive, full]
-    image: opennms/daemon-deltav:${VERSION}
+    image: opennms/daemon-deltav-springboot:${VERSION}
     container_name: delta-v-syslogd
     hostname: syslogd
-    entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m", "-jar", "/opt/daemon-boot-syslogd.jar"]
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m", "-jar", "/opt/daemon-boot-syslogd.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -288,11 +284,10 @@ services:
 
   eventtranslator:
     profiles: [passive, full]
-    image: opennms/daemon-deltav:${VERSION}
+    image: opennms/daemon-deltav-springboot:${VERSION}
     container_name: delta-v-eventtranslator
     hostname: eventtranslator
-    entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m", "-jar", "/opt/daemon-boot-eventtranslator.jar"]
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m", "-jar", "/opt/daemon-boot-eventtranslator.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -382,11 +377,10 @@ services:
 
   provisiond:
     profiles: [lite, passive, full]
-    image: opennms/daemon-deltav:${VERSION}
+    image: opennms/daemon-deltav-springboot:${VERSION}
     container_name: delta-v-provisiond
     hostname: provisiond
-    entrypoint: []
-    command: ["java", "-Xms512m", "-Xmx1g", "-jar", "/opt/daemon-boot-provisiond.jar"]
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m", "-jar", "/opt/daemon-boot-provisiond.jar"]
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -415,11 +409,10 @@ services:
 
   bsmd:
     profiles: [lite, full]
-    image: opennms/daemon-deltav:${VERSION}
+    image: opennms/daemon-deltav-springboot:${VERSION}
     container_name: delta-v-bsmd
     hostname: bsmd
-    entrypoint: []
-    command: ["java", "-Xms256m", "-Xmx512m",
+    command: ["java", "-Xms256m", "-Xmx512m", "-XX:MaxMetaspaceSize=256m",
               "-Dorg.opennms.alarms.snapshot.sync.ms=10000",
               "-jar", "/opt/daemon-boot-bsmd.jar"]
     depends_on:
@@ -447,9 +440,8 @@ services:
 
   perspectivepollerd:
     profiles: [full]
-    image: opennms/daemon-deltav:${VERSION}
-    entrypoint: []
-    command: ["java", "-Xms512m", "-Xmx1g",
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m",
               "-Dorg.opennms.core.ipc.rpc.force-remote=true",
               "-jar", "/opt/daemon-boot-perspectivepollerd.jar"]
     container_name: delta-v-perspectivepollerd
@@ -481,9 +473,8 @@ services:
 
   alarmd:
     profiles: [lite, passive, full]
-    image: opennms/daemon-deltav:${VERSION}
-    entrypoint: []
-    command: ["java", "-Xms512m", "-Xmx1g", "-jar", "/opt/daemon-boot-alarmd.jar"]
+    image: opennms/daemon-deltav-springboot:${VERSION}
+    command: ["java", "-Xms512m", "-Xmx1g", "-XX:MaxMetaspaceSize=256m", "-jar", "/opt/daemon-boot-alarmd.jar"]
     container_name: delta-v-alarmd
     hostname: alarmd
     depends_on:


### PR DESCRIPTION
## Summary

- Replace 4.75GB Sentinel/Karaf-based image with lightweight Alpine + jlink JRE image for all 9 Spring Boot daemons
- New `opennms/jre-deltav:21` base image: 143MB (Alpine 3.21 + custom JRE with 22 modules + diagnostic tools)
- New `opennms/daemon-deltav-springboot` image: 3.55GB (9 fat JARs on jre-deltav base)
- Existing `opennms/daemon-deltav` image unchanged for 4 remaining Karaf daemons
- Add `-XX:MaxMetaspaceSize=256m` to all Spring Boot daemon commands (measured range: 76-137MB across daemons)

## Key changes

- `Dockerfile.jre` — multi-stage jlink build with 22 Java modules + diagnostic tools (jcmd, curl, tcpdump, htop, dig, etc.)
- `Dockerfile.springboot` — simple FROM jre-deltav + COPY 9 fat JARs
- `build.sh` — new `jre` command, `deltav` now builds both springboot and Karaf images, auto-builds JRE in `all`/`push` flows
- `docker-compose.yml` — 9 services switched to `daemon-deltav-springboot`, entrypoint overrides removed, MaxMetaspaceSize added

## Test plan

- [x] JRE base image builds (143MB), java/jcmd/curl verified
- [x] Springboot image builds with all 9 JARs
- [x] All 9 Spring Boot daemons start and report actuator health UP
- [x] `jcmd 1 VM.version` works inside containers (JDK diagnostics)
- [x] Provisiond JSR-223 ScriptCache works (java.scripting module added)
- [x] Karaf daemons unaffected (still on daemon-deltav image)

## Note on image size

The springboot image (3.55GB) is larger than initially estimated because 9 self-contained fat JARs contain ~2GB of duplicated dependencies. Phase 2 (layered JAR deduplication using Spring Boot's extract feature) will address this after all Karaf daemons are migrated.