### PR TITLE
refactor: replace JaxbUtils with Jackson XmlMapper in DaemonEventConfDao

### DIFF
--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -83,6 +83,16 @@
                 <artifactId>jackson-module-parameter-names</artifactId>
                 <version>2.19.4</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>2.19.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <version>2.19.4</version>
+            </dependency>
             <!-- Pin jboss-logging 3.6.1.Final — parent POM manages 3.5.3 which
                  lacks Logger.getMessageLogger(MethodHandles.Lookup,...) required
                  by Hibernate 7 / Spring Boot 4 -->
@@ -158,6 +168,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- Jackson XML — replaces JaxbUtils for eventconf XML deserialization.
+             jackson-module-jaxb-annotations reads existing javax.xml.bind
+             annotations on opennms-config-model Event class. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
         </dependency>
 
         <!-- Database -->

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonEventConfDao.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/DaemonEventConfDao.java
@@ -21,13 +21,15 @@
  */
 package org.opennms.core.daemon.common;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.opennms.core.xml.JaxbUtils;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
 import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.model.EventConfEvent;
 import org.opennms.netmgt.xml.eventconf.Event;
@@ -54,6 +56,14 @@ import org.slf4j.LoggerFactory;
 public class DaemonEventConfDao implements EventConfDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(DaemonEventConfDao.class);
+
+    private static final XmlMapper XML_MAPPER;
+    static {
+        XML_MAPPER = new XmlMapper();
+        XML_MAPPER.registerModule(new JaxbAnnotationModule());
+        XML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        XML_MAPPER.setDefaultUseWrapper(false);
+    }
 
     private volatile Events events;
 
