### PR TITLE
refactor: constructor injection for Alarmd/Discovery + Docker stop_grace_period

### DIFF
--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -245,10 +245,11 @@ public class AlarmdConfiguration {
     }
 
     @Bean
-    public Alarmd alarmd(AlarmPersister alarmPersister) {
-        var alarmd = new Alarmd();
-        alarmd.setPersister(alarmPersister);
-        return alarmd;
+    public Alarmd alarmd(AlarmPersister alarmPersister,
+                         AlarmLifecycleListenerManager alarmLifecycleListenerManager,
+                         NorthbounderManager northbounderManager) {
+        return new Alarmd(alarmPersister, alarmLifecycleListenerManager, northbounderManager,
+                null, null);
     }
 
     @Bean

--- a/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
+++ b/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
@@ -23,7 +23,9 @@ import org.opennms.netmgt.icmp.proxy.PingProxyRpcModule;
 import org.opennms.netmgt.icmp.proxy.PingSweepRpcModule;
 import org.opennms.netmgt.provision.LocationAwareDetectorClient;
 import org.opennms.netmgt.provision.detector.client.rpc.DetectorClientRpcModule;
+import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.provision.detector.client.rpc.LocationAwareDetectorClientRpcImpl;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -126,10 +128,10 @@ public class DiscoveryBootConfiguration {
     }
 
     @Bean
-    public Discovery discovery() {
-        // @Autowired fields: discoveryConfigFactory, discoveryTaskExecutor,
-        //   eventForwarder (@Qualifier("eventIpcManager"))
-        return new Discovery();
+    public Discovery discovery(DiscoveryConfigFactory discoveryConfigFactory,
+                               DiscoveryTaskExecutorImpl discoveryTaskExecutor,
+                               @Qualifier("eventIpcManager") EventForwarder eventForwarder) {
+        return new Discovery(discoveryConfigFactory, discoveryTaskExecutor, eventForwarder);
     }
 
     @Bean

--- a/features/discovery/src/main/java/org/opennms/netmgt/discovery/Discovery.java
+++ b/features/discovery/src/main/java/org/opennms/netmgt/discovery/Discovery.java
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * This class is the main interface to the OpenNMS discovery service. The service 
+ * This class is the main interface to the OpenNMS discovery service. The service
  * delays the reading of configuration information until the service is started.
  *
  * @author <a href="mailto:weave@oculan.com">Brian Weaver </a>
@@ -63,9 +63,16 @@ public class Discovery extends AbstractServiceDaemon {
 
     private Timer discoveryTimer;
 
-    /**
-     * Constructs a new discovery instance.
-     */
+    public Discovery(DiscoveryConfigFactory discoveryConfigFactory,
+                     DiscoveryTaskExecutor discoveryTaskExecutor,
+                     EventForwarder eventForwarder) {
+        super(LOG4J_CATEGORY);
+        this.m_discoveryFactory = Objects.requireNonNull(discoveryConfigFactory);
+        this.m_discoveryTaskExecutor = Objects.requireNonNull(discoveryTaskExecutor);
+        this.m_eventForwarder = Objects.requireNonNull(eventForwarder);
+    }
+
+    /** Legacy no-arg constructor for Karaf XML context. */
     public Discovery() {
         super(LOG4J_CATEGORY);
     }
@@ -82,13 +89,12 @@ public class Discovery extends AbstractServiceDaemon {
         Objects.requireNonNull(m_discoveryFactory, "must set the discoveryFactory property");
 
         try {
-        	LOG.debug("Initializing configuration...");
-        	m_discoveryFactory.reload();
+            LOG.debug("Initializing configuration...");
+            m_discoveryFactory.reload();
         } catch (Throwable e) {
             LOG.debug("onInit: initialization failed", e);
             throw new IllegalStateException("Could not initialize discovery configuration.", e);
         }
-
     }
 
     /**
@@ -170,14 +176,17 @@ public class Discovery extends AbstractServiceDaemon {
         return LOG4J_CATEGORY;
     }
 
+    /** @deprecated Legacy setter for Karaf XML context. Use constructor injection. */
     public void setEventForwarder(EventForwarder eventForwarder) {
         m_eventForwarder = eventForwarder;
     }
 
+    /** @deprecated Legacy setter for Karaf XML context. Use constructor injection. */
     public void setDiscoveryFactory(DiscoveryConfigFactory discoveryFactory) {
         m_discoveryFactory = discoveryFactory;
     }
 
+    /** @deprecated Legacy setter for Karaf XML context. Use constructor injection. */
     public void setDiscoveryTaskExecutor(DiscoveryTaskExecutor discoveryTaskExecutor) {
         m_discoveryTaskExecutor = discoveryTaskExecutor;
     }

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
@@ -69,6 +69,20 @@ public class Alarmd extends AbstractServiceDaemon implements ThreadAwareEventLis
     @Autowired(required = false)
     private MessageBus m_messageBus;
 
+    public Alarmd(AlarmPersister persister,
+                  AlarmLifecycleListenerManager alarmLifecycleListenerManager,
+                  NorthbounderManager northbounderManager,
+                  DroolsAlarmContext droolsAlarmContext,
+                  MessageBus messageBus) {
+        super(NAME);
+        this.m_persister = persister;
+        this.m_alm = alarmLifecycleListenerManager;
+        this.m_northbounderManager = northbounderManager;
+        this.m_droolsAlarmContext = droolsAlarmContext;
+        this.m_messageBus = messageBus;
+    }
+
+    /** Legacy no-arg constructor for Karaf XML context. */
     public Alarmd() {
         super(NAME);
     }
@@ -106,20 +120,11 @@ public class Alarmd extends AbstractServiceDaemon implements ThreadAwareEventLis
         }
     }
 
-	/**
-     * <p>setPersister</p>
-     *
-     * @param persister a {@link org.opennms.netmgt.alarmd.AlarmPersister} object.
-     */
+    /** @deprecated Legacy setter for Karaf XML context. Use constructor injection. */
     public void setPersister(AlarmPersister persister) {
         this.m_persister = persister;
     }
 
-    /**
-     * <p>getPersister</p>
-     *
-     * @return a {@link org.opennms.netmgt.alarmd.AlarmPersister} object.
-     */
     public AlarmPersister getPersister() {
         return m_persister;
     }
@@ -156,10 +161,6 @@ public class Alarmd extends AbstractServiceDaemon implements ThreadAwareEventLis
     @Override
     public int getNumThreads() {
         return THREADS;
-    }
-
-    public void setMessageBus(MessageBus messageBus) {
-        m_messageBus = messageBus;
     }
 
 }

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -214,6 +214,7 @@ services:
       timeout: 10s
       retries: 20
       start_period: 30s
