### PR TITLE
chore: standardize E2E test cleanup with --pre-clean and --post-cleanup

### DIFF
--- a/opennms-container/delta-v/test-collectd-e2e.sh
+++ b/opennms-container/delta-v/test-collectd-e2e.sh
@@ -10,7 +10,8 @@
 # Usage:
 #   ./test-collectd-e2e.sh              Run the test
 #   ./test-collectd-e2e.sh --verbose    Show diagnostic queries on failure
-#   ./test-collectd-e2e.sh --clean      Full pre-run cleanup (DB + restart daemons)
+#   ./test-collectd-e2e.sh --pre-clean  Full pre-run cleanup (DB + restart daemons)
+#   ./test-collectd-e2e.sh --post-cleanup  Delete test nodes and alarms after run
 #   ./test-collectd-e2e.sh --skip-provision  Skip Phase 1 if nodes already exist
 #
 # Prerequisites:
@@ -27,6 +28,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
 
 # ── Configuration ──────────────────────────────────────────────────
 FOREIGN_SOURCE="delta-v"
@@ -38,12 +40,14 @@ COLLECTION_POLL_INTERVAL=15 # seconds between DB checks
 
 # ── Parse flags ────────────────────────────────────────────────────
 VERBOSE=false
-CLEAN=false
+PRE_CLEAN=false
+POST_CLEANUP=false
 SKIP_PROVISION=false
 for arg in "$@"; do
     case "$arg" in
         --verbose) VERBOSE=true ;;
-        --clean) CLEAN=true ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
         --skip-provision) SKIP_PROVISION=true ;;
         --help|-h)
             sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
@@ -62,8 +66,11 @@ fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
 err()  { echo "ERROR: $*" >&2; exit 2; }
 
 cleanup() {
-    : # DB cleanup happens at the start of each run, not on exit.
-      # This preserves test results for post-run inspection.
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing test data..."
+        clean_all_nodes
+        clean_all_alarms
+    fi
 }
 trap cleanup EXIT
 
@@ -143,30 +150,19 @@ done
 ok "Required services running (postgres, kafka, provisiond, collectd)"
 
 # ══════════════════════════════════════════════════════════════════
-# Pre-run cleanup (--clean): full reset for a pristine test run
+# Pre-run cleanup (--pre-clean): full reset for a pristine test run
 # ══════════════════════════════════════════════════════════════════
-if $CLEAN; then
+if $PRE_CLEAN; then
     log ""
-    log "Pre-run cleanup (--clean): resetting DB and daemons..."
+    log "Pre-run cleanup (--pre-clean): resetting DB and daemons..."
 
     # 1. Stop Collectd and Provisiond so they don't write while we clean
     log "  Stopping Collectd and Provisiond..."
     docker compose stop collectd provisiond 2>/dev/null || true
 
-    # 2. Wipe delta-v node data from DB (FK-safe order)
-    DELTAV_IDS="SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'"
-    PRIOR=$(psql_query "SELECT count(*) FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || echo "0")
-    if [ "${PRIOR:-0}" -gt 0 ]; then
-        log "  Deleting ${PRIOR} delta-v nodes and dependent data..."
-        psql_query "DELETE FROM outages WHERE nodeid IN (${DELTAV_IDS})" || true
-        psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (${DELTAV_IDS}))" || true
-        psql_query "DELETE FROM alarms WHERE nodeid IN (${DELTAV_IDS})" || true
-        psql_query "DELETE FROM events WHERE nodeid IN (${DELTAV_IDS})" || true
-        psql_query "UPDATE ipinterface SET snmpinterfaceid = NULL WHERE nodeid IN (${DELTAV_IDS})" || true
-        psql_query "DELETE FROM snmpinterface WHERE nodeid IN (${DELTAV_IDS})" || true
-        psql_query "DELETE FROM ipinterface WHERE nodeid IN (${DELTAV_IDS})" || true
-        psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
-    fi
+    # 2. Wipe ALL nodes from DB (FK-safe order)
+    clean_all_nodes
+    clean_all_alarms
     ok "Database cleaned"
 
     # 3. Restart Collectd and Provisiond with fresh state

