### PR TITLE
refactor: introduce TopologyUpdaterRegistry for EnhancedLinkd

### DIFF
--- a/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
@@ -104,6 +104,7 @@ import org.opennms.netmgt.topologies.service.impl.OnmsTopologyDaoInMemoryImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -208,10 +209,11 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public CdpTopologyService cdpTopologyService(CdpLinkDaoJpa cdpLinkDao,
+    public CdpTopologyService cdpTopologyService(PlatformTransactionManager transactionManager,
+                                                  CdpLinkDaoJpa cdpLinkDao,
                                                   CdpElementDaoJpa cdpElementDao,
                                                   TopologyEntityCache topologyEntityCache) {
-        var svc = new CdpTopologyServiceImpl();
+        var svc = new CdpTopologyServiceImpl(transactionManager);
         svc.setCdpLinkDao(cdpLinkDao);
         svc.setCdpElementDao(cdpElementDao);
         svc.setTopologyEntityCache(topologyEntityCache);
@@ -219,10 +221,11 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public LldpTopologyService lldpTopologyService(LldpLinkDaoJpa lldpLinkDao,
+    public LldpTopologyService lldpTopologyService(PlatformTransactionManager transactionManager,
+                                                    LldpLinkDaoJpa lldpLinkDao,
                                                     LldpElementDaoJpa lldpElementDao,
                                                     TopologyEntityCache topologyEntityCache) {
-        var svc = new LldpTopologyServiceImpl();
+        var svc = new LldpTopologyServiceImpl(transactionManager);
         svc.setLldpLinkDao(lldpLinkDao);
         svc.setLldpElementDao(lldpElementDao);
         svc.setTopologyEntityCache(topologyEntityCache);
@@ -230,11 +233,12 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public OspfTopologyService ospfTopologyService(OspfLinkDaoJpa ospfLinkDao,
+    public OspfTopologyService ospfTopologyService(PlatformTransactionManager transactionManager,
+                                                    OspfLinkDaoJpa ospfLinkDao,
                                                     OspfElementDaoJpa ospfElementDao,
                                                     OspfAreaDaoJpa ospfAreaDao,
                                                     TopologyEntityCache topologyEntityCache) {
-        var svc = new OspfTopologyServiceImpl();
+        var svc = new OspfTopologyServiceImpl(transactionManager);
         svc.setOspfLinkDao(ospfLinkDao);
         svc.setOspfElementDao(ospfElementDao);
         svc.setOspfAreaDao(ospfAreaDao);
@@ -243,10 +247,11 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public IsisTopologyService isisTopologyService(IsIsLinkDaoJpa isisLinkDao,
+    public IsisTopologyService isisTopologyService(PlatformTransactionManager transactionManager,
+                                                    IsIsLinkDaoJpa isisLinkDao,
                                                     IsIsElementDaoJpa isisElementDao,
                                                     TopologyEntityCache topologyEntityCache) {
-        var svc = new IsisTopologyServiceImpl();
+        var svc = new IsisTopologyServiceImpl(transactionManager);
         svc.setIsisLinkDao(isisLinkDao);
         svc.setIsisElementDao(isisElementDao);
         svc.setTopologyEntityCache(topologyEntityCache);
@@ -254,13 +259,14 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public BridgeTopologyService bridgeTopologyService(BridgeElementDaoJpa bridgeElementDao,
+    public BridgeTopologyService bridgeTopologyService(PlatformTransactionManager transactionManager,
+                                                        BridgeElementDaoJpa bridgeElementDao,
                                                         BridgeBridgeLinkDaoJpa bridgeBridgeLinkDao,
                                                         BridgeMacLinkDaoJpa bridgeMacLinkDao,
                                                         BridgeStpLinkDaoJpa bridgeStpLinkDao,
                                                         IpNetToMediaDaoJpa ipNetToMediaDao,
                                                         TopologyEntityCache topologyEntityCache) {
-        var svc = new BridgeTopologyServiceImpl();
+        var svc = new BridgeTopologyServiceImpl(transactionManager);
         svc.setBridgeElementDao(bridgeElementDao);
         svc.setBridgeBridgeLinkDao(bridgeBridgeLinkDao);
         svc.setBridgeMacLinkDao(bridgeMacLinkDao);
@@ -271,9 +277,10 @@ public class EnlinkdDaemonConfiguration {
     }
 
     @Bean
-    public IpNetToMediaTopologyService ipNetToMediaTopologyService(IpNetToMediaDaoJpa ipNetToMediaDao,
+    public IpNetToMediaTopologyService ipNetToMediaTopologyService(PlatformTransactionManager transactionManager,
+                                                                    IpNetToMediaDaoJpa ipNetToMediaDao,
                                                                     IpInterfaceDao ipInterfaceDao) {
-        var svc = new IpNetToMediaTopologyServiceImpl();
+        var svc = new IpNetToMediaTopologyServiceImpl(transactionManager);
         svc.setIpNetToMediaDao(ipNetToMediaDao);
         svc.setIpInterfaceDao(ipInterfaceDao);
         return svc;

--- a/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/opennms/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
@@ -45,6 +45,7 @@ import org.opennms.netmgt.enlinkd.CdpOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.DiscoveryBridgeDomains;
 import org.opennms.netmgt.enlinkd.EnhancedLinkd;
 import org.opennms.netmgt.enlinkd.EventProcessor;
+import org.opennms.netmgt.enlinkd.TopologyUpdaterRegistry;
 import org.opennms.netmgt.enlinkd.IsisOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.LldpOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.NetworkRouterTopologyUpdater;
@@ -85,6 +86,7 @@ import org.opennms.netmgt.enlinkd.service.api.IpNetToMediaTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.IsisTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.LldpTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.NodeTopologyService;
+import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
 import org.opennms.netmgt.enlinkd.service.api.OspfTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.UserDefinedLinkTopologyService;
 import org.opennms.netmgt.enlinkd.service.impl.BridgeTopologyServiceImpl;
@@ -365,7 +367,33 @@ public class EnlinkdDaemonConfiguration {
         return new DiscoveryBridgeDomains(bridgeTopologyService);
     }
 
-    // ── 8. EnhancedLinkd daemon ──────────────────────────────────────
+    // ── 8. TopologyUpdaterRegistry + EnhancedLinkd daemon ──────────
+
+    @Bean
+    public TopologyUpdaterRegistry topologyUpdaterRegistry(
+            NodesOnmsTopologyUpdater nodesTopologyUpdater,
+            CdpOnmsTopologyUpdater cdpTopologyUpdater,
+            LldpOnmsTopologyUpdater lldpTopologyUpdater,
+            IsisOnmsTopologyUpdater isisTopologyUpdater,
+            OspfOnmsTopologyUpdater ospfTopologyUpdater,
+            OspfAreaOnmsTopologyUpdater ospfAreaTopologyUpdater,
+            BridgeOnmsTopologyUpdater bridgeTopologyUpdater,
+            NetworkRouterTopologyUpdater networkRouterTopologyUpdater,
+            UserDefinedLinkTopologyUpdater userDefinedLinkTopologyUpdater,
+            DiscoveryBridgeDomains discoveryBridgeDomains) {
+        var registry = new TopologyUpdaterRegistry();
+        registry.put(ProtocolSupported.NODES, nodesTopologyUpdater);
+        registry.put(ProtocolSupported.CDP, cdpTopologyUpdater);
+        registry.put(ProtocolSupported.LLDP, lldpTopologyUpdater);
+        registry.put(ProtocolSupported.ISIS, isisTopologyUpdater);
+        registry.put(ProtocolSupported.OSPF, ospfTopologyUpdater);
+        registry.put(ProtocolSupported.OSPFAREA, ospfAreaTopologyUpdater);
+        registry.put(ProtocolSupported.BRIDGE, bridgeTopologyUpdater);
+        registry.put(ProtocolSupported.NETWORKROUTER, networkRouterTopologyUpdater);
+        registry.put(ProtocolSupported.USERDEFINED, userDefinedLinkTopologyUpdater);
+        registry.setDiscoveryBridgeDomains(discoveryBridgeDomains);
+        return registry;
+    }
 
     @Bean
     public EnhancedLinkd enhancedLinkd(EnhancedLinkdConfig linkdConfig,
@@ -377,27 +405,14 @@ public class EnlinkdDaemonConfiguration {
                                         BridgeTopologyService bridgeTopologyService,
                                         IpNetToMediaTopologyService ipNetToMediaTopologyService,
                                         LocationAwareSnmpClient locationAwareSnmpClient,
-                                        NodesOnmsTopologyUpdater nodesTopologyUpdater,
-                                        BridgeOnmsTopologyUpdater bridgeTopologyUpdater,
-                                        CdpOnmsTopologyUpdater cdpTopologyUpdater,
-                                        LldpOnmsTopologyUpdater lldpTopologyUpdater,
-                                        IsisOnmsTopologyUpdater isisTopologyUpdater,
-                                        OspfOnmsTopologyUpdater ospfTopologyUpdater,
-                                        OspfAreaOnmsTopologyUpdater ospfAreaTopologyUpdater,
-                                        DiscoveryBridgeDomains discoveryBridgeDomains,
-                                        UserDefinedLinkTopologyUpdater userDefinedLinkTopologyUpdater,
-                                        NetworkRouterTopologyUpdater networkRouterTopologyUpdater) {
+                                        TopologyUpdaterRegistry registry) {
         return new EnhancedLinkd(
                 linkdConfig, nodeTopologyService,
                 bridgeTopologyService, cdpTopologyService,
                 isisTopologyService, ipNetToMediaTopologyService,
                 lldpTopologyService, ospfTopologyService,
                 locationAwareSnmpClient,
-                nodesTopologyUpdater, bridgeTopologyUpdater,
-                cdpTopologyUpdater, lldpTopologyUpdater,
-                isisTopologyUpdater, ospfTopologyUpdater,
-                ospfAreaTopologyUpdater, discoveryBridgeDomains,
-                userDefinedLinkTopologyUpdater, networkRouterTopologyUpdater);
+                registry);
     }
 
     // ── 9. Event Processor ───────────────────────────────────────────

--- a/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -86,17 +86,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
     private final OspfTopologyService m_ospfTopologyService;
     private final LocationAwareSnmpClient m_locationAwareSnmpClient;
 
-    // Non-final: reload() reassigns these via .clone()
-    private NodesOnmsTopologyUpdater m_nodesTopologyUpdater;
-    private BridgeOnmsTopologyUpdater m_bridgeTopologyUpdater;
-    private CdpOnmsTopologyUpdater m_cdpTopologyUpdater;
-    private LldpOnmsTopologyUpdater m_lldpTopologyUpdater;
-    private IsisOnmsTopologyUpdater m_isisTopologyUpdater;
-    private OspfOnmsTopologyUpdater m_ospfTopologyUpdater;
-    private OspfAreaOnmsTopologyUpdater m_ospfAreaTopologyUpdater;
-    private DiscoveryBridgeDomains m_discoveryBridgeDomains;
-    private UserDefinedLinkTopologyUpdater m_userDefinedLinkTopologyUpdater;
-    private NetworkRouterTopologyUpdater m_networkRouterTopologyUpdater;
+    private final TopologyUpdaterRegistry m_registry;
 
     private final List<SchedulableNodeCollectorGroup> m_groups = new ArrayList<>();
 
@@ -113,16 +103,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
             LldpTopologyService lldpTopologyService,
             OspfTopologyService ospfTopologyService,
             LocationAwareSnmpClient locationAwareSnmpClient,
-            NodesOnmsTopologyUpdater nodesTopologyUpdater,
-            BridgeOnmsTopologyUpdater bridgeTopologyUpdater,
-            CdpOnmsTopologyUpdater cdpTopologyUpdater,
-            LldpOnmsTopologyUpdater lldpTopologyUpdater,
-            IsisOnmsTopologyUpdater isisTopologyUpdater,
-            OspfOnmsTopologyUpdater ospfTopologyUpdater,
-            OspfAreaOnmsTopologyUpdater ospfAreaTopologyUpdater,
-            DiscoveryBridgeDomains discoveryBridgeDomains,
-            UserDefinedLinkTopologyUpdater userDefinedLinkTopologyUpdater,
-            NetworkRouterTopologyUpdater networkRouterTopologyUpdater) {
+            TopologyUpdaterRegistry registry) {
         super(LOG_PREFIX);
         m_linkdConfig = linkdConfig;
         m_queryMgr = queryMgr;
@@ -133,16 +114,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
         m_lldpTopologyService = lldpTopologyService;
         m_ospfTopologyService = ospfTopologyService;
         m_locationAwareSnmpClient = locationAwareSnmpClient;
-        m_nodesTopologyUpdater = nodesTopologyUpdater;
-        m_bridgeTopologyUpdater = bridgeTopologyUpdater;
-        m_cdpTopologyUpdater = cdpTopologyUpdater;
-        m_lldpTopologyUpdater = lldpTopologyUpdater;
-        m_isisTopologyUpdater = isisTopologyUpdater;
-        m_ospfTopologyUpdater = ospfTopologyUpdater;
-        m_ospfAreaTopologyUpdater = ospfAreaTopologyUpdater;
-        m_discoveryBridgeDomains = discoveryBridgeDomains;
-        m_userDefinedLinkTopologyUpdater = userDefinedLinkTopologyUpdater;
-        m_networkRouterTopologyUpdater = networkRouterTopologyUpdater;
+        m_registry = registry;
     }
 
     /**
@@ -175,9 +147,9 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
 
     private void schedule(boolean init) {
         if (init) {
-            scheduleAndRegisterOnmsTopologyUpdater(m_nodesTopologyUpdater);
-            scheduleAndRegisterOnmsTopologyUpdater(m_networkRouterTopologyUpdater);
-            scheduleAndRegisterOnmsTopologyUpdater(m_userDefinedLinkTopologyUpdater);
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.NODES));
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.NETWORKROUTER));
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.USERDEFINED));
         }
 
         if (m_linkdConfig.useCdpDiscovery()) {
@@ -185,7 +157,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
             nodeCollectionGroupCdp.setScheduler(m_scheduler);
             nodeCollectionGroupCdp.schedule();
             m_groups.add(nodeCollectionGroupCdp);
-            scheduleAndRegisterOnmsTopologyUpdater(m_cdpTopologyUpdater);
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.CDP));
         } else {
             m_cdpTopologyService.deletePersistedData();
         }
@@ -195,7 +167,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
             nodeCollectionGroupLldp.setScheduler(m_scheduler);
             nodeCollectionGroupLldp.schedule();
             m_groups.add(nodeCollectionGroupLldp);
-            scheduleAndRegisterOnmsTopologyUpdater(m_lldpTopologyUpdater);
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.LLDP));
        } else {
             m_lldpTopologyService.deletePersistedData();
         }
@@ -205,7 +177,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
             nodeCollectionGroupIsis.setScheduler(m_scheduler);
             nodeCollectionGroupIsis.schedule();
             m_groups.add(nodeCollectionGroupIsis);
-            scheduleAndRegisterOnmsTopologyUpdater(m_isisTopologyUpdater);
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.ISIS));
         } else {
             m_isisTopologyService.deletePersistedData();
         }
@@ -215,8 +187,8 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
             nodeCollectionGroupOspf.setScheduler(m_scheduler);
             nodeCollectionGroupOspf.schedule();
             m_groups.add(nodeCollectionGroupOspf);
-            scheduleAndRegisterOnmsTopologyUpdater(m_ospfTopologyUpdater);
-            scheduleAndRegisterOnmsTopologyUpdater(m_ospfAreaTopologyUpdater);
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.OSPF));
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.OSPFAREA));
         } else {
             m_ospfTopologyService.deletePersistedData();
         }
@@ -231,7 +203,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
             nodeCollectionGroupBridge.schedule();
             m_groups.add(nodeCollectionGroupBridge);
             scheduleDiscoveryBridgeDomain();
-            scheduleAndRegisterOnmsTopologyUpdater(m_bridgeTopologyUpdater);
+            scheduleAndRegisterOnmsTopologyUpdater(m_registry.get(ProtocolSupported.BRIDGE));
         } else {
             m_bridgeTopologyService.deletePersistedData();
         }
@@ -248,13 +220,14 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
     }
 
     public void scheduleDiscoveryBridgeDomain() {
-            m_discoveryBridgeDomains.setScheduler(m_scheduler);
-            m_discoveryBridgeDomains.setPollInterval(m_linkdConfig.getBridgeTopologyInterval());
-            m_discoveryBridgeDomains.setInitialSleepTime(m_linkdConfig.getBridgeTopologyInterval()+m_linkdConfig.getInitialSleepTime());
-            m_discoveryBridgeDomains.setMaxthreads(m_linkdConfig.getDiscoveryBridgeThreads());
+            var dbd = m_registry.getDiscoveryBridgeDomains();
+            dbd.setScheduler(m_scheduler);
+            dbd.setPollInterval(m_linkdConfig.getBridgeTopologyInterval());
+            dbd.setInitialSleepTime(m_linkdConfig.getBridgeTopologyInterval()+m_linkdConfig.getInitialSleepTime());
+            dbd.setMaxthreads(m_linkdConfig.getDiscoveryBridgeThreads());
             LOG.info("scheduleDiscoveryBridgeDomain: Scheduling {}",
-                     m_discoveryBridgeDomains.getInfo());
-            m_discoveryBridgeDomains.schedule();
+                     dbd.getInfo());
+            dbd.schedule();
     }
 
     /**
@@ -342,118 +315,31 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
     }
 
     public void runDiscoveryBridgeDomains() {
-            m_discoveryBridgeDomains.runSchedulable();
+            m_registry.getDiscoveryBridgeDomains().runSchedulable();
+    }
+
+    private boolean isEnabled(ProtocolSupported proto) {
+        return switch (proto) {
+            case CDP -> m_linkdConfig.useCdpDiscovery();
+            case LLDP -> m_linkdConfig.useLldpDiscovery();
+            case ISIS -> m_linkdConfig.useIsisDiscovery();
+            case OSPF, OSPFAREA -> m_linkdConfig.useOspfDiscovery();
+            case BRIDGE -> m_linkdConfig.useBridgeDiscovery();
+            case NODES, USERDEFINED, NETWORKROUTER -> true;
+        };
     }
 
     public void forceTopologyUpdaterRun(ProtocolSupported proto) {
-        switch (proto) {
-        case CDP:
-            if (m_linkdConfig.useCdpDiscovery()) {
-                m_cdpTopologyUpdater.forceRun();
-            }
-            break;
-
-        case LLDP:
-            if (m_linkdConfig.useLldpDiscovery()) {
-                m_lldpTopologyUpdater.forceRun();
-            }
-            break;
-
-        case ISIS:
-            if (m_linkdConfig.useIsisDiscovery()) {
-                m_isisTopologyUpdater.forceRun();
-            }
-            break;
-
-        case OSPFAREA:
-            if (m_linkdConfig.useOspfDiscovery()) {
-                m_ospfAreaTopologyUpdater.forceRun();
-            }
-            break;
-
-        case OSPF:
-            if (m_linkdConfig.useOspfDiscovery()) {
-                m_ospfTopologyUpdater.forceRun();
-            }
-            break;
-
-        case BRIDGE:
-            if (m_linkdConfig.useBridgeDiscovery()) {
-                m_bridgeTopologyUpdater.forceRun();
-            }
-            break;
-
-        case NODES:
-            m_nodesTopologyUpdater.forceRun();
-            break;
-
-        case USERDEFINED:
-            m_userDefinedLinkTopologyUpdater.forceRun();
-            break;
-
-        case NETWORKROUTER:
-            m_networkRouterTopologyUpdater.forceRun();
-            break;
-
-        default:
-            break;
-
+        TopologyUpdater updater = m_registry.get(proto);
+        if (updater != null && isEnabled(proto)) {
+            updater.forceRun();
         }
-
     }
 
     public void runTopologyUpdater(ProtocolSupported proto) {
-        switch (proto) {
-            case CDP:
-                if (m_linkdConfig.useCdpDiscovery()) {
-                    m_cdpTopologyUpdater.runSchedulable();
-                }
-                break;
-
-            case LLDP:
-                if (m_linkdConfig.useLldpDiscovery()) {
-                    m_lldpTopologyUpdater.runSchedulable();
-                }
-                break;
-
-            case ISIS:
-                if (m_linkdConfig.useIsisDiscovery()) {
-                    m_isisTopologyUpdater.runSchedulable();
-                }
-                break;
-
-            case OSPF:
-                if (m_linkdConfig.useOspfDiscovery()) {
-                    m_ospfTopologyUpdater.runSchedulable();
-                }
-                break;
-
-            case OSPFAREA:
-                if (m_linkdConfig.useOspfDiscovery()) {
-                    m_ospfAreaTopologyUpdater.runSchedulable();
-                }
-                break;
-
-            case BRIDGE:
-                if (m_linkdConfig.useBridgeDiscovery()) {
-                    m_bridgeTopologyUpdater.runSchedulable();
-                }
-                break;
-
-            case NODES:
-                m_nodesTopologyUpdater.runSchedulable();
-                break;
-
-            case USERDEFINED:
-                m_userDefinedLinkTopologyUpdater.runSchedulable();
-                break;
-
-            case NETWORKROUTER:
-                m_networkRouterTopologyUpdater.runSchedulable();
-                break;
-
-            default:
-                break;
+        TopologyUpdater updater = m_registry.get(proto);
+        if (updater != null && isEnabled(proto)) {
+            updater.runSchedulable();
         }
     }
 
@@ -531,29 +417,33 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
         return m_ipNetToMediaTopologyService;
     }
 
+    public TopologyUpdaterRegistry getRegistry() {
+        return m_registry;
+    }
+
     public NodesOnmsTopologyUpdater getNodesTopologyUpdater() {
-        return m_nodesTopologyUpdater;
+        return m_registry.get(ProtocolSupported.NODES, NodesOnmsTopologyUpdater.class);
     }
     public NetworkRouterTopologyUpdater getNetworkRouterTopologyUpdater() {
-        return m_networkRouterTopologyUpdater;
+        return m_registry.get(ProtocolSupported.NETWORKROUTER, NetworkRouterTopologyUpdater.class);
     }
     public CdpOnmsTopologyUpdater getCdpTopologyUpdater() {
-        return m_cdpTopologyUpdater;
+        return m_registry.get(ProtocolSupported.CDP, CdpOnmsTopologyUpdater.class);
     }
     public LldpOnmsTopologyUpdater getLldpTopologyUpdater() {
-        return m_lldpTopologyUpdater;
+        return m_registry.get(ProtocolSupported.LLDP, LldpOnmsTopologyUpdater.class);
     }
     public IsisOnmsTopologyUpdater getIsisTopologyUpdater() {
-        return m_isisTopologyUpdater;
+        return m_registry.get(ProtocolSupported.ISIS, IsisOnmsTopologyUpdater.class);
     }
     public BridgeOnmsTopologyUpdater getBridgeTopologyUpdater() {
-        return m_bridgeTopologyUpdater;
+        return m_registry.get(ProtocolSupported.BRIDGE, BridgeOnmsTopologyUpdater.class);
     }
     public OspfOnmsTopologyUpdater getOspfTopologyUpdater() {
-        return m_ospfTopologyUpdater;
+        return m_registry.get(ProtocolSupported.OSPF, OspfOnmsTopologyUpdater.class);
     }
     public OspfAreaOnmsTopologyUpdater getOspfAreaTopologyUpdater() {
-        return m_ospfAreaTopologyUpdater;
+        return m_registry.get(ProtocolSupported.OSPFAREA, OspfAreaOnmsTopologyUpdater.class);
     }
 
     @Override
@@ -563,45 +453,33 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
         m_groups.forEach(Schedulable::unschedule);
         m_groups.clear();
 
-        if (m_ospfTopologyUpdater.isRegistered()) {
-            m_ospfTopologyUpdater.unschedule();
-            m_ospfTopologyUpdater.unregister();
-            m_ospfTopologyUpdater = OspfOnmsTopologyUpdater.clone(m_ospfTopologyUpdater);
-        }
+        reloadUpdater(ProtocolSupported.OSPF, OspfOnmsTopologyUpdater.class, OspfOnmsTopologyUpdater::clone);
+        reloadUpdater(ProtocolSupported.OSPFAREA, OspfAreaOnmsTopologyUpdater.class, OspfAreaOnmsTopologyUpdater::clone);
+        reloadUpdater(ProtocolSupported.LLDP, LldpOnmsTopologyUpdater.class, LldpOnmsTopologyUpdater::clone);
+        reloadUpdater(ProtocolSupported.ISIS, IsisOnmsTopologyUpdater.class, IsisOnmsTopologyUpdater::clone);
+        reloadUpdater(ProtocolSupported.CDP, CdpOnmsTopologyUpdater.class, CdpOnmsTopologyUpdater::clone);
 
-        if (m_ospfAreaTopologyUpdater.isRegistered()) {
-                m_ospfAreaTopologyUpdater.unschedule();
-                m_ospfAreaTopologyUpdater.unregister();
-                m_ospfAreaTopologyUpdater = OspfAreaOnmsTopologyUpdater.clone(m_ospfAreaTopologyUpdater);
-        }
-
-        if (m_lldpTopologyUpdater.isRegistered()) {
-            m_lldpTopologyUpdater.unschedule();
-            m_lldpTopologyUpdater.unregister();
-            m_lldpTopologyUpdater = LldpOnmsTopologyUpdater.clone(m_lldpTopologyUpdater);
-        }
-
-        if (m_isisTopologyUpdater.isRegistered()) {
-            m_isisTopologyUpdater.unschedule();
-            m_isisTopologyUpdater.unregister();
-            m_isisTopologyUpdater = IsisOnmsTopologyUpdater.clone(m_isisTopologyUpdater);
-        }
-
-        if (m_cdpTopologyUpdater.isRegistered()) {
-            m_cdpTopologyUpdater.unschedule();
-            m_cdpTopologyUpdater.unregister();
-            m_cdpTopologyUpdater = CdpOnmsTopologyUpdater.clone(m_cdpTopologyUpdater);
-        }
-
-        if (m_bridgeTopologyUpdater.isRegistered()) {
-            m_bridgeTopologyUpdater.unschedule();
-            m_bridgeTopologyUpdater.unregister();
-            m_bridgeTopologyUpdater = BridgeOnmsTopologyUpdater.clone(m_bridgeTopologyUpdater);
-            m_discoveryBridgeDomains.unschedule();
-            m_discoveryBridgeDomains = DiscoveryBridgeDomains.clone(m_discoveryBridgeDomains);
+        var bridgeUpdater = m_registry.get(ProtocolSupported.BRIDGE, BridgeOnmsTopologyUpdater.class);
+        if (bridgeUpdater != null && bridgeUpdater.isRegistered()) {
+            bridgeUpdater.unschedule();
+            bridgeUpdater.unregister();
+            m_registry.put(ProtocolSupported.BRIDGE, BridgeOnmsTopologyUpdater.clone(bridgeUpdater));
+            m_registry.getDiscoveryBridgeDomains().unschedule();
+            m_registry.setDiscoveryBridgeDomains(
+                    DiscoveryBridgeDomains.clone(m_registry.getDiscoveryBridgeDomains()));
         }
 
         schedule(false);
+    }
+
+    private <T extends TopologyUpdater> void reloadUpdater(
+            ProtocolSupported proto, Class<T> type, java.util.function.UnaryOperator<T> cloner) {
+        T updater = m_registry.get(proto, type);
+        if (updater != null && updater.isRegistered()) {
+            updater.unschedule();
+            updater.unregister();
+            m_registry.put(proto, cloner.apply(updater));
+        }
     }
 
     @Override

--- a/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/TopologyUpdaterRegistry.java
+++ b/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/TopologyUpdaterRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.enlinkd;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
+import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
+
+/**
+ * Registry for topology updaters keyed by {@link ProtocolSupported}.
+ *
+ * <p>Replaces the 10 individual updater fields in {@link EnhancedLinkd} with a
+ * single map-based lookup. Also holds the {@link DiscoveryBridgeDomains}
+ * instance which is coupled to the BRIDGE updater lifecycle.</p>
+ */
+public class TopologyUpdaterRegistry {
+
+    private final Map<ProtocolSupported, TopologyUpdater> updaters = new EnumMap<>(ProtocolSupported.class);
+    private DiscoveryBridgeDomains discoveryBridgeDomains;
+
+    public TopologyUpdater get(ProtocolSupported protocol) {
+        return updaters.get(protocol);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends TopologyUpdater> T get(ProtocolSupported protocol, Class<T> type) {
+        return (T) updaters.get(protocol);
+    }
+
+    public void put(ProtocolSupported protocol, TopologyUpdater updater) {
+        updaters.put(protocol, updater);
+    }
+
+    public DiscoveryBridgeDomains getDiscoveryBridgeDomains() {
+        return discoveryBridgeDomains;
+    }
+
+    public void setDiscoveryBridgeDomains(DiscoveryBridgeDomains discoveryBridgeDomains) {
+        this.discoveryBridgeDomains = discoveryBridgeDomains;
+    }
+}

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
@@ -57,7 +57,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyShared;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,10 +64,13 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
 public class BridgeTopologyServiceImpl extends TopologyServiceImpl implements BridgeTopologyService {
-    
+
     private final static Logger LOG = LoggerFactory.getLogger(BridgeTopologyServiceImpl.class);
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
+
+    public BridgeTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
+    }
 
     private final Object lock = new Object();
     private BridgeElementDao m_bridgeElementDao;

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/CdpTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/CdpTopologyServiceImpl.java
@@ -44,7 +44,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,13 +51,13 @@ public class CdpTopologyServiceImpl extends TopologyServiceImpl implements CdpTo
 
     private static final Logger LOG = LoggerFactory.getLogger(CdpTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
-    
+    private final PlatformTransactionManager m_transactionManager;
+
     private CdpLinkDao m_cdpLinkDao;
     private CdpElementDao m_cdpElementDao;
-    
-    public CdpTopologyServiceImpl() {
+
+    public CdpTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IpNetToMediaTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IpNetToMediaTopologyServiceImpl.java
@@ -37,22 +37,21 @@ import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
 public class IpNetToMediaTopologyServiceImpl implements
         IpNetToMediaTopologyService {
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private final static Logger LOG = LoggerFactory.getLogger(IpNetToMediaTopologyServiceImpl.class);
 
     private IpNetToMediaDao m_ipNetToMediaDao;
-    private IpInterfaceDao m_ipInterfaceDao;    
+    private IpInterfaceDao m_ipInterfaceDao;
 
-    public IpNetToMediaTopologyServiceImpl() {
+    public IpNetToMediaTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IsisTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/IsisTopologyServiceImpl.java
@@ -43,7 +43,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,13 +50,13 @@ public class IsisTopologyServiceImpl extends TopologyServiceImpl implements Isis
 
     private static final Logger LOG = LoggerFactory.getLogger(IsisTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private IsIsLinkDao m_isisLinkDao;
     private IsIsElementDao m_isisElementDao;
 
-    public IsisTopologyServiceImpl() {
+    public IsisTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/LldpTopologyServiceImpl.java
@@ -44,7 +44,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,13 +51,13 @@ public class LldpTopologyServiceImpl extends TopologyServiceImpl implements Lldp
 
     private static final Logger LOG = LoggerFactory.getLogger(LldpTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private LldpLinkDao m_lldpLinkDao;
     private LldpElementDao m_lldpElementDao;
 
-    public LldpTopologyServiceImpl() {
+    public LldpTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/OspfTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/OspfTopologyServiceImpl.java
@@ -45,7 +45,6 @@ import org.opennms.netmgt.enlinkd.service.api.TopologyService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,14 +52,14 @@ public class OspfTopologyServiceImpl extends TopologyServiceImpl implements Ospf
 
     private static final Logger LOG = LoggerFactory.getLogger(OspfTopologyServiceImpl.class);
 
-    @Autowired
-    private PlatformTransactionManager m_transactionManager;
+    private final PlatformTransactionManager m_transactionManager;
 
     private OspfLinkDao m_ospfLinkDao;
     private OspfElementDao m_ospfElementDao;
     private OspfAreaDao m_ospfAreaDao;
 
-    public OspfTopologyServiceImpl() {
+    public OspfTopologyServiceImpl(PlatformTransactionManager transactionManager) {
+        m_transactionManager = transactionManager;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Introduce `TopologyUpdaterRegistry` backed by `EnumMap<ProtocolSupported, TopologyUpdater>` to replace 10 individual updater fields in `EnhancedLinkd`
- Constructor reduced from 19 to 10 parameters
- Two 50-line switch statements in `forceTopologyUpdaterRun()` and `runTopologyUpdater()` replaced with map lookups + `isEnabled()` helper
- `reload()` uses generic `reloadUpdater()` method with type-safe method references
- Backward-compatible getters delegate to registry for existing test compatibility

## Depends on
- PR #109 (constructor injection cleanup) — includes that commit

## Changed files
- **New:** `TopologyUpdaterRegistry.java` — simple registry with EnumMap + DiscoveryBridgeDomains
- `EnhancedLinkd.java` — uses registry, eliminates switch statements (-107 net lines)
- `EnlinkdDaemonConfiguration.java` — builds and wires registry as a bean

## Test plan
- [ ] `mvn compile` passes for all Enlinkd modules
- [ ] Enlinkd E2E tests pass (`test-enlinkd-e2e.sh`)