### PR TITLE
refactor: exclude opennms-dao from daemon-boot fat JARs (Phase 5a)

### DIFF
--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -231,6 +231,8 @@
                      javax.persistence annotations — the Jakarta version from model-jakarta is used instead -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -244,6 +246,7 @@
                 <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -224,6 +224,8 @@
                      javax.persistence annotations — not needed here (no JPA) -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -279,6 +281,7 @@
                      javax.persistence annotations — not needed here (no JPA) -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -326,6 +329,7 @@
                      javax.persistence annotations — not needed here (no JPA) -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config-model</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -339,6 +343,7 @@
                 <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/rest/BsmdRestController.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/opennms/netmgt/bsm/rest/BsmdRestController.java
@@ -34,7 +34,7 @@ import org.opennms.netmgt.bsm.service.BusinessServiceStateMachine;
 import org.opennms.netmgt.bsm.service.model.BusinessService;
 import org.opennms.netmgt.bsm.service.model.Status;
 import org.opennms.netmgt.bsm.service.model.graph.GraphVertex;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -101,7 +101,7 @@ public class BsmdRestController {
             return mapper.toDto(bs);
         });
         reloadStateMachine();
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+        return ResponseEntity.status(201).body(result);
     }
 
     @PutMapping("/{id}")
@@ -166,7 +166,7 @@ public class BsmdRestController {
         try {
             return manager.getBusinessServiceById(id);
         } catch (NoSuchElementException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+            throw new ResponseStatusException(HttpStatusCode.valueOf(404),
                     "Business service not found: " + id);
         }
     }
@@ -187,7 +187,7 @@ public class BsmdRestController {
                 case "application" -> manager.addApplicationEdge(bs,
                         manager.getApplicationById(edgeDto.getApplicationId()),
                         mapFn, edgeDto.getWeight());
-                default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                default -> throw new ResponseStatusException(HttpStatusCode.valueOf(400),
                         "Unknown edge type: " + edgeDto.getType());
             }
         }

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -228,6 +228,8 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -355,6 +357,7 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -393,6 +396,7 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -173,6 +173,8 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -208,6 +208,8 @@
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -262,6 +264,7 @@
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -211,6 +211,8 @@
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -218,6 +218,8 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -230,6 +230,8 @@
                 <!-- Exclude ServiceMix Quartz — Spring Boot Quartz brings its own -->
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.quartz</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -258,6 +260,7 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -366,6 +369,7 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Summary

- Exclude `opennms-dao` (37 Hibernate 3.x DAO classes) from 8 daemon-boot fat JARs where it leaked in through feature module transitive dependencies
- At runtime, daemon-boots use `model-jakarta`'s `@Repository` DaoJpa classes — the legacy Hibernate DAOs are dead weight
- Fix `BsmdRestController` for Spring 7 API (`ResponseStatusException` takes `HttpStatusCode`, not `HttpStatus`)

## Details

Phase 5a of legacy module elimination (see `docs/plans/2026-04-01-legacy-module-elimination.md`).

Exclusions added per daemon-boot:
| daemon-boot | opennms-dao excluded from |
|---|---|
| alarmd | opennms-alarmd, opennms-alarm-api |
| bsmd | bsm-daemon, bsm-service-impl, opennms-alarmd, opennms-alarm-api |
| collectd | collection-impl, collection-snmp-collector, timeseries |
| discovery | features/discovery |
| enlinkd | enlinkd-daemon, enlinkd-service-impl |
| perspectivepollerd | perspectivepoller |
| pollerd | poller-impl |
| provisiond | opennms-provisiond, provision-persistence, snmp-metadata-adapter |

Verified clean:
- syslogd: `events/syslog` only has `opennms-dao` in test scope
- eventtranslator, minion, telemetryd, trapd: never pulled `opennms-dao`

## Test plan

- [x] All 13 daemon-boots compile and produce fat JARs
- [x] `opennms-dao` JAR absent from all 13 fat JARs (verified via `unzip -l`)
- [ ] E2E smoke test on labbox — deploy updated JARs and verify daemons start