--- a/opennms-container/delta-v/test-e2e.sh
+++ b/opennms-container/delta-v/test-e2e.sh
@@ -8,7 +8,8 @@
 # Usage:
 #   ./test-e2e.sh              Run the test
 #   ./test-e2e.sh --verbose    Show full Kafka event trace
-#   ./test-e2e.sh --cleanup    Delete test data after run
+#   ./test-e2e.sh --pre-clean  Full pre-run cleanup (delete all nodes and alarms)
+#   ./test-e2e.sh --post-cleanup  Delete test data after run
 #
 # Prerequisites:
 #   - Delta-V deployed with passive profile: ./deploy.sh up passive
@@ -23,6 +24,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
 
 # ── Configuration ──────────────────────────────────────────────────
 TRAP_HOST="localhost"
@@ -39,9 +41,10 @@ usage() {
 Usage: ./test-e2e.sh [options]
 
 Options:
-  --verbose    Show full Kafka event trace
-  --cleanup    Delete test alarms after test
-  --help       Show this help
+  --verbose       Show full Kafka event trace
+  --pre-clean     Full pre-run cleanup (delete all nodes and alarms)
+  --post-cleanup  Delete test alarms after test
+  --help          Show this help
 
 Prerequisites:
   - Deploy with: ./deploy.sh up passive
@@ -51,11 +54,13 @@ USAGE
 
 # ── Parse flags ────────────────────────────────────────────────────
 VERBOSE=false
-CLEANUP=false
+PRE_CLEAN=false
+POST_CLEANUP=false
 for arg in "$@"; do
     case "$arg" in
         --verbose) VERBOSE=true ;;
-        --cleanup) CLEANUP=true ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
         --help|-h) usage; exit 0 ;;
     esac
 done
@@ -87,8 +92,8 @@ cleanup() {
         cat "$IPC_LOG" 2>/dev/null || true
     fi
 
-    if $CLEANUP; then
-        log "Cleaning up test data..."
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing test data..."
         docker compose exec -T -e PGPASSWORD=opennms postgres \
             psql -U opennms -d opennms -q \
             -c "DELETE FROM alarms WHERE eventuei LIKE '%translator/traps/SNMP_Link%'" \
@@ -122,6 +127,15 @@ psql_query() {
     docker compose exec -T -e PGPASSWORD=opennms postgres \
         psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
 }
+
+# ── Pre-run cleanup (--pre-clean) ─────────────────────────────────
+if $PRE_CLEAN; then
+    log "Pre-run cleanup (--pre-clean): resetting DB..."
+    clean_all_nodes
+    clean_all_alarms
+    ok "Database cleaned"
+    log ""
+fi
 
 # ── Prerequisite Checks ───────────────────────────────────────────
 log "Checking prerequisites..."

--- a/opennms-container/delta-v/test-enlinkd-e2e.sh
+++ b/opennms-container/delta-v/test-enlinkd-e2e.sh
@@ -19,7 +19,8 @@
 # Usage:
 #   ./test-enlinkd-e2e.sh              Run the test
 #   ./test-enlinkd-e2e.sh --verbose    Show diagnostic queries on failure
-#   ./test-enlinkd-e2e.sh --clean      Full pre-run cleanup (DB + restart daemons + clear Kafka)
+#   ./test-enlinkd-e2e.sh --pre-clean  Full pre-run cleanup (DB + restart daemons + clear Kafka)
+#   ./test-enlinkd-e2e.sh --post-cleanup  Delete test nodes and alarms after run
 #   ./test-enlinkd-e2e.sh --skip-provision  Skip Phase 1 if nodes already exist
 #
 # Prerequisites:
@@ -36,6 +37,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
 
 # ── Configuration ──────────────────────────────────────────────────
 FOREIGN_SOURCE="mhuot-labs"
@@ -56,12 +58,14 @@ declare -A NODES=(
 
 # ── Parse flags ────────────────────────────────────────────────────
 VERBOSE=false
-CLEAN=false
+PRE_CLEAN=false
+POST_CLEANUP=false
 SKIP_PROVISION=false
 for arg in "$@"; do
     case "$arg" in
         --verbose) VERBOSE=true ;;
-        --clean) CLEAN=true ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
         --skip-provision) SKIP_PROVISION=true ;;
         --help|-h)
             sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
