### PR TITLE
fix: prevent legacy commonConfigs loading in Spring Boot daemons

### DIFF
--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonProvisioningConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonProvisioningConfiguration.java
@@ -23,18 +23,19 @@ package org.opennms.core.daemon.common;
 
 import org.opennms.core.daemon.common.registry.LocalServiceDetectorRegistry;
 import org.opennms.core.mate.api.EntityScopeProvider;
+import org.opennms.core.spring.BeanUtils;
 import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Shared provisioning infrastructure for all Spring Boot daemons.
+ * Shared infrastructure for all Spring Boot daemons.
  *
  * <p>Provides default beans that satisfy autowired dependencies in
- * provisioning-related classes (detector clients, import jobs, etc.).
- * Both beans use {@code @ConditionalOnMissingBean} so any daemon can
- * override with a real implementation.</p>
+ * provisioning-related classes and legacy static lookup bridges.
+ * Conditional beans use {@code @ConditionalOnMissingBean} so any daemon
+ * can override with a real implementation.</p>
  *
  * <ul>
  *   <li>{@link NoOpEntityScopeProvider} — disables MATE variable interpolation.
@@ -42,6 +43,8 @@ import org.springframework.context.annotation.Configuration;
  *       with a bean backed by database DAOs.</li>
  *   <li>{@link LocalServiceDetectorRegistry} — SPI-based detector discovery.
  *       Returns empty unless detector factory JARs are on the classpath.</li>
+ *   <li>{@link BeanUtils} — bridges legacy static bean lookups to this
+ *       daemon's ApplicationContext.</li>
  * </ul>
  */
 @Configuration
@@ -57,5 +60,21 @@ public class DaemonProvisioningConfiguration {
     @ConditionalOnMissingBean(ServiceDetectorRegistry.class)
     public ServiceDetectorRegistry serviceDetectorRegistry() {
         return new LocalServiceDetectorRegistry();
+    }
+
+    /**
+     * Bridges legacy {@link BeanUtils} static lookups to the daemon's Spring
+     * Boot ApplicationContext.
+     *
+     * <p>{@code BeanUtils} implements {@code ApplicationContextAware}. Registering
+     * it as a bean causes Spring to call {@code setApplicationContext()}, setting
+     * the static {@code m_context} field. This prevents the legacy fallback path
+     * through {@link org.opennms.core.spring.ContextRegistry} which would load
+     * {@code applicationContext-commonConfigs.xml} and fail on missing config
+     * files in per-daemon containers.</p>
+     */
+    @Bean
+    public BeanUtils beanUtils() {
+        return new BeanUtils();
     }
 }

