### PR TITLE
docs: update README and next-session prompt

### DIFF
--- a/docs/plans/next-session-prompt.md
+++ b/docs/plans/next-session-prompt.md
@@ -1,4 +1,4 @@
-# Next Session Prompt: PerspectivePollerd Migration & Dead Daemon Cleanup
+# Next Session Prompt
 
 > Copy everything below the line into the next Claude Code conversation.
 
@@ -6,89 +6,40 @@
 
 ## Context
 
-We're on the `eventbus-redesign` branch of OpenNMS Horizon (Delta-V architecture). The Strike Fighter plan, Phase A core elimination, EventDao/Notifd/Minion REST elimination, and Minion E2E pipeline are all complete. The Delta-V architecture has 17 services running on 3 images (horizon, daemon, minion) with Kafka-only event transport.
+All 12 daemons run as standalone Spring Boot 4 apps. The opennms-services monolith has been eliminated (PR #65). All 6 E2E test suites pass (78/78). Recent PRs:
 
-Three cleanup items remain. A design spec has been written, reviewed (3 rounds of spec review — all issues resolved), and approved:
+- **PR #66**: BeanUtils bridge in daemon-common — prevents legacy ContextRegistry fallback
+- **PR #68**: Dependency freshening — commons-jxpath, log4j2, postgresql, removed ehcache/dbunit
+- **PR #69**: DaemonEntityScopeProvider — real MATE interpolation (node/interface/service/SCV/env scopes)
+- **PR #70**: Missing merge() methods + findByIpAddress for Enlinkd Jakarta models
+- **PR #71**: Standardized `--pre-clean` / `--post-cleanup` across all E2E tests
 
-**Design spec:** `docs/plans/2026-03-12-perspectivepollerd-cleanup-design.md`
+## What's Next
 
-## What to Implement
+Prioritized follow-ups from memory:
 
-### Task 1: PerspectivePollerd Daemon-Loader Module (the bulk of the work)
+### 1. Thresholding E2E Tests (highest value)
+Verify thresholding works end-to-end in Collectd, Pollerd, PerspectivePollerd. The `EntityScopeProvider` prerequisite is now satisfied (PR #69). `ThresholdingService` is still stubbed with a no-op — needs real implementation.
 
-Create `core/daemon-loader-perspectivepoller/` following the established daemon-loader pattern (14 existing modules as reference). PerspectivePollerd is the last remaining daemon to extract.
+### 2. AbstractServiceDaemon → SpringServiceDaemon Interface
+All 12 daemon classes still extend `AbstractServiceDaemon`. Convert to a leaner `SpringServiceDaemon` interface. The `SpringServiceDaemonSmartLifecycle` adapter already wraps the daemons.
 
-**Key details (from the spec):**
-- PerspectivePollerd implements `SpringServiceDaemon` → needs `SpringDaemonLifecycleManager` (like Ticketer)
-- Uses real `LocationAwarePollerClient` (not LocalPollerClient like Pollerd) for Minion RPC delegation
-- `LocationAwarePollerClientImpl` is wired directly in the daemon-loader XML (the `poller.client-rpc` bundle has no Spring-Context header)
-- `LocationAwarePollerClientImpl` has 5 `@Autowired` fields: `ServiceMonitorRegistry`, `PollerClientRpcModule`, `RpcClientFactory`, `RpcTargetHelper`, `EntityScopeProvider`
-- `RpcClientFactory` comes from `osgi:reference` (Kafka RPC Blueprint). All DAOs come from `onmsgi:reference`.
-- `ServiceRegistry` from `osgi:reference` is required for all `onmsgi:reference` proxies to resolve
-- `PollerClientRpcModule` needs a `pollerExecutor` bean (`@Qualifier("pollerExecutor")`)
-- Event subscription via `AnnotationBasedEventListenerAdapter` for both daemon and tracker
-- TSID node-id = 7
-- `<context:annotation-config/>` required (constructor injection via `@Autowired`)
+### 3. Constructor Injection Cleanup
+Remove `@Autowired` field injection from service implementation classes (`features/poller/impl`, `features/collection/impl`, `features/event-translator`). Convert to constructor injection following the daemon-boot pattern.
 
-**Reference implementations:**
-- `core/daemon-loader-pollerd/` — closest match (also a poller, same base dependencies)
-- `core/daemon-loader-ticketer/` — same lifecycle pattern (`SpringDaemonLifecycleManager`)
-- `core/daemon-loader-provisiond/` — same `NoOpTracerRegistry` and `EntityScopeProvider` pattern
+## Current E2E Baseline (2026-03-28)
 
-**Files to create:**
-- `core/daemon-loader-perspectivepoller/pom.xml` — bundle packaging, `Import-Package: *;resolution:=optional`, `DynamicImport-Package: *`, `Spring-Context` with `create-asynchronously:=true`
-- `core/daemon-loader-perspectivepoller/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-perspectivepoller.xml` — flat Spring XML with all OSGi refs and local beans
+| Test | Passed |
+|------|--------|
+| test-collectd-e2e.sh | 4/4 |
+| test-minion-e2e.sh | 13/13 |
+| test-syslog-e2e.sh | 15/15 |
+| test-passive-e2e.sh | 16/16 |
+| test-enlinkd-e2e.sh | 18/18 |
+| test-e2e.sh | 12/12 |
 
-**Files to modify:**
-- `core/pom.xml` — add `<module>daemon-loader-perspectivepoller</module>`
+## Key Constraints
 
-### Task 2: Karaf Feature + Sentinel Assembly + Docker Compose
-
-**Karaf feature** in `container/features/src/main/resources/features.xml`:
-- New `opennms-daemon-perspectivepoller` feature
-- Must include: `opennms-spring-extender`, `opennms-event-forwarder-kafka`, `opennms-distributed-core-impl`, `opennms-persistence`, `opennms-config`, `opennms-core-daemon`, `opennms-core-ipc-rpc-kafka`
-- Bundles: collection API, thresholding API, icmp-api, poller-api, kv-store-api, poll-outages-api, mate-api, poller.client-rpc, opennms-services, perspectivepoller, daemon-loader-perspectivepoller
-
-**Sentinel assembly** (`features/container/sentinel/pom.xml`):
-- Add `opennms-daemon-perspectivepoller` to `<installedFeatures>`
-
-**Docker Compose** (`opennms-container/delta-v/docker-compose.yml`):
-- New `perspectivepollerd` service (image: `opennms/daemon:delta-v`, TSID=7, profiles: [full])
-- POSTGRES_* env vars, db-init dependency, JAR overlay volumes (event-forwarder-kafka, features.xml, events.daemon)
-- Overlay at `./perspectivepollerd-overlay/etc:/opt/sentinel-etc-overlay:ro`
-
-**Container overlay** (`opennms-container/delta-v/perspectivepollerd-overlay/`):
-- `etc/featuresBoot.d/perspectivepoller.boot`
-- `etc/org.opennms.core.health.cfg.cfg` (health ignore: distributed.datasource, core-impl, dao-impl)
-
-**Named volume:** `perspectivepollerd-data:`
-
-This brings Delta-V from 17 → 18 services.
-
-### Task 3: Remove Dead Notifd Mbean from JMX Config
-
-Delete the `OpenNMS.Notifd` mbean block (lines 57-68) from `opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml`. Notifd was fully eliminated — its JMX MBean definition is dead.
-
-### Task 4: Verification
-
-- Grep `opennms-base-assembly/src/main/filtered/etc/` for deleted daemon references (Notifd, Queued, Vacuumd, Statsd, Actiond, Ackd) — should be zero
-- Confirm `promoteQueueData` absent from active configs
-- Build the daemon-loader module
-- Rebuild Sentinel assembly + Docker images
-- Start PerspectivePollerd container and verify health
-
-## Approach
-
-Use the **writing-plans** skill to create a detailed implementation plan from the design spec, then use **subagent-driven-development** to execute it. The design spec has been through 3 rounds of review — all issues resolved. Do NOT re-brainstorm; go straight to planning and implementation.
-
-## Key Files to Reference
-
-- **Design spec:** `docs/plans/2026-03-12-perspectivepollerd-cleanup-design.md`
-- **Reference daemon-loader (Pollerd):** `core/daemon-loader-pollerd/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-pollerd.xml`
-- **Reference daemon-loader (Ticketer):** `core/daemon-loader-ticketer/src/main/resources/META-INF/opennms/applicationContext-daemon-loader-ticketer.xml`
-- **Karaf features:** `container/features/src/main/resources/features.xml` (Pollerd feature at line 2106)
-- **Sentinel assembly:** `features/container/sentinel/pom.xml`
-- **Docker Compose:** `opennms-container/delta-v/docker-compose.yml`
-- **PerspectivePollerd source:** `features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollerd.java`
-- **LocationAwarePollerClientImpl:** `features/poller/client-rpc/src/main/java/org/opennms/netmgt/poller/client/rpc/LocationAwarePollerClientImpl.java`
-- **JMX config:** `opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml`
+- Must work on a feature branch with a PR against `pbrane/delta-v` (NEVER against `OpenNMS/opennms`)
+- Rebuild all 12 daemon-boot JARs before `./build.sh deltav`
+- Run `--pre-clean` on Enlinkd tests to avoid stale node interference

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -35,13 +35,13 @@ All 12 daemons have been migrated from Karaf to Spring Boot 4. Each runs as an i
 | Telemetryd         | Done   | #52  | Yes          | Telemetry ingestion bridge |
 | **Collectd**       | **Done** | **#56** | **Yes** | **SNMP data collection via Minion SNMP proxy** |
 
-### Collectd Migration Details
+### Shared Infrastructure (daemon-common)
 
-Collectd was the last daemon migrated to Spring Boot. Key architectural decisions:
+All 12 daemons share infrastructure from `core/daemon-common`:
 
-- **Two-layer SNMP collection**: `SnmpCollector` runs locally in the Collectd JVM (`force-remote=false`). Inside `collect()`, the `LocationAwareSnmpClient` sends individual SNMP walk requests via Kafka RPC to the Minion at the node's actual location. The Minion executes the walks and returns raw SNMP data.
-- **Time-series persistence**: Uses `InMemoryStorage` by default. The TSS pipeline (TimeseriesPersisterFactory → TimeseriesStorageManager → InMemoryStorage) is wired as a `PersisterFactory` bean.
-- **Legacy BeanUtils bypass**: `SnmpCollector` obtains `LocationAwareSnmpClient` via `BeanUtils.getBean("daoContext", ...)` in monolithic OpenNMS. In Spring Boot, the client is injected into ServiceLoader-loaded collectors at startup.
+- **BeanUtils bridge**: `BeanUtils` is registered as a Spring bean so legacy static lookups (`BeanUtils.getBean(...)`) route to the daemon's own ApplicationContext instead of falling through to the legacy `ContextRegistry` XML context chain.
+- **MATE EntityScopeProvider**: `DaemonEntityScopeProvider` resolves MATE metadata expressions (`${node:label}`, `${scv:alias:password}`, `${asset:region}`) in daemons with database access (Provisiond, Pollerd, Collectd, Enlinkd, PerspectivePollerd). Daemons without DAOs fall back to `NoOpEntityScopeProvider`.
+- **Secure Credentials Vault**: JCEKS-backed `SecureCredentialsVault` reads from `${opennms.home}/etc/scv.jce` for `${scv:...}` credential interpolation.
 - **Thresholding**: Stubbed with a no-op `ThresholdingService`. Full thresholding support is a follow-up task.
 
 ### Karaf Image Retirement
@@ -123,6 +123,26 @@ Web UI: **http://localhost:8980/opennms** (admin / admin)
 # Reset (destroy all data)
 ./deploy.sh reset
 ```
+
+## E2E Tests
+
+Six end-to-end test suites validate the full pipeline:
+
+```bash
+cd opennms-container/delta-v
+
+bash test-collectd-e2e.sh        # SNMP data collection via Minion
+bash test-minion-e2e.sh          # Trap → Minion → Kafka → Alarmd lifecycle
+bash test-syslog-e2e.sh          # Syslog → Minion → Kafka → Alarmd lifecycle
+bash test-passive-e2e.sh         # Passive status via EventTranslator + Pollerd
+bash test-enlinkd-e2e.sh         # LLDP/CDP link discovery on Containerlab cEOS
+bash test-e2e.sh                 # Full alarm create/clear via SNMP traps
+```
+
+All scripts support:
+- `--verbose` — show diagnostic output on failure
+- `--pre-clean` — delete all nodes and alarms from DB before running
+- `--post-cleanup` — delete test data after run
 
 ## Build Script Reference
 


### PR DESCRIPTION
## Summary

- Replace Collectd-specific migration details with shared infrastructure section (BeanUtils bridge, DaemonEntityScopeProvider, JCEKS SCV)
- Add E2E Tests section documenting all 6 suites and `--pre-clean`/`--post-cleanup` flags
- Rewrite stale next-session-prompt with current follow-up priorities (thresholding, AbstractServiceDaemon refactor, constructor injection cleanup)