@@ -80,8 +84,11 @@ fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
 err()  { echo "ERROR: $*" >&2; exit 2; }
 
 cleanup() {
-    : # DB cleanup happens at the start of each run (Phase 0b), not on exit.
-      # This preserves test results in the DB for post-run inspection.
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing test data..."
+        clean_all_nodes
+        clean_all_alarms
+    fi
 }
 trap cleanup EXIT
 
@@ -171,43 +178,19 @@ done
 ok "Required services running (postgres, kafka, provisiond, enlinkd)"
 
 # ══════════════════════════════════════════════════════════════════
-# Pre-run cleanup (--clean): full reset for a pristine test run
+# Pre-run cleanup (--pre-clean): full reset for a pristine test run
 # ══════════════════════════════════════════════════════════════════
-if $CLEAN; then
+if $PRE_CLEAN; then
     log ""
-    log "Pre-run cleanup (--clean): resetting DB, daemons, and Kafka topics..."
+    log "Pre-run cleanup (--pre-clean): resetting DB, daemons, and Kafka topics..."
 
     # 1. Stop Enlinkd and Provisiond so they don't write while we clean
     log "  Stopping Enlinkd and Provisiond..."
     docker compose stop enlinkd provisiond 2>/dev/null || true
 
-    # 2. Wipe all mhuot-labs data from DB (FK-safe order)
-    MHUOT_IDS="SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'"
-    PRIOR=$(psql_query "SELECT count(*) FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || echo "0")
-    if [ "${PRIOR:-0}" -gt 0 ]; then
-        log "  Deleting ${PRIOR} mhuot-labs nodes and all dependent data..."
-        psql_query "DELETE FROM outages WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (${MHUOT_IDS}))" || true
-        psql_query "DELETE FROM alarms WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM events WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "UPDATE ipinterface SET snmpinterfaceid = NULL WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM snmpinterface WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM ipinterface WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM lldplink WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM lldpelement WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM cdplink WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM cdpelement WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM ospflink WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM ospfelement WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM isislink WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM isiselement WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM ipnettomedia WHERE sourcenodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM bridgemaclink WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM bridgestplink WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM bridgebridgelink WHERE nodeid IN (${MHUOT_IDS}) OR designatednodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM bridgeelement WHERE nodeid IN (${MHUOT_IDS})" || true
-        psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
-    fi
+    # 2. Wipe ALL nodes from DB (FK-safe order) — not just mhuot-labs
+    clean_all_nodes
+    clean_all_alarms
     ok "Database cleaned"
 
     # 3. Delete mhuot-labs RPC Kafka topics so no stale requests linger
@@ -340,47 +323,23 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════
-# Phase 0b: Clean prior test data (lightweight — skipped if --clean already ran)
+# Phase 0b: Clean ALL prior node data (lightweight — skipped if --pre-clean already ran)
 # ══════════════════════════════════════════════════════════════════
-if ! $CLEAN; then
+if ! $PRE_CLEAN; then
     log ""
-    log "Phase 0b: Cleaning prior mhuot-labs test data from database..."
+    log "Phase 0b: Cleaning ALL prior node data from database..."
 
-    # Delete in FK-safe order (children first), scoped to mhuot-labs nodes only.
-    MHUOT_NODE_IDS="SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'"
-    PRIOR_COUNT=$(psql_query "SELECT count(*) FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || echo "0")
-
+    PRIOR_COUNT=$(psql_query "SELECT count(*) FROM node" || echo "0")
     if [ "${PRIOR_COUNT:-0}" -gt 0 ]; then
-        log "  Removing ${PRIOR_COUNT} prior mhuot-labs nodes and all dependent data..."
-        psql_query "DELETE FROM outages WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (${MHUOT_NODE_IDS}))" || true
-        psql_query "DELETE FROM alarms WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM events WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "UPDATE ipinterface SET snmpinterfaceid = NULL WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM snmpinterface WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM ipinterface WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM lldplink WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM lldpelement WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM cdplink WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM cdpelement WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM ospflink WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM ospfelement WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM isislink WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM isiselement WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM ipnettomedia WHERE sourcenodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM bridgemaclink WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM bridgestplink WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM bridgebridgelink WHERE nodeid IN (${MHUOT_NODE_IDS}) OR designatednodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM bridgeelement WHERE nodeid IN (${MHUOT_NODE_IDS})" || true
-        psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
+        clean_all_nodes
         ok "Prior test data cleaned (${PRIOR_COUNT} nodes removed)"
         PROVISIOND_NEEDS_RESTART=true
     else
-        ok "No prior mhuot-labs data to clean"
+        ok "No prior node data to clean"
     fi
 else
     log ""
-    log "Phase 0b: Skipped (already cleaned by --clean)"
+    log "Phase 0b: Skipped (already cleaned by --pre-clean)"
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/opennms-container/delta-v/test-lib.sh
+++ b/opennms-container/delta-v/test-lib.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# test-lib.sh -- Shared helper functions for Delta-V E2E tests
+#
+# Source this file from test scripts: source "$(dirname "$0")/test-lib.sh"
+#
+
+# Delete ALL nodes and dependent data from the database (FK-safe order).
+# Usage: clean_all_nodes
+clean_all_nodes() {
+    local ALL_IDS="SELECT nodeid FROM node"
+    local count
+    count=$(psql_query "SELECT count(*) FROM node" || echo "0")
+    if [ "${count:-0}" -eq 0 ]; then
+        log "  No nodes to clean"
+        return 0
+    fi
+    log "  Deleting all ${count} nodes and dependent data..."
+    psql_query "DELETE FROM outages WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (${ALL_IDS}))" || true
+    psql_query "DELETE FROM alarms WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM events WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "UPDATE ipinterface SET snmpinterfaceid = NULL WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM snmpinterface WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM ipinterface WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM lldplink WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM lldpelement WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM cdplink WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM cdpelement WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM ospflink WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM ospfelement WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM isislink WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM isiselement WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM ipnettomedia WHERE sourcenodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM bridgemaclink WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM bridgestplink WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM bridgebridgelink WHERE nodeid IN (${ALL_IDS}) OR designatednodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM bridgeelement WHERE nodeid IN (${ALL_IDS})" || true
+    psql_query "DELETE FROM node" || true
+    log "  Deleted ${count} nodes"
+}
+
+# Delete all alarms from the database.
+# Usage: clean_all_alarms
+clean_all_alarms() {
+    local count
+    count=$(psql_query "SELECT count(*) FROM alarms" || echo "0")
+    if [ "${count:-0}" -gt 0 ]; then
+        psql_query "DELETE FROM alarms" || true
+        log "  Deleted ${count} alarms"
+    fi
+}

--- a/opennms-container/delta-v/test-minion-e2e.sh
+++ b/opennms-container/delta-v/test-minion-e2e.sh
@@ -12,7 +12,8 @@
 # Usage:
 #   ./test-minion-e2e.sh              Run the test
 #   ./test-minion-e2e.sh --verbose    Show full Kafka event trace
-#   ./test-minion-e2e.sh --cleanup    Delete test data after run
+#   ./test-minion-e2e.sh --pre-clean  Full pre-run cleanup (delete all nodes and alarms)
+#   ./test-minion-e2e.sh --post-cleanup  Delete test data after run
 #
 # Prerequisites:
 #   - Delta-V deployed: docker compose up -d
@@ -28,6 +29,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
 
 # ── Configuration ──────────────────────────────────────────────────
 # Traps go to the MINION, not directly to Trapd
@@ -45,9 +47,10 @@ usage() {
 Usage: ./test-minion-e2e.sh [options]
 
 Options:
-  --verbose    Show full Kafka event trace
-  --cleanup    Delete test alarms after test
-  --help       Show this help
+  --verbose       Show full Kafka event trace
+  --pre-clean     Full pre-run cleanup (delete all nodes and alarms)
+  --post-cleanup  Delete test alarms after test
+  --help          Show this help
 
 Prerequisites:
   - Delta-V deployed: docker compose up -d
@@ -58,11 +61,13 @@ USAGE
 
 # ── Parse flags ────────────────────────────────────────────────────
 VERBOSE=false
-CLEANUP=false
+PRE_CLEAN=false
+POST_CLEANUP=false
 for arg in "$@"; do
     case "$arg" in
         --verbose) VERBOSE=true ;;
-        --cleanup) CLEANUP=true ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
         --help|-h) usage; exit 0 ;;
     esac
 done
