### PR TITLE
refactor: convert Enlinkd topology services to constructor injection

### DIFF
--- a/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
@@ -104,6 +104,7 @@ import org.opennms.netmgt.topologies.service.impl.OnmsTopologyDaoInMemoryImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -208,10 +209,11 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public CdpTopologyService cdpTopologyService(CdpLinkDaoJpa cdpLinkDao,
+    public CdpTopologyService cdpTopologyService(PlatformTransactionManager transactionManager,
+                                                  CdpLinkDaoJpa cdpLinkDao,
                                                   CdpElementDaoJpa cdpElementDao,
                                                   TopologyEntityCache topologyEntityCache) {
-        var svc = new CdpTopologyServiceImpl();
+        var svc = new CdpTopologyServiceImpl(transactionManager);
         svc.setCdpLinkDao(cdpLinkDao);
         svc.setCdpElementDao(cdpElementDao);
         svc.setTopologyEntityCache(topologyEntityCache);
@@ -219,10 +221,11 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public LldpTopologyService lldpTopologyService(LldpLinkDaoJpa lldpLinkDao,
+    public LldpTopologyService lldpTopologyService(PlatformTransactionManager transactionManager,
+                                                    LldpLinkDaoJpa lldpLinkDao,
                                                     LldpElementDaoJpa lldpElementDao,
                                                     TopologyEntityCache topologyEntityCache) {
-        var svc = new LldpTopologyServiceImpl();
+        var svc = new LldpTopologyServiceImpl(transactionManager);
         svc.setLldpLinkDao(lldpLinkDao);
         svc.setLldpElementDao(lldpElementDao);
         svc.setTopologyEntityCache(topologyEntityCache);
@@ -230,11 +233,12 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public OspfTopologyService ospfTopologyService(OspfLinkDaoJpa ospfLinkDao,
+    public OspfTopologyService ospfTopologyService(PlatformTransactionManager transactionManager,
+                                                    OspfLinkDaoJpa ospfLinkDao,
                                                     OspfElementDaoJpa ospfElementDao,
                                                     OspfAreaDaoJpa ospfAreaDao,
                                                     TopologyEntityCache topologyEntityCache) {
-        var svc = new OspfTopologyServiceImpl();
+        var svc = new OspfTopologyServiceImpl(transactionManager);
         svc.setOspfLinkDao(ospfLinkDao);
         svc.setOspfElementDao(ospfElementDao);
         svc.setOspfAreaDao(ospfAreaDao);
@@ -243,10 +247,11 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public IsisTopologyService isisTopologyService(IsIsLinkDaoJpa isisLinkDao,
+    public IsisTopologyService isisTopologyService(PlatformTransactionManager transactionManager,
+                                                    IsIsLinkDaoJpa isisLinkDao,
                                                     IsIsElementDaoJpa isisElementDao,
                                                     TopologyEntityCache topologyEntityCache) {
-        var svc = new IsisTopologyServiceImpl();
+        var svc = new IsisTopologyServiceImpl(transactionManager);
         svc.setIsisLinkDao(isisLinkDao);
         svc.setIsisElementDao(isisElementDao);
         svc.setTopologyEntityCache(topologyEntityCache);
@@ -254,13 +259,14 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public BridgeTopologyService bridgeTopologyService(BridgeElementDaoJpa bridgeElementDao,
+    public BridgeTopologyService bridgeTopologyService(PlatformTransactionManager transactionManager,
+                                                        BridgeElementDaoJpa bridgeElementDao,
                                                         BridgeBridgeLinkDaoJpa bridgeBridgeLinkDao,
                                                         BridgeMacLinkDaoJpa bridgeMacLinkDao,
                                                         BridgeStpLinkDaoJpa bridgeStpLinkDao,
                                                         IpNetToMediaDaoJpa ipNetToMediaDao,
                                                         TopologyEntityCache topologyEntityCache) {
-        var svc = new BridgeTopologyServiceImpl();
+        var svc = new BridgeTopologyServiceImpl(transactionManager);
         svc.setBridgeElementDao(bridgeElementDao);
         svc.setBridgeBridgeLinkDao(bridgeBridgeLinkDao);
         svc.setBridgeMacLinkDao(bridgeMacLinkDao);
@@ -271,9 +277,10 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public IpNetToMediaTopologyService ipNetToMediaTopologyService(IpNetToMediaDaoJpa ipNetToMediaDao,
+    public IpNetToMediaTopologyService ipNetToMediaTopologyService(PlatformTransactionManager transactionManager,
+                                                                    IpNetToMediaDaoJpa ipNetToMediaDao,
                                                                     IpInterfaceDao ipInterfaceDao) {
-        var svc = new IpNetToMediaTopologyServiceImpl();
+        var svc = new IpNetToMediaTopologyServiceImpl(transactionManager);
         svc.setIpNetToMediaDao(ipNetToMediaDao);
         svc.setIpInterfaceDao(ipInterfaceDao);
         return svc;

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
@@ -57,7 +57,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyShared;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,10 +64,13 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
 public class BridgeTopologyServiceImpl extends TopologyServiceImpl implements BridgeTopologyService {
-    
+
     private final static Logger LOG = LoggerFactory.getLogger(BridgeTopologyServiceImpl.class);
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
+
+    public BridgeTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
+    }
 
     private final Object lock = new Object();
     private BridgeElementDao m_bridgeElementDao;

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/CdpTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/CdpTopologyServiceImpl.java
@@ -44,7 +44,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,13 +51,13 @@ public class CdpTopologyServiceImpl extends TopologyServiceImpl implements CdpTo
 
     private static final Logger LOG = LoggerFactory.getLogger(CdpTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
-    
+    private final PlatformTransactionManager m_transactionManager;
+
     private CdpLinkDao m_cdpLinkDao;
     private CdpElementDao m_cdpElementDao;
-    
-    public CdpTopologyServiceImpl() {
+
+    public CdpTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IpNetToMediaTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IpNetToMediaTopologyServiceImpl.java
@@ -37,22 +37,21 @@ import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
 public class IpNetToMediaTopologyServiceImpl implements
         IpNetToMediaTopologyService {
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private final static Logger LOG = LoggerFactory.getLogger(IpNetToMediaTopologyServiceImpl.class);
 
     private IpNetToMediaDao m_ipNetToMediaDao;
-    private IpInterfaceDao m_ipInterfaceDao;    
+    private IpInterfaceDao m_ipInterfaceDao;
 
-    public IpNetToMediaTopologyServiceImpl() {
+    public IpNetToMediaTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IsisTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IsisTopologyServiceImpl.java
@@ -43,7 +43,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,13 +50,13 @@ public class IsisTopologyServiceImpl extends TopologyServiceImpl implements Isis
 
     private static final Logger LOG = LoggerFactory.getLogger(IsisTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private IsIsLinkDao m_isisLinkDao;
     private IsIsElementDao m_isisElementDao;
 
-    public IsisTopologyServiceImpl() {
+    public IsisTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
@@ -44,7 +44,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,13 +51,13 @@ public class LldpTopologyServiceImpl extends TopologyServiceImpl implements Lldp
 
     private static final Logger LOG = LoggerFactory.getLogger(LldpTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private LldpLinkDao m_lldpLinkDao;
     private LldpElementDao m_lldpElementDao;
 
-    public LldpTopologyServiceImpl() {
+    public LldpTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/OspfTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/OspfTopologyServiceImpl.java
@@ -45,7 +45,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,14 +52,14 @@ public class OspfTopologyServiceImpl extends TopologyServiceImpl implements Ospf
 
     private static final Logger LOG = LoggerFactory.getLogger(OspfTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private OspfLinkDao m_ospfLinkDao;
     private OspfElementDao m_ospfElementDao;
     private OspfAreaDao m_ospfAreaDao;
 
-    public OspfTopologyServiceImpl() {
+    public OspfTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Replace `@Autowired` field injection of `PlatformTransactionManager` with explicit constructor injection in all 6 Enlinkd topology service implementations
- Fields are now `final`, making dependencies immutable and visible in the configuration class
- `EnlinkdDaemonConfiguration` passes `PlatformTransactionManager` explicitly to each service constructor

## Changed files
- `BridgeTopologyServiceImpl`, `CdpTopologyServiceImpl`, `IsisTopologyServiceImpl`, `IpNetToMediaTopologyServiceImpl`, `LldpTopologyServiceImpl`, `OspfTopologyServiceImpl` — constructor injection + final fields
- `EnlinkdDaemonConfiguration` — updated bean factory methods

## Test plan
- [ ] `mvn compile` passes for affected modules
- [ ] Enlinkd E2E tests pass (`test-enlinkd-e2e.sh`)