### PR TITLE
build: add Delta-V fast-build targets to Makefile

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -100,6 +100,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # NOTE: Keep DAEMON_BOOTS in sync with DELTAV_MODULES in Makefile.
+      # The Makefile's deltav targets use the same module list for local
+      # dev iteration (with mvnd + skip flags). This workflow keeps
+      # checkstyle/enforcer enabled as CI quality gates.
       - name: Compile daemon-boot modules
         run: |
           ulimit -n 65536 || true

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,22 @@
 #   make it-tests                       Build and run all integration tests
 #   make all-test                       Build and run all tests (unit + integration)
 #
+# Delta-V fast-build targets (mvnd, parallel, skip flags):
+#   make deltav                         Rebuild all Delta-V daemon boot JARs (no --also-make)
+#   make deltav-full                    Rebuild Delta-V daemon boot JARs + all transitive deps
+#   make deltav-daemon DAEMON=provisiond   Rebuild a single daemon boot JAR
+#
 # Overridable variables (set on command line or in environment):
-#   MODULE       Maven module selector, e.g. :opennms-dao or groupId:artifactId
-#   TEST         Test class name for test-class target (suffix IT = integration test)
-#   MAVEN_FLAGS  Extra Maven flags (default: -DskipTests -B)
-#   MAVEN_OPTS   JVM options for Maven (has a sensible default below)
+#   MODULE           Maven module selector, e.g. :opennms-dao or groupId:artifactId
+#   DAEMON           Delta-V daemon short name for deltav-daemon (e.g. provisiond, minion)
+#   TEST             Test class name for test-class target (suffix IT = integration test)
+#   MAVEN_FLAGS      Extra Maven flags (default: -DskipTests -B)
+#   MAVEN_OPTS       JVM options for Maven (has a sensible default below)
+#   DELTAV_THREADS   Parallel threads for Delta-V builds (default: 4, matches Apple Silicon P-cores)
 # ==============================================================================
 
 MODULE      ?=
+DAEMON      ?=
 TEST        ?=
 MAVEN_FLAGS ?= -DskipTests -B
 MAVEN_OPTS  ?= -Xmx3g \
@@ -32,15 +40,37 @@ MAVEN_OPTS  ?= -Xmx3g \
                -Dmaven.wagon.http.retryHandler.count=3
 
 MVN         := ./mvnw
+MVND        := mvnd
 COMMON      := --color=always \
                -Djava.awt.headless=true \
                -Daether.connector.resumeDownloads=false \
                -Daether.connector.basic.threads=1 \
                -Droot.dir=$(CURDIR)
 
+# Delta-V fast-build configuration.
+# -T 4 targets the 4 performance cores on Apple Silicon M-series (4P+6E).
+# Override DELTAV_THREADS for other machines (e.g. DELTAV_THREADS=8 on x86 servers).
+DELTAV_THREADS ?= 4
+DELTAV_FLAGS   := -T $(DELTAV_THREADS) \
+                  -DskipTests \
+                  -DskipCheckstyle \
+                  -DskipEnforcer \
+                  -Dmaven.javadoc.skip=true
+
+# The Delta-V daemon boot JARs and their shared support modules.
+# No trailing comma. Keep alphabetical after the shared modules.
+#
+# NOTE: Keep this list in sync with .github/workflows/delta-v-build-images.yml
+#       which has its own DAEMON_BOOTS variable listing the same modules.
+#       If you add, remove, or rename a daemon-boot module, update BOTH.
+#       (These lists are separate because CI keeps checkstyle/enforcer
+#       enabled as quality gates — the dev targets below skip them for
+#       speed.)
+DELTAV_MODULES := :org.opennms.core.daemon-registry,:org.opennms.core.daemon-common,:org.opennms.core.daemon-boot-minion-common,:org.opennms.core.daemon-boot-alarmd,:org.opennms.core.daemon-boot-bsmd,:org.opennms.core.daemon-boot-collectd,:org.opennms.core.daemon-boot-discovery,:org.opennms.core.daemon-boot-enlinkd,:org.opennms.core.daemon-boot-eventtranslator,:org.opennms.core.daemon-boot-minion,:org.opennms.core.daemon-boot-perspectivepollerd,:org.opennms.core.daemon-boot-pollerd,:org.opennms.core.daemon-boot-provisiond,:org.opennms.core.daemon-boot-syslogd,:org.opennms.core.daemon-boot-telemetryd,:org.opennms.core.daemon-boot-trapd
+
 export MAVEN_OPTS
 
-.PHONY: help build module dependents test-class test ui clean
+.PHONY: help build module dependents test-class test ui clean deltav deltav-full deltav-daemon
 
 .DEFAULT_GOAL := help
 
@@ -49,10 +79,12 @@ help: ## Show this help
 	  | awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Variables (override on command line):"
