### PR TITLE
feat: Spring Boot 4 Minion + BSM jakarta port + all 12 daemons healthy

### DIFF
--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -213,6 +213,13 @@
             </exclusions>
         </dependency>
 
+        <!-- Model API (persistence-free types including ServiceDaemon interface) -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- javax.persistence API — needed at runtime so legacy opennms-model classes
              on the classpath don't cause ClassNotFoundException when Spring's classpath
              scanner encounters them. -->

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -1,0 +1,464 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.core</artifactId>
+        <version>36.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.daemon-boot-minion-common</artifactId>
+    <packaging>jar</packaging>
+    <name>OpenNMS :: Core :: Daemon Boot :: Minion Common</name>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-boot.version>4.0.3</spring-boot.version>
+        <enforcer-skip-banned-dependencies>true</enforcer-skip-banned-dependencies>
+        <enforcer-skip-dependency-convergence>true</enforcer-skip-dependency-convergence>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import Spring Boot BOM FIRST for version precedence over parent POM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Pin Logback to match Spring Boot 4 requirements.
+                 Parent POM manages logback-classic at 1.2.13 which is
+                 incompatible with Spring Boot 4's Configurator API. -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <!-- Pin SLF4J 2.0.17: parent POM manages 1.7.36 which is
+                 incompatible with Logback 1.5.x and Spring Boot 4 -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <!-- Pin Jackson 2.19.4: parent POM manages 2.16.2 which lacks
+                 JsonFormat$Shape.POJO required by Jackson 3.x (tools.jackson.databind).
+                 Spring Boot 4's BOM wants 2.20.2 but parent POM overrides it. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-json-org</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-csv</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-scala_2.13</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <!-- Pin JUnit 5.12.2 / Platform 1.12.2: parent POM manages 5.9.2 / 1.9.2
+                 which are incompatible with maven-surefire-plugin 3.5.5 -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- ============================================================ -->
+        <!-- Spring Boot                                                  -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- SLF4J 2.x -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Shared daemon infrastructure (SmartLifecycle, OpennmsHome,   -->
+        <!-- NoOpTracerRegistry, Kafka event transport, DataSource)       -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.daemon-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <!-- Exclude ALL ServiceMix Spring 4.2.x bundles; Spring Boot 4 provides Spring 7 -->
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <!-- Exclude ActiveMQ Camel (brings camel-spring with old Spring dep) -->
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <!-- Exclude Hibernate 3.x -->
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <!-- Logging conflicts -->
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- IPC: Kafka RPC Server                                        -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.rpc</groupId>
+            <artifactId>org.opennms.core.ipc.rpc.kafka</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- IPC: Sink Common (AbstractMessageDispatcherFactory)          -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.sink</groupId>
+            <artifactId>org.opennms.core.ipc.sink.common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- IPC: Kafka Sink Client (producer)                            -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.sink.kafka</groupId>
+            <artifactId>org.opennms.core.ipc.sink.kafka.client</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- IPC: Kafka Twin Subscriber                                   -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.twin.kafka</groupId>
+            <artifactId>org.opennms.core.ipc.twin.kafka.subscriber</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- IPC: Off-heap buffering                                      -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.sink</groupId>
+            <artifactId>org.opennms.core.ipc.sink.offheap</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Distributed core API (MinionIdentity, Identity)              -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.features.distributed</groupId>
+            <artifactId>core-api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- DAO APIs (DistPollerDao): exclude opennms-model                -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-dao-api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Model API + Jakarta model (persistence-free types)           -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-jakarta</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- OSGi API interfaces (for ConfigurationAdmin adapter)         -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <version>7.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>7.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Metrics                                                       -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Test                                                          -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion><groupId>org.junit.vintage</groupId><artifactId>junit-vintage-engine</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core.ipc.rpc</groupId>
+            <artifactId>org.opennms.core.ipc.rpc.common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+                <configuration>
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.12.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>1.12.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/KafkaRpcServerConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/KafkaRpcServerConfiguration.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.opennms.core.ipc.rpc.kafka.KafkaRpcServerManager;
+import org.opennms.core.rpc.api.RpcModule;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Spring Boot {@link Configuration} that wraps the OSGi-designed
+ * {@link KafkaRpcServerManager} in a Spring {@link SmartLifecycle}.
+ *
+ * <p>Lifecycle phase 300 ensures the RPC server starts <b>after</b> the
+ * Twin subscriber (phase 100) and the Sink client (phase 200). Shutdown
+ * reverses this order automatically.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.rpc.enabled", havingValue = "true", matchIfMissing = true)
+public class KafkaRpcServerConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaRpcServerConfiguration.class);
+
+    @Bean
+    public KafkaRpcServerManager kafkaRpcServerManager(
+            @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
+            MinionIdentity minionIdentity,
+            TracerRegistry tracerRegistry) {
+
+        Properties kafkaProperties = new Properties();
+        kafkaProperties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        SpringKafkaConfigProvider configProvider = new SpringKafkaConfigProvider(kafkaProperties);
+        MetricRegistry metricRegistry = new MetricRegistry();
+
+        return new KafkaRpcServerManager(configProvider, minionIdentity, tracerRegistry, metricRegistry);
+    }
+
+    @Bean
+    public SmartLifecycle kafkaRpcServerLifecycle(
+            KafkaRpcServerManager manager,
+            RpcModuleRegistry rpcModuleRegistry) {
+
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                LOG.info("Starting Kafka RPC server (phase 300)");
+                try {
+                    manager.init();
+                    for (String moduleId : rpcModuleRegistry.getModuleIds()) {
+                        rpcModuleRegistry.getModule(moduleId).ifPresent(module -> {
+                            try {
+                                @SuppressWarnings("rawtypes")
+                                RpcModule rawModule = module;
+                                manager.bind(rawModule);
+                                LOG.info("Bound RPC module: {}", moduleId);
+                            } catch (Exception e) {
+                                LOG.error("Failed to bind RPC module: {}", moduleId, e);
+                            }
+                        });
+                    }
+                    running = true;
+                    LOG.info("Kafka RPC server started with {} module(s)", rpcModuleRegistry.getModuleIds().size());
+                } catch (Exception e) {
+                    LOG.error("Failed to initialize Kafka RPC server", e);
+                }
+            }
+
+            @Override
+            public void stop() {
+                LOG.info("Stopping Kafka RPC server (phase 300)");
+                for (String moduleId : rpcModuleRegistry.getModuleIds()) {
+                    rpcModuleRegistry.getModule(moduleId).ifPresent(module -> {
+                        try {
+                            @SuppressWarnings("rawtypes")
+                            RpcModule rawModule = module;
+                            manager.unbind(rawModule);
+                            LOG.info("Unbound RPC module: {}", moduleId);
+                        } catch (Exception e) {
+                            LOG.error("Failed to unbind RPC module: {}", moduleId, e);
+                        }
+                    });
+                }
+                manager.destroy();
+                running = false;
+                LOG.info("Kafka RPC server stopped");
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 300;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/KafkaSinkClientConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/KafkaSinkClientConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.ipc.sink.kafka.client.KafkaRemoteMessageDispatcherFactory;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Spring Boot {@link Configuration} that wraps the OSGi-designed
+ * {@link KafkaRemoteMessageDispatcherFactory} in a Spring {@link SmartLifecycle}.
+ *
+ * <p>The factory uses setter injection because it was designed for OSGi blueprint
+ * wiring. We set {@code bundleContext} to {@code null} so the factory's
+ * {@code onInit()} skips OSGi metrics registration.</p>
+ *
+ * <p>Lifecycle phase 200 ensures the Sink client starts <b>after</b> the
+ * Twin subscriber (phase 100) and <b>before</b> the RPC server (phase 300).
+ * Shutdown reverses this order automatically.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.sink.enabled", havingValue = "true", matchIfMissing = true)
+public class KafkaSinkClientConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSinkClientConfiguration.class);
+
+    @Bean
+    public KafkaRemoteMessageDispatcherFactory kafkaRemoteMessageDispatcherFactory(
+            @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
+            MinionIdentity minionIdentity,
+            TracerRegistry tracerRegistry) {
+
+        Properties kafkaProps = new Properties();
+        kafkaProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        KafkaRemoteMessageDispatcherFactory factory = new KafkaRemoteMessageDispatcherFactory();
+        factory.setConfigAdmin(new SpringConfigurationAdmin(kafkaProps));
+        factory.setBundleContext(null);
+        factory.setTracerRegistry(tracerRegistry);
+        factory.setIdentity(minionIdentity);
+        factory.setMetrics(new MetricRegistry());
+
+        return factory;
+    }
+
+    @Bean
+    public SmartLifecycle kafkaSinkClientLifecycle(
+            KafkaRemoteMessageDispatcherFactory factory) {
+
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                LOG.info("Starting Kafka Sink client (phase 200)");
+                try {
+                    factory.init();
+                    running = true;
+                    LOG.info("Kafka Sink client started");
+                } catch (Exception e) {
+                    LOG.error("Failed to initialize Kafka Sink client", e);
+                }
+            }
+
+            @Override
+            public void stop() {
+                LOG.info("Stopping Kafka Sink client (phase 200)");
+                factory.destroy();
+                running = false;
+                LOG.info("Kafka Sink client stopped");
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 200;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/KafkaTwinSubscriberConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/KafkaTwinSubscriberConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.opennms.core.ipc.twin.api.TwinSubscriber;
+import org.opennms.core.ipc.twin.kafka.subscriber.KafkaTwinSubscriber;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Spring Boot {@link Configuration} that wraps the OSGi-designed
+ * {@link KafkaTwinSubscriber} in a Spring {@link SmartLifecycle}.
+ *
+ * <p>Lifecycle phase 100 ensures the Twin subscriber starts <b>first</b>,
+ * before the Sink client (phase 200) and the RPC server (phase 300).
+ * This allows config sync to complete before message dispatch and
+ * request handling begin. Shutdown reverses this order automatically.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.twin.enabled", havingValue = "true", matchIfMissing = true)
+public class KafkaTwinSubscriberConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTwinSubscriberConfiguration.class);
+
+    @Bean
+    public KafkaTwinSubscriber kafkaTwinSubscriber(
+            @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
+            MinionIdentity minionIdentity,
+            TracerRegistry tracerRegistry) {
+
+        Properties kafkaProps = new Properties();
+        kafkaProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        return new KafkaTwinSubscriber(
+                minionIdentity,
+                new SpringKafkaConfigProvider(kafkaProps),
+                tracerRegistry,
+                new MetricRegistry());
+    }
+
+
+
+    @Bean
+    public SmartLifecycle kafkaTwinSubscriberLifecycle(KafkaTwinSubscriber subscriber) {
+
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                LOG.info("Starting Kafka Twin subscriber (phase 100)");
+                try {
+                    subscriber.init();
+                    running = true;
+                    LOG.info("Kafka Twin subscriber started");
+                } catch (Exception e) {
+                    LOG.error("Failed to initialize Kafka Twin subscriber", e);
+                }
+            }
+
+            @Override
+            public void stop() {
+                LOG.info("Stopping Kafka Twin subscriber (phase 100)");
+                try {
+                    subscriber.close();
+                } catch (IOException e) {
+                    LOG.warn("Error closing Kafka Twin subscriber", e);
+                }
+                running = false;
+                LOG.info("Kafka Twin subscriber stopped");
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 100;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/MinionDistPollerDao.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/MinionDistPollerDao.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.opennms.core.criteria.Criteria;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.model.OnmsDistPoller;
+
+/**
+ * A database-free {@link DistPollerDao} for Minion deployments.
+ *
+ * <p>Minion does not have a local PostgreSQL instance, so this implementation
+ * derives the poller identity solely from {@link SpringMinionIdentity}. All
+ * mutating operations throw {@link UnsupportedOperationException}.</p>
+ */
+public class MinionDistPollerDao implements DistPollerDao {
+
+    private final OnmsDistPoller self;
+
+    public MinionDistPollerDao(SpringMinionIdentity identity) {
+        this.self = new OnmsDistPoller();
+        self.setId(identity.getId());
+        self.setLabel(identity.getId());
+        self.setLocation(identity.getLocation());
+        self.setType("Minion");
+    }
+
+    @Override
+    public OnmsDistPoller whoami() {
+        return self;
+    }
+
+    // ------------------------------------------------------------------ //
+    // Read-only / no-op operations                                         //
+    // ------------------------------------------------------------------ //
+
+    @Override
+    public void lock() {
+    }
+
+    @Override
+    public void initialize(Object obj) {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public int countAll() {
+        return 1;
+    }
+
+    @Override
+    public List<OnmsDistPoller> findAll() {
+        return Collections.singletonList(self);
+    }
+
+    @Override
+    public List<OnmsDistPoller> findMatching(Criteria criteria) {
+        return Collections.singletonList(self);
+    }
+
+    @Override
+    public int countMatching(Criteria criteria) {
+        return 1;
+    }
+
+    @Override
+    public OnmsDistPoller get(String id) {
+        return self.getId().equals(id) ? self : null;
+    }
+
+    @Override
+    public OnmsDistPoller load(String id) {
+        return get(id);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Mutating operations — not supported on Minion                       //
+    // ------------------------------------------------------------------ //
+
+    @Override
+    public void delete(OnmsDistPoller entity) {
+        throw new UnsupportedOperationException("MinionDistPollerDao is read-only");
+    }
+
+    @Override
+    public void delete(String key) {
+        throw new UnsupportedOperationException("MinionDistPollerDao is read-only");
+    }
+
+    @Override
+    public String save(OnmsDistPoller entity) {
+        throw new UnsupportedOperationException("MinionDistPollerDao is read-only");
+    }
+
+    @Override
+    public void saveOrUpdate(OnmsDistPoller entity) {
+        throw new UnsupportedOperationException("MinionDistPollerDao is read-only");
+    }
+
+    @Override
+    public void update(OnmsDistPoller entity) {
+        throw new UnsupportedOperationException("MinionDistPollerDao is read-only");
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/MinionProperties.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/MinionProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "opennms.minion")
+public class MinionProperties {
+
+    private String id = "00000000-0000-0000-0000-000000000001";
+    private String location = "Default";
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/RpcModuleRegistry.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/RpcModuleRegistry.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.opennms.core.rpc.api.RpcModule;
+import org.springframework.stereotype.Component;
+
+/**
+ * Collects all {@link RpcModule} beans and indexes them by module ID.
+ *
+ * <p>In the Karaf/OSGi world, {@code RpcModule} implementations were
+ * discovered dynamically via {@code <reference-list>} with bind/unbind
+ * callbacks. In Spring Boot, all {@code RpcModule} beans are injected
+ * as a {@code List} and indexed once at construction time.</p>
+ */
+@Component
+public class RpcModuleRegistry {
+
+    private final Map<String, RpcModule<?, ?>> modules;
+
+    @SuppressWarnings("rawtypes")
+    public RpcModuleRegistry(List<RpcModule> modules) {
+        Map<String, RpcModule<?, ?>> map = new HashMap<>();
+        for (RpcModule module : modules) {
+            map.put(module.getId(), module);
+        }
+        this.modules = map;
+    }
+
+    public Optional<RpcModule<?, ?>> getModule(String id) {
+        return Optional.ofNullable(modules.get(id));
+    }
+
+    public Set<String> getModuleIds() {
+        return Collections.unmodifiableSet(modules.keySet());
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/SpringConfigurationAdmin.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/SpringConfigurationAdmin.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Properties;
+import java.util.Set;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * Minimal {@link ConfigurationAdmin} adapter that exposes Kafka properties from Spring
+ * configuration to OSGi-designed components such as
+ * {@code KafkaRemoteMessageDispatcherFactory} (Sink client).
+ *
+ * <p>Only {@link #getConfiguration(String)} and {@link #getConfiguration(String, String)}
+ * return meaningful results; all factory/create methods throw
+ * {@link UnsupportedOperationException} since they are not needed in a Spring Boot context.
+ */
+public class SpringConfigurationAdmin implements ConfigurationAdmin {
+
+    private final Configuration configuration;
+
+    public SpringConfigurationAdmin(Properties kafkaProperties) {
+        Hashtable<String, Object> dict = new Hashtable<>();
+        kafkaProperties.forEach((key, value) -> dict.put(key.toString(), value));
+        this.configuration = new SimpleConfiguration(dict);
+    }
+
+    @Override
+    public Configuration getConfiguration(String pid) throws IOException {
+        return configuration;
+    }
+
+    @Override
+    public Configuration getConfiguration(String pid, String location) throws IOException {
+        return configuration;
+    }
+
+    @Override
+    public Configuration getFactoryConfiguration(String factoryPid, String name) throws IOException {
+        throw new UnsupportedOperationException("Not supported in Spring Boot context");
+    }
+
+    @Override
+    public Configuration getFactoryConfiguration(String factoryPid, String name, String location) throws IOException {
+        throw new UnsupportedOperationException("Not supported in Spring Boot context");
+    }
+
+    @Override
+    public Configuration createFactoryConfiguration(String factoryPid) throws IOException {
+        throw new UnsupportedOperationException("Not supported in Spring Boot context");
+    }
+
+    @Override
+    public Configuration createFactoryConfiguration(String factoryPid, String location) throws IOException {
+        throw new UnsupportedOperationException("Not supported in Spring Boot context");
+    }
+
+    @Override
+    public Configuration[] listConfigurations(String filter) throws IOException, InvalidSyntaxException {
+        return new Configuration[]{configuration};
+    }
+
+    private static class SimpleConfiguration implements Configuration {
+
+        private final Dictionary<String, Object> properties;
+
+        SimpleConfiguration(Dictionary<String, Object> properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public Dictionary<String, Object> getProperties() {
+            return properties;
+        }
+
+        @Override
+        public Dictionary<String, Object> getProcessedProperties(ServiceReference<?> reference) {
+            return properties;
+        }
+
+        @Override
+        public String getPid() {
+            return "spring-kafka";
+        }
+
+        @Override
+        public String getFactoryPid() {
+            return null;
+        }
+
+        @Override
+        public String getBundleLocation() {
+            return null;
+        }
+
+        @Override
+        public void setBundleLocation(String location) {
+            // no-op: bundle location is not applicable in a Spring Boot context
+        }
+
+        @Override
+        public long getChangeCount() {
+            return 0L;
+        }
+
+        @Override
+        public void update() throws IOException {
+            // no-op: properties are provided by Spring and do not change at runtime
+        }
+
+        @Override
+        public void update(Dictionary<String, ?> updatedProperties) throws IOException {
+            // no-op: properties are provided by Spring and do not change at runtime
+        }
+
+        @Override
+        public boolean updateIfDifferent(Dictionary<String, ?> updatedProperties) throws IOException {
+            return false;
+        }
+
+        @Override
+        public void delete() throws IOException {
+            // no-op: lifecycle is managed by Spring, not OSGi CM
+        }
+
+        @Override
+        public void addAttributes(Configuration.ConfigurationAttribute... attributes) throws IOException {
+            // no-op: attributes are not used in Spring Boot context
+        }
+
+        @Override
+        public Set<Configuration.ConfigurationAttribute> getAttributes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void removeAttributes(Configuration.ConfigurationAttribute... attributes) throws IOException {
+            // no-op: attributes are not used in Spring Boot context
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(this);
+        }
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/SpringKafkaConfigProvider.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/SpringKafkaConfigProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import java.util.Properties;
+
+import org.opennms.core.ipc.common.kafka.KafkaConfigProvider;
+
+public class SpringKafkaConfigProvider implements KafkaConfigProvider {
+
+    private final Properties kafkaProperties;
+
+    public SpringKafkaConfigProvider(Properties kafkaProperties) {
+        this.kafkaProperties = new Properties();
+        this.kafkaProperties.putAll(kafkaProperties);
+    }
+
+    @Override
+    public Properties getProperties() {
+        Properties copy = new Properties();
+        copy.putAll(kafkaProperties);
+        return copy;
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/SpringMinionIdentity.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/opennms/minion/common/SpringMinionIdentity.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import org.opennms.distributed.core.api.MinionIdentity;
+
+public class SpringMinionIdentity implements MinionIdentity {
+
+    private final String id;
+    private final String location;
+
+    public SpringMinionIdentity(MinionProperties properties) {
+        this.id = properties.getId();
+        this.location = properties.getLocation();
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getLocation() {
+        return location;
+    }
+
+    @Override
+    public String getType() {
+        return "Minion";
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/MinionDistPollerDaoTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/MinionDistPollerDaoTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.model.OnmsDistPoller;
+
+class MinionDistPollerDaoTest {
+
+    private SpringMinionIdentity buildIdentity(String id, String location) {
+        MinionProperties properties = new MinionProperties();
+        properties.setId(id);
+        properties.setLocation(location);
+        return new SpringMinionIdentity(properties);
+    }
+
+    @Test
+    void whoamiReturnsIdentityBasedPoller() {
+        SpringMinionIdentity identity = buildIdentity("minion-01", "NYC");
+        MinionDistPollerDao dao = new MinionDistPollerDao(identity);
+
+        OnmsDistPoller poller = dao.whoami();
+
+        assertThat(poller.getId()).isEqualTo("minion-01");
+        assertThat(poller.getLabel()).isEqualTo("minion-01");
+        assertThat(poller.getLocation()).isEqualTo("NYC");
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/RpcModuleRegistryTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/RpcModuleRegistryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.core.rpc.echo.EchoRpcModule;
+
+class RpcModuleRegistryTest {
+
+    @Test
+    void registersModulesById() {
+        EchoRpcModule echo = new EchoRpcModule();
+        RpcModuleRegistry registry = new RpcModuleRegistry(List.of(echo));
+
+        assertThat(registry.getModule("Echo")).isPresent();
+        assertThat(registry.getModule("Echo").get()).isSameAs(echo);
+        assertThat(registry.getModule("NonExistent")).isEmpty();
+    }
+
+    @Test
+    void getModuleIdsReturnsAllRegistered() {
+        EchoRpcModule echo = new EchoRpcModule();
+        RpcModuleRegistry registry = new RpcModuleRegistry(List.of(echo));
+        assertThat(registry.getModuleIds()).containsExactly("Echo");
+    }
+
+    @Test
+    void emptyListProducesEmptyRegistry() {
+        RpcModuleRegistry registry = new RpcModuleRegistry(List.of());
+        assertThat(registry.getModuleIds()).isEmpty();
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/SpringConfigurationAdminTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/SpringConfigurationAdminTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Dictionary;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.osgi.service.cm.Configuration;
+
+class SpringConfigurationAdminTest {
+
+    @Test
+    void getConfigurationReturnsSinkProperties() throws Exception {
+        Properties kafkaProps = new Properties();
+        kafkaProps.setProperty("bootstrap.servers", "kafka:9092");
+
+        SpringConfigurationAdmin admin = new SpringConfigurationAdmin(kafkaProps);
+        Configuration config = admin.getConfiguration("org.opennms.core.ipc.sink.kafka");
+
+        Dictionary<String, Object> dict = config.getProperties();
+        assertThat(dict.get("bootstrap.servers")).isEqualTo("kafka:9092");
+    }
+
+    @Test
+    void anyPidReturnsSameProperties() throws Exception {
+        Properties kafkaProps = new Properties();
+        kafkaProps.setProperty("bootstrap.servers", "localhost:9092");
+
+        SpringConfigurationAdmin admin = new SpringConfigurationAdmin(kafkaProps);
+
+        assertThat(admin.getConfiguration("any.pid").getProperties().get("bootstrap.servers"))
+            .isEqualTo("localhost:9092");
+        assertThat(admin.getConfiguration("other.pid", "location").getProperties().get("bootstrap.servers"))
+            .isEqualTo("localhost:9092");
+    }
+
+    @Test
+    void getPidReturnsSpringKafka() throws Exception {
+        SpringConfigurationAdmin admin = new SpringConfigurationAdmin(new Properties());
+        assertThat(admin.getConfiguration("any.pid").getPid()).isEqualTo("spring-kafka");
+    }
+
+    @Test
+    void createFactoryConfigurationThrowsUnsupported() {
+        SpringConfigurationAdmin admin = new SpringConfigurationAdmin(new Properties());
+
+        assertThatThrownBy(() -> admin.createFactoryConfiguration("any.factory"))
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> admin.createFactoryConfiguration("any.factory", "location"))
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> admin.getFactoryConfiguration("factory", "name"))
+            .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> admin.getFactoryConfiguration("factory", "name", "location"))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void listConfigurationsReturnsSingleElement() throws Exception {
+        SpringConfigurationAdmin admin = new SpringConfigurationAdmin(new Properties());
+        Configuration[] result = admin.listConfigurations(null);
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void multiplePropertiesAreAllPopulated() throws Exception {
+        Properties kafkaProps = new Properties();
+        kafkaProps.setProperty("bootstrap.servers", "kafka:9092");
+        kafkaProps.setProperty("security.protocol", "SASL_SSL");
+        kafkaProps.setProperty("sasl.mechanism", "PLAIN");
+
+        SpringConfigurationAdmin admin = new SpringConfigurationAdmin(kafkaProps);
+        Dictionary<String, Object> dict = admin.getConfiguration("any.pid").getProperties();
+
+        assertThat(dict.get("bootstrap.servers")).isEqualTo("kafka:9092");
+        assertThat(dict.get("security.protocol")).isEqualTo("SASL_SSL");
+        assertThat(dict.get("sasl.mechanism")).isEqualTo("PLAIN");
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/SpringKafkaConfigProviderTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/SpringKafkaConfigProviderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+class SpringKafkaConfigProviderTest {
+
+    @Test
+    void returnsConfiguredProperties() {
+        Properties input = new Properties();
+        input.setProperty("bootstrap.servers", "kafka:9092");
+
+        SpringKafkaConfigProvider provider = new SpringKafkaConfigProvider(input);
+
+        Properties result = provider.getProperties();
+        assertThat(result.getProperty("bootstrap.servers")).isEqualTo("kafka:9092");
+    }
+
+    @Test
+    void returnsDefensiveCopy() {
+        Properties input = new Properties();
+        input.setProperty("bootstrap.servers", "kafka:9092");
+
+        SpringKafkaConfigProvider provider = new SpringKafkaConfigProvider(input);
+
+        Properties firstCopy = provider.getProperties();
+        firstCopy.setProperty("bootstrap.servers", "tampered:9999");
+
+        Properties secondCopy = provider.getProperties();
+        assertThat(secondCopy.getProperty("bootstrap.servers")).isEqualTo("kafka:9092");
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/SpringMinionIdentityTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/opennms/minion/common/SpringMinionIdentityTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SpringMinionIdentityTest {
+
+    @Test
+    void exposesIdAndLocation() {
+        MinionProperties properties = new MinionProperties();
+        properties.setId("minion-01");
+        properties.setLocation("NYC");
+
+        SpringMinionIdentity identity = new SpringMinionIdentity(properties);
+
+        assertThat(identity.getId()).isEqualTo("minion-01");
+        assertThat(identity.getLocation()).isEqualTo("NYC");
+        assertThat(identity.getType()).isEqualTo("Minion");
+    }
+}

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms</groupId>
+        <artifactId>org.opennms.core</artifactId>
+        <version>36.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.daemon-boot-minion</artifactId>
+    <packaging>jar</packaging>
+    <name>OpenNMS :: Core :: Daemon Boot :: Minion</name>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-boot.version>4.0.3</spring-boot.version>
+        <enforcer-skip-banned-dependencies>true</enforcer-skip-banned-dependencies>
+        <enforcer-skip-dependency-convergence>true</enforcer-skip-dependency-convergence>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import Spring Boot BOM FIRST for version precedence over parent POM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Pin Logback to match Spring Boot 4 requirements.
+                 Parent POM manages logback-classic at 1.2.13 which is
+                 incompatible with Spring Boot 4's Configurator API. -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.5.32</version>
+            </dependency>
+            <!-- Pin SLF4J 2.0.17: parent POM manages 1.7.36 which is
+                 incompatible with Logback 1.5.x and Spring Boot 4 -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <!-- Pin Jackson 2.19.4: parent POM manages 2.16.2 which lacks
+                 JsonFormat$Shape.POJO required by Jackson 3.x (tools.jackson.databind).
+                 Spring Boot 4's BOM wants 2.20.2 but parent POM overrides it. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-json-org</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-csv</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-scala_2.13</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <!-- Pin JUnit 5.12.2 / Platform 1.12.2: parent POM manages 5.9.2 / 1.9.2
+                 which are incompatible with maven-surefire-plugin 3.5.5 -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>5.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.12.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- ============================================================ -->
+        <!-- Spring Boot                                                  -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- SLF4J 2.x -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Core: daemon-boot-minion-common (IPC wiring layer)           -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.daemon-boot-minion-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- RPC modules (execute on Minion)                              -->
+        <!-- ============================================================ -->
+
+        <!-- SNMP proxy RPC (module ID "SNMP") -->
+        <dependency>
+            <groupId>org.opennms.core.snmp</groupId>
+            <artifactId>org.opennms.core.snmp.proxy.rpc-impl</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ICMP proxy RPC (module IDs "PING", "PING-SWEEP") -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>org.opennms.icmp.proxy.rpc-impl</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Echo RPC (module ID "Echo") -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.rpc</groupId>
+            <artifactId>org.opennms.core.ipc.rpc.common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Poller RPC (module ID "Poller") -->
+        <dependency>
+            <groupId>org.opennms.features.poller</groupId>
+            <artifactId>org.opennms.features.poller.client-rpc</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Collector RPC (module ID "Collect") -->
+        <dependency>
+            <groupId>org.opennms.features.collection</groupId>
+            <artifactId>org.opennms.features.collection.client-rpc</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Detector RPC (module ID "Detect") -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detectorclient-rpc</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Requisition RPC (module ID "Requisition") -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-requisition-service</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Sink modules (produce messages on Minion)                    -->
+        <!-- ============================================================ -->
+
+        <!-- Trap listener + TrapSinkModule -->
+        <dependency>
+            <groupId>org.opennms.features.events</groupId>
+            <artifactId>org.opennms.features.events.traps</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Syslog listener + SyslogSinkModule
+             CRITICAL: Exclude Camel 2.x (incompatible with Spring Boot 4 / Spring 7).
+             SyslogReceiverJavaNetImpl (pure Java DatagramSocket) will be used instead of
+             SyslogReceiverCamelNettyImpl. -->
+        <dependency>
+            <groupId>org.opennms.features.events</groupId>
+            <artifactId>org.opennms.features.events.syslog</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.camel</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Minion heartbeat producer -->
+        <dependency>
+            <groupId>org.opennms.features.minion.heartbeat</groupId>
+            <artifactId>org.opennms.features.minion.heartbeat.producer</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Minion heartbeat common (HeartbeatModule) -->
+        <dependency>
+            <groupId>org.opennms.features.minion.heartbeat</groupId>
+            <artifactId>org.opennms.features.minion.heartbeat.common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Registries                                                   -->
+        <!-- ============================================================ -->
+
+        <!-- ServiceMonitorRegistry -->
+        <dependency>
+            <groupId>org.opennms.features.poller</groupId>
+            <artifactId>org.opennms.features.poller.api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ServiceCollectorRegistry -->
+        <dependency>
+            <groupId>org.opennms.features.collection</groupId>
+            <artifactId>org.opennms.features.collection.api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ServiceDetectorRegistry -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-registry</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Protocol implementations                                     -->
+        <!-- ============================================================ -->
+
+        <!-- Core monitors: TCP, HTTP, DNS, ICMP, SNMP, SSH, SSL, etc. -->
+        <dependency>
+            <groupId>org.opennms.features.poller.monitors</groupId>
+            <artifactId>org.opennms.features.poller.monitors.core</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- SNMP collector -->
+        <dependency>
+            <groupId>org.opennms.features.collection</groupId>
+            <artifactId>org.opennms.features.collection.snmp-collector</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Best-match ICMP pinger (JNA, pure Java) -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-icmp-best</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- SNMP4J implementation -->
+        <dependency>
+            <groupId>org.opennms.core.snmp</groupId>
+            <artifactId>org.opennms.core.snmp.implementations.snmp4j</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Runtime: legacy class loading compatibility                  -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- OSGi API interfaces at runtime: KafkaRemoteMessageDispatcherFactory and other
+             IPC classes reference OSGi types (BundleContext, ConfigurationAdmin) in their
+             method signatures. Spring introspects these during bean creation, so the classes
+             must be on the classpath even though no OSGi container is running. -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <version>7.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>7.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- opennms-model at runtime scope: many protocol modules (PingSweepRpcModule,
+             DiscoveryConfigFactory, etc.) transitively reference classes in opennms-model
+             (IPPollAddress, OnmsNode, etc.). Spring's classpath scanning triggers class
+             loading even for unused references. Runtime scope keeps them loadable without
+             compiling against them. ServiceMix exclusions still apply via the transitive
+             dependencies that actually pull opennms-model. -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-model</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- ============================================================ -->
+        <!-- Test                                                          -->
+        <!-- ============================================================ -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion><groupId>org.junit.vintage</groupId><artifactId>junit-vintage-engine</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+                <configuration>
+                    <includeJUnit5Engines>
+                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
+                    </includeJUnit5Engines>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.12.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>1.12.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/CollectorConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/CollectorConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
+import org.opennms.netmgt.collection.client.rpc.CollectorClientRpcModule;
+import org.opennms.netmgt.collection.support.DefaultServiceCollectorRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the Collector RPC module (module ID "Collect") and its
+ * {@link ServiceCollectorRegistry}.
+ *
+ * <p>The {@link DefaultServiceCollectorRegistry} discovers collector implementations
+ * via {@link java.util.ServiceLoader} from
+ * {@code META-INF/services/org.opennms.netmgt.collection.api.ServiceCollector}.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.collector.enabled", havingValue = "true", matchIfMissing = true)
+public class CollectorConfiguration {
+
+    @Bean
+    public ServiceCollectorRegistry serviceCollectorRegistry() {
+        return new DefaultServiceCollectorRegistry();
+    }
+
+    @Bean
+    public Executor collectorExecutor() {
+        return Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "collector-rpc");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @Bean
+    public CollectorClientRpcModule collectorClientRpcModule(ServiceCollectorRegistry serviceCollectorRegistry,
+                                                              @org.springframework.beans.factory.annotation.Qualifier("collectorExecutor") Executor collectorExecutor) {
+        CollectorClientRpcModule module = new CollectorClientRpcModule();
+        module.setServiceCollectorRegistry(serviceCollectorRegistry);
+        module.setExecutor(collectorExecutor);
+        return module;
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/DetectorConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/DetectorConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import org.opennms.core.daemon.common.registry.LocalServiceDetectorRegistry;
+import org.opennms.netmgt.provision.detector.client.rpc.DetectorClientRpcModule;
+import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the Detector RPC module (module ID "Detect") and its
+ * {@link ServiceDetectorRegistry}.
+ *
+ * <p>Uses {@link LocalServiceDetectorRegistry} which discovers
+ * {@link org.opennms.netmgt.provision.ServiceDetectorFactory} implementations
+ * via {@link java.util.ServiceLoader}.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.detector.enabled", havingValue = "true", matchIfMissing = true)
+public class DetectorConfiguration {
+
+    @Bean
+    public ServiceDetectorRegistry serviceDetectorRegistry() {
+        return new LocalServiceDetectorRegistry();
+    }
+
+    @Bean
+    public Executor scanExecutor() {
+        return Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "detector-rpc");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @Bean
+    public DetectorClientRpcModule detectorClientRpcModule(ServiceDetectorRegistry serviceDetectorRegistry,
+                                                            @org.springframework.beans.factory.annotation.Qualifier("scanExecutor") Executor scanExecutor) {
+        DetectorClientRpcModule module = new DetectorClientRpcModule();
+        module.setServiceDetectorRegistry(serviceDetectorRegistry);
+        module.setExecutor(scanExecutor);
+        return module;
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/EchoRpcConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/EchoRpcConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import org.opennms.core.rpc.echo.EchoRpcModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the Echo RPC module (module ID "Echo").
+ *
+ * <p>Always enabled (no conditional) because Echo is required for
+ * Minion health checks from the core instance.</p>
+ */
+@Configuration
+public class EchoRpcConfiguration {
+
+    @Bean
+    public EchoRpcModule echoRpcModule() {
+        return new EchoRpcModule();
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/HeartbeatConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/HeartbeatConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.ipc.sink.api.SyncDispatcher;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.opennms.minion.heartbeat.common.HeartbeatModule;
+import org.opennms.minion.heartbeat.common.MinionIdentityDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the heartbeat producer that sends periodic identity messages
+ * to the core instance via the Sink API.
+ *
+ * <p>The original {@code HeartbeatProducer} uses OSGi's {@code FrameworkUtil.getBundle()}
+ * to get the Minion version, which NPEs outside an OSGi container. This configuration
+ * creates an inline heartbeat that uses Spring Boot's build properties for version info.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.heartbeat.enabled", havingValue = "true", matchIfMissing = true)
+public class HeartbeatConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeartbeatConfiguration.class);
+    private static final int PERIOD_MS = 30_000;
+
+    @Bean(destroyMethod = "cancel")
+    public Timer heartbeatTimer(
+            MinionIdentity identity,
+            MessageDispatcherFactory dispatcherFactory,
+            @Value("${spring.application.version:0.0.0}") String version) {
+
+        MinionIdentityDTO identityDTO = new MinionIdentityDTO(identity);
+        SyncDispatcher<MinionIdentityDTO> dispatcher =
+                dispatcherFactory.createSyncDispatcher(new HeartbeatModule());
+
+        Timer timer = new Timer("minion-heartbeat", true);
+        timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    identityDTO.setVersion(version);
+                    identityDTO.setTimestamp(new Date());
+                    dispatcher.send(identityDTO);
+                    LOG.info("Sent heartbeat for minion {} at {}", identity.getId(), identity.getLocation());
+                } catch (Throwable t) {
+                    LOG.error("Heartbeat failed, retrying in {}ms", PERIOD_MS, t);
+                }
+            }
+        }, 0, PERIOD_MS);
+        return timer;
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/IcmpProxyConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/IcmpProxyConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import org.opennms.netmgt.icmp.PingerFactory;
+import org.opennms.netmgt.icmp.best.BestMatchPingerFactory;
+import org.opennms.netmgt.icmp.proxy.PingProxyRpcModule;
+import org.opennms.netmgt.icmp.proxy.PingSweepRpcModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the ICMP proxy RPC modules (module IDs "PING" and "PING-SWEEP").
+ *
+ * <p>Provides a {@link BestMatchPingerFactory} that auto-detects the best
+ * available ICMP implementation (JNI, JNA, or NullPinger) and injects it
+ * into both ping modules.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.icmp.enabled", havingValue = "true", matchIfMissing = true)
+public class IcmpProxyConfiguration {
+
+    @Bean
+    public PingerFactory pingerFactory() {
+        return new BestMatchPingerFactory();
+    }
+
+    @Bean
+    public PingProxyRpcModule pingProxyRpcModule(PingerFactory pingerFactory) {
+        PingProxyRpcModule module = new PingProxyRpcModule();
+        module.setPingerFactory(pingerFactory);
+        return module;
+    }
+
+    @Bean
+    public PingSweepRpcModule pingSweepRpcModule(PingerFactory pingerFactory) {
+        PingSweepRpcModule module = new PingSweepRpcModule();
+        module.setPingerFactory(pingerFactory);
+        return module;
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/MinionApplication.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/MinionApplication.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import org.opennms.core.daemon.common.EventConfEnrichmentService;
+import org.opennms.minion.common.MinionProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.data.jpa.autoconfigure.DataJpaRepositoriesAutoConfiguration;
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication(
+    scanBasePackages = {
+        "org.opennms.minion.common",
+        "org.opennms.minion.boot",
+        "org.opennms.core.daemon.common"
+    },
+    exclude = {
+        HibernateJpaAutoConfiguration.class,
+        DataJpaRepositoriesAutoConfiguration.class
+    },
+    excludeName = {
+        "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"
+    }
+)
+@ComponentScan(
+    basePackages = "org.opennms.core.daemon.common",
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = EventConfEnrichmentService.class
+    )
+)
+@EnableScheduling
+@EnableConfigurationProperties(MinionProperties.class)
+public class MinionApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MinionApplication.class, args);
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/MinionApplication.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/MinionApplication.java
@@ -47,7 +47,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     }
 )
 @ComponentScan(
-    basePackages = "org.opennms.core.daemon.common",
+    basePackages = {
+        "org.opennms.minion.common",
+        "org.opennms.minion.boot",
+        "org.opennms.core.daemon.common"
+    },
     excludeFilters = @ComponentScan.Filter(
         type = FilterType.ASSIGNABLE_TYPE,
         classes = EventConfEnrichmentService.class

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/MinionInfraConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/MinionInfraConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import org.opennms.core.daemon.common.NoOpTracerRegistry;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.Identity;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.opennms.minion.common.MinionDistPollerDao;
+import org.opennms.minion.common.MinionProperties;
+import org.opennms.minion.common.SpringMinionIdentity;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Shared infrastructure beans that multiple protocol subsystems depend on.
+ *
+ * <p>Provides identity, tracing, and DAO beans that were previously wired
+ * via OSGi blueprint in the Karaf Minion container.</p>
+ */
+@Configuration
+public class MinionInfraConfiguration {
+
+    @Bean
+    @Primary
+    public SpringMinionIdentity minionIdentity(MinionProperties properties) {
+        return new SpringMinionIdentity(properties);
+    }
+
+    @Bean
+    public TracerRegistry tracerRegistry() {
+        return new NoOpTracerRegistry();
+    }
+
+    @Bean
+    @Primary
+    public DistPollerDao distPollerDao(SpringMinionIdentity identity) {
+        return new MinionDistPollerDao(identity);
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/PollerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/PollerConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import org.opennms.netmgt.poller.ServiceMonitorRegistry;
+import org.opennms.netmgt.poller.client.rpc.PollerClientRpcModule;
+import org.opennms.netmgt.poller.support.DefaultServiceMonitorRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the Poller RPC module (module ID "Poller") and its
+ * {@link ServiceMonitorRegistry}.
+ *
+ * <p>The {@link DefaultServiceMonitorRegistry} discovers monitor implementations
+ * via {@link java.util.ServiceLoader} from
+ * {@code META-INF/services/org.opennms.netmgt.poller.ServiceMonitor}.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.poller.enabled", havingValue = "true", matchIfMissing = true)
+public class PollerConfiguration {
+
+    @Bean
+    public ServiceMonitorRegistry serviceMonitorRegistry() {
+        return new DefaultServiceMonitorRegistry();
+    }
+
+    @Bean
+    public Executor pollerExecutor() {
+        return Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "poller-rpc");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @Bean
+    public PollerClientRpcModule pollerClientRpcModule(ServiceMonitorRegistry serviceMonitorRegistry,
+                                                       @org.springframework.beans.factory.annotation.Qualifier("pollerExecutor") Executor pollerExecutor) {
+        PollerClientRpcModule module = new PollerClientRpcModule();
+        module.setServiceMonitorRegistry(serviceMonitorRegistry);
+        module.setExecutor(pollerExecutor);
+        return module;
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/SnmpProxyConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/SnmpProxyConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import org.opennms.netmgt.snmp.proxy.common.SnmpProxyRpcModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the SNMP proxy RPC module (module ID "SNMP").
+ *
+ * <p>Executes SNMP GET/SET/WALK requests locally on the Minion using
+ * the current SnmpStrategy. Replaces the Karaf blueprint that registered
+ * {@code SnmpProxyRpcModule.INSTANCE} into the OSGi service registry.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.snmp.enabled", havingValue = "true", matchIfMissing = true)
+public class SnmpProxyConfiguration {
+
+    @Bean
+    public SnmpProxyRpcModule snmpProxyRpcModule() {
+        return SnmpProxyRpcModule.INSTANCE;
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/SyslogListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/SyslogListenerConfiguration.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.syslogd.SyslogConfigBean;
+import org.opennms.netmgt.syslogd.SyslogReceiverJavaNetImpl;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the syslog listener using the pure-Java DatagramSocket implementation.
+ *
+ * <p><strong>CRITICAL:</strong> Uses {@link SyslogReceiverJavaNetImpl}, NOT
+ * {@code SyslogReceiverCamelNettyImpl}. Camel 2.x has been excluded from
+ * the POM (incompatible with Spring 7 / Spring Boot 4).</p>
+ *
+ * <p>When enabled, opens UDP port 1514 (configurable) to receive syslog
+ * messages and forwards them to the core instance via the Sink API. Port
+ * binding is inside this conditional -- when disabled, port 1514 is never
+ * opened.</p>
+ *
+ * <p>Lifecycle phase 400: listeners start last, after RPC server (300)
+ * and Sink client (200) are ready. The receiver's {@code run()} method
+ * blocks, so it is started in a dedicated daemon thread.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.syslog.enabled", havingValue = "true", matchIfMissing = true)
+public class SyslogListenerConfiguration {
+
+    @Value("${opennms.minion.syslog.port:1514}")
+    private int syslogPort;
+
+    @Value("${opennms.minion.syslog.address:#{null}}")
+    private String listenAddress;
+
+    @Bean
+    public SyslogConfigBean syslogConfigBean() {
+        SyslogConfigBean config = new SyslogConfigBean();
+        config.setSyslogPort(syslogPort);
+        config.setListenAddress(listenAddress);
+        config.setNewSuspectOnMessage(false);
+        config.setBatchSize(100);
+        config.setBatchIntervalMs(500);
+        config.setQueueSize(10000);
+        return config;
+    }
+
+    @Bean
+    public SyslogReceiverJavaNetImpl syslogReceiver(SyslogConfigBean config,
+                                                     MessageDispatcherFactory messageDispatcherFactory,
+                                                     DistPollerDao distPollerDao) {
+        SyslogReceiverJavaNetImpl receiver = new SyslogReceiverJavaNetImpl(config);
+        receiver.setMessageDispatcherFactory(messageDispatcherFactory);
+        receiver.setDistPollerDao(distPollerDao);
+        return receiver;
+    }
+
+    @Bean
+    public SmartLifecycle syslogListenerLifecycle(SyslogReceiverJavaNetImpl syslogReceiver) {
+        return new SmartLifecycle() {
+            private volatile boolean running;
+            private Thread receiverThread;
+
+            @Override
+            public void start() {
+                receiverThread = new Thread(syslogReceiver, "SyslogReceiver");
+                receiverThread.setDaemon(true);
+                receiverThread.start();
+                running = true;
+            }
+
+            @Override
+            public void stop() {
+                try {
+                    syslogReceiver.stop();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 400;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/TrapListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/TrapListenerConfiguration.java
@@ -22,7 +22,6 @@
 package org.opennms.minion.boot;
 
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
-import org.opennms.core.ipc.twin.api.TwinSubscriber;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.trapd.TrapdConfigBean;
 import org.opennms.netmgt.trapd.TrapListener;
@@ -68,19 +67,15 @@ public class TrapListenerConfiguration {
     public TrapListener trapListener(TrapdConfigBean config,
                                      MessageDispatcherFactory messageDispatcherFactory,
                                      DistPollerDao distPollerDao) throws Exception {
-        TrapListener listener = new TrapListener(config);
-        listener.setMessageDispatcherFactory(messageDispatcherFactory);
-        listener.setDistPollerDao(distPollerDao);
-        return listener;
+        return new TrapListener(config, messageDispatcherFactory, distPollerDao);
     }
 
     /**
      * SmartLifecycle that activates the TrapListener at phase 400.
      *
-     * <p>Calls {@code TrapListener.start()} which uses a 5-second fallback timer
-     * to open the trap port with default config when no Twin publisher is
-     * available. The Delta-V trapd daemon does not yet publish TrapListenerConfig
-     * via Twin, so we skip the Twin subscription and open immediately.</p>
+     * <p>Opens the trap port synchronously with default config. No Twin
+     * subscription — the Delta-V trapd daemon doesn't publish TrapListenerConfig
+     * via Twin, so we bypass the Twin/timer path entirely.</p>
      */
     @Bean
     public SmartLifecycle trapListenerLifecycle(TrapListener trapListener) {
@@ -89,12 +84,7 @@ public class TrapListenerConfiguration {
 
             @Override
             public void start() {
-                // Ensure TwinSubscriber is null so start() uses the 5-second
-                // fallback timer to open the trap port with default config.
-                // The @Autowired field would otherwise wait for a Twin config
-                // that the Delta-V trapd daemon doesn't publish yet.
-                trapListener.unbind(null);
-                trapListener.start();
+                trapListener.openWithDefaultConfig();
                 running = true;
             }
 

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/TrapListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/TrapListenerConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot;
+
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.ipc.twin.api.TwinSubscriber;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.trapd.TrapdConfigBean;
+import org.opennms.netmgt.trapd.TrapListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the SNMP trap listener and its Sink producer.
+ *
+ * <p>When enabled, opens UDP port 1162 (configurable) to receive SNMP traps
+ * and forwards them to the core instance via the Sink API. Port binding
+ * is inside this conditional -- when disabled, port 1162 is never opened.</p>
+ *
+ * <p>Lifecycle phase 400: listeners start last, after RPC server (300)
+ * and Sink client (200) are ready.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.traps.enabled", havingValue = "true", matchIfMissing = true)
+public class TrapListenerConfiguration {
+
+    @Value("${opennms.minion.traps.port:1162}")
+    private int trapPort;
+
+    @Value("${opennms.minion.traps.address:*}")
+    private String trapAddress;
+
+    @Bean
+    public TrapdConfigBean trapdConfigBean() {
+        TrapdConfigBean config = new TrapdConfigBean();
+        config.setSnmpTrapPort(trapPort);
+        config.setSnmpTrapAddress(trapAddress);
+        config.setNewSuspectOnTrap(false);
+        config.setBatchSize(100);
+        config.setBatchIntervalMs(500);
+        config.setQueueSize(10000);
+        return config;
+    }
+
+    @Bean
+    public TrapListener trapListener(TrapdConfigBean config,
+                                     MessageDispatcherFactory messageDispatcherFactory,
+                                     DistPollerDao distPollerDao) throws Exception {
+        TrapListener listener = new TrapListener(config);
+        listener.setMessageDispatcherFactory(messageDispatcherFactory);
+        listener.setDistPollerDao(distPollerDao);
+        return listener;
+    }
+
+    /**
+     * SmartLifecycle that activates the TrapListener at phase 400.
+     *
+     * <p>On start, calls {@code bind(TwinSubscriber)} which sets the subscriber
+     * and immediately subscribes for configuration updates. When the core sends
+     * a TrapListenerConfig via Twin, the listener opens the trap port. This
+     * replaces the OSGi dynamic bind/unbind pattern.</p>
+     *
+     * <p>We do NOT call {@code TrapListener.start()} here because {@code bind()}
+     * already subscribes (calling {@code start()} would double-subscribe).</p>
+     */
+    @Bean
+    public SmartLifecycle trapListenerLifecycle(TrapListener trapListener, TwinSubscriber twinSubscriber) {
+        return new SmartLifecycle() {
+            private volatile boolean running;
+
+            @Override
+            public void start() {
+                trapListener.bind(twinSubscriber);
+                running = true;
+            }
+
+            @Override
+            public void stop() {
+                trapListener.stop();
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 400;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/TrapListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/TrapListenerConfiguration.java
@@ -77,22 +77,24 @@ public class TrapListenerConfiguration {
     /**
      * SmartLifecycle that activates the TrapListener at phase 400.
      *
-     * <p>On start, calls {@code bind(TwinSubscriber)} which sets the subscriber
-     * and immediately subscribes for configuration updates. When the core sends
-     * a TrapListenerConfig via Twin, the listener opens the trap port. This
-     * replaces the OSGi dynamic bind/unbind pattern.</p>
-     *
-     * <p>We do NOT call {@code TrapListener.start()} here because {@code bind()}
-     * already subscribes (calling {@code start()} would double-subscribe).</p>
+     * <p>Calls {@code TrapListener.start()} which uses a 5-second fallback timer
+     * to open the trap port with default config when no Twin publisher is
+     * available. The Delta-V trapd daemon does not yet publish TrapListenerConfig
+     * via Twin, so we skip the Twin subscription and open immediately.</p>
      */
     @Bean
-    public SmartLifecycle trapListenerLifecycle(TrapListener trapListener, TwinSubscriber twinSubscriber) {
+    public SmartLifecycle trapListenerLifecycle(TrapListener trapListener) {
         return new SmartLifecycle() {
             private volatile boolean running;
 
             @Override
             public void start() {
-                trapListener.bind(twinSubscriber);
+                // Ensure TwinSubscriber is null so start() uses the 5-second
+                // fallback timer to open the trap port with default config.
+                // The @Autowired field would otherwise wait for a Twin config
+                // that the Delta-V trapd daemon doesn't publish yet.
+                trapListener.unbind(null);
+                trapListener.start();
                 running = true;
             }
 

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/CollectorsEndpoint.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/CollectorsEndpoint.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot.actuator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom actuator endpoint at {@code /actuator/collectors} listing all registered service collectors.
+ *
+ * <p>Replaces the Karaf shell command {@code list-collectors}. The registry is optional
+ * since the collector subsystem may be disabled via {@code opennms.minion.collector.enabled=false}.</p>
+ */
+@Component
+@Endpoint(id = "collectors")
+public class CollectorsEndpoint {
+
+    private final ServiceCollectorRegistry registry;
+
+    @Autowired(required = false)
+    public CollectorsEndpoint(ServiceCollectorRegistry registry) {
+        this.registry = registry;
+    }
+
+    @ReadOperation
+    public Map<String, Object> collectors() {
+        if (registry == null) {
+            return Map.of(
+                "count", 0,
+                "classNames", Collections.emptySet()
+            );
+        }
+        Set<String> classNames = registry.getCollectorClassNames();
+        return Map.of(
+            "count", classNames.size(),
+            "classNames", classNames
+        );
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/DetectorsEndpoint.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/DetectorsEndpoint.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot.actuator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom actuator endpoint at {@code /actuator/detectors} listing all registered service detectors.
+ *
+ * <p>Replaces the Karaf shell command {@code list-detectors}. The registry is optional
+ * since the detector subsystem may be disabled via {@code opennms.minion.detector.enabled=false}.</p>
+ */
+@Component
+@Endpoint(id = "detectors")
+public class DetectorsEndpoint {
+
+    private final ServiceDetectorRegistry registry;
+
+    @Autowired(required = false)
+    public DetectorsEndpoint(ServiceDetectorRegistry registry) {
+        this.registry = registry;
+    }
+
+    @ReadOperation
+    public Map<String, Object> detectors() {
+        if (registry == null) {
+            return Map.of(
+                "count", 0,
+                "serviceNames", Collections.emptySet()
+            );
+        }
+        Set<String> serviceNames = registry.getServiceNames();
+        return Map.of(
+            "count", serviceNames.size(),
+            "serviceNames", serviceNames
+        );
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/MinionInfoContributor.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/MinionInfoContributor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot.actuator;
+
+import java.util.Map;
+
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Contributes Minion identity information to the {@code /actuator/info} endpoint.
+ *
+ * <p>Replaces the Karaf shell command {@code opennms:id}.</p>
+ */
+@Component
+public class MinionInfoContributor implements InfoContributor {
+
+    private final MinionIdentity identity;
+
+    public MinionInfoContributor(MinionIdentity identity) {
+        this.identity = identity;
+    }
+
+    @Override
+    public void contribute(Info.Builder builder) {
+        builder.withDetail("minion", Map.of(
+            "id", identity.getId(),
+            "location", identity.getLocation(),
+            "type", identity.getType()
+        ));
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/MonitorsEndpoint.java
+++ b/core/daemon-boot-minion/src/main/java/org/opennms/minion/boot/actuator/MonitorsEndpoint.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.minion.boot.actuator;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.opennms.minion.common.RpcModuleRegistry;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom actuator endpoint at {@code /actuator/monitors} listing all registered RPC modules.
+ *
+ * <p>Replaces the Karaf shell command {@code list-monitors}.</p>
+ */
+@Component
+@Endpoint(id = "monitors")
+public class MonitorsEndpoint {
+
+    private final RpcModuleRegistry registry;
+
+    public MonitorsEndpoint(RpcModuleRegistry registry) {
+        this.registry = registry;
+    }
+
+    @ReadOperation
+    public Map<String, Object> monitors() {
+        Set<String> moduleIds = registry.getModuleIds();
+        return Map.of(
+            "count", moduleIds.size(),
+            "modules", moduleIds
+        );
+    }
+}

--- a/core/daemon-boot-minion/src/main/resources/application.yml
+++ b/core/daemon-boot-minion/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: 8080
+
+opennms:
+  home: ${OPENNMS_HOME:/opt/minion}
+  instance:
+    id: ${OPENNMS_INSTANCE_ID:OpenNMS}
+  minion:
+    id: ${MINION_ID:minion-default-01}
+    location: ${MINION_LOCATION:Default}
+    rpc.enabled: true
+    sink.enabled: true
+    twin.enabled: true
+    snmp.enabled: true
+    icmp.enabled: true
+    traps.enabled: true
+    syslog.enabled: true
+    poller.enabled: true
+    collector.enabled: true
+    detector.enabled: true
+    telemetry.enabled: true
+    heartbeat.enabled: true
+  kafka:
+    bootstrap-servers: ${KAFKA_IPC_BOOTSTRAP_SERVERS:localhost:9092}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,env,detectors,monitors,collectors
+  endpoint:
+    health:
+      show-details: always
+
+spring:
+  application:
+    name: opennms-minion

--- a/core/daemon-boot-minion/src/main/resources/logback-spring.xml
+++ b/core/daemon-boot-minion/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.opennms" level="${MINION_LOG_LEVEL:-INFO}"/>
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.springframework" level="WARN"/>
+
+    <springProfile name="debug">
+        <logger name="org.opennms" level="DEBUG"/>
+        <logger name="org.apache.kafka" level="INFO"/>
+    </springProfile>
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonDataSourceConfiguration.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonDataSourceConfiguration.java
@@ -1,10 +1,12 @@
 package org.opennms.core.daemon.common;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @EnableTransactionManagement
+@ConditionalOnProperty(name = "spring.datasource.url")
 public class DaemonDataSourceConfiguration {
     // Spring Boot auto-configuration handles:
     // - HikariCP DataSource from spring.datasource.* properties

--- a/core/daemon-common/src/test/java/org/opennms/core/daemon/common/DaemonDataSourceConfigurationTest.java
+++ b/core/daemon-common/src/test/java/org/opennms/core/daemon/common/DaemonDataSourceConfigurationTest.java
@@ -3,6 +3,7 @@ package org.opennms.core.daemon.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -12,6 +13,14 @@ class DaemonDataSourceConfigurationTest {
     void hasRequiredAnnotations() {
         assertThat(DaemonDataSourceConfiguration.class.isAnnotationPresent(Configuration.class)).isTrue();
         assertThat(DaemonDataSourceConfiguration.class.isAnnotationPresent(EnableTransactionManagement.class)).isTrue();
+    }
+
+    @Test
+    void hasConditionalOnPropertyGuard() {
+        ConditionalOnProperty annotation = DaemonDataSourceConfiguration.class
+            .getAnnotation(ConditionalOnProperty.class);
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.name()).containsExactly("spring.datasource.url");
     }
 
     @Test

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,8 @@
     <module>criteria</module>
     <module>daemon</module>
     <module>daemon-common</module>
+    <module>daemon-boot-minion-common</module>
+    <module>daemon-boot-minion</module>
     <module>daemon-sink-kafka</module>
     <module>daemon-boot-alarmd</module>
     <module>daemon-boot-trapd</module>

--- a/features/bsm/persistence/api/pom.xml
+++ b/features/bsm/persistence/api/pom.xml
@@ -39,12 +39,13 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/ApplicationEdgeEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/ApplicationEdgeEntity.java
@@ -24,13 +24,13 @@ package org.opennms.netmgt.bsm.persistence.api;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.PrimaryKeyJoinColumn;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import org.opennms.netmgt.dao.util.ReductionKeyHelper;
 import org.opennms.netmgt.model.OnmsApplication;

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceChildEdgeEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceChildEdgeEntity.java
@@ -24,13 +24,13 @@ package org.opennms.netmgt.bsm.persistence.api;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.PrimaryKeyJoinColumn;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import com.google.common.collect.Sets;
 

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
@@ -24,22 +24,22 @@ package org.opennms.netmgt.bsm.persistence.api;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorColumn;
-import javax.persistence.DiscriminatorType;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
 
@@ -75,7 +75,7 @@ public class BusinessServiceEdgeEntity implements EdgeEntity {
     private AbstractMapFunctionEntity m_mapFunction;
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
@@ -26,21 +26,21 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.MapKeyColumn;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
 import org.opennms.netmgt.bsm.persistence.api.functions.reduce.AbstractReductionFunctionEntity;
@@ -79,7 +79,7 @@ public class BusinessServiceEntity {
     }
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/IPServiceEdgeEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/IPServiceEdgeEntity.java
@@ -24,14 +24,14 @@ package org.opennms.netmgt.bsm.persistence.api;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.PrimaryKeyJoinColumn;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import javax.validation.constraints.Size;
 
 import org.opennms.netmgt.dao.util.ReductionKeyHelper;

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/SingleReductionKeyEdgeEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/SingleReductionKeyEdgeEntity.java
@@ -24,13 +24,13 @@ package org.opennms.netmgt.bsm.persistence.api;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.PrimaryKeyJoinColumn;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-import javax.persistence.UniqueConstraint;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.persistence.UniqueConstraint;
 import javax.validation.constraints.Size;
 
 import com.google.common.collect.Sets;

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/AbstractMapFunctionEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/AbstractMapFunctionEntity.java
@@ -21,17 +21,17 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.map;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorColumn;
-import javax.persistence.DiscriminatorType;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "bsm_map")
@@ -43,7 +43,7 @@ public abstract class AbstractMapFunctionEntity {
     private Long m_id;
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/DecreaseEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/DecreaseEntity.java
@@ -21,8 +21,8 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.map;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 @Entity
 @DiscriminatorValue(value="decrease")

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IdentityEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IdentityEntity.java
@@ -21,8 +21,8 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.map;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 @Entity
 @DiscriminatorValue(value="identity")

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IgnoreEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IgnoreEntity.java
@@ -21,8 +21,8 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.map;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 @Entity
 @DiscriminatorValue(value="ignore")

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IncreaseEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/IncreaseEntity.java
@@ -21,8 +21,8 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.map;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 @Entity
 @DiscriminatorValue(value="increase")

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/SetToEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/map/SetToEntity.java
@@ -23,9 +23,9 @@ package org.opennms.netmgt.bsm.persistence.api.functions.map;
 
 import java.util.Objects;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 import org.opennms.netmgt.model.OnmsSeverity;
 

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/AbstractReductionFunctionEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/AbstractReductionFunctionEntity.java
@@ -21,17 +21,17 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorColumn;
-import javax.persistence.DiscriminatorType;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "bsm_reduce")
@@ -43,7 +43,7 @@ public abstract class AbstractReductionFunctionEntity {
     private Long m_id;
 
     @Id
-    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId")
+    @SequenceGenerator(name = "opennmsSequence", sequenceName = "opennmsNxtId", allocationSize = 1)
     @GeneratedValue(generator = "opennmsSequence")
     @Column(name = "id", nullable = false)
     public Long getId() {

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ExponentialPropagationEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ExponentialPropagationEntity.java
@@ -21,9 +21,9 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 @Entity
 @DiscriminatorValue(value="exponential-propagation")

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityAboveEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityAboveEntity.java
@@ -21,9 +21,9 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 @Entity
 @DiscriminatorValue(value="highest-severity-above")

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/HighestSeverityEntity.java
@@ -21,8 +21,8 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 @Entity
 @DiscriminatorValue(value="highest-severity")

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ThresholdEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/functions/reduce/ThresholdEntity.java
@@ -21,9 +21,9 @@
  */
 package org.opennms.netmgt.bsm.persistence.api.functions.reduce;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 
 import com.google.common.base.Preconditions;
 

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -47,7 +47,6 @@ import org.opennms.netmgt.snmp.TrapListenerConfig;
 import org.opennms.netmgt.snmp.TrapNotificationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class TrapListener implements TrapNotificationListener {
     private static final Logger LOG = LoggerFactory.getLogger(TrapListener.class);
@@ -58,10 +57,8 @@ public class TrapListener implements TrapNotificationListener {
 
     private long subscriberTimeoutMs = 60 * 1000;
 
-    @Autowired
     private MessageDispatcherFactory m_messageDispatcherFactory;
 
-    @Autowired
     private DistPollerDao m_distPollerDao;
 
     private boolean m_registeredForTraps;
@@ -70,7 +67,6 @@ public class TrapListener implements TrapNotificationListener {
 
     private AsyncDispatcher<TrapInformationWrapper> m_dispatcher;
 
-    @Autowired
     private TwinSubscriber m_twinSubscriber;
 
     private Closeable m_twinSubscription;
@@ -80,6 +76,19 @@ public class TrapListener implements TrapNotificationListener {
     public TrapListener(final TrapdConfig config) throws SocketException {
         Objects.requireNonNull(config, "Config cannot be null");
         m_config = config;
+    }
+
+    /**
+     * Full constructor for Spring Boot — all dependencies explicit, no field injection.
+     * TwinSubscriber is intentionally omitted; use {@link #bind(TwinSubscriber)} for
+     * OSGi environments where Twin is available.
+     */
+    public TrapListener(final TrapdConfig config,
+                        final MessageDispatcherFactory messageDispatcherFactory,
+                        final DistPollerDao distPollerDao) throws SocketException {
+        this(config);
+        m_messageDispatcherFactory = Objects.requireNonNull(messageDispatcherFactory);
+        m_distPollerDao = Objects.requireNonNull(distPollerDao);
     }
 
     @Override
@@ -141,6 +150,18 @@ public class TrapListener implements TrapNotificationListener {
         }
     }
 
+    /**
+     * Opens the trap port synchronously with default config.
+     * Use this in environments (like Spring Boot daemons) where Twin is not
+     * available and the port should open immediately during startup.
+     */
+    public void openWithDefaultConfig() {
+        synchronized (configuredLock) {
+            m_configured = true;
+            this.open(new TrapListenerConfig());
+        }
+    }
+
     public void subscribe() {
         m_twinSubscription = m_twinSubscriber.subscribe(TrapListenerConfig.TWIN_KEY, TrapListenerConfig.class, (config) -> {
             try (Logging.MDCCloseable mdc = Logging.withPrefixCloseable(Trapd.LOG4J_CATEGORY)) {
@@ -190,10 +211,12 @@ public class TrapListener implements TrapNotificationListener {
     }
 
     public void stop() {
-        try {
-            m_twinSubscription.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        if (m_twinSubscription != null) {
+            try {
+                m_twinSubscription.close();
+            } catch (IOException e) {
+                LOG.warn("stop: exception occurred closing twin subscription", e);
+            }
         }
 
         this.close();

--- a/opennms-container/delta-v/Dockerfile.minion-boot
+++ b/opennms-container/delta-v/Dockerfile.minion-boot
@@ -1,0 +1,23 @@
+ARG JRE_IMAGE=opennms/jre-deltav:21
+FROM ${JRE_IMAGE}
+
+LABEL org.opencontainers.image.title="Delta-V Minion (Spring Boot)"
+LABEL org.opencontainers.image.description="Spring Boot 4 Minion - SNMP/ICMP proxy, trap/syslog listener, telemetry receiver"
+
+# ICMP proxy requires NET_RAW capability. On Alpine/musl, setcap on the Java
+# binary breaks libjli.so resolution (musl ignores LD_LIBRARY_PATH for
+# capability-enhanced binaries). Instead, grant NET_RAW via Docker's
+# --cap-add=NET_RAW in docker-compose.yml.
+USER root
+
+RUN addgroup -g 10001 minion && \
+    adduser -u 10001 -G minion -h /opt/minion -s /bin/sh -D minion && \
+    mkdir -p /opt/minion/etc && chown -R minion:minion /opt/minion
+
+COPY --chmod=755 entrypoint-minion.sh /opt/entrypoint-minion.sh
+COPY staging/minion-boot/daemon-boot-minion.jar /opt/daemon-boot-minion.jar
+
+EXPOSE 8080/tcp 1162/udp 1514/udp
+
+USER minion
+ENTRYPOINT ["/opt/entrypoint-minion.sh"]

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -202,11 +202,29 @@ do_deltav_images() {
         -t "opennms/minion-deltav:latest" \
         .
 
+    # --- Stage Minion Boot fat JAR ---
+    log "Staging Minion Boot fat JAR..."
+    mkdir -p "$SCRIPT_DIR/staging/minion-boot"
+    # Copy only the fat JAR (exclude -sources.jar, -javadoc.jar, .original)
+    find "$REPO_ROOT/core/daemon-boot-minion/target" \
+        -maxdepth 1 -name "*.jar" \
+        ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*.original" \
+        -exec cp {} "$SCRIPT_DIR/staging/minion-boot/daemon-boot-minion.jar" \;
+
+    # --- Build Minion Boot image ---
+    log "Building opennms/minion-boot:$VERSION..."
+    docker build \
+        --build-arg "VERSION=$VERSION" \
+        -f Dockerfile.minion-boot \
+        -t "opennms/minion-boot:$VERSION" \
+        -t "opennms/minion-boot:latest" \
+        .
+
     # Clean up staging
     rm -rf "$SCRIPT_DIR/staging"
 
     log "Delta-V images built:"
-    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav" | sort | head -20
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot" | sort | head -20
 }
 
 

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -91,9 +91,11 @@ services:
       retries: 3
 
   minion:
-    image: opennms/minion-deltav:${VERSION}
+    image: opennms/minion-boot:${VERSION}
     container_name: delta-v-minion
     hostname: minion-default-01
+    cap_add:
+      - NET_RAW
     depends_on:
       kafka:
         condition: service_healthy
@@ -104,22 +106,16 @@ services:
       JAVA_OPTS: >-
         -Xms256m -Xmx512m
         -Djava.security.egd=file:/dev/./urandom
-    volumes:
-      - minion-data:/opt/minion/data
     ports:
-      - "8301:8201"
-      - "11162:1162/udp"
-      - "1514:1514/udp"
+      - "8301:8080"           # Actuator (was 8201 Karaf SSH)
+      - "11162:1162/udp"      # SNMP Trapd
+      - "1514:1514/udp"       # Syslog
     healthcheck:
-      # Check Kafka RPC/Sink/Twin connectivity via the health API.
-      # Skip the Echo RPC passive check (requires probes from monolithic OpenNMS)
-      # and the bundle check (some bundles have unresolved optional deps).
-      # If all 3 Kafka connections show "Success", Minion can process RPC requests.
-      test: ["CMD-SHELL", "curl -sf 'http://localhost:8181/minion/rest/health?tag=broker' | grep -o '\"Success\"' | wc -l | grep -q '[3-9]'"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
       interval: 30s
       timeout: 10s
       retries: 10
-      start_period: 60s
+      start_period: 45s
 
   pollerd:
     profiles: [lite, full]
@@ -483,5 +479,4 @@ services:
 volumes:
   pgdata:
   kafkadata:
-  minion-data:
   collectd-data:

--- a/opennms-container/delta-v/entrypoint-minion.sh
+++ b/opennms-container/delta-v/entrypoint-minion.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+JAVA_OPTS="${JAVA_OPTS:--Xms256m -Xmx512m}"
+SPRING_ARGS=""
+
+# Legacy env var bridge (operator contract)
+[ -n "$MINION_ID" ]        && SPRING_ARGS="$SPRING_ARGS --opennms.minion.id=$MINION_ID"
+[ -n "$MINION_LOCATION" ]  && SPRING_ARGS="$SPRING_ARGS --opennms.minion.location=$MINION_LOCATION"
+[ -n "$MINION_LOG_LEVEL" ] && SPRING_ARGS="$SPRING_ARGS --logging.level.org.opennms=$MINION_LOG_LEVEL"
+
+# Kafka IPC bridge
+[ -n "$KAFKA_IPC_BOOTSTRAP_SERVERS" ] && SPRING_ARGS="$SPRING_ARGS --opennms.kafka.bootstrap-servers=$KAFKA_IPC_BOOTSTRAP_SERVERS"
+
+# Optional JMX
+if [ -n "$MINION_JMX_PORT" ]; then
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=$MINION_JMX_PORT"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=$MINION_JMX_PORT"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+fi
+
+# Optional: load operator's minion-config.yaml
+if [ -f /etc/opennms/minion/minion-config.yaml ]; then
+    SPRING_ARGS="$SPRING_ARGS --spring.config.additional-location=file:/etc/opennms/minion/minion-config.yaml"
+fi
+
+exec java $JAVA_OPTS -jar /opt/daemon-boot-minion.jar $SPRING_ARGS

--- a/opennms-container/delta-v/test-collectd-e2e.sh
+++ b/opennms-container/delta-v/test-collectd-e2e.sh
@@ -212,6 +212,22 @@ REQEOF
             ok "Requisition created"
         fi
 
+        # Add requisition-def so Provisiond auto-imports on startup
+        mkdir -p provisiond-overlay/etc
+        cat > provisiond-overlay/etc/provisiond-configuration.xml <<PROVEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
+  foreign-source-dir="/opt/deltav/etc/foreign-sources"
+  requistion-dir="/opt/deltav/etc/imports"
+  importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
+  <requisition-def import-name="${FOREIGN_SOURCE}"
+                   import-url-resource="file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
+</provisiond-configuration>
+PROVEOF
+        ok "Provisiond configuration updated with ${FOREIGN_SOURCE} import"
+
         # Restart Provisiond to pick up config and trigger import
         log "  Restarting Provisiond to import requisition..."
         docker compose restart provisiond

--- a/opennms-container/delta-v/test-minion-e2e.sh
+++ b/opennms-container/delta-v/test-minion-e2e.sh
@@ -17,7 +17,7 @@
 #
 # Prerequisites:
 #   - Delta-V deployed: docker compose up -d
-#   - Minion healthy: docker compose exec minion bin/client "opennms:health-check"
+#   - Minion healthy: curl -sf http://localhost:8301/actuator/health
 #   - snmptrap available on host (net-snmp)
 #
 # Exit codes:
@@ -168,8 +168,8 @@ if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qw "delta-v-minion"; th
 fi
 ok "All required services running (including Minion)"
 
-# Verify Minion location
-MINION_LOCATION=$(docker compose exec -T minion cat /opt/minion/etc/org.opennms.minion.controller.cfg 2>/dev/null | grep "location" | head -1 | cut -d= -f2 | tr -d ' ' || echo "unknown")
+# Verify Minion location (Boot4: read from Spring env, not Karaf cfg file)
+MINION_LOCATION=$(docker compose exec -T minion sh -c 'echo ${MINION_LOCATION:-unknown}' 2>/dev/null || echo "unknown")
 log "Minion location: $MINION_LOCATION"
 
 # ── Start Kafka Consumers ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Spring Boot 4 Minion** — complete migration from Karaf to Spring Boot with 10 protocol handlers (SNMP, ICMP, traps, syslog, poller, collector, detector, heartbeat, echo)
- **BSM jakarta port** — port 17 BSM entity classes from javax.persistence to jakarta.persistence for Hibernate 7
- **Trap listener fix** — constructor injection + synchronous port binding (was async race condition)
- **Collectd E2E test fix** — add provisiond requisition-def so import is scheduled

## Commits

1. `feat: Minion-to-Spring-Boot-4 migration` — daemon-boot-minion module, daemon-boot-minion-common, Docker image, entrypoint
2. `fix: fix Minion component scan and trap listener activation` — correct scanBasePackages
3. `fix: convert TrapListener to constructor injection` — synchronous port binding
4. `feat: port BSM entities from javax.persistence to jakarta.persistence` — 17 files, allocationSize=1
5. `fix: add provisiond requisition-def in collectd E2E test` — scheduling fix

## Test plan

| Test Suite | Result |
|-----------|--------|
| test-e2e.sh (trap pipeline) | 12/12 PASS |
| test-minion-e2e.sh (Minion forwarding) | 13/13 PASS |
| test-syslog-e2e.sh (syslog via Minion) | 15/15 PASS |
| test-collectd-e2e.sh (SNMP collection) | 9/9 PASS |
| test-passive-e2e.sh (passive monitoring) | 18/20 PASS |
| test-enlinkd-e2e.sh (link discovery) | Blocked on infra |

**67/69 tests passing.** 2 passive outage failures are a known gap (Twin API pipeline).