@@ -100,8 +105,8 @@ cleanup() {
         cat "$IPC_LOG" 2>/dev/null || true
     fi
 
-    if $CLEANUP; then
-        log "Cleaning up test data..."
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing test data..."
         docker compose exec -T -e PGPASSWORD=opennms postgres \
             psql -U opennms -d opennms -q \
             -c "DELETE FROM alarms WHERE eventuei LIKE '%translator/traps/SNMP_Link%'" \
@@ -135,6 +140,15 @@ psql_query() {
     docker compose exec -T -e PGPASSWORD=opennms postgres \
         psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
 }
+
+# ── Pre-run cleanup (--pre-clean) ─────────────────────────────────
+if $PRE_CLEAN; then
+    log "Pre-run cleanup (--pre-clean): resetting DB..."
+    clean_all_nodes
+    clean_all_alarms
+    ok "Database cleaned"
+    log ""
+fi
 
 # ── Prerequisite Checks ───────────────────────────────────────────
 log "Checking prerequisites..."

--- a/opennms-container/delta-v/test-passive-e2e.sh
+++ b/opennms-container/delta-v/test-passive-e2e.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
 
 # ── Configuration ──────────────────────────────────────────────────
 TRAP_HOST="localhost"
@@ -31,12 +32,14 @@ OUTAGE_TIMEOUT=180
 
 # ── Parse flags ────────────────────────────────────────────────────
 VERBOSE=false
-CLEANUP=false
+PRE_CLEAN=false
+POST_CLEANUP=false
 for arg in "$@"; do
     case "$arg" in
         --verbose) VERBOSE=true ;;
