### PR TITLE
ci: add GHCR multi-arch image build workflow for Delta-V releases

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -1,0 +1,219 @@
+# Delta-V Build & Push Images
+#
+# Builds all Delta-V Docker images (16 total) and pushes them to GitHub
+# Container Registry (GHCR) as multi-arch images (linux/amd64 + linux/arm64).
+#
+# Trigger: Push a tag matching 'delta-v-*' (e.g., delta-v-1.0.0)
+#          or run manually via workflow_dispatch.
+#
+# Images built:
+#   Base layers:
+#     - ghcr.io/<owner>/jre-deltav:21          Custom JRE (jlink, Alpine)
+#     - ghcr.io/<owner>/daemon-base:<version>  Shared libs for all daemons
+#
+#   Daemons (12 Spring Boot fat JARs):
+#     - ghcr.io/<owner>/alarmd:<version>
+#     - ghcr.io/<owner>/bsmd:<version>
+#     - ghcr.io/<owner>/collectd:<version>
+#     - ghcr.io/<owner>/discovery:<version>
+#     - ghcr.io/<owner>/enlinkd:<version>
+#     - ghcr.io/<owner>/eventtranslator:<version>
+#     - ghcr.io/<owner>/perspectivepollerd:<version>
+#     - ghcr.io/<owner>/pollerd:<version>
+#     - ghcr.io/<owner>/provisiond:<version>
+#     - ghcr.io/<owner>/syslogd:<version>
+#     - ghcr.io/<owner>/telemetryd:<version>
+#     - ghcr.io/<owner>/trapd:<version>
+#
+#   Infrastructure:
+#     - ghcr.io/<owner>/minion-boot:<version>  Spring Boot Minion
+#     - ghcr.io/<owner>/db-init:<version>      Liquibase schema migration
+#
+# Usage after build:
+#   1. Set IMAGE_PREFIX in opennms-container/delta-v/.env:
+#        IMAGE_PREFIX=ghcr.io/<owner>
+#
+#   2. Authenticate to GHCR (one-time):
+#        echo $GITHUB_TOKEN | docker login ghcr.io -u <username> --password-stdin
+#
+#   3. Pull and deploy:
+#        cd opennms-container/delta-v
+#        docker compose pull
+#        ./deploy.sh up lite    # or passive, full
+#
+#   4. Verify:
+#        ./deploy.sh status
+#        ./deploy.sh test
+
+name: Delta-V Build & Push Images
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'delta-v-*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+  JAVA_VERSION: '21'
+  PLATFORMS: linux/amd64,linux/arm64
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build & Push Delta-V Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          cache: maven
+
+      - name: Extract version from POM
+        id: version
+        run: |
+          VERSION=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compile daemon-boot modules
+        run: |
+          ulimit -n 65536 || true
+          DAEMON_BOOTS=":org.opennms.core.daemon-boot-alarmd,:org.opennms.core.daemon-boot-bsmd,:org.opennms.core.daemon-boot-collectd,:org.opennms.core.daemon-boot-discovery,:org.opennms.core.daemon-boot-enlinkd,:org.opennms.core.daemon-boot-eventtranslator,:org.opennms.core.daemon-boot-minion,:org.opennms.core.daemon-boot-perspectivepollerd,:org.opennms.core.daemon-boot-pollerd,:org.opennms.core.daemon-boot-provisiond,:org.opennms.core.daemon-boot-syslogd,:org.opennms.core.daemon-boot-telemetryd,:org.opennms.core.daemon-boot-trapd"
+          ./mvnw -B -DskipTests --projects "${DAEMON_BOOTS}" -am install
+
+      - name: Compile db-init
+        run: ./mvnw -B -DskipTests -f core/db-init/pom.xml package
+
+      - name: Build and push JRE base image
+        working-directory: opennms-container/delta-v
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -f Dockerfile.jre \
+            -t "${{ env.IMAGE_PREFIX }}/jre-deltav:21" \
+            -t "${{ env.IMAGE_PREFIX }}/jre-deltav:latest" \
+            --push \
+            .
+
+      - name: Stage and deduplicate daemon JARs
+        working-directory: opennms-container/delta-v
+        run: ./compute-shared-libs.sh "${{ github.workspace }}" "${{ steps.version.outputs.version }}"
+
+      - name: Build and push daemon-base image
+        working-directory: opennms-container/delta-v
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build --no-cache \
+            --platform ${{ env.PLATFORMS }} \
+            -f Dockerfile.daemon-base \
+            --build-arg "JRE_IMAGE=${{ env.IMAGE_PREFIX }}/jre-deltav:21" \
+            -t "${{ env.IMAGE_PREFIX }}/daemon-base:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/daemon-base:latest" \
+            --push \
+            .
+
+      - name: Build and push per-daemon images
+        working-directory: opennms-container/delta-v
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd"
+          for name in $DAEMONS; do
+            MAIN_CLASS=$(cat "staging/$name/.main_class")
+            echo "==> Building $name (main: $MAIN_CLASS)..."
+            docker buildx build \
+              --platform ${{ env.PLATFORMS }} \
+              -f Dockerfile.daemon-per \
+              --build-arg "VERSION=${VERSION}" \
+              --build-arg "DAEMON_BASE_IMAGE=${{ env.IMAGE_PREFIX }}/daemon-base" \
+              --build-arg "DAEMON_NAME=$name" \
+              --build-arg "MAIN_CLASS=$MAIN_CLASS" \
+              -t "${{ env.IMAGE_PREFIX }}/$name:${VERSION}" \
+              -t "${{ env.IMAGE_PREFIX }}/$name:latest" \
+              --push \
+              .
+          done
+
+      - name: Stage and build Minion Boot image
+        working-directory: opennms-container/delta-v
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          mkdir -p staging/minion-boot
+          find "${{ github.workspace }}/core/daemon-boot-minion/target" \
+            -maxdepth 1 -name "*.jar" \
+            ! -name "*-sources.jar" ! -name "*-javadoc.jar" ! -name "*.original" \
+            -exec cp {} staging/minion-boot/daemon-boot-minion.jar \;
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            --build-arg "VERSION=${VERSION}" \
+            --build-arg "JRE_IMAGE=${{ env.IMAGE_PREFIX }}/jre-deltav:21" \
+            -f Dockerfile.minion-boot \
+            -t "${{ env.IMAGE_PREFIX }}/minion-boot:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/minion-boot:latest" \
+            --push \
+            .
+
+      - name: Build and push db-init image
+        working-directory: core/db-init
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -t "${{ env.IMAGE_PREFIX }}/db-init:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/db-init:latest" \
+            --push \
+            .
+
+      - name: Print image summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "## Delta-V Images Published to GHCR"
+          echo ""
+          echo "Platforms: ${{ env.PLATFORMS }}"
+          echo "Registry:  ${{ env.IMAGE_PREFIX }}"
+          echo "Version:   ${VERSION}"
+          echo ""
+          echo "### Quick Start"
+          echo ""
+          echo "1. Set IMAGE_PREFIX in opennms-container/delta-v/.env:"
+          echo "     IMAGE_PREFIX=${{ env.IMAGE_PREFIX }}"
+          echo ""
+          echo "2. Pull and deploy:"
+          echo "     cd opennms-container/delta-v"
+          echo "     docker compose pull"
+          echo "     ./deploy.sh up lite"
+          echo ""
+          echo "### Images"
+          DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init jre-deltav daemon-base"
+          for name in $DAEMONS; do
+            echo "  ${{ env.IMAGE_PREFIX }}/$name:${VERSION}"
+          done

