### PR TITLE
chore: skip CI/CodeQL on docs-only PRs + fix entity count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,8 +3,16 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main", "develop" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
   pull_request:
     branches: [ "main", "develop" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
   schedule:
     - cron: '20 5 * * 1'
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Delta-V has removed Apache Karaf/OSGi from the runtime architecture. All 12 serv
 | `daemon-common` | DataSource, Kafka event transport (with EventConfDao enrichment), Kafka RPC client, JdbcDistPollerDao, JdbcInterfaceToNodeCache, AbstractDaoJpa, EventIpcManagerEnrichingWrapper |
 | `daemon-boot-minion-common` | Minion shared infra: KafkaTwinSubscriberConfiguration, PassiveStatusTwinSubscriber, SnmpV3 config sync |
 | `daemon-sink-kafka` | KafkaSinkBridge — consumes from Minion Sink topics (`OpenNMS.Sink.*`) |
-| `opennms-model-jakarta` | 17 Jakarta Persistence entities + 15 JPA DAOs for Hibernate 7 + 15 Enlinkd AttributeConverters |
+| `opennms-model-jakarta` | 43 Jakarta Persistence entities + 15 JPA DAOs for Hibernate 7 + 15 Enlinkd AttributeConverters |
 
 ### Other Components Removed
 


### PR DESCRIPTION
## Summary

- **CI path filters**: Add `paths-ignore` for `**.md`, `docs/**`, `LICENSE*` to both `ci.yml` and `codeql-analysis.yml`. Docs-only PRs no longer trigger a 25-minute full Maven build + CodeQL java-kotlin analysis.
- **README fix**: model-jakarta entity count updated from 17 → 43 (all entities now ported).

## Test plan

- [x] This PR itself should demonstrate the fix — CI should skip or complete instantly since it only changes .yml and .md files
- [x] Scheduled CodeQL runs (Monday cron) are unaffected by paths-ignore
- [x] `workflow_dispatch` on ci.yml is unaffected (no paths-ignore on that trigger)