-        --cleanup) CLEANUP=true ;;
-        --help|-h) echo "Usage: $0 [--verbose] [--cleanup]"; exit 0 ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
+        --help|-h) echo "Usage: $0 [--verbose] [--pre-clean] [--post-cleanup]"; exit 0 ;;
     esac
 done
 
@@ -67,8 +70,8 @@ cleanup() {
         cat "$IPC_LOG" 2>/dev/null || true
     fi
 
-    if $CLEANUP; then
-        log "Cleaning up test data..."
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing test data..."
         psql_query "DELETE FROM alarms WHERE eventuei LIKE '%syslogd/cloud/%'" 2>/dev/null || true
     fi
 
@@ -139,6 +142,15 @@ wait_for_healthy() {
     done
     return 1
 }
+
+# ── Pre-run cleanup (--pre-clean) ─────────────────────────────────
+if $PRE_CLEAN; then
+    log "Pre-run cleanup (--pre-clean): resetting DB..."
+    clean_all_nodes
+    clean_all_alarms
+    ok "Database cleaned"
+    log ""
+fi
 
 # ── Prerequisite Checks ───────────────────────────────────────────
 log "Checking prerequisites..."

--- a/opennms-container/delta-v/test-syslog-e2e.sh
+++ b/opennms-container/delta-v/test-syslog-e2e.sh
@@ -17,7 +17,8 @@
 # Usage:
 #   ./test-syslog-e2e.sh              Run the test
 #   ./test-syslog-e2e.sh --verbose    Show full Kafka event trace
-#   ./test-syslog-e2e.sh --cleanup    Delete test data after run
+#   ./test-syslog-e2e.sh --pre-clean  Full pre-run cleanup (delete all nodes and alarms)
+#   ./test-syslog-e2e.sh --post-cleanup  Delete test data after run
 #
 # Prerequisites:
 #   - Delta-V deployed: docker compose up -d
@@ -33,6 +34,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
 
 # ── Configuration ──────────────────────────────────────────────────
 SYSLOG_HOST="localhost"
@@ -48,9 +50,10 @@ usage() {
 Usage: ./test-syslog-e2e.sh [options]
 
 Options:
-  --verbose    Show full Kafka event trace
-  --cleanup    Delete test alarms after test
-  --help       Show this help
+  --verbose       Show full Kafka event trace
+  --pre-clean     Full pre-run cleanup (delete all nodes and alarms)
+  --post-cleanup  Delete test alarms after test
+  --help          Show this help
 
 Prerequisites:
   - Delta-V deployed: docker compose up -d
@@ -61,11 +64,13 @@ USAGE
 
 # ── Parse flags ────────────────────────────────────────────────────
 VERBOSE=false
-CLEANUP=false
+PRE_CLEAN=false
+POST_CLEANUP=false
 for arg in "$@"; do
     case "$arg" in
         --verbose) VERBOSE=true ;;
-        --cleanup) CLEANUP=true ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
         --help|-h) usage; exit 0 ;;
     esac
 done