@@ -100,11 +110,7 @@ public class DaemonEventConfDao implements EventConfDao {
                 String xmlContent = dbEvent.getXmlContent();
                 if (xmlContent != null && !xmlContent.trim().isEmpty()) {
                     try {
-                        // TODO: Replace JaxbUtils with Jackson XmlMapper to eliminate
-                        // EclipseLink MOXy class-scanning and javax/jakarta classpath issues.
-                        // JaxbUtils works in the Karaf-era classpath but fails in Spring Boot
-                        // daemons due to ResourceTypeUtils ClassNotFoundException.
-                        Event event = JaxbUtils.unmarshal(Event.class, xmlContent);
+                        Event event = XML_MAPPER.readValue(xmlContent, Event.class);
                         if (event != null) {
                             eventsForSource.addEvent(event);
                         }

--- a/core/daemon-common/src/test/java/org/opennms/core/daemon/common/DaemonEventConfDaoXmlMapperTest.java
+++ b/core/daemon-common/src/test/java/org/opennms/core/daemon/common/DaemonEventConfDaoXmlMapperTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.xml.eventconf.Event;
+import org.opennms.netmgt.xml.eventconf.LogDestType;
+
+class DaemonEventConfDaoXmlMapperTest {
+
+    private static XmlMapper xmlMapper;
+
+    @BeforeAll
+    static void setUp() {
+        xmlMapper = new XmlMapper();
+        xmlMapper.registerModule(new JaxbAnnotationModule());
+        xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        xmlMapper.setDefaultUseWrapper(false);
+    }
+
+    @Test
+    void deserializesBasicEventFields() throws Exception {
+        String xml = """
+                <event xmlns="http://xmlns.opennms.org/xsd/eventconf">
+                    <uei>uei.opennms.org/test/sampleEvent</uei>
+                    <event-label>Sample Test Event</event-label>
+                    <descr>A test event description</descr>
+                    <logmsg dest="logndisplay">Test log message</logmsg>
+                    <severity>Warning</severity>
+                </event>
+                """;
+
+        Event event = xmlMapper.readValue(xml, Event.class);
+
+        assertThat(event.getUei()).isEqualTo("uei.opennms.org/test/sampleEvent");
+        assertThat(event.getEventLabel()).isEqualTo("Sample Test Event");
+        assertThat(event.getDescr()).isEqualTo("A test event description");
+        assertThat(event.getSeverity()).isEqualTo("Warning");
+        assertThat(event.getLogmsg()).isNotNull();
+        assertThat(event.getLogmsg().getContent()).isEqualTo("Test log message");
+        assertThat(event.getLogmsg().getDest()).isEqualTo(LogDestType.LOGNDISPLAY);
+    }
+
+    @Test
+    void deserializesEventWithoutNamespace() throws Exception {
+        String xml = """
+                <event>
+                    <uei>uei.opennms.org/test/noNamespace</uei>
+                    <event-label>No Namespace Event</event-label>
+                    <descr>Event without XML namespace</descr>
+                    <logmsg dest="logonly">Namespace-free log message</logmsg>
+                    <severity>Minor</severity>
+                </event>
+                """;
+
+        Event event = xmlMapper.readValue(xml, Event.class);
+
+        assertThat(event.getUei()).isEqualTo("uei.opennms.org/test/noNamespace");
+        assertThat(event.getEventLabel()).isEqualTo("No Namespace Event");
+        assertThat(event.getSeverity()).isEqualTo("Minor");
+        assertThat(event.getLogmsg().getDest()).isEqualTo(LogDestType.LOGONLY);
+    }
+
+    @Test
+    void deserializesAlarmData() throws Exception {
+        String xml = """
+                <event xmlns="http://xmlns.opennms.org/xsd/eventconf">
+                    <uei>uei.opennms.org/test/alarmEvent</uei>
+                    <event-label>Alarm Test Event</event-label>
+                    <descr>Event with alarm data</descr>
+                    <logmsg dest="logndisplay">Alarm log message</logmsg>
+                    <severity>Major</severity>
+                    <alarm-data reduction-key="%uei%:%dpname%:%nodeid%" alarm-type="1" auto-clean="false"/>
+                </event>
+                """;
+
+        Event event = xmlMapper.readValue(xml, Event.class);
+
+        assertThat(event.getUei()).isEqualTo("uei.opennms.org/test/alarmEvent");
+        assertThat(event.getSeverity()).isEqualTo("Major");
+        assertThat(event.getAlarmData()).isNotNull();
+        assertThat(event.getAlarmData().getReductionKey()).isEqualTo("%uei%:%dpname%:%nodeid%");
+        assertThat(event.getAlarmData().getAlarmType()).isEqualTo(1);
+        assertThat(event.getAlarmData().getAutoClean()).isFalse();
+    }
+
+    @Test
+    void deserializesAlarmDataWithClearKey() throws Exception {
+        String xml = """
+                <event xmlns="http://xmlns.opennms.org/xsd/eventconf">
+                    <uei>uei.opennms.org/test/resolveEvent</uei>
+                    <event-label>Resolution Event</event-label>
+                    <descr>Resolution event with clear key</descr>
+                    <logmsg dest="logndisplay">Resolved</logmsg>
+                    <severity>Normal</severity>
+                    <alarm-data reduction-key="%uei%:%dpname%:%nodeid%"
+                                clear-key="uei.opennms.org/test/alarmEvent:%dpname%:%nodeid%"
+                                alarm-type="2"/>
+                </event>
+                """;
+
+        Event event = xmlMapper.readValue(xml, Event.class);
+
+        assertThat(event.getAlarmData()).isNotNull();
+        assertThat(event.getAlarmData().getAlarmType()).isEqualTo(2);
+        assertThat(event.getAlarmData().getClearKey())
+                .isEqualTo("uei.opennms.org/test/alarmEvent:%dpname%:%nodeid%");
+    }
+
+    @Test
+    void deserializesEventWithMask() throws Exception {
+        String xml = """
+                <event xmlns="http://xmlns.opennms.org/xsd/eventconf">
+                    <mask>
+                        <maskelement>
+                            <mename>id</mename>
+                            <mevalue>.1.3.6.1.4.1.9</mevalue>
+                        </maskelement>
+                        <maskelement>
+                            <mename>generic</mename>
+                            <mevalue>6</mevalue>
+                        </maskelement>
+                        <maskelement>
+                            <mename>specific</mename>
+                            <mevalue>1</mevalue>
+                        </maskelement>
+                    </mask>
+                    <uei>uei.opennms.org/test/maskedEvent</uei>
+                    <event-label>Masked Event</event-label>
+                    <descr>Event with mask elements</descr>
+                    <logmsg dest="logndisplay">Masked event</logmsg>
+                    <severity>Warning</severity>
+                </event>
+                """;
+
+        Event event = xmlMapper.readValue(xml, Event.class);
+
+        assertThat(event.getUei()).isEqualTo("uei.opennms.org/test/maskedEvent");
+        assertThat(event.getMask()).isNotNull();
+        assertThat(event.getMask().getMaskelements()).isNotEmpty();
+    }
+
+    @Test
+    void ignoresUnknownElements() throws Exception {
+        String xml = """
+                <event xmlns="http://xmlns.opennms.org/xsd/eventconf">
+                    <uei>uei.opennms.org/test/unknownFields</uei>
+                    <event-label>Unknown Fields Event</event-label>
+                    <descr>Event with unknown elements</descr>
+                    <logmsg dest="logndisplay">Test</logmsg>
+                    <severity>Indeterminate</severity>
+                    <totally-unknown-element>should be ignored</totally-unknown-element>
+                </event>
+                """;
+
+        Event event = xmlMapper.readValue(xml, Event.class);
+
+        assertThat(event.getUei()).isEqualTo("uei.opennms.org/test/unknownFields");
+        assertThat(event.getSeverity()).isEqualTo("Indeterminate");
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `JaxbUtils.unmarshal()` with Jackson `XmlMapper` in `DaemonEventConfDao` to eliminate EclipseLink MOXy class-scanning that triggers `ClassNotFoundException` for `opennms-model` types not on the Spring Boot daemon classpath
- Add `jackson-dataformat-xml` and `jackson-module-jaxb-annotations` dependencies (pinned at 2.19.4) to daemon-common POM
- Configure XmlMapper with `JaxbAnnotationModule` (reads existing `javax.xml.bind` annotations), `FAIL_ON_UNKNOWN_PROPERTIES=false`, and `setDefaultUseWrapper(false)` for JAXB-compatible unwrapped list handling
- Add 6 unit tests covering basic fields, namespaced/non-namespaced XML, alarm-data, mask with nested lists, and unknown element tolerance

## Test plan

- [x] 6 new unit tests pass (`DaemonEventConfDaoXmlMapperTest`)
- [x] All existing daemon-common tests pass (2 pre-existing failures unrelated)
- [x] `daemon-boot-alarmd` compiles with changes
- [ ] `make build` full compile
- [ ] Docker E2E: `build.sh deltav` + `deploy.sh up full` + health check all 12 daemons