### PR TITLE
fix: implement missing DAO methods and merge() for Enlinkd Jakarta models

### DIFF
--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeBridgeLink.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeBridgeLink.java
@@ -190,4 +190,24 @@ public class BridgeBridgeLink implements Serializable {
     public void setBridgeBridgeLinkLastPollTime(Date bridgeLinkLastPollTime) {
         m_bridgeBridgeLinkLastPollTime = bridgeLinkLastPollTime;
     }
+
+    public void merge(BridgeBridgeLink element) {
+        if (element == null)
+                return;
+
+        setBridgePortIfIndex(element.getBridgePortIfIndex());
+        setBridgePortIfName(element.getBridgePortIfName());
+        setVlan(element.getVlan());
+
+        setDesignatedNode(element.getDesignatedNode());
+        setDesignatedPort(element.getDesignatedPort());
+        setDesignatedPortIfIndex(element.getDesignatedPortIfIndex());
+        setDesignatedPortIfName(element.getDesignatedPortIfName());
+        setDesignatedVlan(element.getDesignatedVlan());
+        if (element.getBridgeBridgeLinkLastPollTime() == null)
+            setBridgeBridgeLinkLastPollTime(element.getBridgeBridgeLinkCreateTime());
+        else
+           setBridgeBridgeLinkLastPollTime(element.getBridgeBridgeLinkLastPollTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeElement.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeElement.java
@@ -243,4 +243,21 @@ public class BridgeElement implements Serializable {
     public void setBridgeNodeLastPollTime(Date bridgeNodeLastPollTime) {
         m_bridgeNodeLastPollTime = bridgeNodeLastPollTime;
     }
+
+    public void merge(BridgeElement element) {
+        if (element == null)
+            return;
+
+        setBaseBridgeAddress(element.getBaseBridgeAddress());
+        setBaseNumPorts(element.getBaseNumPorts());
+        setBaseType(element.getBaseType());
+
+        setStpProtocolSpecification(element.getStpProtocolSpecification());
+        setStpPriority(element.getStpPriority());
+        setStpDesignatedRoot(element.getStpDesignatedRoot());
+        setStpRootCost(element.getStpRootCost());
+        setStpRootPort(element.getStpRootPort());
+
+        setBridgeNodeLastPollTime(element.getBridgeNodeCreateTime());
+    }
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeMacLink.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeMacLink.java
@@ -176,4 +176,18 @@ public class BridgeMacLink implements Serializable {
     public void setBridgeMacLinkLastPollTime(Date bridgeMacLinkLastPollTime) {
         m_bridgeMacLinkLastPollTime = bridgeMacLinkLastPollTime;
     }
+
+    public void merge(BridgeMacLink element) {
+        if (element == null)
+            return;
+        setBridgePortIfIndex(element.getBridgePortIfIndex());
+        setBridgePortIfName(element.getBridgePortIfName());
+        setVlan(element.getVlan());
+        setLinkType(element.getLinkType());
+        if (element.getBridgeMacLinkLastPollTime() == null)
+            setBridgeMacLinkLastPollTime(element.getBridgeMacLinkCreateTime());
+        else
+            setBridgeMacLinkLastPollTime(element.getBridgeMacLinkLastPollTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeStpLink.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/BridgeStpLink.java
@@ -259,4 +259,22 @@ public class BridgeStpLink implements Serializable {
     public void setBridgeStpLinkLastPollTime(Date bridgeLinkLastPollTime) {
         m_bridgeStpLinkLastPollTime = bridgeLinkLastPollTime;
     }
+
+    public void merge(BridgeStpLink element) {
+        if (element == null)
+            return;
+
+        setStpPortState(element.getStpPortState());
+        setStpPortEnable(element.getStpPortEnable());
+        setStpPortIfIndex(element.getStpPortIfIndex());
+        setStpPortIfName(element.getStpPortIfName());
+        setVlan(element.getVlan());
+
+        setDesignatedRoot(element.getDesignatedRoot());
+        setDesignatedCost(element.getDesignatedCost());
+        setDesignatedBridge(element.getDesignatedBridge());
+        setDesignatedPort(element.getDesignatedPort());
+        setBridgeStpLinkLastPollTime(element.getBridgeStpLinkCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/CdpElement.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/CdpElement.java
@@ -154,4 +154,13 @@ public final class CdpElement implements Serializable {
     public void setCdpNodeLastPollTime(Date cdpNodeLastPollTime) {
         m_cdpNodeLastPollTime = cdpNodeLastPollTime;
     }
+
+    public void merge(CdpElement element) {
+        if (element == null)
+            return;
+        setCdpGlobalRun(element.getCdpGlobalRun());
+        setCdpGlobalDeviceId(element.getCdpGlobalDeviceId());
+        setCdpNodeLastPollTime(element.getCdpNodeCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/CdpLink.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/CdpLink.java
@@ -244,4 +244,17 @@ public class CdpLink implements Serializable {
     public void setCdpLinkLastPollTime(Date cdpLinkLastPollTime) {
         m_cdpLinkLastPollTime = cdpLinkLastPollTime;
     }
+
+    public void merge(CdpLink link) {
+        if (link == null) return;
+        setCdpInterfaceName(link.getCdpInterfaceName());
+        setCdpCacheAddressType(link.getCdpCacheAddressType());
+        setCdpCacheAddress(link.getCdpCacheAddress());
+        setCdpCacheVersion(link.getCdpCacheVersion());
+        setCdpCacheDeviceId(link.getCdpCacheDeviceId());
+        setCdpCacheDevicePort(link.getCdpCacheDevicePort());
+        setCdpCacheDevicePlatform(link.getCdpCacheDevicePlatform());
+        setCdpLinkLastPollTime(link.getCdpLinkCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/IpNetToMedia.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/IpNetToMedia.java
@@ -188,4 +188,14 @@ public class IpNetToMedia implements Serializable {
     public void setLastPollTime(Date lastPollTime) {
         m_lastPollTime = lastPollTime;
     }
+
+    public void merge(IpNetToMedia element) {
+        setNode(element.getNode());
+        setIfIndex(element.getIfIndex());
+        setPort(element.getPort());
+        setSourceNode(element.getSourceNode());
+        setSourceIfIndex(element.getSourceIfIndex());
+        setLastPollTime(element.getCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/IsIsElement.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/IsIsElement.java
@@ -141,4 +141,14 @@ public final class IsIsElement implements Serializable {
     public void setIsisNodeLastPollTime(Date isisNodeLastPollTime) {
         m_isisNodeLastPollTime = isisNodeLastPollTime;
     }
+
+    public void merge(IsIsElement element) {
+        if (element == null)
+            return;
+        setIsisSysID(element.getIsisSysID());
+        setIsisSysAdminState(element.getIsisSysAdminState());
+
+        setIsisNodeLastPollTime(element.getIsisNodeCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/IsIsLink.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/IsIsLink.java
@@ -237,4 +237,18 @@ public class IsIsLink implements Serializable {
     public void setIsisLinkLastPollTime(Date isisLinkLastPollTime) {
         m_isisLinkLastPollTime = isisLinkLastPollTime;
     }
+
+    public void merge(IsIsLink link) {
+        setIsisCircIfIndex(link.getIsisCircIfIndex());
+        setIsisCircAdminState(link.getIsisCircAdminState());
+
+        setIsisISAdjState(link.getIsisISAdjState());
+        setIsisISAdjNeighSNPAAddress(link.getIsisISAdjNeighSNPAAddress());
+        setIsisISAdjNeighSysType(link.getIsisISAdjNeighSysType());
+        setIsisISAdjNeighSysID(link.getIsisISAdjNeighSysID());
+        setIsisISAdjNbrExtendedCircID(link.getIsisISAdjNbrExtendedCircID());
+
+        setIsisLinkLastPollTime(link.getIsisLinkCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/LldpElement.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/LldpElement.java
@@ -130,4 +130,14 @@ public final class LldpElement implements Serializable {
     public void setLldpNodeLastPollTime(Date lldpNodeLastPollTime) {
         m_lldpNodeLastPollTime = lldpNodeLastPollTime;
     }
+
+    public void merge(LldpElement element) {
+        if (element == null)
+            return;
+        setLldpChassisId(element.getLldpChassisId());
+        setLldpChassisIdSubType(element.getLldpChassisIdSubType());
+        setLldpSysname(element.getLldpSysname());
+        setLldpNodeLastPollTime(element.getLldpNodeCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/LldpLink.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/LldpLink.java
@@ -224,4 +224,22 @@ public class LldpLink implements Serializable {
     public void setLldpLinkLastPollTime(Date lldpLinkLastPollTime) {
         m_lldpLinkLastPollTime = lldpLinkLastPollTime;
     }
+
+    public void merge(LldpLink link) {
+        setLldpPortId(link.getLldpPortId());
+        setLldpPortIdSubType(link.getLldpPortIdSubType());
+        setLldpPortDescr(link.getLldpPortDescr());
+        setLldpPortIfindex(link.getLldpPortIfindex());
+
+        setLldpRemChassisId(link.getLldpRemChassisId());
+        setLldpRemChassisIdSubType(link.getLldpRemChassisIdSubType());
+        setLldpRemSysname(link.getLldpRemSysname());
+
+        setLldpRemPortId(link.getLldpRemPortId());
+        setLldpRemPortIdSubType(link.getLldpRemPortIdSubType());
+        setLldpRemPortDescr(link.getLldpRemPortDescr());
+
+        setLldpLinkLastPollTime(link.getLldpLinkCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/OspfArea.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/OspfArea.java
@@ -182,4 +182,18 @@ public class OspfArea implements Serializable {
         m_ospfAreaLastPollTime = ospfAreaLastPollTime;
         return this;
     }
+
+    public void merge(OspfArea area) {
+        if (area == null)
+            return;
+        setOspfAreaId(area.getOspfAreaId());
+        setOspfAuthType(area.getOspfAuthType());
+        setOspfImportAsExtern(area.getOspfImportAsExtern());
+        setOspfAreaBdrRtrCount(area.getOspfAreaBdrRtrCount());
+        setOspfAsBdrRtrCount(area.getOspfAsBdrRtrCount());
+        setOspfAreaLsaCount(area.getOspfAreaLsaCount());
+        setOspfAreaCreateTime(area.getOspfAreaCreateTime());
+        setOspfAreaLastPollTime(area.getOspfAreaCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/OspfElement.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/OspfElement.java
@@ -218,4 +218,17 @@ public final class OspfElement implements Serializable {
     public void setOspfNodeLastPollTime(Date ospfNodeLastPollTime) {
         m_ospfNodeLastPollTime = ospfNodeLastPollTime;
     }
+
+    public void merge(OspfElement element) {
+        if (element == null)
+            return;
+        setOspfRouterId(element.getOspfRouterId());
+        setOspfRouterIdIfindex(element.getOspfRouterIdIfindex());
+        setOspfRouterIdNetmask(element.getOspfRouterIdNetmask());
+        setOspfAdminStat(element.getOspfAdminStat());
+        setOspfASBdrRtrStatus(element.getOspfASBdrRtrStatus());
+        setOspfBdrRtrStatus(element.getOspfASBdrRtrStatus());
+        setOspfNodeLastPollTime(element.getOspfNodeCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/OspfLink.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/model/OspfLink.java
@@ -184,4 +184,21 @@ public class OspfLink implements Serializable {
     public void setOspfLinkLastPollTime(Date ospfLinkLastPollTime) {
         m_ospfLinkLastPollTime = ospfLinkLastPollTime;
     }
+
+    public void merge(OspfLink link) {
+        if (link == null)
+            return;
+        setOspfIpAddr(link.getOspfIpAddr());
+        setOspfIpMask(link.getOspfIpMask());
+        setOspfIfIndex(link.getOspfIfIndex());
+        setOspfAddressLessIndex(link.getOspfAddressLessIndex());
+        setOspfIfAreaId(link.getOspfIfAreaId());
+
+        setOspfRemRouterId(link.getOspfRemRouterId());
+        setOspfRemIpAddr(link.getOspfRemIpAddr());
+        setOspfRemAddressLessIndex(link.getOspfRemAddressLessIndex());
+
+        setOspfLinkLastPollTime(link.getOspfLinkCreateTime());
+    }
+
 }

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/IpInterfaceDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/IpInterfaceDaoJpa.java
@@ -87,8 +87,8 @@ public class IpInterfaceDaoJpa extends AbstractDaoJpa<OnmsIpInterface, Integer> 
 
     @Override
     public List<OnmsIpInterface> findByIpAddress(String ipAddress) {
-        throw new UnsupportedOperationException(
-                "IpInterfaceDaoJpa.findByIpAddress not implemented — not required by Provisiond");
+        return find("from OnmsIpInterface ipInterface where ipInterface.ipAddress = ?1",
+                InetAddressUtils.addr(ipAddress));
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Implement `IpInterfaceDaoJpa.findByIpAddress()` — was a stub throwing `UnsupportedOperationException`, causing Enlinkd's IpNetToMedia processing to fail during SNMP walks
- Add missing `merge()` methods to all 14 Jakarta Enlinkd model classes (`LldpElement`, `LldpLink`, `CdpElement`, `CdpLink`, `BridgeElement`, `BridgeBridgeLink`, `BridgeMacLink`, `BridgeStpLink`, `IsIsElement`, `IsIsLink`, `OspfElement`, `OspfLink`, `OspfArea`, `IpNetToMedia`) — copied verbatim from upstream `features/enlinkd/persistence/api` models

These methods are called by Enlinkd's topology service implementations during SNMP walk result processing. Without them, link discovery crashed with `NoSuchMethodError` and SNMP interface collection failed with `UnsupportedOperationException`.

## Root Cause

When the Jakarta model copies were created for the Spring Boot migration, the `merge()` methods and some DAO query implementations were omitted because they weren't needed by Provisiond (the first daemon migrated). Enlinkd needs them for topology link persistence.

## E2E Test Results

| Test Suite | Result |
|---|---|
| test-enlinkd-e2e.sh | **18/18** (was failing with 0 LLDP links) |

## Test plan

- [x] Enlinkd E2E: SNMP interfaces collected on all 5 nodes
- [x] Enlinkd E2E: LLDP links discovered (16 entries, 8 unique pairs)
- [x] Build compiles cleanly