--- a/opennms-container/delta-v/Dockerfile.daemon-per
+++ b/opennms-container/delta-v/Dockerfile.daemon-per
@@ -8,7 +8,8 @@
 # Built automatically by build.sh for each of the 12 daemons.
 
 ARG VERSION
-FROM opennms/daemon-base:${VERSION}
+ARG DAEMON_BASE_IMAGE=opennms/daemon-base
+FROM ${DAEMON_BASE_IMAGE}:${VERSION}
 
 ARG DAEMON_NAME
 ARG MAIN_CLASS

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -5,9 +5,12 @@
 # + Discovery + Trapd + Syslogd + EventTranslator + Enlinkd
 # + Provisiond + Bsmd + PerspectivePollerd + Telemetryd
 #
-# Images: Each daemon has its own image (opennms/<daemon>:${VERSION}) built
-# from a shared daemon-base layer. Build with: ./build.sh deltav
+# Images: Each daemon has its own image (${IMAGE_PREFIX}/<daemon>:${VERSION})
+# built from a shared daemon-base layer. Build with: ./build.sh deltav
 # Per-service config overlays remain as local bind mounts.
+#
+# To use GHCR images, set in .env:
+#   IMAGE_PREFIX=ghcr.io/mhuot
 #
 # Usage:
 #   docker compose up -d
@@ -68,7 +71,7 @@ services:
   # Liquibase migrations, then exits. All services that need PostgreSQL
   # should depend on this with condition: service_completed_successfully.
   db-init:
-    image: opennms/db-init:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/db-init:${VERSION}
     container_name: delta-v-db-init
     depends_on:
       postgres:
@@ -93,7 +96,7 @@ services:
       retries: 3
 
   minion:
-    image: opennms/minion-boot:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/minion-boot:${VERSION}
     container_name: delta-v-minion
     hostname: minion-default-01
     cap_add:
@@ -121,7 +124,7 @@ services:
 
   pollerd:
     profiles: [lite, full]
-    image: opennms/pollerd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/pollerd:${VERSION}
     container_name: delta-v-pollerd
     hostname: pollerd
     depends_on:
@@ -152,7 +155,7 @@ services:
 
   collectd:
     profiles: [lite, full]
-    image: opennms/collectd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/collectd:${VERSION}
     container_name: delta-v-collectd
     hostname: collectd
     depends_on:
