### PR TITLE
refactor: replace DiscoveryConfigFactory XML loading with Jackson XmlMapper — Phase 4

### DIFF
--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -271,7 +271,7 @@
             <version>${opentracingVersion}</version>
         </dependency>
 
-        <!-- EventConfDao + DefaultEventConfDao (event matching) -->
+        <!-- DiscoveryConfigurationFactory interface + config model -->
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-config-api</artifactId>
@@ -282,6 +282,16 @@
                 <exclusion><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- Jackson XmlMapper with JAXB annotation support -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>

--- a/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
+++ b/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
@@ -1,14 +1,22 @@
 package org.opennms.netmgt.discovery.boot;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import javax.sql.DataSource;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
 import org.opennms.core.daemon.common.SpringServiceDaemonSmartLifecycle;
 import org.opennms.core.daemon.common.JdbcDistPollerDao;
 import org.opennms.core.daemon.common.JdbcInterfaceToNodeCache;
 import org.opennms.netmgt.config.DiscoveryConfigFactory;
+import org.opennms.netmgt.config.api.DiscoveryConfigurationFactory;
+import org.opennms.netmgt.config.discovery.DiscoveryConfiguration;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 import org.opennms.netmgt.discovery.Discovery;
@@ -25,7 +33,10 @@ import org.opennms.netmgt.provision.LocationAwareDetectorClient;
 import org.opennms.netmgt.provision.detector.client.rpc.DetectorClientRpcModule;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.provision.detector.client.rpc.LocationAwareDetectorClientRpcImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,6 +48,15 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class DiscoveryBootConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DiscoveryBootConfiguration.class);
+
+    private static final XmlMapper XML_MAPPER;
+    static {
+        XML_MAPPER = new XmlMapper();
+        XML_MAPPER.registerModule(new JaxbAnnotationModule());
+        XML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
 
     // -- DAO / Cache --
 
@@ -53,12 +73,21 @@ public class DiscoveryBootConfiguration {
     // -- Discovery Config --
 
     /**
-     * Reads discovery-configuration.xml from ${opennms.home}/etc/.
-     * The Docker overlay MUST include this file or startup will fail with IOException.
+     * Reads discovery-configuration.xml via Jackson XmlMapper, then wraps the
+     * deserialized model in {@link DiscoveryConfigFactory} for backward
+     * compatibility with feature-module code that still references the concrete
+     * class (RangeChunker, DiscoveryTaskExecutorImpl).
      */
     @Bean
-    public DiscoveryConfigFactory discoveryConfigFactory() throws Exception {
-        return new DiscoveryConfigFactory();
+    public DiscoveryConfigurationFactory discoveryConfigFactory(
+            @Value("${opennms.home}") String opennmsHome) throws IOException {
+        var configFile = new File(opennmsHome, "etc/discovery-configuration.xml");
+        if (!configFile.exists()) {
+            throw new IOException("discovery-configuration.xml not found at " + configFile);
+        }
+        LOG.info("Loading discovery configuration from {}", configFile);
+        var model = XML_MAPPER.readValue(configFile, DiscoveryConfiguration.class);
+        return new DiscoveryConfigFactory(model);
     }
 
     // -- ICMP Ping RPC --
@@ -128,7 +157,7 @@ public class DiscoveryBootConfiguration {
     }
 
     @Bean
-    public Discovery discovery(DiscoveryConfigFactory discoveryConfigFactory,
+    public Discovery discovery(DiscoveryConfigurationFactory discoveryConfigFactory,
                                DiscoveryTaskExecutorImpl discoveryTaskExecutor,
                                @Qualifier("eventIpcManager") EventForwarder eventForwarder) {
         return new Discovery(discoveryConfigFactory, discoveryTaskExecutor, eventForwarder);

--- a/features/discovery/src/main/java/org/opennms/netmgt/discovery/Discovery.java
+++ b/features/discovery/src/main/java/org/opennms/netmgt/discovery/Discovery.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import org.opennms.netmgt.config.DiscoveryConfigFactory;
+import org.opennms.netmgt.config.api.DiscoveryConfigurationFactory;
 import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
@@ -52,7 +52,7 @@ public class Discovery extends AbstractServiceDaemon {
     protected static final String LOG4J_CATEGORY = "discovery";
 
     @Autowired
-    private DiscoveryConfigFactory m_discoveryFactory;
+    private DiscoveryConfigurationFactory m_discoveryFactory;
 
     @Autowired
     private DiscoveryTaskExecutor m_discoveryTaskExecutor;
@@ -63,7 +63,7 @@ public class Discovery extends AbstractServiceDaemon {
 
     private Timer discoveryTimer;
 
-    public Discovery(DiscoveryConfigFactory discoveryConfigFactory,
+    public Discovery(DiscoveryConfigurationFactory discoveryConfigFactory,
                      DiscoveryTaskExecutor discoveryTaskExecutor,
                      EventForwarder eventForwarder) {
         super(LOG4J_CATEGORY);
@@ -182,7 +182,7 @@ public class Discovery extends AbstractServiceDaemon {
     }
 
     /** @deprecated Legacy setter for Karaf XML context. Use constructor injection. */
-    public void setDiscoveryFactory(DiscoveryConfigFactory discoveryFactory) {
+    public void setDiscoveryFactory(DiscoveryConfigurationFactory discoveryFactory) {
         m_discoveryFactory = discoveryFactory;
     }
 

--- a/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/DiscoveryConfigurationFactory.java
+++ b/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/DiscoveryConfigurationFactory.java
@@ -21,6 +21,7 @@
  */
 package org.opennms.netmgt.config.api;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Iterator;
 import java.util.List;
@@ -122,4 +123,13 @@ public interface DiscoveryConfigurationFactory {
 	 * @return a long
 	 */
 	long getInitialSleepTime();
+
+	/**
+	 * Reload configuration from disk.
+	 *
+	 * @throws IOException if the configuration cannot be read
+	 */
+	default void reload() throws IOException {
+		// Default no-op — Spring Boot daemons load config at bean creation time.
+	}
 }


### PR DESCRIPTION
## Summary
- Widen `Discovery` daemon from concrete `DiscoveryConfigFactory` to `DiscoveryConfigurationFactory` (interface) — backward-compatible type widening
- Add `reload()` as a default method on the `DiscoveryConfigurationFactory` interface
- Boot module loads `discovery-configuration.xml` via Jackson XmlMapper, then wraps model in `DiscoveryConfigFactory(model)` for feature-module compatibility
- Add Jackson XML dependencies (`jackson-dataformat-xml`, `jackson-module-jaxb-annotations`)

**Note:** `opennms-config` dependency is retained because the feature module (`RangeChunker`, `DiscoveryTaskExecutorImpl`) still creates `new DiscoveryConfigFactory(config)` internally. Full decoupling requires moving `DiscoveryConfigFactory` to `features/discovery` (tracked for a future PR).

## Test plan
- [x] `make build` — daemon-boot-discovery, features/discovery, opennms-config-api all compile
- [ ] `build.sh deltav` — all 12 daemon boot JARs build successfully
- [ ] `deploy.sh up full` — discovery container starts and passes /actuator/health
- [ ] E2E: discovery scan runs on configured ranges