### PR TITLE
fix: register detector factories via ServiceLoader for Spring Boot daemons

### DIFF
--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -565,36 +565,96 @@
             </exclusions>
         </dependency>
 
-        <!-- Concrete detector factory classes -->
+        <!-- Concrete detector factory classes (exclusions match opennms-detectorclient-rpc) -->
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-simple</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-lineoriented</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-datagram</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-ssh</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-web</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-jmx</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
 
         <!-- ============================================================ -->

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -565,6 +565,38 @@
             </exclusions>
         </dependency>
 
+        <!-- Concrete detector factory classes -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-simple</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-lineoriented</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-datagram</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-ssh</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-web</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-jmx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- ============================================================ -->
         <!-- Protocol implementations                                     -->
         <!-- ============================================================ -->

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -283,36 +283,96 @@
             </exclusions>
         </dependency>
 
-        <!-- Concrete detector factory classes -->
+        <!-- Concrete detector factory classes (exclusions match opennms-detectorclient-rpc) -->
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-simple</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-lineoriented</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-datagram</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-ssh</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-web</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-jmx</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
         </dependency>
 
         <!-- SNMP proxy RPC -->

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -283,6 +283,38 @@
             </exclusions>
         </dependency>
 
+        <!-- Concrete detector factory classes -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-simple</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-lineoriented</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-datagram</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-ssh</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-web</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-detector-jmx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- SNMP proxy RPC -->
         <dependency>
             <groupId>org.opennms.core.snmp</groupId>

--- a/core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java
@@ -74,6 +74,10 @@ import org.opennms.netmgt.model.jakarta.converter.OnmsSeverityConverter;
 import org.opennms.netmgt.model.jakarta.converter.PrimaryTypeConverter;
 import org.opennms.netmgt.provision.LocationAwareDetectorClient;
 import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
+import org.opennms.netmgt.provision.ServiceDetectorFactory;
+import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
+import org.opennms.netmgt.provision.detector.snmp.GenericSnmpDetectorFactory;
+import org.opennms.core.daemon.common.registry.LocalServiceDetectorRegistry;
 import org.opennms.netmgt.provision.detector.client.rpc.DetectorClientRpcModule;
 import org.opennms.netmgt.provision.detector.client.rpc.LocationAwareDetectorClientRpcImpl;
 import org.opennms.netmgt.provision.dns.client.rpc.DnsLookupClientRpcModule;
