### PR TITLE
refactor: decouple DatabaseSchemaConfigFactory and CollectdConfigFactory from opennms-config

### DIFF
--- a/core/daemon-boot-collectd/src/main/java/org/opennms/netmgt/collectd/boot/CollectdDaemonConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/opennms/netmgt/collectd/boot/CollectdDaemonConfiguration.java
@@ -39,7 +39,10 @@ import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.opennms.netmgt.collectd.Collectd;
 import org.opennms.netmgt.collectd.DefaultResourceTypeMapper;
 import org.opennms.netmgt.collectd.DefaultSnmpCollectionAgentFactory;
-import org.opennms.netmgt.config.CollectdConfigFactory;
+import org.opennms.netmgt.config.api.CollectdConfigFactory;
+import org.opennms.netmgt.config.api.DefaultCollectdConfigFactory;
+import org.opennms.netmgt.config.collectd.CollectdConfiguration;
+import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.config.DataCollectionConfigFactory;
 import org.opennms.netmgt.config.DefaultDataCollectionConfigDao;
 import org.opennms.netmgt.config.DefaultResourceTypesDao;
@@ -119,17 +122,19 @@ public class CollectdDaemonConfiguration {
     // ===================================================================
 
     /**
-     * Loads collectd-configuration.xml via the singleton CollectdConfigFactory.
+     * Loads collectd-configuration.xml via Jackson XmlMapper and creates a
+     * {@link DefaultCollectdConfigFactory} with injected FilterDao.
      *
      * <p>Must run after FilterDaoFactory initialization because
-     * {@code CollectdConfigFactory} validates filter rules against
-     * {@code FilterDaoFactory.getInstance()}.</p>
+     * filter evaluation in package matching requires an active FilterDao.</p>
      */
     @Bean
     @DependsOn("filterDaoInitializer")
-    public CollectdConfigFactory collectdConfigFactory() throws IOException {
-        LOG.info("Initializing CollectdConfigFactory");
-        return new CollectdConfigFactory();
+    public CollectdConfigFactory collectdConfigFactory(FilterDao filterDao) throws IOException {
+        var configFile = new File(opennmsHome, "etc/collectd-configuration.xml");
+        LOG.info("Loading CollectdConfigFactory from {}", configFile);
+        var config = XML_MAPPER.readValue(configFile, CollectdConfiguration.class);
+        return new DefaultCollectdConfigFactory(config, filterDao);
     }
 
     /**

--- a/core/daemon-boot-collectd/src/main/java/org/opennms/netmgt/collectd/boot/CollectdJpaConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/opennms/netmgt/collectd/boot/CollectdJpaConfiguration.java
@@ -21,11 +21,18 @@
  */
 package org.opennms.netmgt.collectd.boot;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import javax.sql.DataSource;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
 import org.opennms.core.tsid.TsidFactory;
-import org.opennms.netmgt.config.DatabaseSchemaConfigFactory;
+import org.opennms.netmgt.config.api.DefaultDatabaseSchemaConfig;
+import org.opennms.netmgt.config.filter.DatabaseSchema;
 import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.filter.FilterDaoFactory;
@@ -79,6 +86,13 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class CollectdJpaConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(CollectdJpaConfiguration.class);
+
+    private static final XmlMapper XML_MAPPER;
+    static {
+        XML_MAPPER = XmlMapper.builder().defaultUseWrapper(false).build();
+        XML_MAPPER.registerModule(new JaxbAnnotationModule());
+        XML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
 
     // ===================================================================
     // Section 1: JPA / Naming
@@ -187,15 +201,20 @@ public class CollectdJpaConfiguration {
         LOG.info("Initializing FilterDaoFactory with JdbcFilterDao");
         var jdbcFilterDao = new JdbcFilterDao();
         jdbcFilterDao.setDataSource(dataSource);
-        try {
-            DatabaseSchemaConfigFactory.init();
-        } catch (Exception e) {
-            throw new RuntimeException("Could not initialize DatabaseSchemaConfigFactory", e);
-        }
-        jdbcFilterDao.setDatabaseSchemaConfigFactory(DatabaseSchemaConfigFactory.getInstance());
+        var schemaConfig = loadDatabaseSchemaConfig();
+        jdbcFilterDao.setDatabaseSchemaConfigFactory(schemaConfig);
         jdbcFilterDao.afterPropertiesSet();
         FilterDaoFactory.setInstance(jdbcFilterDao);
         return jdbcFilterDao;
+    }
+
+    private DefaultDatabaseSchemaConfig loadDatabaseSchemaConfig() {
+        try (var is = getClass().getResourceAsStream("/database-schema.xml")) {
+            var schema = XML_MAPPER.readValue(is, DatabaseSchema.class);
+            return new DefaultDatabaseSchemaConfig(schema);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load database-schema.xml from classpath", e);
+        }
     }
 
     // ===================================================================

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdJpaConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdJpaConfiguration.java
@@ -21,8 +21,14 @@
  */
 package org.opennms.netmgt.perspectivepoller.boot;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import javax.sql.DataSource;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
 import org.opennms.netmgt.collection.api.AttributeGroup;
 import org.opennms.netmgt.collection.api.CollectionAgentFactory;
@@ -32,7 +38,8 @@ import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.Persister;
 import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.opennms.netmgt.collection.api.ServiceParameters;
-import org.opennms.netmgt.config.DatabaseSchemaConfigFactory;
+import org.opennms.netmgt.config.api.DefaultDatabaseSchemaConfig;
+import org.opennms.netmgt.config.filter.DatabaseSchema;
 import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.filter.FilterDaoFactory;
@@ -86,6 +93,13 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class PerspectivePollerdJpaConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(PerspectivePollerdJpaConfiguration.class);
+
+    private static final XmlMapper XML_MAPPER;
+    static {
+        XML_MAPPER = XmlMapper.builder().defaultUseWrapper(false).build();
+        XML_MAPPER.registerModule(new JaxbAnnotationModule());
+        XML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
 
     // ===================================================================
     // Section 1: JPA / Naming
@@ -187,15 +201,20 @@ public class PerspectivePollerdJpaConfiguration {
         LOG.info("Initializing FilterDaoFactory with JdbcFilterDao");
         var jdbcFilterDao = new JdbcFilterDao();
         jdbcFilterDao.setDataSource(dataSource);
-        try {
-            DatabaseSchemaConfigFactory.init();
-        } catch (Exception e) {
-            throw new RuntimeException("Could not initialize DatabaseSchemaConfigFactory", e);
-        }
-        jdbcFilterDao.setDatabaseSchemaConfigFactory(DatabaseSchemaConfigFactory.getInstance());
+        var schemaConfig = loadDatabaseSchemaConfig();
+        jdbcFilterDao.setDatabaseSchemaConfigFactory(schemaConfig);
         jdbcFilterDao.afterPropertiesSet();
         FilterDaoFactory.setInstance(jdbcFilterDao);
         return jdbcFilterDao;
+    }
+
+    private DefaultDatabaseSchemaConfig loadDatabaseSchemaConfig() {
+        try (var is = getClass().getResourceAsStream("/database-schema.xml")) {
+            var schema = XML_MAPPER.readValue(is, DatabaseSchema.class);
+            return new DefaultDatabaseSchemaConfig(schema);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load database-schema.xml from classpath", e);
+        }
     }
 
     // ===================================================================

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdJpaConfiguration.java
@@ -21,8 +21,14 @@
  */
 package org.opennms.netmgt.poller.boot;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import javax.sql.DataSource;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
 import org.opennms.core.tsid.TsidFactory;
 import org.opennms.netmgt.collection.api.AttributeGroup;
@@ -32,7 +38,8 @@ import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.Persister;
 import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.opennms.netmgt.collection.api.ServiceParameters;
-import org.opennms.netmgt.config.DatabaseSchemaConfigFactory;
+import org.opennms.netmgt.config.api.DefaultDatabaseSchemaConfig;
+import org.opennms.netmgt.config.filter.DatabaseSchema;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -94,6 +101,13 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class PollerdJpaConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(PollerdJpaConfiguration.class);
+
+    private static final XmlMapper XML_MAPPER;
+    static {
+        XML_MAPPER = XmlMapper.builder().defaultUseWrapper(false).build();
+        XML_MAPPER.registerModule(new JaxbAnnotationModule());
+        XML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
 
     // ===================================================================
     // Section 1: JPA / Naming
@@ -197,15 +211,20 @@ public class PollerdJpaConfiguration {
         LOG.info("Initializing FilterDaoFactory with JdbcFilterDao");
         var jdbcFilterDao = new JdbcFilterDao();
         jdbcFilterDao.setDataSource(dataSource);
-        try {
-            DatabaseSchemaConfigFactory.init();
-        } catch (Exception e) {
-            throw new RuntimeException("Could not initialize DatabaseSchemaConfigFactory", e);
-        }
-        jdbcFilterDao.setDatabaseSchemaConfigFactory(DatabaseSchemaConfigFactory.getInstance());
+        var schemaConfig = loadDatabaseSchemaConfig();
+        jdbcFilterDao.setDatabaseSchemaConfigFactory(schemaConfig);
         jdbcFilterDao.afterPropertiesSet();
         FilterDaoFactory.setInstance(jdbcFilterDao);
         return jdbcFilterDao;
+    }
+
+    private DefaultDatabaseSchemaConfig loadDatabaseSchemaConfig() {
+        try (var is = getClass().getResourceAsStream("/database-schema.xml")) {
+            var schema = XML_MAPPER.readValue(is, DatabaseSchema.class);
+            return new DefaultDatabaseSchemaConfig(schema);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load database-schema.xml from classpath", e);
+        }
     }
 
     // ===================================================================

--- a/features/collection/core/src/main/java/org/opennms/netmgt/collection/core/CollectionSpecification.java
+++ b/features/collection/core/src/main/java/org/opennms/netmgt/collection/core/CollectionSpecification.java
@@ -50,7 +50,7 @@ import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
 import org.opennms.netmgt.collection.api.ServiceCollector;
 import org.opennms.netmgt.collection.api.ServiceParameters;
 import org.opennms.netmgt.collection.api.ServiceParameters.ParameterName;
-import org.opennms.netmgt.config.CollectdConfigFactory;
+import org.opennms.netmgt.config.api.CollectdConfigFactory;
 import org.opennms.netmgt.config.collectd.Package;
 import org.opennms.netmgt.config.collectd.Parameter;
 import org.opennms.netmgt.config.collectd.Service;

--- a/features/collection/impl/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/features/collection/impl/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -50,7 +50,7 @@ import org.opennms.netmgt.collection.support.CollectionAttributeWrapper;
 import org.opennms.netmgt.collection.support.CollectionResourceWrapper;
 import org.opennms.netmgt.collection.support.CollectionSetVisitorWrapper;
 import org.opennms.netmgt.collection.support.ConstantTimeKeeper;
-import org.opennms.netmgt.config.CollectdConfigFactory;
+import org.opennms.netmgt.config.api.CollectdConfigFactory;
 import org.opennms.netmgt.config.DataCollectionConfigFactory;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.events.api.EventConstants;

--- a/features/collection/impl/src/main/java/org/opennms/netmgt/collectd/Collectd.java
+++ b/features/collection/impl/src/main/java/org/opennms/netmgt/collectd/Collectd.java
@@ -59,7 +59,7 @@ import org.opennms.netmgt.collection.api.ServiceCollector;
 import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
 import org.opennms.netmgt.collection.core.CollectionSpecification;
 import org.opennms.netmgt.collection.core.DefaultCollectdInstrumentation;
-import org.opennms.netmgt.config.CollectdConfigFactory;
+import org.opennms.netmgt.config.api.CollectdConfigFactory;
 import org.opennms.netmgt.config.DataCollectionConfigFactory;
 import org.opennms.netmgt.config.SnmpEventInfo;
 import org.opennms.netmgt.config.SnmpPeerFactory;

--- a/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/DefaultCollectdConfigFactory.java
+++ b/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/DefaultCollectdConfigFactory.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.config.api;
+
+import static org.opennms.core.utils.InetAddressUtils.addr;
+import static org.opennms.core.utils.InetAddressUtils.toIpAddrBytes;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.opennms.netmgt.config.collectd.CollectdConfiguration;
+import org.opennms.netmgt.config.collectd.Collector;
+import org.opennms.netmgt.config.collectd.Package;
+import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link CollectdConfigFactory} that works with
+ * a pre-loaded {@link CollectdConfiguration} model object and an injected
+ * {@link FilterDao}.
+ *
+ * <p>This class replaces the need for daemon-boot modules to depend on
+ * the opennms-config singleton factory. The configuration model can be
+ * loaded via Jackson XmlMapper or any other means, then passed to this
+ * constructor along with a FilterDao for filter evaluation.</p>
+ *
+ * <p>The {@code reload()} and {@code saveCurrent()} operations are not
+ * supported in this implementation — daemon-boot modules load config once
+ * at startup and do not write changes back to disk.</p>
+ */
+public class DefaultCollectdConfigFactory implements CollectdConfigFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultCollectdConfigFactory.class);
+
+    private final CollectdConfiguration localConfig;
+    private final FilterDao filterDao;
+    private final Object mutex = new Object();
+
+    private List<Package> extendedPackages = Collections.emptyList();
+    private List<Collector> extendedCollectors = Collections.emptyList();
+    private List<Package> mergedPackages;
+    private List<Collector> mergedCollectors;
+
+    public DefaultCollectdConfigFactory(final CollectdConfiguration config, final FilterDao filterDao) {
+        this.localConfig = config;
+        this.filterDao = filterDao;
+        rebuildMergedData();
+    }
+
+    private void rebuildMergedData() {
+        synchronized (mutex) {
+            mergedPackages = new ArrayList<>(localConfig.getPackages());
+            mergedPackages.addAll(extendedPackages);
+            mergedCollectors = new ArrayList<>(localConfig.getCollectors());
+            mergedCollectors.addAll(extendedCollectors);
+        }
+    }
+
+    @Override
+    public void reload() throws IOException {
+        LOG.warn("reload() is not supported in DefaultCollectdConfigFactory — config is loaded once at startup");
+    }
+
+    @Override
+    public void saveCurrent() throws IOException {
+        LOG.warn("saveCurrent() is not supported in DefaultCollectdConfigFactory — config changes are not persisted");
+    }
+
+    @Override
+    public CollectdConfiguration getLocalCollectdConfig() {
+        return localConfig;
+    }
+
+    @Override
+    public Integer getThreads() {
+        return localConfig.getThreads();
+    }
+
+    @Override
+    public boolean packageExists(String name) {
+        synchronized (mutex) {
+            for (final Package pkg : mergedPackages) {
+                if (pkg.getName().equals(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public Package getPackage(final String name) {
+        synchronized (mutex) {
+            for (Package pkg : mergedPackages) {
+                if (pkg.getName().equals(name)) {
+                    return pkg;
+                }
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public List<Package> getPackages() {
+        return mergedPackages;
+    }
+
+    @Override
+    public List<Collector> getCollectors() {
+        return mergedCollectors;
+    }
+
+    @Override
+    public boolean domainExists(final String name) {
+        synchronized (mutex) {
+            for (Package pkg : mergedPackages) {
+                if (pkg.getIfAliasDomain() != null && pkg.getIfAliasDomain().equals(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isServiceCollectionEnabled(final OnmsMonitoredService service) {
+        return isServiceCollectionEnabled(service.getIpInterface(), service.getServiceName());
+    }
+
+    @Override
+    public boolean isServiceCollectionEnabled(final OnmsIpInterface iface, final String svcName) {
+        for (Package wpkg : mergedPackages) {
+            if (interfaceInPackage(iface, wpkg)) {
+                if (wpkg.serviceInPackageAndEnabled(svcName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isServiceCollectionEnabled(final String ipAddr, final String svcName) {
+        synchronized (mutex) {
+            for (Package wpkg : mergedPackages) {
+                if (interfaceInPackage(ipAddr, wpkg)) {
+                    if (wpkg.serviceInPackageAndEnabled(svcName)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean interfaceInFilter(String iface, Package pkg) {
+        String filter = pkg.getFilter().getContent();
+        if (iface == null) return false;
+        final InetAddress ifaceAddress = addr(iface);
+
+        LOG.debug("interfaceInFilter: package is {}. filter rules are {}", pkg.getName(), filter);
+        try {
+            final List<InetAddress> ipList = filterDao.getActiveIPAddressList(filter);
+            boolean filterPassed = ipList.contains(ifaceAddress);
+            if (!filterPassed) {
+                LOG.debug("interfaceInFilter: Interface {} passed filter for package {}?: false", iface, pkg.getName());
+            }
+            return filterPassed;
+        } catch (Throwable t) {
+            LOG.error("interfaceInFilter: Failed to map package: {} to an IP List with filter \"{}\"",
+                    pkg.getName(), pkg.getFilter().getContent(), t);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean interfaceInPackage(final String iface, Package pkg) {
+        boolean filterPassed = interfaceInFilter(iface, pkg);
+        if (!filterPassed) {
+            return false;
+        }
+
+        byte[] addr = toIpAddrBytes(iface);
+        boolean hasRangeInclude = pkg.hasIncludeRange(iface);
+        boolean hasSpecific = pkg.hasSpecific(addr);
+        hasSpecific = pkg.hasSpecificUrl(iface, hasSpecific);
+        boolean hasRangeExclude = pkg.hasExcludeRange(iface);
+
+        boolean packagePassed = hasSpecific || (hasRangeInclude && !hasRangeExclude);
+        if (packagePassed) {
+            LOG.info("interfaceInPackage: Interface {} passed filter and specific/range for package {}?: {}",
+                    iface, pkg.getName(), true);
+        } else {
+            LOG.debug("interfaceInPackage: Interface {} passed filter and specific/range for package {}?: {}",
+                    iface, pkg.getName(), false);
+        }
+        return packagePassed;
+    }
+
+    @Override
+    public boolean interfaceInPackage(final OnmsIpInterface iface, Package pkg) {
+        return interfaceInPackage(iface.getIpAddressAsString(), pkg);
+    }
+
+    @Override
+    public void setExternalData(final List<Package> packages, final List<Collector> collectors) {
+        synchronized (mutex) {
+            this.extendedPackages = packages;
+            this.extendedCollectors = collectors;
+            rebuildMergedData();
+        }
+    }
+}

--- a/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/DefaultDatabaseSchemaConfig.java
+++ b/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/DefaultDatabaseSchemaConfig.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.config.api;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.opennms.netmgt.config.filter.Column;
+import org.opennms.netmgt.config.filter.DatabaseSchema;
+import org.opennms.netmgt.config.filter.Join;
+import org.opennms.netmgt.config.filter.Table;
+import org.opennms.netmgt.filter.api.FilterParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link DatabaseSchemaConfig} that works with
+ * a pre-loaded {@link DatabaseSchema} model object.
+ *
+ * <p>This class replaces the need for daemon-boot modules to depend on
+ * {@code DatabaseSchemaConfigFactory} in opennms-config. The schema model
+ * can be loaded via Jackson XmlMapper or any other means, then passed to
+ * this constructor.</p>
+ *
+ * <p>Instances are immutable after construction — the join graph is computed
+ * once in the constructor and never modified.</p>
+ */
+public class DefaultDatabaseSchemaConfig implements DatabaseSchemaConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultDatabaseSchemaConfig.class);
+
+    private final DatabaseSchema config;
+    private final Map<String, Join> primaryJoins;
+
+    public DefaultDatabaseSchemaConfig(final DatabaseSchema config) {
+        this.config = config;
+        this.primaryJoins = buildPrimaryJoins(config);
+    }
+
+    private Map<String, Join> buildPrimaryJoins(final DatabaseSchema schema) {
+        final Map<String, Join> joins = new ConcurrentHashMap<>();
+        final Table primaryTable = findPrimaryTable(schema);
+        if (primaryTable == null) {
+            LOG.warn("No primary table found in database-schema configuration");
+            return joins;
+        }
+
+        Set<String> joinableSet = new HashSet<>();
+        joinableSet.add(primaryTable.getName());
+
+        int joinableCount = 0;
+        while (joinableCount < joinableSet.size()) {
+            joinableCount = joinableSet.size();
+            final Set<String> newSet = new HashSet<>(joinableSet);
+            for (final Table t : schema.getTables()) {
+                if (!joinableSet.contains(t.getName())
+                        && (t.getVisible() == null || t.getVisible().equalsIgnoreCase("true"))) {
+                    for (final Join j : t.getJoins()) {
+                        if (joinableSet.contains(j.getTable())) {
+                            newSet.add(t.getName());
+                            joins.put(t.getName(), j);
+                        }
+                    }
+                }
+            }
+            joinableSet = newSet;
+        }
+        return joins;
+    }
+
+    private static Table findPrimaryTable(final DatabaseSchema schema) {
+        for (final Table t : schema.getTables()) {
+            if ((t.getVisible() == null || t.getVisible().equalsIgnoreCase("true"))
+                    && t.getKey() != null && t.getKey().equals("primary")) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public DatabaseSchema getDatabaseSchema() {
+        return config;
+    }
+
+    @Override
+    public Table getPrimaryTable() {
+        return findPrimaryTable(config);
+    }
+
+    @Override
+    public Table getTableByName(final String name) {
+        for (final Table t : config.getTables()) {
+            if ((t.getVisible() == null || t.getVisible().equalsIgnoreCase("true"))
+                    && t.getName() != null && t.getName().equals(name)) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Table findTableByVisibleColumn(final String colName) {
+        for (final Table t : config.getTables()) {
+            for (final Column col : t.getColumns()) {
+                if ((col.getVisible() == null || col.getVisible().equalsIgnoreCase("true"))
+                        && col.getName().equalsIgnoreCase(colName)) {
+                    return t;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public int getTableCount() {
+        return config.getTables().size();
+    }
+
+    @Override
+    public List<String> getJoinTables(final List<Table> tables) {
+        final List<String> joinedTables = new ArrayList<>();
+        for (int i = 0; i < tables.size(); i++) {
+            final int insertPosition = joinedTables.size();
+            String currentTable = tables.get(i).getName();
+            while (currentTable != null && !joinedTables.contains(currentTable)) {
+                joinedTables.add(insertPosition, currentTable);
+                final Join next = primaryJoins.get(currentTable);
+                if (next != null) {
+                    currentTable = next.getTable();
+                } else {
+                    currentTable = null;
+                }
+            }
+        }
+        return joinedTables;
+    }
+
+    @Override
+    public String constructJoinExprForTables(final List<Table> tables) {
+        final StringBuilder joinExpr = new StringBuilder();
+        final List<String> joinTables = getJoinTables(tables);
+        if (joinTables.isEmpty()) {
+            return "";
+        }
+        joinExpr.append(joinTables.get(0));
+        for (int i = 1; i < joinTables.size(); i++) {
+            final Join currentJoin = primaryJoins.get(joinTables.get(i));
+            if (currentJoin.getType() != null && !currentJoin.getType().equalsIgnoreCase("inner")) {
+                joinExpr.append(" ").append(currentJoin.getType().toUpperCase());
+            }
+            joinExpr.append(" JOIN ").append(joinTables.get(i)).append(" ON (");
+            joinExpr.append(currentJoin.getTable()).append(".").append(currentJoin.getTableColumn()).append(" = ");
+            joinExpr.append(joinTables.get(i)).append(".").append(currentJoin.getColumn()).append(")");
+        }
+        return "FROM " + joinExpr;
+    }
+
+    @Override
+    public String addColumn(final List<Table> tables, final String column) throws FilterParseException {
+        final Table table = findTableByVisibleColumn(column);
+        if (table == null) {
+            throw new FilterParseException("Could not find the column '" + column + "' in filter rule");
+        }
+        if (!tables.contains(table)) {
+            tables.add(table);
+        }
+        return table.getName() + "." + column;
+    }
+}


### PR DESCRIPTION
## Summary
- **DatabaseSchemaConfigFactory** decoupled from all 3 JPA daemon-boot modules (pollerd, perspectivepollerd, collectd) — new `DefaultDatabaseSchemaConfig` in config-api loads via Jackson XmlMapper instead of JAXB singleton
- **CollectdConfigFactory** decoupled from daemon-boot-collectd — new `DefaultCollectdConfigFactory` in config-api uses constructor-injected `FilterDao` instead of `FilterDaoFactory.getInstance()` service locator
- `Collectd`, `CollectableService`, `CollectionSpecification` switched from concrete class to `config.api.CollectdConfigFactory` interface

## Context
Karaf removal Phase 4 continuation. Follows the Jackson XmlMapper pattern established in PRs #91 (Trapd), #93 (Syslogd), #95 (EventTranslator), #96 (Discovery), #97 (SnmpPeerFactory).

## What's NOT in this PR
- **PollerConfigFactory** — 1231-line PollerConfigManager with complex filter validation, 45-method interface depending on `features/poller/api` types. Needs dedicated session.
- **opennms-config POM removal** — SnmpPeerFactory class (48 references), FilterDaoFactory, JdbcFilterDao still in opennms-config. POM dep stays for now.

## Test plan
- [x] `opennms-config-api` compiles with new classes
- [x] All 5 daemon-boot modules compile cleanly (pollerd, perspectivepollerd, collectd, enlinkd, provisiond)
- [x] `features/collection/core` and `features/collection/impl` compile with interface import change
- [ ] E2E: Collectd starts and collects SNMP data
- [ ] E2E: Pollerd starts and polls services