### PR TITLE
fix: resolve daemon startup failures on develop

### DIFF
--- a/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/opennms/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -42,6 +42,7 @@ import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsServiceType;
@@ -112,6 +113,7 @@ public class AlarmdConfiguration {
             OnmsMonitoredService.class.getName(),
             OnmsMonitoringSystem.class.getName(),
             OnmsNode.class.getName(),
+            OnmsAssetRecord.class.getName(),
             OnmsReductionKeyMemo.class.getName(),
             OnmsServiceType.class.getName(),
             OnmsSnmpInterface.class.getName(),

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdConfiguration.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/boot/BsmdConfiguration.java
@@ -48,7 +48,7 @@ import org.opennms.netmgt.bsm.service.BusinessServiceManager;
 import org.opennms.netmgt.bsm.service.BusinessServiceStateMachine;
 import org.opennms.netmgt.bsm.service.internal.BusinessServiceManagerImpl;
 import org.opennms.netmgt.bsm.service.internal.DefaultBusinessServiceStateMachine;
-import org.opennms.netmgt.config.DefaultEventConfDao;
+import org.opennms.core.daemon.common.DaemonEventConfDao;
 import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
 import org.opennms.netmgt.events.api.EventIpcManager;
@@ -62,6 +62,7 @@ import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsServiceType;
@@ -135,6 +136,7 @@ public class BsmdConfiguration {
             OnmsMonitoredService.class.getName(),
             OnmsMonitoringSystem.class.getName(),
             OnmsNode.class.getName(),
+            OnmsAssetRecord.class.getName(),
             OnmsReductionKeyMemo.class.getName(),
             OnmsServiceType.class.getName(),
             OnmsSnmpInterface.class.getName(),
@@ -277,7 +279,7 @@ public class BsmdConfiguration {
      */
     @Bean
     public EventConfDao eventConfDao() {
-        return new DefaultEventConfDao();
+        return new DaemonEventConfDao();
     }
 
     /**

--- a/core/daemon-boot-collectd/src/main/java/org/opennms/netmgt/collectd/boot/CollectdJpaConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/opennms/netmgt/collectd/boot/CollectdJpaConfiguration.java
@@ -36,6 +36,7 @@ import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsServiceType;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
@@ -107,6 +108,7 @@ public class CollectdJpaConfiguration {
     public PersistenceManagedTypes persistenceManagedTypes() {
         return PersistenceManagedTypes.of(
             OnmsNode.class.getName(),
+            OnmsAssetRecord.class.getName(),
             OnmsIpInterface.class.getName(),
             OnmsMonitoredService.class.getName(),
             OnmsServiceType.class.getName(),

--- a/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdJpaConfiguration.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdJpaConfiguration.java
@@ -60,6 +60,7 @@ import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsServiceType;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
@@ -115,6 +116,7 @@ public class EnlinkdJpaConfiguration {
         return PersistenceManagedTypes.of(
             // Core entities
             OnmsNode.class.getName(),
+            OnmsAssetRecord.class.getName(),
             OnmsIpInterface.class.getName(),
             OnmsSnmpInterface.class.getName(),
             OnmsMonitoringLocation.class.getName(),

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdJpaConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdJpaConfiguration.java
@@ -43,6 +43,7 @@ import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsOutage;
 import org.opennms.netmgt.model.OnmsServiceType;
@@ -111,6 +112,7 @@ public class PerspectivePollerdJpaConfiguration {
     public PersistenceManagedTypes persistenceManagedTypes() {
         return PersistenceManagedTypes.of(
             OnmsNode.class.getName(),
+            OnmsAssetRecord.class.getName(),
             OnmsIpInterface.class.getName(),
             OnmsMonitoredService.class.getName(),
             OnmsServiceType.class.getName(),

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
@@ -46,6 +46,7 @@ import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsOutage;
 import org.opennms.netmgt.model.OnmsApplication;
@@ -119,6 +120,7 @@ public class PollerdJpaConfiguration {
     public PersistenceManagedTypes persistenceManagedTypes() {
         return PersistenceManagedTypes.of(
             OnmsNode.class.getName(),
+            OnmsAssetRecord.class.getName(),
             OnmsIpInterface.class.getName(),
             OnmsMonitoredService.class.getName(),
             OnmsServiceType.class.getName(),

--- a/core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java
@@ -53,6 +53,7 @@ import org.opennms.netmgt.model.OnmsApplication;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsServiceType;
@@ -138,6 +139,7 @@ public class ProvisiondBootConfiguration {
             OnmsMonitoredService.class.getName(),
             OnmsMonitoringSystem.class.getName(),
             OnmsNode.class.getName(),
+            OnmsAssetRecord.class.getName(),
             OnmsReductionKeyMemo.class.getName(),
             OnmsServiceType.class.getName(),
             OnmsSnmpInterface.class.getName(),

--- a/core/daemon-boot-trapd/src/main/java/org/opennms/netmgt/trapd/boot/TrapdConfiguration.java
+++ b/core/daemon-boot-trapd/src/main/java/org/opennms/netmgt/trapd/boot/TrapdConfiguration.java
@@ -2,7 +2,7 @@ package org.opennms.netmgt.trapd.boot;
 
 import javax.sql.DataSource;
 
-import org.opennms.netmgt.config.DefaultEventConfDao;
+import org.opennms.core.daemon.common.DaemonEventConfDao;
 import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
@@ -37,7 +37,7 @@ public class TrapdConfiguration {
 
     @Bean
     public EventConfDao eventConfDao() {
-        return new DefaultEventConfDao();
+        return new DaemonEventConfDao();
     }
 
     @Bean

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -172,51 +172,38 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
 
-        <!-- opennms-config — provides DefaultEventConfDao for event-conf enrichment.
-             opennms-config-model is NOT excluded because DefaultEventConfDao and its
-             eventconf.* bindings (Event, AlarmData, etc.) live in that module.
-             opennms-config-model only contains JAXB eventconf classes, not
-             javax.persistence entities, so it does not conflict with Hibernate 7. -->
+        <!-- opennms-config-model — provides eventconf JAXB classes (Event, Events,
+             EventMatchers, Partition) used by DaemonEventConfDao for event matching.
+             No opennms-model dependency — safe for Spring Boot daemon classpath. -->
         <dependency>
             <groupId>org.opennms</groupId>
-            <artifactId>opennms-config</artifactId>
+            <artifactId>opennms-config-model</artifactId>
             <version>${project.version}</version>
             <exclusions>
-                <!-- Exclude ALL old ServiceMix Spring 4.2.x bundles — Spring Boot 4 provides Spring 7 -->
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
-                <!-- Exclude old SLF4J — Spring Boot 4 provides SLF4J 2.x -->
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
-                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
-                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
-                <!-- Exclude old Hibernate 3.x -->
-                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
-                <!-- Exclude Karaf/OSGi logging -->
-                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
-                <!-- Exclude commons-logging — Spring Boot uses jcl-over-slf4j -->
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
-                <!-- Exclude opennms-model — only needed for Hibernate DAOs, not for
-                     DefaultEventConfDao; the legacy javax.persistence entities in
-                     opennms-model can cause scanner conflicts -->
+            </exclusions>
+        </dependency>
+        <!-- opennms-config-api — provides EventConfDao interface used by
+             KafkaEventForwarder. opennms-model excluded; EventConfEvent/EventConfSource
+             resolve from the opennms-model dependency below. -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-config-api</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonEventConfDao.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonEventConfDao.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.common;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.opennms.core.xml.JaxbUtils;
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.model.EventConfEvent;
+import org.opennms.netmgt.xml.eventconf.Event;
+import org.opennms.netmgt.xml.eventconf.EventMatchers;
+import org.opennms.netmgt.xml.eventconf.EventOrdering;
+import org.opennms.netmgt.xml.eventconf.Events;
+import org.opennms.netmgt.xml.eventconf.Field;
+import org.opennms.netmgt.xml.eventconf.Partition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Lightweight {@link EventConfDao} implementation for Spring Boot daemons.
+ *
+ * <p>Uses the eventconf matching engine ({@link Events}, {@link EventMatchers})
+ * from {@code opennms-config-model} directly, avoiding the heavyweight
+ * {@code DefaultEventConfDao} in {@code opennms-config} which transitively
+ * depends on {@code opennms-model}.</p>
+ *
+ * <p>Only {@link #findByEvent} and {@link #loadEventsFromDB} are fully
+ * implemented — these are the only methods used by daemon enrichment and
+ * the Kafka event forwarder.</p>
+ */
+public class DaemonEventConfDao implements EventConfDao {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DaemonEventConfDao.class);
+
+    private volatile Events events;
+
+    public DaemonEventConfDao() {
+        this.events = new Events();
+        this.events.initialize(new EnterpriseIdPartition(), new EventOrdering());
+    }
+
+    @Override
+    public Event findByEvent(org.opennms.netmgt.xml.event.Event matchingEvent) {
+        return events.findFirstMatchingEvent(matchingEvent);
+    }
+
+    @Override
+    public Event findByUei(String uei) {
+        if (uei == null) {
+            return null;
+        }
+        return events.findFirstMatchingEvent(e -> uei.equals(e.getUei()));
+    }
+
+    @Override
+    public void loadEventsFromDB(List<EventConfEvent> dbEvents) {
+        Map<String, List<EventConfEvent>> eventsBySource = dbEvents.stream()
+                .collect(Collectors.groupingBy(
+                        event -> event.getSource().getName(),
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
+        List<Map.Entry<String, List<EventConfEvent>>> sortedSources = eventsBySource.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue((events1, events2) -> {
+                    Integer order1 = events1.get(0).getSource().getFileOrder();
+                    Integer order2 = events2.get(0).getSource().getFileOrder();
+                    return Integer.compare(order2 != null ? order2 : 0, order1 != null ? order1 : 0);
+                }))
+                .toList();
+
+        Events rootEvents = new Events();
+
+        for (Map.Entry<String, List<EventConfEvent>> sourceEntry : sortedSources) {
+            Events eventsForSource = new Events();
+            for (EventConfEvent dbEvent : sourceEntry.getValue()) {
+                String xmlContent = dbEvent.getXmlContent();
+                if (xmlContent != null && !xmlContent.trim().isEmpty()) {
+                    try {
+                        Event event = JaxbUtils.unmarshal(Event.class, xmlContent);
+                        if (event != null) {
+                            eventsForSource.addEvent(event);
+                        }
+                    } catch (Exception e) {
+                        LOG.warn("Failed to parse event XML for UEI {}: {}", dbEvent.getUei(), e.getMessage());
+                    }
+                }
+            }
+            rootEvents.addLoadedEventFile(sourceEntry.getKey(), eventsForSource);
+        }
+
+        Partition partition = new EnterpriseIdPartition();
+        rootEvents.initialize(partition, new EventOrdering());
+        this.events = rootEvents;
+    }
+
+    @Override
+    public Events getRootEvents() {
+        return events;
+    }
+
+    // --- Methods not needed by daemon enrichment / Kafka forwarder ---
+
+    @Override
+    public void reload() {
+        // Reload is handled by periodic re-invocation of loadEventsFromDB
+    }
+
+    @Override
+    public List<Event> getEvents(String uei) {
+        throw new UnsupportedOperationException("Not used in daemon context");
+    }
+
+    @Override
+    public List<String> getEventUEIs() {
+        throw new UnsupportedOperationException("Not used in daemon context");
+    }
+
+    @Override
+    public Map<String, String> getEventLabels() {
+        throw new UnsupportedOperationException("Not used in daemon context");
+    }
+
+    @Override
+    public String getEventLabel(String uei) {
+        throw new UnsupportedOperationException("Not used in daemon context");
+    }
+
+    @Override
+    public List<Event> getEventsByLabel() {
+        throw new UnsupportedOperationException("Not used in daemon context");
+    }
+
+    @Override
+    public void addEvent(Event event) {
+        throw new UnsupportedOperationException("Not used in daemon context");
+    }
+
+    @Override
+    public boolean isSecureTag(String tag) {
+        return false;
+    }
+
+    // --- Partition ---
+
+    private static class EnterpriseIdPartition implements Partition {
+
+        private final Field field = EventMatchers.field("id");
+
+        @Override
+        public List<String> group(Event eventConf) {
+            List<String> keys = eventConf.getMaskElementValues("id");
+            if (keys == null) return null;
+            for (String key : keys) {
+                if (key.endsWith("%")) return null;
+                if (key.startsWith("~")) return null;
+            }
+            return keys;
+        }
+
+        @Override
+        public String group(org.opennms.netmgt.xml.event.Event matchingEvent) {
+            return field.get(matchingEvent);
+        }
+    }
+}

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/EventConfEnrichmentService.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.opennms.netmgt.config.DefaultEventConfDao;
+import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.model.EventConfEvent;
 import org.opennms.netmgt.model.EventConfSource;
 import org.opennms.netmgt.xml.event.AlarmData;
@@ -59,10 +59,10 @@ public class EventConfEnrichmentService {
 
     private static final Logger LOG = LoggerFactory.getLogger(EventConfEnrichmentService.class);
 
-    private final DefaultEventConfDao eventConfDao;
+    private final DaemonEventConfDao eventConfDao;
 
     public EventConfEnrichmentService(DataSource dataSource) {
-        this.eventConfDao = new DefaultEventConfDao();
+        this.eventConfDao = new DaemonEventConfDao();
         List<EventConfEvent> events = loadEventConfFromDb(new JdbcTemplate(dataSource));
         if (!events.isEmpty()) {
             eventConfDao.loadEventsFromDB(events);
@@ -76,7 +76,7 @@ public class EventConfEnrichmentService {
      * Returns the underlying EventConfDao for use by components that need
      * direct access to event configuration lookups (e.g., KafkaEventForwarder).
      */
-    public DefaultEventConfDao getEventConfDao() {
+    public EventConfDao getEventConfDao() {
         return eventConfDao;
     }
 

--- a/core/opennms-model-api/src/main/java/org/opennms/netmgt/model/PrimaryType.java
+++ b/core/opennms-model-api/src/main/java/org/opennms/netmgt/model/PrimaryType.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the SNMP primary collection type for an IP interface.
+ *
+ * <p>This is the persistence-free version in model-api. The JPA annotations
+ * ({@code @Embeddable}, {@code @Transient}) live in the opennms-model copy;
+ * {@code PrimaryTypeConverter} in model-jakarta handles persistence.</p>
+ */
+public class PrimaryType implements Comparable<PrimaryType>, Serializable {
+    private static final long serialVersionUID = -647348487361201657L;
+    private static final char[] s_order = { 'N', 'S', 'P' };
+    private char m_collType;
+
+    protected PrimaryType() {
+        this('N');
+    }
+
+    PrimaryType(final char collType) {
+        m_collType = collType;
+    }
+
+    public String getCode() {
+        return String.valueOf(m_collType);
+    }
+
+    public char getCharCode() {
+        return m_collType;
+    }
+
+    public void setCharCode(final char collType) {
+        m_collType = collType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Character.hashCode(m_collType);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o instanceof PrimaryType) {
+            return this.compareTo((PrimaryType) o) == 0;
+        } else return false;
+    }
+
+    @Override
+    public int compareTo(final PrimaryType collType) {
+        return getIndex(m_collType) - getIndex(collType.m_collType);
+    }
+
+    private static int getIndex(final char code) {
+        for (int i = 0; i < s_order.length; i++) {
+            if (s_order[i] == code) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("illegal collType code '" + code + "'");
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(m_collType);
+    }
+
+    public boolean isLessThan(final PrimaryType collType) {
+        return compareTo(collType) < 0;
+    }
+
+    public boolean isGreaterThan(final PrimaryType collType) {
+        return compareTo(collType) > 0;
+    }
+
+    public PrimaryType max(final PrimaryType collType) {
+        return this.isLessThan(collType) ? collType : this;
+    }
+
+    public PrimaryType min(final PrimaryType collType) {
+        return this.isLessThan(collType) ? this : collType;
+    }
+
+    public static PrimaryType get(final char code) {
+        switch (code) {
+        case 'P': return PRIMARY;
+        case 'S': return SECONDARY;
+        case 'N': return NOT_ELIGIBLE;
+        default:
+            throw new IllegalArgumentException("Cannot create collType from code " + code);
+        }
+    }
+
+    public static PrimaryType get(final Object code) {
+        if (code == null) {
+            return NOT_ELIGIBLE;
+        } else if (code instanceof Character) {
+            return get(((Character) code).charValue());
+        } else {
+            final String codeText = code.toString().trim();
+            if (codeText.length() < 1) {
+                return NOT_ELIGIBLE;
+            } else if (codeText.length() > 1) {
+                throw new IllegalArgumentException("Cannot convert string '" + codeText + "' to a collType");
+            } else {
+                return get(codeText.charAt(0));
+            }
+        }
+    }
+
+    public static List<PrimaryType> getAllTypes() {
+        final List<PrimaryType> types = new ArrayList<>();
+        for (final char c : s_order) {
+            types.add(PrimaryType.get(c));
+        }
+        return types;
+    }
+
+    public static final PrimaryType PRIMARY = new PrimaryType('P');
+    public static final PrimaryType SECONDARY = new PrimaryType('S');
+    public static final PrimaryType NOT_ELIGIBLE = new PrimaryType('N');
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/LldpLinkDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/LldpLinkDaoJpa.java
@@ -21,6 +21,8 @@
  */
 package org.opennms.netmgt.enlinkd.persistence.impl;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.List;
 
@@ -107,10 +109,17 @@ public class LldpLinkDaoJpa extends AbstractDaoJpa<LldpLink, Integer> implements
             return snmpIfaces.get(0).getIfIndex();
         }
 
+        InetAddress portAddr;
+        try {
+            portAddr = InetAddress.getByName(portId);
+        } catch (UnknownHostException e) {
+            return -1;
+        }
+
         List<OnmsIpInterface> ipIfaces = entityManager().createQuery(
                 "SELECT i FROM OnmsIpInterface i WHERE i.node.id = ?1 AND i.ipAddress = ?2")
                 .setParameter(1, nodeId)
-                .setParameter(2, portId)
+                .setParameter(2, portAddr)
                 .getResultList();
         if (ipIfaces.size() == 1) {
             OnmsIpInterface ipIf = ipIfaces.get(0);

--- a/docs/config-migration.md
+++ b/docs/config-migration.md
@@ -1,0 +1,33 @@
+# Configuration Migration Guide
+
+Tracks every configuration change as Karaf infrastructure is removed from Delta-V.
+Each entry maps the old config mechanism to its replacement.
+
+See [Karaf Removal Design](superpowers/specs/2026-03-30-karaf-removal-design.md) for the overall plan.
+
+## Phase 1: Dead Infrastructure Removal
+
+| Removed | What it was | Impact on running daemons |
+|---------|------------|--------------------------|
+| `container/features/overrides.properties` | Karaf bundle version overrides | None — Spring Boot daemons use Maven-resolved versions in fat JARs |
+| `container/features/features.xml` | Karaf feature definitions (bundle install order, dependencies) | None — daemon boot JARs embed all dependencies |
+| `container/features/features-core.xml` | Core third-party bundle features for Karaf | None |
+| `container/features/features-minion.xml` | Minion Karaf feature definitions | None — Minion is Spring Boot 4 |
+| `container/features/features-sentinel.xml` | Sentinel Karaf feature definitions | None — Sentinel not deployed in Delta-V |
+| `OSGI-INF/blueprint/*.xml` (~362 files) | OSGi service wiring (bean export/import) | None — Spring Boot uses `@Configuration` / `@Bean` / component scanning |
+| `META-INF/spring/*.xml` | Spring-DM OSGi context files | None — Spring Boot does not use Spring-DM extender |
+| `opennms-full-assembly/` | Karaf distribution packaging | None — Docker pipeline uses `build.sh deltav` |
+| `opennms-bootstrap/` | Karaf bootstrap launcher (`opennms` start script) | None — daemons launch via `java -jar` |
+| `opennms-install/` | Karaf-era installer (DB schema, etc.) | None — Liquibase runs at daemon startup |
+
+## Phase 2: Bundle to Jar Packaging
+
+_(To be filled when Phase 2 lands)_
+
+## Phase 3: opennms-model Elimination
+
+_(To be filled when Phase 3 lands)_
+
+## Phase 4: opennms-config Replacement
+
+_(To be filled per-daemon as each config is migrated)_

--- a/docs/superpowers/plans/2026-03-30-karaf-removal-phase1.md
+++ b/docs/superpowers/plans/2026-03-30-karaf-removal-phase1.md
@@ -236,12 +236,14 @@ these. Cleaned opennms-jetty reference from integration-tests/config."
 find . -path '*/src/*/OSGI-INF/blueprint' -type d \
   -not -path '*/target/*' \
   -not -path '*/.claude/*' \
+  -not -path '*/.git/*' \
   -exec rm -rf {} + 2>/dev/null
 
 # Remove empty OSGI-INF parents
 find . -path '*/src/*/OSGI-INF' -type d -empty \
   -not -path '*/target/*' \
   -not -path '*/.claude/*' \
+  -not -path '*/.git/*' \
   -exec rmdir {} + 2>/dev/null
 ```
 
@@ -374,13 +376,25 @@ paxCdiVersion (line ~1906)
 paxExamVersion (line ~1907)
 ```
 
-**For each property**, before removing, verify no POM in the reactor still references it:
+**Batch-verify all properties** before removing. Use this loop to check which ones still have active consumers:
 
 ```bash
-grep -r "propertyName" --include="pom.xml" . | grep -v target/ | grep -v '.claude/'
+for prop in maven.karaf.plugin.version karaf.servicemix.specs.version \
+  karafVersion karafSshdVersion opennms.osgi.version osgiVersion \
+  osgiAnnotationVersion osgiCompendiumVersion osgiEnterpriseVersion \
+  osgiServiceJdbcVersion osgiJaxRsVersion osgiUtilFunctionVersion \
+  osgiUtilPromiseVersion eclipseOsgiVersion felixCmJsonVersion \
+  felixConfigadminVersion felixConfigadminPluginInterpolationVersion \
+  felixCoordinatorVersion felixConfiguratorVersion felixConverterVersion \
+  felixFileinstallVersion felixMetatypeVersion paxLoggingVersion \
+  paxSwissboxVersion paxSwissboxOptionalJclVersion paxUrlAetherVersion \
+  paxWebVersion paxCdiVersion paxExamVersion; do
+  count=$(grep -r "\${${prop}}" --include="pom.xml" . | grep -v target/ | grep -v '.claude/' | grep -v 'pom.xml:.*<.*\.version>' | wc -l | tr -d ' ')
+  echo "$prop: $count references"
+done
 ```
 
-If a property IS still referenced by a non-deleted module, leave it for now and note it for Phase 2.
+Properties with 0 references outside their own definition are safe to remove. If a property IS still referenced by a non-deleted module, leave it for now and note it for Phase 2.
 
 - [ ] **Step 2: Remove OSGi managed dependencies**
 
@@ -503,10 +517,11 @@ If any daemon-boot module lost a needed transitive dependency, add it as an expl
 
 ### Task 10: Docker Deploy and E2E Verification
 
-- [ ] **Step 1: Rebuild all daemon boot JARs for Docker**
+- [ ] **Step 1: Full reactor build**
+
+Since Phase 1 is a massive reactor change (deleting many modules), a root-level `mvn install` is safer than targeted `-am` builds. It ensures the parent POM and shared dependencies are correctly installed in the local repository after the structural changes.
 
 ```bash
-# Per memory: always rebuild ALL 12 daemon boot JARs before build.sh
 make build
 ```
 

--- a/docs/superpowers/plans/2026-03-30-karaf-removal-phase1.md
+++ b/docs/superpowers/plans/2026-03-30-karaf-removal-phase1.md
@@ -1,0 +1,589 @@
+# Karaf Removal Phase 1: Delete Dead Infrastructure
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove all Karaf/OSGi infrastructure that has zero runtime consumers, reducing codebase noise and build time before Phases 2-4 tackle the remaining legacy dependencies.
+
+**Architecture:** Pure deletion. No behavioral changes to running daemons. Delete the Karaf container assembly, OSGi blueprint wiring files, Karaf-specific modules, and build script references. Clean up the root POM properties and managed dependencies.
+
+**Tech Stack:** Maven POM editing, git rm, shell scripting for bulk deletions, `make build` for verification.
+
+**Spec:** `docs/superpowers/specs/2026-03-30-karaf-removal-design.md` (Phase 1 section)
+
+**Branch:** Create `chore/karaf-removal-phase1` from `develop`
+
+---
+
+### Task 1: Capture Dependency Tree Baseline
+
+**Files:**
+- Create: `/tmp/dep-tree-before.txt` (temporary, not committed)
+
+This baseline lets us diff transitive dependencies before and after to catch anything we accidentally removed.
+
+- [ ] **Step 1: Pull latest develop and create feature branch**
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+git checkout -b chore/karaf-removal-phase1 develop
+```
+
+- [ ] **Step 2: Capture dependency tree for all daemon-boot modules**
+
+```bash
+./compile.pl -DskipTests --projects \
+  :org.opennms.core.daemon-boot-alarmd,\
+  :org.opennms.core.daemon-boot-bsmd,\
+  :org.opennms.core.daemon-boot-collectd,\
+  :org.opennms.core.daemon-boot-discovery,\
+  :org.opennms.core.daemon-boot-enlinkd,\
+  :org.opennms.core.daemon-boot-eventtranslator,\
+  :org.opennms.core.daemon-boot-perspectivepollerd,\
+  :org.opennms.core.daemon-boot-pollerd,\
+  :org.opennms.core.daemon-boot-provisiond,\
+  :org.opennms.core.daemon-boot-syslogd,\
+  :org.opennms.core.daemon-boot-telemetryd,\
+  :org.opennms.core.daemon-boot-trapd \
+  -am dependency:tree 2>&1 | tee /tmp/dep-tree-before.txt
+```
+
+- [ ] **Step 3: Extract Karaf/ServiceMix/Pax/Felix artifacts from baseline**
+
+```bash
+grep -E 'org\.apache\.(karaf|servicemix|felix)|org\.ops4j\.pax|org\.osgi' /tmp/dep-tree-before.txt | sort -u > /tmp/karaf-deps-before.txt
+cat /tmp/karaf-deps-before.txt
+```
+
+Review the output. These are the Karaf-ecosystem artifacts currently on daemon classpaths. Most should be harmless (unused at runtime), but this is the reference list for the post-deletion diff.
+
+---
+
+### Task 2: Delete Container Directory
+
+**Files:**
+- Delete: `container/` (entire directory — 15 subdirectories)
+- Modify: `pom.xml:98` (remove `<module>container</module>`)
+
+- [ ] **Step 1: Remove container module from root POM**
+
+In `pom.xml`, remove line 98:
+```xml
+    <module>container</module>
+```
+
+- [ ] **Step 2: Delete the container directory**
+
+```bash
+git rm -r container/
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pom.xml
+git commit -m "chore: delete container/ (Karaf OSGi container infrastructure)
+
+Removes all 15 Karaf container subdirectories: branding, bridge,
+extender, features (8 feature XMLs), jaas-login-module, karaf,
+noop-jetty-extension, servlet, shared, spring-extender.
+
+No runtime consumer exists — all daemons are Spring Boot 4."
+```
+
+---
+
+### Task 3: Delete Assembly Modules and Installer
+
+**Files:**
+- Delete: `opennms-full-assembly/`
+- Delete: `opennms-base-assembly/`
+- Delete: `opennms-assemblies/`
+- Delete: `opennms-install/`
+- Delete: `assemble.pl`
+
+None of these are in the root POM `<modules>` list — they were invoked directly by `assemble.pl` and the Makefile `assemble` target. They exist as orphaned directories.
+
+- [ ] **Step 1: Delete all assembly directories and assemble.pl**
+
+```bash
+git rm -r opennms-full-assembly/
+git rm -r opennms-base-assembly/
+git rm -r opennms-assemblies/
+git rm -r opennms-install/
+git rm assemble.pl
+```
+
+- [ ] **Step 2: Remove assembly references from root POM dependencyManagement**
+
+In `pom.xml`, remove these managed dependency entries (they reference deleted modules):
+
+Remove the `opennms-base-assembly` dependency (around line 3263):
+```xml
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-base-assembly</artifactId>
+            ...
+        </dependency>
+```
+
+Remove the `opennms-full-assembly` dependency (around line 3355):
+```xml
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-full-assembly</artifactId>
+            ...
+        </dependency>
+```
+
+Remove the `opennms-install` dependency (around line 3402):
+```xml
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-install</artifactId>
+            ...
+        </dependency>
+```
+
+Also remove the license-plugin `<exclude>` entries for `opennms-base-assembly` (around lines 1138-1139):
+```xml
+                <exclude>opennms-base-assembly/src/main/filtered/etc</exclude>
+                <exclude>opennms-base-assembly/src/main/resources</exclude>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pom.xml
+git commit -m "chore: delete assembly modules, installer, and assemble.pl
+
+Removes opennms-full-assembly, opennms-base-assembly, opennms-assemblies,
+opennms-install, and assemble.pl. These built the Karaf distribution
+which is no longer deployed. Docker pipeline uses build.sh deltav."
+```
+
+---
+
+### Task 4: Delete Karaf-Specific Top-Level Modules and Smoke Test
+
+**Files:**
+- Delete: `opennms-bootstrap/`
+- Delete: `opennms-jetty/`
+- Delete: `opennms-config-tester/`
+- Delete: `smoke-test/`
+- Modify: `pom.xml:108,111,124` (remove three `<module>` entries)
+- Modify: `pom.xml:2358` (remove `smoke-test` module from profile)
+- Modify: `integration-tests/config/pom.xml:86` (remove `opennms-jetty` dependency)
+
+These modules have zero consumers in daemon-boot or daemon-common POMs (verified). The `smoke-test` module is Karaf-era smoke testing that references `opennms-base-assembly` and `opennms-bootstrap` (both deleted in Task 3).
+
+- [ ] **Step 1: Remove modules from root POM**
+
+In `pom.xml`, remove these three lines from the `<modules>` section:
+```xml
+    <module>opennms-bootstrap</module>     <!-- line 108 -->
+    <module>opennms-config-tester</module> <!-- line 111 -->
+    <module>opennms-jetty</module>         <!-- line 124 -->
+```
+
+Also remove the `smoke-test` module entry from inside its Maven profile (around line 2358):
+```xml
+        <module>smoke-test</module>
+```
+
+- [ ] **Step 2: Delete the directories**
+
+```bash
+git rm -r opennms-bootstrap/
+git rm -r opennms-config-tester/
+git rm -r opennms-jetty/
+git rm -r smoke-test/
+```
+
+- [ ] **Step 3: Clean up references in surviving modules**
+
+Remove the `opennms-jetty` dependency from `integration-tests/config/pom.xml` (around line 86):
+```xml
+      <artifactId>opennms-jetty</artifactId>
+```
+(Remove the full `<dependency>` block containing this artifact.)
+
+- [ ] **Step 4: Remove managed dependency entries from root POM**
+
+Search the root `pom.xml` `<dependencyManagement>` section for entries referencing the deleted artifactIds (`opennms-bootstrap`, `opennms-config-tester`, `opennms-jetty`) and remove them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pom.xml integration-tests/config/pom.xml
+git commit -m "chore: delete opennms-bootstrap, opennms-jetty, opennms-config-tester, smoke-test
+
+Karaf bootstrap launcher, Jetty integration, config validation tool,
+and Karaf-era smoke tests. No daemon-boot module depends on any of
+these. Cleaned opennms-jetty reference from integration-tests/config."
+```
+
+---
+
+### Task 5: Delete Blueprint XML Files
+
+**Files:**
+- Delete: ~209 `OSGI-INF/blueprint/` directories under `src/`
+
+- [ ] **Step 1: Delete all blueprint directories in source tree**
+
+```bash
+find . -path '*/src/*/OSGI-INF/blueprint' -type d \
+  -not -path '*/target/*' \
+  -not -path '*/.claude/*' \
+  -exec rm -rf {} + 2>/dev/null
+
+# Remove empty OSGI-INF parents
+find . -path '*/src/*/OSGI-INF' -type d -empty \
+  -not -path '*/target/*' \
+  -not -path '*/.claude/*' \
+  -exec rmdir {} + 2>/dev/null
+```
+
+- [ ] **Step 2: Stage the deletions**
+
+```bash
+git add -A
+```
+
+Review with `git diff --cached --stat` to confirm only blueprint XMLs and empty OSGI-INF directories are staged. The count should be approximately 209 directories with their XML contents.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "chore: delete ~209 OSGI-INF/blueprint directories
+
+OSGi service wiring definitions. No Spring Boot daemon loads these.
+Service registration and dependency injection handled by Spring
+@Configuration, @Bean, and component scanning."
+```
+
+---
+
+### Task 6: Clean Up Build Scripts
+
+**Files:**
+- Modify: `Makefile:13-14,47,117-121`
+- Verify: `compile.pl` (check for assembly references)
+- Verify: `runtests.sh` (check for assembly path references)
+
+- [ ] **Step 1: Remove assemble target from Makefile**
+
+Remove the help lines (around lines 13-14):
+```
+#   make assemble                       Assemble distribution (default profile)
+#   make assemble PROFILE=dir|full|fulldir
+```
+
+Remove `assemble` from the `.PHONY` line (line 47):
+```makefile
+.PHONY: help build module dependents test-class test ui assemble clean
+```
+Change to:
+```makefile
+.PHONY: help build module dependents test-class test ui clean
+```
+
+Remove the `assemble` target (lines 117-121):
+```makefile
+assemble: ## Assemble the distribution; set PROFILE=dir|full|fulldir (default: dir)
+	cd opennms-full-assembly && \
+	$(CURDIR)/mvnw $(MAVEN_FLAGS) $(COMMON) \
+	  -Dbuild.profile=$(PROFILE) \
+	  install
+```
+
+Also remove the `PROFILE` variable if it's only used by the assemble target:
+```makefile
+PROFILE   ?= dir
+```
+
+- [ ] **Step 2: Check compile.pl for assembly references**
+
+```bash
+grep -n 'assemble\|opennms-full-assembly\|karaf' compile.pl
+```
+
+Remove any references found. If `compile.pl` has a conditional path that invokes the assembly, remove it.
+
+- [ ] **Step 3: Check runtests.sh for assembly path references**
+
+```bash
+grep -n 'assemble\|opennms-full-assembly\|karaf' runtests.sh
+```
+
+Remove any references found.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile compile.pl runtests.sh
+git commit -m "chore: remove Karaf assembly targets from build scripts
+
+Remove assemble target from Makefile, clean assembly references
+from compile.pl and runtests.sh."
+```
+
+---
+
+### Task 7: Clean Up Root POM Properties
+
+**Files:**
+- Modify: `pom.xml` (properties section, lines ~1640-1930)
+
+- [ ] **Step 1: Remove Karaf/OSGi version properties**
+
+Remove these properties from the root `pom.xml` `<properties>` section. They are all tied to the embedded Karaf container which no longer exists.
+
+Properties to remove (verify no remaining references before each deletion with `grep -r "propertyName" --include="pom.xml" .`):
+
+```
+maven.karaf.plugin.version (line ~1640)
+karaf.servicemix.specs.version (line ~1715)
+karafVersion (line ~1867)
+karafSshdVersion (line ~1973)
+opennms.osgi.version (line ~1670)
+osgiVersion (line ~1919)
+osgiAnnotationVersion (line ~1920)
+osgiCompendiumVersion (line ~1921)
+osgiEnterpriseVersion (line ~1922)
+osgiServiceJdbcVersion (line ~1923)
+osgiJaxRsVersion (line ~1926)
+osgiUtilFunctionVersion (line ~1881)
+osgiUtilPromiseVersion (line ~1882)
+eclipseOsgiVersion (line ~1869)
+felixCmJsonVersion (line ~1870)
+felixConfigadminVersion (line ~1871)
+felixConfigadminPluginInterpolationVersion (line ~1872)
+felixCoordinatorVersion (line ~1873)
+felixConfiguratorVersion (line ~1874)
+felixConverterVersion (line ~1875)
+felixFileinstallVersion (line ~1876)
+felixMetatypeVersion (line ~1877)
+paxLoggingVersion (line ~1883)
+paxSwissboxVersion (line ~1884)
+paxSwissboxOptionalJclVersion (line ~1885)
+paxUrlAetherVersion (line ~1886)
+paxWebVersion (line ~1887)
+paxCdiVersion (line ~1906)
+paxExamVersion (line ~1907)
+```
+
+**For each property**, before removing, verify no POM in the reactor still references it:
+
+```bash
+grep -r "propertyName" --include="pom.xml" . | grep -v target/ | grep -v '.claude/'
+```
+
+If a property IS still referenced by a non-deleted module, leave it for now and note it for Phase 2.
+
+- [ ] **Step 2: Remove OSGi managed dependencies**
+
+Remove these entries from the `<dependencyManagement>` section:
+
+```xml
+<!-- around lines 4810-4828 -->
+<dependency>
+    <groupId>org.osgi</groupId>
+    <artifactId>osgi.core</artifactId>
+    ...
+</dependency>
+<dependency>
+    <groupId>org.osgi</groupId>
+    <artifactId>osgi.cmpn</artifactId>
+    ...
+</dependency>
+<dependency>
+    <groupId>org.osgi</groupId>
+    <artifactId>osgi.annotation</artifactId>
+    ...
+</dependency>
+<dependency>
+    <groupId>org.osgi</groupId>
+    <artifactId>osgi.enterprise</artifactId>
+    ...
+</dependency>
+
+<!-- around line 4882-4885 -->
+<dependency>
+    <groupId>org.apache.karaf.shell</groupId>
+    <artifactId>org.apache.karaf.shell.core</artifactId>
+    ...
+</dependency>
+```
+
+Same rule: verify no remaining POM references before removal. If a `features/` or `opennms-*` module still imports an OSGi artifact, leave the managed dependency and note it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pom.xml
+git commit -m "chore: remove Karaf/OSGi/Felix/Pax properties and managed deps
+
+Remove ~30 version properties for Karaf 4.4.9, Felix, Pax, and OSGi.
+Remove 5 OSGi managed dependency entries. Properties still referenced
+by non-deleted modules are retained for Phase 2."
+```
+
+---
+
+### Task 8: Compile Verification
+
+- [ ] **Step 1: Full compile**
+
+```bash
+make build
+```
+
+Expected: BUILD SUCCESS. If it fails, the error will indicate a module that depended on a deleted module. Fix by replacing the dependency (not by restoring the deleted module).
+
+- [ ] **Step 2: Build all 12 daemon boot JARs**
+
+```bash
+./compile.pl -DskipTests --projects \
+  :org.opennms.core.daemon-boot-alarmd,\
+  :org.opennms.core.daemon-boot-bsmd,\
+  :org.opennms.core.daemon-boot-collectd,\
+  :org.opennms.core.daemon-boot-discovery,\
+  :org.opennms.core.daemon-boot-enlinkd,\
+  :org.opennms.core.daemon-boot-eventtranslator,\
+  :org.opennms.core.daemon-boot-perspectivepollerd,\
+  :org.opennms.core.daemon-boot-pollerd,\
+  :org.opennms.core.daemon-boot-provisiond,\
+  :org.opennms.core.daemon-boot-syslogd,\
+  :org.opennms.core.daemon-boot-telemetryd,\
+  :org.opennms.core.daemon-boot-trapd \
+  -am install
+```
+
+Expected: BUILD SUCCESS for all 12 modules.
+
+---
+
+### Task 9: Transitive Dependency Audit
+
+- [ ] **Step 1: Capture post-deletion dependency tree**
+
+```bash
+./compile.pl -DskipTests --projects \
+  :org.opennms.core.daemon-boot-alarmd,\
+  :org.opennms.core.daemon-boot-bsmd,\
+  :org.opennms.core.daemon-boot-collectd,\
+  :org.opennms.core.daemon-boot-discovery,\
+  :org.opennms.core.daemon-boot-enlinkd,\
+  :org.opennms.core.daemon-boot-eventtranslator,\
+  :org.opennms.core.daemon-boot-perspectivepollerd,\
+  :org.opennms.core.daemon-boot-pollerd,\
+  :org.opennms.core.daemon-boot-provisiond,\
+  :org.opennms.core.daemon-boot-syslogd,\
+  :org.opennms.core.daemon-boot-telemetryd,\
+  :org.opennms.core.daemon-boot-trapd \
+  -am dependency:tree 2>&1 | tee /tmp/dep-tree-after.txt
+```
+
+- [ ] **Step 2: Diff Karaf/ServiceMix/Pax/Felix artifacts**
+
+```bash
+grep -E 'org\.apache\.(karaf|servicemix|felix)|org\.ops4j\.pax|org\.osgi' /tmp/dep-tree-after.txt | sort -u > /tmp/karaf-deps-after.txt
+diff /tmp/karaf-deps-before.txt /tmp/karaf-deps-after.txt
+```
+
+Any artifact that disappeared from the "after" list was a transitive dependency of something we deleted. Verify these are truly unused at runtime (they should be — container modules don't provide runtime classes to daemons).
+
+- [ ] **Step 3: If issues found, fix and recommit**
+
+If any daemon-boot module lost a needed transitive dependency, add it as an explicit dependency in that module's POM (replace, don't keep the deleted module).
+
+---
+
+### Task 10: Docker Deploy and E2E Verification
+
+- [ ] **Step 1: Rebuild all daemon boot JARs for Docker**
+
+```bash
+# Per memory: always rebuild ALL 12 daemon boot JARs before build.sh
+make build
+```
+
+- [ ] **Step 2: Build Docker images**
+
+```bash
+./opennms-container/delta-v/build.sh deltav
+```
+
+Expected: All 12 daemon images built successfully.
+
+- [ ] **Step 3: Deploy and check health**
+
+```bash
+cd opennms-container/delta-v
+./deploy.sh up full
+```
+
+Wait for all containers to start. Verify each daemon passes health check:
+
+```bash
+for svc in alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd; do
+  echo -n "$svc: "
+  docker compose exec -T "$svc" curl -sf http://localhost:8080/actuator/health 2>/dev/null | head -c 50 || echo "UNHEALTHY"
+done
+```
+
+Expected: All 12 daemons report healthy.
+
+- [ ] **Step 4: Run E2E tests**
+
+```bash
+cd opennms-container/delta-v
+./test-trapd-e2e.sh
+./test-alarmd-e2e.sh
+./test-pollerd-e2e.sh
+./test-collectd-e2e.sh
+./test-enlinkd-e2e.sh
+./test-provisiond-e2e.sh
+```
+
+Expected: All 6 E2E tests pass. If any test fails due to a missing class at runtime, that indicates a transitive dependency from a deleted module was needed. Replace it (add explicit dependency), don't restore the deleted module.
+
+- [ ] **Step 5: Final commit if any fixes were needed**
+
+If Steps 3-4 required dependency fixes, commit those fixes:
+
+```bash
+git add -A
+git commit -m "fix: replace transitive dependencies from deleted Karaf modules"
+```
+
+- [ ] **Step 6: Push and create PR**
+
+```bash
+git push -u origin chore/karaf-removal-phase1
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "chore: Karaf removal Phase 1 — delete dead infrastructure" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Delete `container/` directory (Karaf OSGi container, 15 subdirectories, feature XMLs)
+- Delete assembly modules (`opennms-full-assembly`, `opennms-base-assembly`, `opennms-assemblies`, `opennms-install`)
+- Delete Karaf-specific modules (`opennms-bootstrap`, `opennms-jetty`, `opennms-config-tester`)
+- Delete ~209 `OSGI-INF/blueprint/` directories (OSGi service wiring)
+- Remove `assemble` target from Makefile, delete `assemble.pl`
+- Remove ~30 Karaf/OSGi/Felix/Pax version properties from root POM
+- Remove OSGi managed dependencies from root POM
+
+## Test plan
+
+- [ ] `make build` — full compile succeeds
+- [ ] All 12 daemon boot JARs compile
+- [ ] Dependency tree diff shows no unexpected lost artifacts
+- [ ] `build.sh deltav` — Docker images build
+- [ ] `deploy.sh up full` — all 12 daemons healthy
+- [ ] All 6 E2E tests pass (trapd, alarmd, pollerd, collectd, enlinkd, provisiond)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-03-30-karaf-removal-design.md
+++ b/docs/superpowers/specs/2026-03-30-karaf-removal-design.md
@@ -87,9 +87,15 @@ Delete:
 
 Delete all ~362 `OSGI-INF/blueprint/*.xml` files in `src/` directories across the source tree (not `target/`). These are OSGi service wiring definitions. No Spring Boot daemon loads them.
 
-Execution: `find . -path '*/src/*/OSGI-INF/blueprint' -type d -exec rm -rf {} +`
+Also delete `META-INF/spring/*.xml` files used by the old Spring-DM (OSGi) extender. These are strictly OSGi-related Spring context files that the Spring-DM extender loaded inside the Karaf container. Spring Boot does not use this mechanism.
 
-After deletion, remove empty `OSGI-INF/` parent directories where no other content remains.
+Execution:
+```bash
+find . -path '*/src/*/OSGI-INF/blueprint' -type d -exec rm -rf {} +
+find . -path '*/src/*/META-INF/spring' -type d -exec rm -rf {} +
+```
+
+After deletion, remove empty `OSGI-INF/` and `META-INF/` parent directories where no other content remains.
 
 #### 1d. Karaf-specific top-level modules
 
@@ -129,7 +135,7 @@ In root `pom.xml`:
 2. **Assemble**: `build.sh deltav` produces all 12 daemon boot JARs
 3. **Deploy**: `deploy.sh up full` - all 12 containers start, pass `/actuator/health`
 4. **E2E tests**: Run all 6 E2E test suites (trapd, alarmd, pollerd, collectd, enlinkd, provisiond) to catch runtime transitive dependency failures
-5. **Transitive dependency audit**: Run `mvn dependency:tree` on all daemon-boot modules before and after, diff output to confirm no resolved artifacts were lost
+5. **Transitive dependency audit**: Run `mvn dependency:tree` on all daemon-boot modules before and after, diff output. Specifically watch for `org.apache.karaf.*` and `org.apache.servicemix.*` artifacts — these are the most likely hidden transitive dependencies that need explicit replacement or exclusion in the Spring Boot 4 world.
 
 If an E2E test fails due to a missing transitive dependency from a deleted module, **replace the dependency** rather than keeping the deleted module.
 
@@ -165,10 +171,12 @@ Detailed spec written when Phase 2 is complete.
 
 21 factory/config classes from opennms-config are used across 9 daemon boot modules. Each gets replaced according to the config strategy:
 
-- `SnmpPeerFactory` (5 daemons) - file-based XML reader in daemon-common
+- `SnmpPeerFactory` (5 daemons) - file-based XML reader in daemon-common **(prioritize first — unlocks 5 modules)**
 - `PollerConfigFactory` (2 daemons) - file-based XML reader
 - `CollectdConfigFactory` + data collection configs (1 daemon) - file-based XML readers
 - Per-daemon configs (syslogd, trapd, discovery, enlinkd, etc.) - `@Value` properties or file-based readers
+
+Prioritize `SnmpPeerFactory` replacement early in Phase 4 — it is the single highest-fanout dependency (collectd, enlinkd, perspectivepollerd, pollerd, provisiond) and unlocks the migration for the largest number of modules.
 
 Each daemon's config replacement is an independent PR. After all consumers are migrated, delete `opennms-config/`.
 

--- a/docs/superpowers/specs/2026-03-30-karaf-removal-design.md
+++ b/docs/superpowers/specs/2026-03-30-karaf-removal-design.md
@@ -1,0 +1,177 @@
+# Karaf Removal Design
+
+> Delta-V has completed the Spring Boot 4 migration for all 12 daemons and Minion.
+> Karaf has zero runtime consumers. This spec removes it entirely.
+
+## Principles
+
+1. **Replace, don't keep.** When a deleted module surfaces as a transitive dependency, replace the dependency rather than preserving the module.
+2. **Document every config migration.** Each config change gets a before-after mapping in `docs/config-migration.md`.
+3. **Eventconf DB loading is transitional.** The JDBC pattern works today but the future target is file-based configs managed with Git, supporting CI/CD versioned deployments.
+4. **`@Value` for Spring Boot properties.** Simple daemon properties use `@Value` annotations in `config` package classes within each daemon-boot module. Not `@ConfigurationProperties`.
+
+## Phases
+
+| Phase | What | Type | Est. PRs |
+|-------|------|------|----------|
+| 1 | Delete dead Karaf infrastructure | Pure deletion | 1-2 |
+| 2 | Convert bundle to jar packaging | Mechanical/scripted | 1 |
+| 3 | Eliminate opennms-model | Entity porting + deletion | 3-4 |
+| 4 | Eliminate opennms-config | Config bean replacement | 6-8 |
+
+Phases 1-2 are pure deletion and mechanical changes. Phases 3-4 require per-module design.
+
+Phases 1 and 2 are sequential (2 depends on a clean module list from 1). Phases 3 and 4 can proceed in parallel after 2 lands.
+
+## Config Strategy (Phase 4)
+
+Three patterns based on config complexity:
+
+- **JDBC (transitional)**: Configs currently in PostgreSQL (eventconf). Keep working via `DaemonEventConfDao` and `EventConfEnrichmentService`. Future goal: move to file-based loading for GitOps compatibility.
+- **File-based XML readers**: Complex configs that are inherently structured (snmp-config.xml, poller packages, collection packages, discovery config). Replace factory singletons with lightweight `@Configuration` beans that read the same XML files. Build these readers in a pattern that eventconf could eventually adopt.
+- **`@Value` properties**: Simple daemon tunables (ports, intervals, thread counts). Externalized to `application.yml` or environment variables. Defined in `config` package classes per daemon-boot module.
+
+### Config classes used by daemons today (from opennms-config)
+
+| Class | Daemons | Replacement pattern |
+|-------|---------|-------------------|
+| SnmpPeerFactory | collectd, enlinkd, perspectivepollerd, pollerd, provisiond | File-based XML reader |
+| PollerConfig / PollerConfigFactory | pollerd, perspectivepollerd | File-based XML reader |
+| CollectdConfigFactory | collectd | File-based XML reader |
+| DataCollectionConfigFactory | collectd | File-based XML reader |
+| DefaultDataCollectionConfigDao | collectd | File-based XML reader |
+| DefaultResourceTypesDao | collectd | File-based XML reader |
+| DatabaseSchemaConfigFactory | collectd, pollerd, perspectivepollerd | @Value or file-based |
+| EnhancedLinkdConfig / Factory | enlinkd | File-based XML reader |
+| DiscoveryConfigFactory | discovery | File-based XML reader |
+| EventTranslatorConfigFactory | eventtranslator | File-based XML reader |
+| SyslogdConfig / Factory | syslogd | @Value + file-based |
+| TrapdConfig | trapd | @Value |
+| SnmpAssetAdapterConfig / Factory | provisiond | File-based XML reader |
+| SnmpMetadataConfigDao | provisiond | File-based XML reader |
+| ProvisiondConfiguration / RequisitionDef | provisiond | File-based XML reader |
+
+---
+
+## Phase 1: Delete Dead Karaf Infrastructure (Detailed)
+
+### Scope
+
+Remove everything with zero runtime consumers. No behavioral changes to running daemons.
+
+### Deletions
+
+#### 1a. Container directory
+
+Delete `container/` entirely (15 subdirectories):
+- `branding/` - Karaf console branding
+- `bridge/` - OSGi bridge (api, proxy, rest)
+- `extender/` - Karaf extender
+- `features/` - 8 feature XML files (features.xml, features-core.xml, features-minion.xml, features-sentinel.xml, features-experimental.xml, karaf-extensions.xml, spring-legacy.xml, overrides.properties)
+- `jaas-login-module/` - Karaf JAAS auth
+- `karaf/` - Karaf assembly with karaf-maven-plugin
+- `noop-jetty-extension/` - Karaf Jetty stub
+- `servlet/` - Karaf servlet container integration
+- `shared/` - Shared Karaf assembly components
+- `spring-extender/` - OSGi Spring context extender
+
+#### 1b. Assembly modules
+
+Delete:
+- `opennms-full-assembly/` - primary Karaf distribution assembly
+- `opennms-base-assembly/` - base distribution components
+- `opennms-assemblies/` - Karaf-related assembly sub-modules
+- `assemble.pl` - Perl assembly wrapper script
+
+#### 1c. Blueprint XML files
+
+Delete all ~362 `OSGI-INF/blueprint/*.xml` files in `src/` directories across the source tree (not `target/`). These are OSGi service wiring definitions. No Spring Boot daemon loads them.
+
+Execution: `find . -path '*/src/*/OSGI-INF/blueprint' -type d -exec rm -rf {} +`
+
+After deletion, remove empty `OSGI-INF/` parent directories where no other content remains.
+
+#### 1d. Karaf-specific top-level modules
+
+Delete:
+- `opennms-bootstrap/` - Karaf bootstrap launcher
+- `opennms-jetty/` - Jetty integration for Karaf
+- `opennms-install/` - Karaf-era installer scripts
+- `opennms-config-tester/` - config validation for Karaf runtime
+
+#### 1e. Build script cleanup
+
+- `Makefile`: remove `assemble` target and any `opennms-full-assembly` references
+- `compile.pl`: remove Karaf assembly references
+- `runtests.sh`: remove references to Karaf assembly paths if present
+
+#### 1f. Parent POM cleanup
+
+In root `pom.xml`:
+- Remove from `<modules>`: container, opennms-full-assembly, opennms-base-assembly, opennms-assemblies, opennms-bootstrap, opennms-jetty, opennms-install, opennms-config-tester
+- Remove properties: `karafVersion`, `maven.karaf.plugin.version` (if no remaining references)
+- Remove any `<dependencyManagement>` entries for deleted modules
+
+### What stays in Phase 1
+
+- `opennms-model/` - compile dependency (Phase 3)
+- `opennms-config/` - used by 9 daemon boot modules (Phase 4)
+- `opennms-dao/`, `opennms-dao-api/` - DAO interfaces still consumed
+- `opennms-config-model/`, `opennms-config-api/`, `opennms-config-jaxb/` - config model classes
+- `<packaging>bundle</packaging>` in POMs - Phase 2
+- `maven-bundle-plugin` declarations - Phase 2
+- All `core/` modules
+- All `features/` modules that are compile dependencies of daemon boot modules
+
+### Verification
+
+1. **Compile**: `make build` succeeds (all modules in reactor still compile)
+2. **Assemble**: `build.sh deltav` produces all 12 daemon boot JARs
+3. **Deploy**: `deploy.sh up full` - all 12 containers start, pass `/actuator/health`
+4. **E2E tests**: Run all 6 E2E test suites (trapd, alarmd, pollerd, collectd, enlinkd, provisiond) to catch runtime transitive dependency failures
+5. **Transitive dependency audit**: Run `mvn dependency:tree` on all daemon-boot modules before and after, diff output to confirm no resolved artifacts were lost
+
+If an E2E test fails due to a missing transitive dependency from a deleted module, **replace the dependency** rather than keeping the deleted module.
+
+---
+
+## Phase 2: Convert Bundle to Jar Packaging (High Level)
+
+Convert 1,028 POMs from `<packaging>bundle</packaging>` to `<packaging>jar</packaging>`. Remove `maven-bundle-plugin` declarations. This is a scripted, mechanical change.
+
+The OSGi manifests generated by the bundle plugin are not consumed by any runtime. Spring Boot fat JARs ignore them.
+
+Verification: same as Phase 1 (compile, assemble, deploy, E2E).
+
+Detailed spec written when Phase 1 is complete.
+
+---
+
+## Phase 3: Eliminate opennms-model (High Level)
+
+28 entity classes exist in `core/opennms-model-jakarta`. 6 classes in model-jakarta still require opennms-model at compile time for types not yet in model-api: `EventBuilder`, `NodeLabelChangedEventBuilder`, `AlarmSummary`, `SituationSummary`, `HeatMapElement`, `OnmsCriteria`.
+
+Steps:
+1. Move remaining needed types to model-api (lightweight, no JPA)
+2. Remove opennms-model compile dependency from model-jakarta
+3. Remove opennms-model compile dependency from daemon-common
+4. Delete `opennms-model/` entirely
+
+Detailed spec written when Phase 2 is complete.
+
+---
+
+## Phase 4: Eliminate opennms-config (High Level)
+
+21 factory/config classes from opennms-config are used across 9 daemon boot modules. Each gets replaced according to the config strategy:
+
+- `SnmpPeerFactory` (5 daemons) - file-based XML reader in daemon-common
+- `PollerConfigFactory` (2 daemons) - file-based XML reader
+- `CollectdConfigFactory` + data collection configs (1 daemon) - file-based XML readers
+- Per-daemon configs (syslogd, trapd, discovery, enlinkd, etc.) - `@Value` properties or file-based readers
+
+Each daemon's config replacement is an independent PR. After all consumers are migrated, delete `opennms-config/`.
+
+The Karaf-era `EventConfInitializer` in `core/event-forwarder-kafka` is dead code (replaced by `KafkaEventTransportConfiguration` in daemon-common). Delete it as part of this phase.
+
+Detailed spec written when Phase 2 is complete.


### PR DESCRIPTION
## Summary

- **DaemonEventConfDao**: Replace `DefaultEventConfDao` (from `opennms-config`) with a lightweight `DaemonEventConfDao` that uses `Events` from `opennms-config-model` directly. Eliminates the transitive `opennms-model` dependency that caused `ClassNotFoundException` at runtime in all 12 daemon boot JARs.
- **PrimaryType in model-api**: Copy `PrimaryType` to `core/opennms-model-api` (stripped of JPA annotations) so `PrimaryTypeConverter` in `model-jakarta` can resolve it without `opennms-model`.
- **OnmsAssetRecord in PersistenceManagedTypes**: Add `OnmsAssetRecord` to 7 daemon JPA configs. Hibernate 7 requires all `@OneToOne`/`@ManyToOne` targets to be in the persistence unit.
- **LldpLinkDaoJpa InetAddress fix**: Parse `portId` String to `InetAddress` before the IP interface query. Hibernate 7 enforces strict parameter type checking.

## Test plan

- [ ] Clean `.m2/repository/org/opennms` SNAPSHOT artifacts
- [ ] `make build` — full compile succeeds
- [ ] Build all 12 daemon boot JARs (`build.sh deltav`)
- [ ] Docker deploy: all 12 daemons start and report healthy via `/actuator/health`
- [ ] Run E2E tests: trapd, alarmd, pollerd, collectd, enlinkd, provisiond
- [ ] Verify event enrichment: alarm reduction keys contain expanded parameter values