-	@echo "  MODULE       Maven module selector (e.g. :opennms-dao)          (current: $(MODULE))"
-	@echo "  TEST         Test class name (suffix IT = integration test)     (current: $(TEST))"
-	@echo "  MAVEN_FLAGS  Extra Maven flags                                  (current: $(MAVEN_FLAGS))"
-	@echo "  MAVEN_OPTS   JVM options passed to Maven"
+	@echo "  MODULE           Maven module selector (e.g. :opennms-dao)          (current: $(MODULE))"
+	@echo "  DAEMON           Delta-V daemon short name (e.g. provisiond)        (current: $(DAEMON))"
+	@echo "  TEST             Test class name (suffix IT = integration test)     (current: $(TEST))"
+	@echo "  MAVEN_FLAGS      Extra Maven flags                                  (current: $(MAVEN_FLAGS))"
+	@echo "  DELTAV_THREADS   Parallel threads for deltav targets                (current: $(DELTAV_THREADS))"
+	@echo "  MAVEN_OPTS       JVM options passed to Maven"
 
 build: ## Compile and package all modules (tests skipped)
 	$(MVN) $(MAVEN_FLAGS) $(COMMON) \
@@ -111,3 +143,30 @@ ui: ## Install, build, and test the Vue UI
 
 clean: ## Remove all build artifacts
 	$(MVN) -B clean
+
+# ==============================================================================
+# Delta-V fast-build targets (mvnd + skip flags, targeted module lists)
+# ==============================================================================
+
+deltav: ## Fast rebuild of all Delta-V daemon boot JARs (mvnd, no -am)
+	@command -v $(MVND) >/dev/null 2>&1 || (echo "ERROR: mvnd not found. Install with: brew install mvndaemon/homebrew-mvnd/mvnd" && exit 1)
+	$(MVND) $(DELTAV_FLAGS) $(COMMON) \
+	  -Dbuild.profile=default \
+	  --projects $(DELTAV_MODULES) \
+	  install
+
+deltav-full: ## Rebuild Delta-V daemon boot JARs with all transitive deps (mvnd, --also-make)
+	@command -v $(MVND) >/dev/null 2>&1 || (echo "ERROR: mvnd not found. Install with: brew install mvndaemon/homebrew-mvnd/mvnd" && exit 1)
+	$(MVND) $(DELTAV_FLAGS) $(COMMON) \
+	  -Dbuild.profile=default \
+	  --projects $(DELTAV_MODULES) \
+	  --also-make \
+	  install
+
+deltav-daemon: ## Rebuild a single Delta-V daemon boot JAR; set DAEMON=provisiond (etc)
+	@test -n "$(DAEMON)" || (echo "ERROR: DAEMON is required, e.g.: make deltav-daemon DAEMON=provisiond" && exit 1)
+	@command -v $(MVND) >/dev/null 2>&1 || (echo "ERROR: mvnd not found. Install with: brew install mvndaemon/homebrew-mvnd/mvnd" && exit 1)
+	$(MVND) $(DELTAV_FLAGS) $(COMMON) \
+	  -Dbuild.profile=default \
+	  --projects :org.opennms.core.daemon-boot-$(DAEMON) \
+	  install


### PR DESCRIPTION
## Summary

Adds three Makefile targets that use \`mvnd\` with parallelism and skip flags for the Delta-V dev iteration loop, cutting build time from ~10 minutes to 2-4 seconds for the common change-and-rebuild cases.

## New Targets

| Target | Time | Use when |
|--------|------|----------|
| \`make deltav-daemon DAEMON=provisiond\` | **2s** | Changed only one daemon's boot config |
| \`make deltav\` | **4s** | Changed daemon-common/registry — rebuilds all 13 boot JARs |
| \`make deltav-full\` | ~10min | After \`git pull\` / new deps — uses \`--also-make\` |

## Configuration

- \`DELTAV_THREADS=4\` — matches Apple Silicon M-series performance-core count (4P+6E on MacBook Air). Override for x86 servers: \`make deltav DELTAV_THREADS=8\`.
- \`DELTAV_FLAGS\` — skips tests, checkstyle, enforcer, javadoc.
- Requires \`mvnd\` (\`brew install mvndaemon/homebrew-mvnd/mvnd\`). Existing targets still use \`./mvnw\`.

## Why It's Fast

The dev loop speedup comes from dropping \`--also-make\`. When only a handful of modules actually changed, walking all 219 transitive dependencies adds ~3s × 219 = ~10min of pure Maven lifecycle overhead, even though nothing needs to recompile.

\`make deltav\` explicitly lists all 16 Delta-V modules (3 shared + 13 daemon boot) so dependents don't need walking.

## Test plan
- [x] \`make deltav-daemon DAEMON=provisiond\` — 2.2s
- [x] \`make deltav\` — 4.0s
- [x] \`make help\` shows new targets and variables
- [x] Resulting JARs identical to \`make build\` output