### PR TITLE
fix: add SnmpPeerFactory bean to Pollerd and PerspectivePollerd

### DIFF
--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
@@ -28,6 +28,9 @@ import org.opennms.netmgt.collection.api.CollectionAgentFactory;
 import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.opennms.netmgt.config.PollerConfig;
 import org.opennms.netmgt.config.PollerConfigFactory;
+import org.opennms.netmgt.config.SnmpPeerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.dao.api.ApplicationDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
@@ -64,6 +67,21 @@ import org.springframework.context.SmartLifecycle;
  */
 @Configuration
 public class PerspectivePollerdDaemonConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PerspectivePollerdDaemonConfiguration.class);
+
+    /**
+     * Initializes the SNMP peer factory singleton from snmp-config.xml.
+     * Required by SnmpMonitorStrategy.getRuntimeAttributes() which calls
+     * SnmpPeerFactory.getInstance().getAgentConfig() to resolve SNMP
+     * credentials for each polled service.
+     */
+    @Bean
+    public SnmpPeerFactory snmpPeerFactory() throws IOException {
+        LOG.info("Initializing SnmpPeerFactory");
+        SnmpPeerFactory.init();
+        return SnmpPeerFactory.getInstance();
+    }
 
     /**
      * Loads poller-configuration.xml via the singleton PollerConfigFactory.

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
@@ -30,6 +30,7 @@ import org.opennms.features.distributed.kvstore.json.noop.NoOpJsonStore;
 import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.opennms.netmgt.config.PollerConfig;
 import org.opennms.netmgt.config.PollerConfigFactory;
+import org.opennms.netmgt.config.SnmpPeerFactory;
 import org.opennms.netmgt.config.dao.outages.api.ReadablePollOutagesDao;
 import org.opennms.netmgt.config.dao.outages.impl.OnmsPollOutagesDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
@@ -99,6 +100,19 @@ public class PollerdDaemonConfiguration {
     public ReadablePollOutagesDao pollOutagesDao() throws IOException {
         LOG.info("Initializing OnmsPollOutagesDao with NoOpJsonStore");
         return new OnmsPollOutagesDao(new NoOpJsonStore());
+    }
+
+    /**
+     * Initializes the SNMP peer factory singleton from snmp-config.xml.
+     * Required by SnmpMonitorStrategy.getRuntimeAttributes() which calls
+     * SnmpPeerFactory.getInstance().getAgentConfig() to resolve SNMP
+     * credentials for each polled service.
+     */
+    @Bean
+    public SnmpPeerFactory snmpPeerFactory() throws IOException {
+        LOG.info("Initializing SnmpPeerFactory");
+        SnmpPeerFactory.init();
+        return SnmpPeerFactory.getInstance();
     }
 
     /**

--- a/opennms-container/delta-v/perspectivepollerd-overlay/etc/snmp-config.xml
+++ b/opennms-container/delta-v/perspectivepollerd-overlay/etc/snmp-config.xml
@@ -1,0 +1,1 @@
+<snmp-config xmlns="http://xmlns.opennms.org/xsd/config/snmp" version="v2c" read-community="public" timeout="1800" retry="1"/>

--- a/opennms-container/delta-v/pollerd-overlay/etc/snmp-config.xml
+++ b/opennms-container/delta-v/pollerd-overlay/etc/snmp-config.xml
@@ -1,0 +1,1 @@
+<snmp-config xmlns="http://xmlns.opennms.org/xsd/config/snmp" version="v2c" read-community="public" timeout="1800" retry="1"/>


### PR DESCRIPTION
## Summary

- Adds `SnmpPeerFactory` Spring bean to Pollerd and PerspectivePollerd boot configurations
- Adds `snmp-config.xml` to both daemon overlay directories
- Fixes missing `Logger` declaration in `PerspectivePollerdDaemonConfiguration`

## What it fixes

Pollerd crashes with `NullPointerException: Cannot invoke "SnmpPeerFactory.getAgentConfig()"` when polling SNMP services on remote-location nodes. The `SnmpMonitorStrategy.getRuntimeAttributes()` calls `SnmpPeerFactory.getInstance()` which returns null because the factory was never initialized.

Provisiond, Collectd, and Enlinkd all had explicit `SnmpPeerFactory` beans — Pollerd and PerspectivePollerd were missed during the Spring Boot migration.

## Test plan

- [x] Both modules compile successfully
- [x] Pollerd logs `Initializing SnmpPeerFactory` at startup
- [x] No more `NullPointerException` in poll threads
- [x] Pollerd health check returns UP