@@ -230,6 +234,28 @@ public class ProvisiondBootConfiguration {
     @Bean
     public SnmpProfileMapper snmpProfileMapper() {
         return new NoOpSnmpProfileMapper();
+    }
+
+    /**
+     * Override the default {@link LocalServiceDetectorRegistry} to inject
+     * {@link SnmpAgentConfigFactory} into SNMP detector factories.
+     *
+     * <p>ServiceLoader creates factory instances without Spring DI, so
+     * {@code @Autowired} fields like {@code SnmpAgentConfigFactory} are null.
+     * This bean post-processes the registry to wire the SNMP config.</p>
+     */
+    @Bean
+    public ServiceDetectorRegistry serviceDetectorRegistry(SnmpAgentConfigFactory snmpAgentConfigFactory) {
+        var registry = new LocalServiceDetectorRegistry();
+        // Inject SnmpAgentConfigFactory into any GenericSnmpDetectorFactory instances
+        for (String className : registry.getClassNames()) {
+            ServiceDetectorFactory<?> factory = registry.getDetectorFactoryByClassName(className);
+            if (factory instanceof GenericSnmpDetectorFactory<?> snmpFactory) {
+                snmpFactory.setAgentConfigFactory(snmpAgentConfigFactory);
+                LOG.info("Injected SnmpAgentConfigFactory into detector factory: {}", className);
+            }
+        }
+        return registry;
     }
 
     // ===================================================================

--- a/core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/opennms/netmgt/provision/boot/ProvisiondBootConfiguration.java
@@ -77,7 +77,6 @@ import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
 import org.opennms.netmgt.provision.ServiceDetectorFactory;
 import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
 import org.opennms.netmgt.provision.detector.snmp.GenericSnmpDetectorFactory;
-import org.opennms.core.daemon.common.registry.LocalServiceDetectorRegistry;
 import org.opennms.netmgt.provision.detector.client.rpc.DetectorClientRpcModule;
 import org.opennms.netmgt.provision.detector.client.rpc.LocationAwareDetectorClientRpcImpl;
 import org.opennms.netmgt.provision.dns.client.rpc.DnsLookupClientRpcModule;
@@ -237,25 +236,32 @@ public class ProvisiondBootConfiguration {
     }
 
     /**
-     * Override the default {@link LocalServiceDetectorRegistry} to inject
-     * {@link SnmpAgentConfigFactory} into SNMP detector factories.
+     * Inject {@link SnmpAgentConfigFactory} into SNMP detector factories after
+     * the {@link ServiceDetectorRegistry} bean is created by daemon-common.
      *
      * <p>ServiceLoader creates factory instances without Spring DI, so
      * {@code @Autowired} fields like {@code SnmpAgentConfigFactory} are null.
-     * This bean post-processes the registry to wire the SNMP config.</p>
+     * This bean wires the SNMP config into the factories post-creation.</p>
      */
     @Bean
-    public ServiceDetectorRegistry serviceDetectorRegistry(SnmpAgentConfigFactory snmpAgentConfigFactory) {
-        var registry = new LocalServiceDetectorRegistry();
-        // Inject SnmpAgentConfigFactory into any GenericSnmpDetectorFactory instances
-        for (String className : registry.getClassNames()) {
-            ServiceDetectorFactory<?> factory = registry.getDetectorFactoryByClassName(className);
-            if (factory instanceof GenericSnmpDetectorFactory<?> snmpFactory) {
-                snmpFactory.setAgentConfigFactory(snmpAgentConfigFactory);
-                LOG.info("Injected SnmpAgentConfigFactory into detector factory: {}", className);
+    public SmartLifecycle detectorRegistrySnmpConfigInjector(
+            ServiceDetectorRegistry registry, SnmpAgentConfigFactory snmpAgentConfigFactory) {
+        return new SmartLifecycle() {
+            private boolean running = false;
+            @Override public void start() {
+                for (String className : registry.getClassNames()) {
+                    ServiceDetectorFactory<?> factory = registry.getDetectorFactoryByClassName(className);
+                    if (factory instanceof GenericSnmpDetectorFactory<?> snmpFactory) {
+                        snmpFactory.setAgentConfigFactory(snmpAgentConfigFactory);
+                        LOG.info("Injected SnmpAgentConfigFactory into detector factory: {}", className);
+                    }
+                }
+                running = true;
             }
-        }
-        return registry;
+            @Override public void stop() { running = false; }
+            @Override public boolean isRunning() { return running; }
+            @Override public int getPhase() { return 0; }
+        };
     }
 
     // ===================================================================

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/registry/LocalServiceDetectorRegistry.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/registry/LocalServiceDetectorRegistry.java
@@ -35,7 +35,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Local ServiceDetectorRegistry for standalone daemon containers.
- * Discovers ServiceDetectorFactory implementations via ServiceLoader.
+ * Discovers ServiceDetectorFactory implementations via ServiceLoader,
+ * then falls back to explicit reflection for factories that ServiceLoader
+ * cannot discover across OSGi bundle boundaries.
  * Used by both Provisiond and Discovery daemon-loaders.
  */
 public class LocalServiceDetectorRegistry implements ServiceDetectorRegistry {
@@ -43,14 +45,69 @@ public class LocalServiceDetectorRegistry implements ServiceDetectorRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(LocalServiceDetectorRegistry.class);
     private final Map<String, ServiceDetectorFactory<?>> factoryByClassName = new HashMap<>();
 
+    /**
+     * Detector factories to register explicitly because OSGi's ServiceLoader
+     * can't discover them across bundle boundaries. These are concrete factory
+     * classes with no-arg constructors that Delta-V deployments require.
+     */
+    private static final String[] EXPLICIT_DETECTOR_FACTORIES = {
+        // opennms-detector-simple
+        "org.opennms.netmgt.provision.detector.icmp.IcmpDetectorFactory",
+        "org.opennms.netmgt.provision.detector.snmp.SnmpDetectorFactory",
+        "org.opennms.netmgt.provision.detector.smb.SmbDetectorFactory",
+        "org.opennms.netmgt.provision.detector.loop.LoopDetectorFactory",
+        // opennms-detector-lineoriented
+        "org.opennms.netmgt.provision.detector.msexchange.MSExchangeDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.CitrixDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.DominoIIOPDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.FtpDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.HttpDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.HttpsDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.ImapDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.ImapsDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.LdapDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.LdapsDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.MemcachedDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.NotesHttpDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.NrpeDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.Pop3DetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.SmtpDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.TcpDetectorFactory",
+        "org.opennms.netmgt.provision.detector.simple.TrivialTimeDetectorFactory",
+        // opennms-detector-datagram
+        "org.opennms.netmgt.provision.detector.datagram.DnsDetectorFactory",
+        "org.opennms.netmgt.provision.detector.datagram.NtpDetectorFactory",
+        // opennms-detector-ssh
+        "org.opennms.netmgt.provision.detector.ssh.SshDetectorFactory",
+        // opennms-detector-web
+        "org.opennms.netmgt.provision.detector.web.WebDetectorFactory",
+        // opennms-detector-jmx
+        "org.opennms.netmgt.provision.detector.jmx.Jsr160DetectorFactory",
+    };
+
     public LocalServiceDetectorRegistry() {
         ServiceLoader<ServiceDetectorFactory> loader = ServiceLoader.load(ServiceDetectorFactory.class);
         for (ServiceDetectorFactory<?> factory : loader) {
-            String className = factory.getDetectorClass().getCanonicalName();
-            factoryByClassName.put(className, factory);
-            LOG.info("Registered detector factory: {} -> {}", className, factory.getClass().getCanonicalName());
+            String detectorClassName = factory.getDetectorClass().getCanonicalName();
+            factoryByClassName.put(detectorClassName, factory);
+            LOG.info("Registered detector factory via ServiceLoader: {} -> {}", detectorClassName, factory.getClass().getCanonicalName());
         }
-        LOG.info("Loaded {} detector factories via ServiceLoader", factoryByClassName.size());
+        // In Karaf OSGi, ServiceLoader can't discover factories across bundle boundaries.
+        // Explicitly register factories via reflection using DynamicImport-Package: *.
+        for (String factoryClassName : EXPLICIT_DETECTOR_FACTORIES) {
+            try {
+                Class<?> clazz = Class.forName(factoryClassName, true, LocalServiceDetectorRegistry.class.getClassLoader());
+                ServiceDetectorFactory<?> factory = (ServiceDetectorFactory<?>) clazz.getDeclaredConstructor().newInstance();
+                String detectorClassName = factory.getDetectorClass().getCanonicalName();
+                if (!factoryByClassName.containsKey(detectorClassName)) {
+                    factoryByClassName.put(detectorClassName, factory);
+                    LOG.info("Registered detector factory via reflection: {} -> {}", detectorClassName, factoryClassName);
+                }
+            } catch (Exception e) {
+                LOG.warn("Could not register detector factory {}: {}", factoryClassName, e.getMessage());
+            }
+        }
+        LOG.info("Loaded {} detector factories total", factoryByClassName.size());
     }
 
     @Override

--- a/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -3,8 +3,16 @@
   foreign-source-dir="/opt/deltav/etc/foreign-sources"
   requistion-dir="/opt/deltav/etc/imports"
   importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
-  <requisition-def import-name="home-network"
-                   import-url-resource="file:///opt/deltav/etc/imports/home-network.xml">
-    <cron-schedule>0 0/5 * * * ?</cron-schedule>
+  <requisition-def import-name="delta-v"
+                   import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
+  <requisition-def import-name="cloud-services"
+                   import-url-resource="file:///opt/deltav/etc/imports/cloud-services.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
+  <requisition-def import-name="mhuot-labs"
+                   import-url-resource="file:///opt/deltav/etc/imports/mhuot-labs.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
   </requisition-def>
 </provisiond-configuration>

--- a/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -3,16 +3,8 @@
   foreign-source-dir="/opt/deltav/etc/foreign-sources"
   requistion-dir="/opt/deltav/etc/imports"
   importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
-  <requisition-def import-name="delta-v"
-                   import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-  <requisition-def import-name="cloud-services"
-                   import-url-resource="file:///opt/deltav/etc/imports/cloud-services.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-  <requisition-def import-name="mhuot-labs"
-                   import-url-resource="file:///opt/deltav/etc/imports/mhuot-labs.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  <requisition-def import-name="home-network"
+                   import-url-resource="file:///opt/deltav/etc/imports/home-network.xml">
+    <cron-schedule>0 0/5 * * * ?</cron-schedule>
   </requisition-def>
 </provisiond-configuration>

--- a/opennms-provision/opennms-detector-datagram/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+++ b/opennms-provision/opennms-detector-datagram/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
@@ -1,0 +1,2 @@
+org.opennms.netmgt.provision.detector.datagram.DnsDetectorFactory
+org.opennms.netmgt.provision.detector.datagram.NtpDetectorFactory

--- a/opennms-provision/opennms-detector-jmx/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+++ b/opennms-provision/opennms-detector-jmx/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
@@ -1,0 +1,1 @@
+org.opennms.netmgt.provision.detector.jmx.Jsr160DetectorFactory

--- a/opennms-provision/opennms-detector-lineoriented/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
@@ -1,0 +1,17 @@
+org.opennms.netmgt.provision.detector.msexchange.MSExchangeDetectorFactory
+org.opennms.netmgt.provision.detector.simple.CitrixDetectorFactory
+org.opennms.netmgt.provision.detector.simple.DominoIIOPDetectorFactory
+org.opennms.netmgt.provision.detector.simple.FtpDetectorFactory
+org.opennms.netmgt.provision.detector.simple.HttpDetectorFactory
+org.opennms.netmgt.provision.detector.simple.HttpsDetectorFactory
+org.opennms.netmgt.provision.detector.simple.ImapDetectorFactory
+org.opennms.netmgt.provision.detector.simple.ImapsDetectorFactory
+org.opennms.netmgt.provision.detector.simple.LdapDetectorFactory
+org.opennms.netmgt.provision.detector.simple.LdapsDetectorFactory
+org.opennms.netmgt.provision.detector.simple.MemcachedDetectorFactory
+org.opennms.netmgt.provision.detector.simple.NotesHttpDetectorFactory
+org.opennms.netmgt.provision.detector.simple.NrpeDetectorFactory
+org.opennms.netmgt.provision.detector.simple.Pop3DetectorFactory
+org.opennms.netmgt.provision.detector.simple.SmtpDetectorFactory
+org.opennms.netmgt.provision.detector.simple.TcpDetectorFactory
+org.opennms.netmgt.provision.detector.simple.TrivialTimeDetectorFactory

--- a/opennms-provision/opennms-detector-simple/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+++ b/opennms-provision/opennms-detector-simple/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
@@ -1,5 +1,4 @@
 org.opennms.netmgt.provision.detector.icmp.IcmpDetectorFactory
 org.opennms.netmgt.provision.detector.snmp.SnmpDetectorFactory
-org.opennms.netmgt.provision.detector.snmp.GenericSnmpDetectorFactory
 org.opennms.netmgt.provision.detector.smb.SmbDetectorFactory
 org.opennms.netmgt.provision.detector.loop.LoopDetectorFactory

--- a/opennms-provision/opennms-detector-simple/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+++ b/opennms-provision/opennms-detector-simple/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
@@ -1,0 +1,5 @@
+org.opennms.netmgt.provision.detector.icmp.IcmpDetectorFactory
+org.opennms.netmgt.provision.detector.snmp.SnmpDetectorFactory
+org.opennms.netmgt.provision.detector.snmp.GenericSnmpDetectorFactory
+org.opennms.netmgt.provision.detector.smb.SmbDetectorFactory
+org.opennms.netmgt.provision.detector.loop.LoopDetectorFactory

--- a/opennms-provision/opennms-detector-ssh/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+++ b/opennms-provision/opennms-detector-ssh/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
@@ -1,0 +1,1 @@
+org.opennms.netmgt.provision.detector.ssh.SshDetectorFactory

--- a/opennms-provision/opennms-detector-web/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+++ b/opennms-provision/opennms-detector-web/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
@@ -1,0 +1,1 @@
+org.opennms.netmgt.provision.detector.web.WebDetectorFactory


### PR DESCRIPTION
## Summary

- Register `ServiceDetectorFactory` implementations via `ServiceLoader` for Delta-V Spring Boot daemons
- Add detector module dependencies to Provisiond and Minion fat JARs
- Inject `SnmpAgentConfigFactory` into SNMP detector factories post-ServiceLoader instantiation

Without this fix, all service detection silently fails because detector factory classes are not on the classpath and have no `META-INF/services` registration. This leaves `ifservices` and `snmpinterface` tables empty, blocking Collectd and Pollerd from scheduling work.

## Root Cause

The Delta-V architecture forces all detector RPCs through Kafka (`RPC_KAFKA_FORCE_REMOTE=true`). In monolithic OpenNMS, detectors run locally in-process. The `LocalServiceDetectorRegistry` uses `java.util.ServiceLoader` to discover factories, matching the pattern established for monitors (`LocalServiceMonitorRegistry`) and collectors (`LocalServiceCollectorRegistry`). However, the detector modules were missing:

1. `META-INF/services` files for ServiceLoader discovery
2. POM dependencies in `daemon-boot-minion` and `daemon-boot-provisiond`
3. Spring OSGi exclusions (detector modules pull in ServiceMix Spring 4.x bundles)
4. `SnmpAgentConfigFactory` injection (ServiceLoader skips `@Autowired` fields)

## Changes

| File | Change |
|------|--------|
| 6 detector modules | Add `META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory` (26 factories) |
| `daemon-boot-minion/pom.xml` | Add 6 detector module deps with Spring OSGi exclusions |
| `daemon-boot-provisiond/pom.xml` | Add 6 detector module deps with Spring OSGi exclusions |
| `LocalServiceDetectorRegistry` | Add `EXPLICIT_DETECTOR_FACTORIES` reflection fallback (matches `EXPLICIT_MONITORS` pattern) |
| `ProvisiondBootConfiguration` | `SmartLifecycle` bean injects `SnmpAgentConfigFactory` into SNMP detector factories |

## Test plan

- [x] Provisiond loads 26 detector factories via ServiceLoader
- [x] Minion loads 26 detector factories and binds `Detect` RPC module
- [x] SNMP service detected and persisted to `ifservices`
- [x] `detectAgents()` finds SNMP service → `AgentScan` runs
- [x] ifTable/ifXTable walked → SNMP interfaces persisted (43 interfaces on UniFi Dream Router)
- [x] SSH, HTTP, HTTPS, DNS services detected and persisted
- [x] All 13 Delta-V services healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)