### PR TITLE
fix: cherry-pick NMS-19538 — avoid rebuildPackageIpListMap during Pollerd init

### DIFF
--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/MonitoredServiceDaoJpa.java
@@ -192,6 +192,17 @@ public class MonitoredServiceDaoJpa extends AbstractDaoJpa<OnmsMonitoredService,
     }
 
     @Override
+    public List<OnmsMonitoredService> findAllServicesForScheduling() {
+        return find(
+                "SELECT DISTINCT svc FROM OnmsMonitoredService svc "
+                + "LEFT JOIN FETCH svc.serviceType "
+                + "LEFT JOIN FETCH svc.ipInterface ip "
+                + "LEFT JOIN FETCH ip.node n "
+                + "LEFT JOIN FETCH n.location "
+                + "WHERE svc.status IN ('A', 'N')");
+    }
+
+    @Override
     public List<OnmsMonitoredService> findByNode(int nodeId) {
         return find(
                 "SELECT svc FROM OnmsMonitoredService svc "

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoredServiceDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoredServiceDao.java
@@ -113,4 +113,12 @@ public interface MonitoredServiceDao extends LegacyOnmsDao<OnmsMonitoredService,
     OnmsMonitoredService getPrimaryService(Integer nodeId, String svcName);
 
     List<OnmsMonitoredService> findByNode(final int nodeId);
+
+    /**
+     * Find all services eligible for poller scheduling (status 'A' or 'N')
+     * with eager-fetched associations to avoid N+1 lazy loading during bulk init.
+     *
+     * @return a {@link java.util.List} object.
+     */
+    List<OnmsMonitoredService> findAllServicesForScheduling();
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockMonitoredServiceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockMonitoredServiceDao.java
@@ -171,6 +171,13 @@ public class MockMonitoredServiceDao extends AbstractMockDao<OnmsMonitoredServic
     }
 
     @Override
+    public List<OnmsMonitoredService> findAllServicesForScheduling() {
+        return findAll().stream()
+                .filter(svc -> "A".equals(svc.getStatus()) || "N".equals(svc.getStatus()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public List<OnmsMonitoredService> findByNode(final int nodeId) {
         return findAll().stream()
                  .filter(svc -> svc.getNodeId() == nodeId)

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/UnimplementedMonitoredServiceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/UnimplementedMonitoredServiceDao.java
@@ -162,4 +162,9 @@ public class UnimplementedMonitoredServiceDao implements MonitoredServiceDao {
     public List<OnmsMonitoredService> findByNode(int nodeId) {
         throw new UnsupportedOperationException("Not yet implemented!");
     }
+
+    @Override
+    public List<OnmsMonitoredService> findAllServicesForScheduling() {
+        throw new UnsupportedOperationException("Not yet implemented!");
+    }
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/MonitoredServiceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/MonitoredServiceDaoHibernate.java
@@ -139,6 +139,16 @@ public class MonitoredServiceDaoHibernate extends AbstractDaoHibernate<OnmsMonit
     }
 
     @Override
+    public List<OnmsMonitoredService> findAllServicesForScheduling() {
+        return find("select distinct svc from OnmsMonitoredService as svc " +
+                "left join fetch svc.serviceType " +
+                "left join fetch svc.ipInterface as ip " +
+                "left join fetch ip.node as node " +
+                "left join fetch node.location " +
+                "where svc.status in ('A', 'N')");
+    }
+
+    @Override
     public List<OnmsMonitoredService> findByNode(int nodeId) {
         return find("select distinct svc from OnmsMonitoredService as svc " +
                     "left join fetch svc.ipInterface as iface " +

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/MonitoredServiceDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/MonitoredServiceDaoIT.java
@@ -22,6 +22,7 @@
 package org.opennms.netmgt.dao;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.opennms.core.utils.InetAddressUtils.addr;
@@ -103,6 +104,69 @@ public class MonitoredServiceDaoIT implements InitializingBean {
             assertNotNull(ifservice.getServiceType());
         }
         
+    }
+
+    @Test
+    @Transactional
+    public void testFindAllServicesForScheduling() {
+        // All services from DatabasePopulator have status 'A'.
+        // Mark one service as 'D' (deleted) so we can verify it's excluded.
+        final OnmsMonitoredService svcToDelete = m_monitoredServiceDao.get(
+                m_databasePopulator.getNode1().getId(), addr("192.168.1.1"), "SNMP");
+        assertNotNull(svcToDelete);
+        svcToDelete.setStatus("D");
+        m_monitoredServiceDao.saveOrUpdate(svcToDelete);
+        m_monitoredServiceDao.flush();
+
+        // Mark another service as 'N' (not monitored) — should still be included.
+        final OnmsMonitoredService svcNotMonitored = m_monitoredServiceDao.get(
+                m_databasePopulator.getNode1().getId(), addr("192.168.1.1"), "ICMP");
+        assertNotNull(svcNotMonitored);
+        svcNotMonitored.setStatus("N");
+        m_monitoredServiceDao.saveOrUpdate(svcNotMonitored);
+        m_monitoredServiceDao.flush();
+
+        final List<OnmsMonitoredService> allSvcs = m_monitoredServiceDao.findAllServices();
+        final List<OnmsMonitoredService> schedulingSvcs = m_monitoredServiceDao.findAllServicesForScheduling();
+
+        // Detach all entities so lazy loading will fail — this proves the
+        // query eagerly fetched the associations we need.
+        m_monitoredServiceDao.clear();
+
+        // Should have one fewer than findAllServices (the 'D' service is excluded)
+        assertTrue(schedulingSvcs.size() > 0);
+        assertTrue("findAllServicesForScheduling should return fewer services than findAllServices " +
+                        "because deleted services are excluded",
+                schedulingSvcs.size() < allSvcs.size());
+
+        for (OnmsMonitoredService svc : schedulingSvcs) {
+            // Only 'A' or 'N' statuses should be present
+            assertTrue("Expected status A or N but got " + svc.getStatus(),
+                    "A".equals(svc.getStatus()) || "N".equals(svc.getStatus()));
+
+            // Verify associations are eagerly fetched (no lazy-load after clear)
+            assertNotNull(svc.getServiceType());
+            assertNotNull(svc.getIpInterface());
+            assertNotNull(svc.getIpInterface().getNode());
+            assertNotNull(svc.getIpInterface().getNode().getLocation());
+            assertNotNull(svc.getIpInterface().getNode().getLocation().getLocationName());
+        }
+
+        // Verify the 'D' service is not in the result
+        for (OnmsMonitoredService svc : schedulingSvcs) {
+            assertFalse("Deleted service should not be in scheduling results",
+                    svc.getId().equals(svcToDelete.getId()));
+        }
+
+        // Verify the 'N' service IS in the result
+        boolean foundNotMonitored = false;
+        for (OnmsMonitoredService svc : schedulingSvcs) {
+            if (svc.getId().equals(svcNotMonitored.getId())) {
+                foundNotMonitored = true;
+                assertEquals("N", svc.getStatus());
+            }
+        }
+        assertTrue("Service with status 'N' should be included in scheduling results", foundNotMonitored);
     }
 
     @Test

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/Poller.java
@@ -23,7 +23,6 @@ package org.opennms.netmgt.poller;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -32,8 +31,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-import org.opennms.core.criteria.Criteria;
-import org.opennms.core.criteria.restrictions.InRestriction;
 import org.opennms.core.logging.Logging;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.collection.api.PersisterFactory;
@@ -264,7 +261,10 @@ public class Poller extends AbstractServiceDaemon {
 
 
         // Schedule the interfaces currently in the database asynchronously
-        // to avoid blocking daemon initialization
+        // to avoid blocking daemon initialization.
+        // m_initialized is set after scheduling completes so that
+        // findPackageForService() does not call rebuildPackageIpListMap()
+        // for every service during bulk init.
         //
         ExecutorService executor = getExecutorService();
         executor.execute(() -> {
@@ -274,6 +274,8 @@ public class Poller extends AbstractServiceDaemon {
                     scheduleExistingServices();
                 } catch (Throwable sqlE) {
                     LOG.error("start: Failed to schedule existing interfaces", sqlE);
+                } finally {
+                    m_initialized = true;
                 }
             });
         });
@@ -291,8 +293,6 @@ public class Poller extends AbstractServiceDaemon {
 
             throw new UndeclaredThrowableException(t);
         }
-
-        m_initialized = true;
 
     }
 
@@ -438,10 +438,7 @@ public class Poller extends AbstractServiceDaemon {
     }
 
     private int scheduleServices() {
-        final Criteria criteria = new Criteria(OnmsMonitoredService.class);
-        criteria.addRestriction(new InRestriction("status", Arrays.asList("A", "N")));
-
-        final List<OnmsMonitoredService> services =  m_monitoredServiceDao.findMatching(criteria);
+        final List<OnmsMonitoredService> services = m_monitoredServiceDao.findAllServicesForScheduling();
         final Map<Integer, Set<OnmsOutage>> outagesByServiceId = m_outageDao.currentOutagesByServiceId();
         for (OnmsMonitoredService service : services) {
             scheduleService(service, outagesByServiceId.getOrDefault(service.getId(), Collections.emptySet()));

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/MockPollerConfig.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/MockPollerConfig.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.Vector;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.opennms.netmgt.config.BasicScheduleUtils;
 import org.opennms.netmgt.config.PollerConfig;
@@ -81,6 +82,8 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
     private boolean m_pollAll = true;
 
     private boolean m_pathOutageEnabled = false;
+
+    private AtomicInteger m_rebuildPackageIpListMapCallCount = new AtomicInteger(0);
 
     private boolean m_serviceUnresponsiveEnabled = false;
 
@@ -403,8 +406,15 @@ public class MockPollerConfig extends OverrideablePollOutagesDaoImpl implements 
 
     @Override
     public void rebuildPackageIpListMap() {
-        // TODO Auto-generated method stub
+        m_rebuildPackageIpListMapCallCount.incrementAndGet();
+    }
 
+    public int getRebuildPackageIpListMapCallCount() {
+        return m_rebuildPackageIpListMapCallCount.get();
+    }
+
+    public void resetRebuildPackageIpListMapCallCount() {
+        m_rebuildPackageIpListMapCallCount.set(0);
     }
 
     @Override

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
@@ -1588,6 +1588,29 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
                         greaterThanOrEqualTo(beforeDown));
     }
 
+    /**
+     * Verify that rebuildPackageIpListMap() is NOT called during bulk
+     * scheduling at startup. Before the NMS-19538 fix, m_initialized was set
+     * to true before async scheduling ran, causing rebuildPackageIpListMap()
+     * to be called for every service — turning a seconds-long startup into
+     * a multi-hour crawl on large systems.
+     */
+    @Test
+    public void testNoRebuildPackageIpListMapDuringInit() throws Exception {
+        m_pollerConfig.resetRebuildPackageIpListMapCallCount();
+
+        startDaemons();
+
+        // Wait for the async scheduling to complete and polling to start
+        await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> m_poller.getNumPolls() > 0);
+
+        // During bulk init, m_initialized is false, so rebuildPackageIpListMap
+        // should NOT have been called
+        assertEquals("rebuildPackageIpListMap should not be called during initial scheduling",
+                0, m_pollerConfig.getRebuildPackageIpListMapCallCount());
+    }
+
     //
     // Utility methods
     //


### PR DESCRIPTION
## Summary

- Cherry-picks upstream [OpenNMS/opennms#8308](https://github.com/OpenNMS/opennms/pull/8308) (NMS-19538)
- Adds matching `findAllServicesForScheduling()` implementation to `MonitoredServiceDaoJpa` for Spring Boot daemons

## What it fixes

During Pollerd startup, `m_initialized` was set to `true` before async `scheduleExistingServices()` ran. This caused `rebuildPackageIpListMap()` to be called for **every service** during bulk init — turning a seconds-long startup into a multi-hour crawl on large systems.

**Fix:** Move `m_initialized = true` into a `finally` block after scheduling completes, and add a dedicated `findAllServicesForScheduling()` DAO method with eager fetch joins to avoid N+1 lazy loading.

## Test plan

- [x] Cherry-pick applies cleanly to develop
- [x] `findAllServicesForScheduling()` added to `MonitoredServiceDaoJpa` (Jakarta/JPA DAO used by Spring Boot Pollerd)
- [ ] Upstream tests included: `MonitoredServiceDaoIT.testFindAllServicesForScheduling()`, `PollerIT.testNoRebuildPackageIpListMapDuringInit()`