### PR TITLE
fix: update Newts tests for constructor injection

### DIFF
--- a/features/newts/src/test/java/org/opennms/netmgt/dao/support/NewtsResourceStorageDaoTest.java
+++ b/features/newts/src/test/java/org/opennms/netmgt/dao/support/NewtsResourceStorageDaoTest.java
@@ -83,10 +83,7 @@ public class NewtsResourceStorageDaoTest {
     public void setUp() {
         m_searcher = mock(CassandraSearcher.class);
 
-        m_nrs = new NewtsResourceStorageDao();
-        m_nrs.setSearcher(m_searcher);
-        m_nrs.setSearchableCache(m_cache);
-        m_nrs.setContext(Context.DEFAULT_CONTEXT);
+        m_nrs = new NewtsResourceStorageDao(m_context, m_searcher, null, null, null, m_cache);
     }
 
     @Test

--- a/features/newts/src/test/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategyTest.java
+++ b/features/newts/src/test/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategyTest.java
@@ -83,10 +83,7 @@ public class NewtsFetchStrategyTest {
         m_resourceDao = mock(ResourceDao.class);
         m_sampleRepository = mock(SampleRepository.class);
  
-        m_newtsFetchStrategy = new NewtsFetchStrategy();
-        m_newtsFetchStrategy.setContext(m_context);
-        m_newtsFetchStrategy.setResourceDao(m_resourceDao);
-        m_newtsFetchStrategy.setSampleRepository(m_sampleRepository);
+        m_newtsFetchStrategy = new NewtsFetchStrategy(m_context, m_resourceDao, m_sampleRepository);
     }
 
     @After

--- a/features/newts/src/test/java/org/opennms/netmgt/newts/NewtsWriterTest.java
+++ b/features/newts/src/test/java/org/opennms/netmgt/newts/NewtsWriterTest.java
@@ -61,8 +61,7 @@ public class NewtsWriterTest {
 
         LatchedSampleRepository sampleRepo = new LatchedSampleRepository(numWriterThreads);
         MetricRegistry registry = new MetricRegistry();
-        NewtsWriter writer = new NewtsWriter(1, ringBufferSize, numWriterThreads, registry);
-        writer.setSampleRepository(sampleRepo);
+        NewtsWriter writer = new NewtsWriter(sampleRepo, null, 1, ringBufferSize, numWriterThreads, registry);
 
         for (int i = 0; i < ringBufferSize*2; i++) {
             Resource x = new Resource("x");
@@ -84,8 +83,7 @@ public class NewtsWriterTest {
         Lock lock = new ReentrantLock();
         LockedSampleRepository sampleRepo = new LockedSampleRepository(lock);
         MetricRegistry registry = new MetricRegistry();
-        NewtsWriter writer = new NewtsWriter(1, ringBufferSize, numWriterThreads, registry);
-        writer.setSampleRepository(sampleRepo);
+        NewtsWriter writer = new NewtsWriter(sampleRepo, null, 1, ringBufferSize, numWriterThreads, registry);
 
         lock.lock();
         for (int i = 0; i < ringBufferSize; i++) {


### PR DESCRIPTION
## Summary
- Update 3 Newts test classes to use constructor signatures from PR #111
- `NewtsResourceStorageDaoTest` — pass context, searcher, cache via constructor
- `NewtsFetchStrategyTest` — pass context, resourceDao, sampleRepository via constructor  
- `NewtsWriterTest` — pass sampleRepository, indexer via constructor

These tests broke after PR #111 removed the no-arg constructors and setters.

## Test plan
- [x] All 3 test files compile
- [x] 80/80 E2E tests passing across 6 suites