@@ -179,7 +182,7 @@ services:
 
   discovery:
     profiles: [passive, full]
-    image: opennms/discovery:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/discovery:${VERSION}
     container_name: delta-v-discovery
     hostname: discovery
     depends_on:
@@ -211,7 +214,7 @@ services:
 
   trapd:
     profiles: [passive, full]
-    image: opennms/trapd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/trapd:${VERSION}
     container_name: delta-v-trapd
     hostname: trapd
     depends_on:
@@ -242,7 +245,7 @@ services:
 
   syslogd:
     profiles: [passive, full]
-    image: opennms/syslogd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/syslogd:${VERSION}
     container_name: delta-v-syslogd
     hostname: syslogd
     depends_on:
@@ -274,7 +277,7 @@ services:
 
   eventtranslator:
     profiles: [passive, full]
-    image: opennms/eventtranslator:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/eventtranslator:${VERSION}
     container_name: delta-v-eventtranslator
     hostname: eventtranslator
     depends_on:
@@ -303,7 +306,7 @@ services:
 
   enlinkd:
     profiles: [full]
-    image: opennms/enlinkd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/enlinkd:${VERSION}
     container_name: delta-v-enlinkd
     hostname: enlinkd
     environment:
@@ -331,7 +334,7 @@ services:
 
   provisiond:
     profiles: [lite, passive, full]
-    image: opennms/provisiond:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/provisiond:${VERSION}
     container_name: delta-v-provisiond
     hostname: provisiond
     depends_on:
@@ -364,7 +367,7 @@ services:
 
   bsmd:
     profiles: [lite, full]
-    image: opennms/bsmd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/bsmd:${VERSION}
     container_name: delta-v-bsmd
     hostname: bsmd
     depends_on:
@@ -393,7 +396,7 @@ services:
 
   perspectivepollerd:
     profiles: [full]
-    image: opennms/perspectivepollerd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/perspectivepollerd:${VERSION}
     container_name: delta-v-perspectivepollerd
     hostname: perspectivepollerd
     depends_on:
@@ -424,7 +427,7 @@ services:
 
   alarmd:
     profiles: [lite, passive, full]
-    image: opennms/alarmd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/alarmd:${VERSION}
     container_name: delta-v-alarmd
     hostname: alarmd
     depends_on:
@@ -451,7 +454,7 @@ services:
 
   telemetryd:
     profiles: [full]
-    image: opennms/telemetryd:${VERSION}
+    image: ${IMAGE_PREFIX:-opennms}/telemetryd:${VERSION}
     container_name: delta-v-telemetryd
     hostname: telemetryd
     depends_on:


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that builds and pushes all 16 Delta-V Docker images to GitHub Container Registry (GHCR) with multi-architecture support (linux/amd64 + linux/arm64).

## Trigger

- **Tag push**: `delta-v-*` (e.g., `git tag delta-v-1.0.0 && git push --tags`)
- **Manual**: workflow_dispatch from the Actions tab

## Images Built (16 total)

| Category | Images |
|----------|--------|
| Base layers | `jre-deltav:21`, `daemon-base:<version>` |
| Daemons (12) | `alarmd`, `bsmd`, `collectd`, `discovery`, `enlinkd`, `eventtranslator`, `perspectivepollerd`, `pollerd`, `provisiond`, `syslogd`, `telemetryd`, `trapd` |
| Infrastructure | `minion-boot`, `db-init` |

All images are pushed as `ghcr.io/<owner>/<name>:<version>` and `ghcr.io/<owner>/<name>:latest`.

## How to Use

```bash
# 1. Set IMAGE_PREFIX in opennms-container/delta-v/.env
IMAGE_PREFIX=ghcr.io/pbrane

# 2. Authenticate to GHCR (one-time)
echo $GITHUB_TOKEN | docker login ghcr.io -u <username> --password-stdin

# 3. Pull and deploy
cd opennms-container/delta-v
docker compose pull
./deploy.sh up lite    # or passive, full

# 4. Verify
./deploy.sh status
./deploy.sh test
```

## Changes

| File | Change |
|------|--------|
| `.github/workflows/delta-v-build-images.yml` | New workflow: compile, build, push 16 multi-arch images via QEMU + buildx |
| `opennms-container/delta-v/docker-compose.yml` | Parameterize image refs with `${IMAGE_PREFIX:-opennms}` (backward compatible) |
| `opennms-container/delta-v/Dockerfile.daemon-per` | Add `DAEMON_BASE_IMAGE` build arg for GHCR base image references |

## Test plan

- [x] Workflow builds and pushes all 16 images (verified on mhuot/delta-v fork)
- [x] ARM64 images run natively on Apple Silicon (no Rosetta emulation)
- [x] `docker compose pull` + `./deploy.sh up lite` deploys successfully from GHCR
- [x] All 13 services healthy after deploy
- [ ] Tag-triggered build (ready for first release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)