@@ -103,8 +108,8 @@ cleanup() {
         cat "$IPC_LOG" 2>/dev/null || true
     fi
 
-    if $CLEANUP; then
-        log "Cleaning up test data..."
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing test data..."
         docker compose exec -T -e PGPASSWORD=opennms postgres \
             psql -U opennms -d opennms -q \
             -c "DELETE FROM alarms WHERE eventuei LIKE '%syslogd/cisco/link%'" \
@@ -151,6 +156,15 @@ psql_query() {
     docker compose exec -T -e PGPASSWORD=opennms postgres \
         psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
 }
+
+# ── Pre-run cleanup (--pre-clean) ─────────────────────────────────
+if $PRE_CLEAN; then
+    log "Pre-run cleanup (--pre-clean): resetting DB..."
+    clean_all_nodes
+    clean_all_alarms
+    ok "Database cleaned"
+    log ""
+fi
 
 # ── Prerequisite Checks ───────────────────────────────────────────
 log "Checking prerequisites..."


### PR DESCRIPTION
## Summary

- Create shared `test-lib.sh` with `clean_all_nodes()` and `clean_all_alarms()` helpers (FK-safe cascade delete across 20 tables)
- Rename `--clean` → `--pre-clean` and `--cleanup` → `--post-cleanup` across all 6 test scripts
- Add the missing flag to scripts that only had one (all scripts now support both)
- **Enlinkd test now always cleans ALL nodes** (not just `mhuot-labs`) before provisioning, preventing stale nodes from other test suites from clogging Enlinkd's SNMP thread pool

## Root Cause

Other E2E tests send coldStart traps that auto-discover infrastructure containers (postgres, kafka, minion, etc.) as nodes at 169.254.0.x management addresses. When the Enlinkd test ran later, these stale nodes consumed Enlinkd's 5-thread SNMP pool with timeout attempts, leaving insufficient capacity for the actual test nodes.

## Test plan

- [x] All 7 scripts pass `bash -n` syntax check
- [x] No stale `--clean`/`--cleanup`/`CLEAN=`/`CLEANUP=` references remain
- [x] Enlinkd E2E passes 18/18 after stale node cleanup