--- a/docs/superpowers/plans/2026-03-28-split-common-configs-fix-e2e.md
+++ b/docs/superpowers/plans/2026-03-28-split-common-configs-fix-e2e.md
@@ -1,0 +1,239 @@
+# Split commonConfigs.xml and Fix E2E Tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 2 Enlinkd E2E failures (caused by monolithic commonConfigs.xml loading) and the 6 test-e2e.sh failures (caused by wrong trap port) so all 6 E2E test suites pass.
+
+**Architecture:** Register `BeanUtils` as a Spring bean in `daemon-common` so all 12 daemon-boot apps set `BeanUtils.m_context` via `ApplicationContextAware`, preventing the legacy `ContextRegistry` → `commonConfigs.xml` fallback. Fix `test-e2e.sh` to send traps through Minion (port 11162) instead of directly to Trapd (port 1162).
+
+**Tech Stack:** Java 17, Spring Boot 4, Shell scripting
+
+**Spec:** `docs/superpowers/specs/2026-03-28-split-common-configs-fix-e2e-design.md`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonProvisioningConfiguration.java` | Modify | Add `BeanUtils` bean registration |
+| `opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java` | Modify | Widen catch block in `getSecureCredentialsScope()` |
+| `opennms-container/delta-v/test-e2e.sh` | Modify | Change trap port, add Minion check |
+
+---
+
+### Task 1: Register BeanUtils Bean in daemon-common
+
+**Files:**
+- Modify: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonProvisioningConfiguration.java`
+
+- [ ] **Step 1: Add BeanUtils import and bean method**
+
+Add the import and bean method to `DaemonProvisioningConfiguration`:
+
+```java
+// Add import:
+import org.opennms.core.spring.BeanUtils;
+```
+
+Add this bean method after the existing `serviceDetectorRegistry()` method (before the closing brace of the class):
+
+```java
+    /**
+     * Bridges legacy {@link BeanUtils} static lookups to the daemon's Spring
+     * Boot ApplicationContext.
+     *
+     * <p>{@code BeanUtils} implements {@code ApplicationContextAware}. Registering
+     * it as a bean causes Spring to call {@code setApplicationContext()}, setting
+     * the static {@code m_context} field. This prevents the legacy fallback path
+     * through {@link org.opennms.core.spring.ContextRegistry} which would load
+     * {@code applicationContext-commonConfigs.xml} and fail on missing config
+     * files in per-daemon containers.</p>
+     */
+    @Bean
+    public BeanUtils beanUtils() {
+        return new BeanUtils();
+    }
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run:
+```bash
+cd /Users/david/development/src/opennms/delta-v
+./compile.pl -DskipTests --projects :org.opennms.core.daemon-common install
+```
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonProvisioningConfiguration.java
+git commit -m "fix: register BeanUtils bean in daemon-common to prevent legacy context loading
+
+BeanUtils.m_context was never set in Spring Boot daemons because
+BeanUtils (in org.opennms.core.spring) was outside the component
+scan. This caused BeanUtils.getBean() to fall through to
+ContextRegistry, which loaded applicationContext-commonConfigs.xml
+and failed on missing config files (e.g., poller-configuration.xml
+in Enlinkd's container).
+
+Registering BeanUtils as a bean triggers ApplicationContextAware
+injection, setting m_context so all lookups use the daemon's own
+Spring Boot context."
+```
+
+---
+
+### Task 2: Widen SnmpPeerFactory Catch Block
+
+**Files:**
+- Modify: `opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java:291`
+
+- [ ] **Step 1: Change catch clause**
+
+In `getSecureCredentialsScope()` (line 291), change:
+
+```java
+            } catch (FatalBeanException e) {
+                LOG.warn("SnmpPeerFactory: Error retrieving EntityScopeProvider bean");
+            }
+```
+
+to:
+
+```java
+            } catch (Exception e) {
+                LOG.warn("SnmpPeerFactory: Error retrieving EntityScopeProvider bean: {}", e.getMessage());
+            }
+```
+
+This catches `NoSuchBeanDefinitionException` (extends `BeansException`, not `FatalBeanException`) if a daemon's context doesn't have the requested bean.
+
+- [ ] **Step 2: Remove unused FatalBeanException import if present**
+
+Check if `FatalBeanException` is still used elsewhere in the file. If not, remove the import:
+```java
+// Remove if unused:
+import org.springframework.beans.FatalBeanException;
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run:
+```bash
+./compile.pl -DskipTests --projects :opennms-config install
+```
+Expected: BUILD SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
+git commit -m "fix: widen SnmpPeerFactory catch to handle NoSuchBeanDefinitionException
+
+The catch block only caught FatalBeanException, but
+NoSuchBeanDefinitionException extends BeansException (different
+hierarchy). With BeanUtils now using the daemon's Spring Boot
+context, beans not registered in that context throw
+NoSuchBeanDefinitionException instead of triggering the legacy
+context chain."
+```
+
+---
+
+### Task 3: Fix test-e2e.sh Trap Port and Add Minion Check
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-e2e.sh`
+
+- [ ] **Step 1: Change TRAP_PORT**
+
+At line 29, change:
+```bash
+TRAP_PORT="1162"
+```
+to:
+```bash
+TRAP_PORT="11162"                    # Minion's mapped trap port (11162 → 1162/udp)
+```
+
+- [ ] **Step 2: Add Minion container check**
+
+After the `REQUIRED_SERVICES` loop (after line 137 `ok "All required services running"`), add:
+
+```bash
+
+# Minion must be running for trap forwarding
+if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qw "delta-v-minion"; then
+    err "Minion container is not running. Start with: docker start delta-v-minion"
+fi
+ok "Minion container running"
+```
+
+- [ ] **Step 3: Update trap-sending log messages**
+
+At line 166, change:
+```bash
+ok "coldStart trap sent to ${TRAP_HOST}:${TRAP_PORT}"
+```
+to:
+```bash
+ok "coldStart trap sent to Minion at ${TRAP_HOST}:${TRAP_PORT}"
+```
+
+At line 162, change:
+```bash
+snmptrap -v 2c -c "$TRAP_COMMUNITY" "${TRAP_HOST}:${TRAP_PORT}" '' \
+```
+The snmptrap command itself doesn't change (it already uses the variable), but update the preceding log line. Find the log line before the snmptrap command in Phase 1 and ensure it mentions Minion. Search for other `snmptrap` invocations and update their surrounding log text similarly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add opennms-container/delta-v/test-e2e.sh
+git commit -m "fix: route test-e2e.sh traps through Minion (port 11162)
+
+In Delta-V, Trapd has no exposed port. All traps go through Minion
+on port 11162. The test was sending to port 1162 (direct to Trapd),
+causing 6/11 test failures. Also adds Minion container health check
+matching test-minion-e2e.sh pattern."
+```
+
+---
+
+### Task 4: Rebuild and Verify
+
+- [ ] **Step 1: Rebuild all 12 daemon-boot JARs**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+make build
+```
+
+Wait for BUILD SUCCESS.
+
+- [ ] **Step 2: Build Docker images**
+
+```bash
+cd opennms-container/delta-v
+./build.sh deltav
+```
+
+- [ ] **Step 3: Deploy and run E2E tests**
+
+```bash
+./deploy.sh down && ./deploy.sh up passive
+# Wait for services to stabilize (~60s)
+
+bash test-collectd-e2e.sh        # expect: 4/4
+bash test-minion-e2e.sh          # expect: 13/13
+bash test-syslog-e2e.sh          # expect: 15/15
+bash test-passive-e2e.sh         # expect: 16/16
+bash test-enlinkd-e2e.sh         # expect: 17/17
+bash test-e2e.sh                 # expect: 11/11
+```
+
+- [ ] **Step 4: Commit any fixes discovered during verification**
+
+If tests reveal issues, fix and commit before proceeding.

--- a/docs/superpowers/specs/2026-03-28-split-common-configs-fix-e2e-design.md
+++ b/docs/superpowers/specs/2026-03-28-split-common-configs-fix-e2e-design.md
@@ -1,0 +1,97 @@
+# Design: Split commonConfigs.xml and Fix E2E Tests
+
+**Date:** 2026-03-28
+**Status:** Approved
+**Scope:** Fix two E2E test suite failures caused by (1) monolithic config loading in per-daemon containers and (2) wrong trap port in test-e2e.sh.
+
+## Problem
+
+After eliminating opennms-services (PR #65), all 12 daemons run as standalone Spring Boot apps. Two E2E test suites have failures:
+
+1. **test-enlinkd-e2e.sh** (2/17 failing) — `applicationContext-commonConfigs.xml` loads all 22 config factories regardless of which daemon runs. When Enlinkd's SNMP RPC chain triggers `SnmpPeerFactory.getSecureCredentialsScope()` → `BeanUtils.getBean("daoContext", "entityScopeProvider", ...)`, `BeanUtils.m_context` is null, causing fallback to `ContextRegistry` → loads `beanRefContext.xml` → `commonConfigs.xml` → tries to init `PollerConfigFactory` → fails (no `poller-configuration.xml` in Enlinkd's container). This breaks SNMP interface collection and LLDP link resolution.
+
+2. **test-e2e.sh** (6/11 failing) — Sends traps to port 1162 (direct to Trapd) but Trapd has no exposed port in Delta-V. All traps must go through Minion on port 11162.
+
+## Root Cause Analysis
+
+### Why BeanUtils.m_context is null
+
+`BeanUtils` (in `org.opennms.core.spring`) implements `ApplicationContextAware`. For `m_context` to be set, `BeanUtils` must be registered as a Spring bean. But:
+
+- Daemon-boot apps scan `org.opennms.core.daemon.common`, NOT `org.opennms.core.spring`
+- No daemon-boot module explicitly registers a `BeanUtils` bean
+- `BeanUtils` has no `@Component` annotation
+
+So `m_context` stays null, and every `BeanUtils.getBean()` call falls through to `ContextRegistry`, which loads the entire legacy XML context chain.
+
+### The Legacy Context Chain
+
+```
+BeanUtils.getBean("daoContext", "entityScopeProvider", ...)
+  → m_context == null
+  → ContextRegistry.getInstance().getBeanFactory("daoContext")
+    → scans classpath for ALL beanRefContext.xml (~20 files)
+    → loads "commonContext" (opennms-config/beanRefContext.xml)
+      → loads applicationContext-commonConfigs.xml
+        → PollerConfigFactory.init() → FAILS (missing poller-configuration.xml)
+        → CollectdConfigFactory → FAILS (missing collectd-configuration.xml)
+        → etc.
+```
+
+## Solution
+
+### Task 1: Register BeanUtils as a Spring Bean in daemon-common
+
+Add a `BeanUtils` bean to `DaemonProvisioningConfiguration` in `core/daemon-common`:
+
+```java
+@Bean
+public BeanUtils beanUtils() {
+    return new BeanUtils();
+}
+```
+
+Spring calls `setApplicationContext()` via `ApplicationContextAware`, setting `m_context` to the daemon's Spring Boot `ApplicationContext`. All subsequent `BeanUtils.getBean()` calls use the daemon's own context directly, bypassing `ContextRegistry` entirely.
+
+**Bean availability for Enlinkd's path:**
+- `SnmpPeerFactory.getSecureCredentialsScope()` requests `"entityScopeProvider"` (EntityScopeProvider)
+- `DaemonProvisioningConfiguration` already provides `NoOpEntityScopeProvider` as `entityScopeProvider` bean
+- Call succeeds; no legacy context needed
+
+**Catch block hardening in SnmpPeerFactory:**
+- `getSecureCredentialsScope()` catches `FatalBeanException`
+- `NoSuchBeanDefinitionException` extends `BeansException`, NOT `FatalBeanException`
+- Widen to `catch (Exception e)` for robustness against beans missing from daemon contexts
+
+### Task 2: Fix test-e2e.sh Trap Port
+
+- Change `TRAP_PORT="1162"` to `TRAP_PORT="11162"`
+- Add Minion container health check (same pattern as test-minion-e2e.sh)
+- Update log messages to reference Minion path
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `core/daemon-common/.../DaemonProvisioningConfiguration.java` | Add `BeanUtils` bean registration |
+| `opennms-config/.../SnmpPeerFactory.java` | Widen catch to `Exception` in `getSecureCredentialsScope()` |
+| `opennms-container/delta-v/test-e2e.sh` | Change trap port 1162 → 11162, add Minion check |
+
+## Verification
+
+Rebuild all 12 daemon-boot JARs, run `build.sh deltav`, then:
+
+```bash
+bash test-collectd-e2e.sh        # expect: 4/4
+bash test-minion-e2e.sh          # expect: 13/13
+bash test-syslog-e2e.sh          # expect: 15/15
+bash test-passive-e2e.sh         # expect: 16/16
+bash test-enlinkd-e2e.sh         # expect: 17/17 (was 15/17)
+bash test-e2e.sh                 # expect: 11/11 (was 5/11)
+```
+
+## Risks
+
+1. **Other BeanUtils.getBean() callers**: Collectors/monitors that call `BeanUtils.getBean()` for beans not in the daemon's context will get `NoSuchBeanDefinitionException`. Mitigated: (a) daemon-boot modules already pre-inject dependencies, (b) the legacy chain would also fail in per-daemon containers, (c) the exception is easier to diagnose than the current hard crash.
+
+2. **Static m_context shared across tests**: `BeanUtils.m_context` is a static field. In unit tests that create multiple Spring contexts, the last context wins. Mitigated: this is existing behavior and test isolation is not affected (tests either mock BeanUtils or set up their own contexts).

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
@@ -65,7 +65,6 @@ import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.SnmpConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.FatalBeanException;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
@@ -288,8 +287,8 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
                 } else {
                     LOG.warn("SnmpPeerFactory: EntityScopeProvider is null, SecureCredentialsVault not available for metadata interpolation");
                 }
-            } catch (FatalBeanException e) {
-                LOG.warn("SnmpPeerFactory: Error retrieving EntityScopeProvider bean");
+            } catch (Exception e) {
+                LOG.warn("SnmpPeerFactory: Error retrieving EntityScopeProvider bean: {}", e.getMessage());
             }
         }
 

--- a/opennms-container/delta-v/test-e2e.sh
+++ b/opennms-container/delta-v/test-e2e.sh
@@ -26,7 +26,7 @@ cd "$SCRIPT_DIR"
 
 # ── Configuration ──────────────────────────────────────────────────
 TRAP_HOST="localhost"
-TRAP_PORT="1162"
+TRAP_PORT="11162"                    # Minion's mapped trap port (11162 → 1162/udp)
 TRAP_COMMUNITY="public"
 NODE_SCAN_TIMEOUT=180
 ALARM_TIMEOUT=30
@@ -136,6 +136,12 @@ for svc in $REQUIRED_SERVICES; do
 done
 ok "All required services running"
 
+# Minion must be running for trap forwarding
+if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qw "delta-v-minion"; then
+    err "Minion container is not running. Start with: docker start delta-v-minion"
+fi
+ok "Minion container running"
+
 # ── Start Kafka Consumers ─────────────────────────────────────────
 log "Starting Kafka event consumers..."
 
@@ -163,7 +169,7 @@ snmptrap -v 2c -c "$TRAP_COMMUNITY" "${TRAP_HOST}:${TRAP_PORT}" '' \
     1.3.6.1.6.3.1.1.5.1 \
     1.3.6.1.2.1.1.3.0 t 0
 
-ok "coldStart trap sent to ${TRAP_HOST}:${TRAP_PORT}"
+ok "coldStart trap sent to Minion at ${TRAP_HOST}:${TRAP_PORT}"
 
 if wait_for_kafka_event "$IPC_LOG" "nodeScanCompleted" "$NODE_SCAN_TIMEOUT" "nodeScanCompleted"; then
     ok "nodeScanCompleted received — node provisioned"


### PR DESCRIPTION
## Summary

- Register `BeanUtils` as a Spring bean in `daemon-common` so all 12 daemon-boot apps set `BeanUtils.m_context` via `ApplicationContextAware`, preventing the legacy `ContextRegistry` → `commonConfigs.xml` fallback that crashed on missing config files in per-daemon containers
- Widen `SnmpPeerFactory.getSecureCredentialsScope()` catch to handle `NoSuchBeanDefinitionException` (extends `BeansException`, not `FatalBeanException`)
- Fix `test-e2e.sh` to route traps through Minion (port 11162) instead of directly to Trapd (port 1162)

## E2E Test Results (all 78/78 passing)

| Test Suite | Before | After |
|---|---|---|
| test-collectd-e2e.sh | 4/4 | **4/4** |
| test-minion-e2e.sh | 13/13 | **13/13** |
| test-syslog-e2e.sh | 15/15 | **15/15** |
| test-passive-e2e.sh | 16/16 | **16/16** |
| test-enlinkd-e2e.sh | 15/17 | **18/18** |
| test-e2e.sh | 5/11 | **12/12** |

## Test plan

- [x] All 6 E2E test suites pass (78/78)
- [x] Enlinkd SNMP interfaces collected on all 5 nodes (was failing)
- [x] Enlinkd LLDP links discovered (was failing)
- [x] test-e2e.sh alarm lifecycle works through Minion path (was failing)
- [x] No regressions in previously-passing suites