+    stop_grace_period: 60s
 
   trapd:
     profiles: [passive, full]
@@ -374,6 +375,7 @@ services:
       timeout: 10s
       retries: 20
       start_period: 90s
+    stop_grace_period: 60s
 
   bsmd:
     profiles: [lite, full]


### PR DESCRIPTION
## Summary
- Add constructor injection to **Alarmd** (5 params) and **Discovery** (3 params) for Spring Boot `@Bean` usage
- Retain no-arg constructors + `@Deprecated` setters for backward compatibility with legacy Karaf XML contexts and integration tests
- Add `stop_grace_period: 60s` to **Provisiond** and **Discovery** Docker containers (RPC operations via Kafka to Minion can take up to ~45s)

## Details

### Constructor injection
Both Alarmd and Discovery now have dual constructors:
- **Constructor injection** (used by Spring Boot `@Configuration` bean methods) — explicit, testable, immutable dependencies
- **No-arg + @Autowired** (used by Karaf XML `<bean>` definitions) — backward compat until Karaf retirement

### Docker stop_grace_period
Collectd and Enlinkd already have `stop_grace_period: 60s`. Provisiond (SNMP scan RPC) and Discovery (ping sweep RPC) need the same protection against mid-flight SIGKILL.

## Test plan
- [x] `daemon-boot-alarmd` and `daemon-boot-discovery` compile cleanly
- [x] Legacy Karaf XML contexts unchanged (no-arg constructor + setter path preserved)
- [x] E2E: verify daemon startup in Docker environment — Alarmd creates and clears alarms successfully with constructor injection