### PR TITLE
docs: add PR #116 planning artifacts and Phase 3 next-session prompt

### DIFF
--- a/docs/plans/2026-04-04-delta-v-monitor-collector-detector-inventory.md
+++ b/docs/plans/2026-04-04-delta-v-monitor-collector-detector-inventory.md
@@ -1,0 +1,642 @@
+# Delta-V Monitor, Collector & Detector Inventory
+
+> **Purpose:** Decide which monitors, collectors, and detectors to carry forward into Delta-V vs. drop with legacy Horizon. This inventory informs the follow-up PR that replaces ServiceLoader + reflection with Spring Boot-native `@Bean` registration.
+>
+> **Voting:** Check the box next to your name for each item you want to **keep**. Leave unchecked to drop. Comment on any item you want to discuss.
+
+---
+
+## Context
+
+PR #112 (merged 2026-04-04) added ServiceLoader + reflection fallback registration for 26 detector factories. The current approach carries forward Karaf-era patterns (ServiceLoader, `EXPLICIT_*` reflection arrays, manual DI via SmartLifecycle). Before we clean this up, we need to decide **what to keep** so we only Spring-Boot-ify what survives.
+
+The same question applies to monitors and collectors, which use the same registration pattern.
+
+---
+
+## Monitors
+
+### Tier 1: Currently Registered in Delta-V (EXPLICIT_MONITORS)
+
+These 9 monitors are explicitly wired into `LocalServiceMonitorRegistry` and are used by Delta-V E2E tests today.
+
+#### IcmpMonitor — ICMP ping — Rec: **Keep**
+> Fundamental availability check
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SnmpMonitor — SNMP polling — Rec: **Keep**
+> Core network monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### TcpMonitor — TCP connect — Rec: **Keep**
+> Generic port availability
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### HttpMonitor — HTTP — Rec: **Keep**
+> Web service monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### HttpsMonitor — HTTPS — Rec: **Keep**
+> Web service monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### DnsMonitor — DNS resolution — Rec: **Keep**
+> Infrastructure monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SshMonitor — SSH — Rec: **Keep**
+> Server availability
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SSLCertMonitor — TLS certificate expiry — Rec: **Keep**
+> Essential ops — cert rotation alerts
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### PageSequenceMonitor — Multi-step HTTP transactions — Rec: **Keep**
+> Widely used for web app monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+---
+
+### Tier 2: Available via ServiceLoader (poller-monitors-core)
+
+These are loaded from `features/poller/monitors/core` via ServiceLoader. Most users never configure them.
+
+#### AvailabilityMonitor — Always UP — Rec: **Keep**
+> Used for passive/manual status
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### ActiveMQMonitor — ActiveMQ broker — Rec: **Evaluate**
+> JMS monitoring — still relevant?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### BgpSessionMonitor — BGP via SNMP — Rec: **Keep**
+> Network infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### CiscoIpSlaMonitor — Cisco IP SLA via SNMP — Rec: **Evaluate**
+> Cisco-specific but SNMP-based
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### CiscoPingMibMonitor — Cisco Ping MIB — Rec: **Evaluate**
+> Cisco-specific but SNMP-based
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### DiskUsageMonitor — Disk via SNMP (hrStorage) — Rec: **Keep**
+> Common server monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### DNSResolutionMonitor — Forward DNS lookup — Rec: **Keep**
+> Complements DnsMonitor
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### DskTableMonitor — Net-SNMP dskTable — Rec: **Keep**
+> Linux server monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### FtpMonitor — FTP — Rec: **Evaluate**
+> Declining protocol
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### HostResourceSwRunMonitor — Process via SNMP (hrSWRun) — Rec: **Keep**
+> Common server monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### HttpPostMonitor — HTTP POST — Rec: **Keep**
+> API monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### ImapMonitor — IMAP — Rec: **Evaluate**
+> Email infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### ImapsMonitor — IMAPS — Rec: **Evaluate**
+> Email infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### JDBCMonitor — JDBC connect — Rec: **Keep**
+> Database monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### JDBCQueryMonitor — JDBC query result — Rec: **Keep**
+> Database monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### JDBCStoredProcedureMonitor — JDBC stored proc — Rec: **Evaluate**
+> Niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### JolokiaBeanMonitor — JMX via Jolokia HTTP — Rec: **Keep**
+> Modern JMX monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### Jsr160Monitor — JMX via JSR-160 RMI — Rec: **Evaluate**
+> Legacy JMX — Jolokia preferred
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LaTableMonitor — Net-SNMP laTable (load avg) — Rec: **Keep**
+> Linux server monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LdapMonitor — LDAP — Rec: **Evaluate**
+> Directory services
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LdapsMonitor — LDAPS — Rec: **Evaluate**
+> Directory services
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LogMatchTableMonitor — Net-SNMP logMatch — Rec: **Evaluate**
+> Niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### MailTransportMonitor — SMTP+POP3 round-trip — Rec: **Evaluate**
+> Email infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### MemcachedMonitor — Memcached — Rec: **Evaluate**
+> Cache infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### MinaSshMonitor — SSH (Apache MINA impl) — Rec: **Evaluate**
+> Duplicate of SshMonitor?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### NrpeMonitor — Nagios NRPE — Rec: **Evaluate**
+> Nagios compatibility
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### NtpMonitor — NTP — Rec: **Keep**
+> Time infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### Pop3Monitor — POP3 — Rec: **Evaluate**
+> Email infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### PrTableMonitor — Net-SNMP prTable (process) — Rec: **Keep**
+> Linux server monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### PtpMonitor — IEEE 1588 PTP via SNMP — Rec: **Evaluate**
+> Precision time protocol
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SmtpMonitor — SMTP — Rec: **Evaluate**
+> Email infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### StrafePingMonitor — ICMP jitter/loss — Rec: **Keep**
+> Network quality monitoring
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### TrivialTimeMonitor — RFC 868 time — Rec: **Drop**
+> Obsolete protocol
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### WebMonitor — HTTP (simple) — Rec: **Evaluate**
+> Overlaps HttpMonitor
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+---
+
+### Tier 3: Drop Candidates (dead tech, ultra-niche, or security concerns)
+
+#### BSFMonitor — Bean Scripting Framework — Rec: **Drop**
+> Dead tech (Rhino/BeanShell)
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### CitrixMonitor — Citrix ICA — Rec: **Drop**
+> Dead tech
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### DominoIIOPMonitor — Lotus Domino IIOP — Rec: **Drop**
+> Dead tech (IBM Notes EOL)
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LoopMonitor — Loopback (always passes) — Rec: **Drop**
+> Testing only
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### NetScalerGroupHealthMonitor — Citrix NetScaler SNMP — Rec: **Drop**
+> Ultra-niche vendor
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### OmsaStorageMonitor — Dell OMSA storage SNMP — Rec: **Drop**
+> Legacy hardware mgmt
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### OpenManageChassisMonitor — Dell OMSA chassis SNMP — Rec: **Drop**
+> Legacy hardware mgmt
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### PercMonitor — Dell PERC RAID SNMP — Rec: **Drop**
+> Legacy hardware mgmt
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SmbMonitor — SMB/CIFS — Rec: **Drop**
+> Niche, security concerns
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SystemExecuteMonitor — Shell command execution — Rec: **Drop**
+> Security risk
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### Win32ServiceMonitor — Windows WMI service — Rec: **Drop**
+> Requires local WMI agent
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+---
+
+### Tier 4: Separate ServiceLoader modules (not in poller-monitors-core)
+
+#### WsManMonitor — features/wsman — Rec: **Drop**
+> WS-Management — niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### WmiMonitor — opennms-wmi — Rec: **Drop**
+> Windows WMI — niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### JCifsMonitor — protocols/cifs — Rec: **Drop**
+> CIFS/SMB file shares
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### RadiusAuthMonitor — protocols/radius — Rec: **Evaluate**
+> RADIUS auth testing
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SeleniumMonitor — protocols/selenium — Rec: **Drop**
+> Headless browser — heavyweight
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### PassiveServiceMonitor — features/poller/api — Rec: **Keep**
+> Passive status (used by E2E)
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+---
+
+## Collectors
+
+#### SnmpCollector — features/collection/snmp-collector — Rec: **Keep**
+> Core SNMP data collection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SnmpCollectorNG — features/collection/snmp-collector — Rec: **Keep**
+> Next-gen SNMP collector
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### HttpCollector — features/collection/collectors — Rec: **Keep**
+> HTTP metric scraping
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### PrometheusCollector — features/prometheus-collector — Rec: **Keep**
+> Modern metric scraping
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### JdbcCollector — features/jdbc-collector — Rec: **Keep**
+> SQL-based collection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### Jsr160Collector — features/collection/collectors — Rec: **Evaluate**
+> JMX collection — Jolokia preferred?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### WsManCollector — features/wsman — Rec: **Drop**
+> WS-Management — niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### WmiCollector — opennms-wmi — Rec: **Drop**
+> Windows WMI — niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### XmlCollector — protocols/xml — Rec: **Evaluate**
+> XML data sources — some users depend on it
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### TcaCollector — features/juniper-tca-collector — Rec: **Drop**
+> Juniper TCA — very niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+---
+
+## Detectors
+
+### Keep
+
+#### IcmpDetector — IcmpDetectorFactory — opennms-detector-simple — Rec: **Keep**
+> Fundamental
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SnmpDetector — SnmpDetectorFactory — opennms-detector-simple — Rec: **Keep**
+> Fundamental — requires SnmpAgentConfigFactory injection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### TcpDetector — TcpDetectorFactory — opennms-detector-lineoriented — Rec: **Keep**
+> Generic port detection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### HttpDetector — HttpDetectorFactory — opennms-detector-lineoriented — Rec: **Keep**
+> Web service detection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### HttpsDetector — HttpsDetectorFactory — opennms-detector-lineoriented — Rec: **Keep**
+> Web service detection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### FtpDetector — FtpDetectorFactory — opennms-detector-lineoriented — Rec: **Keep**
+> FTP detection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### DnsDetector — DnsDetectorFactory — opennms-detector-datagram — Rec: **Keep**
+> DNS infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### NtpDetector — NtpDetectorFactory — opennms-detector-datagram — Rec: **Keep**
+> Time infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SshDetector — SshDetectorFactory — opennms-detector-ssh — Rec: **Keep**
+> Server detection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### WebDetector — WebDetectorFactory — opennms-detector-web — Rec: **Keep**
+> HTTP detection (alt impl)
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LoopDetector — LoopDetectorFactory — opennms-detector-simple — Rec: **Keep**
+> Used for cloud service detection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+### Evaluate
+
+#### Pop3Detector — Pop3DetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Email — still relevant?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### SmtpDetector — SmtpDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Email — still relevant?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### ImapDetector — ImapDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Email — still relevant?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### ImapsDetector — ImapsDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Email — still relevant?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LdapDetector — LdapDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Directory services
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### LdapsDetector — LdapsDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Directory services
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### NrpeDetector — NrpeDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Nagios compatibility
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### MemcachedDetector — MemcachedDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> Cache infrastructure
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### TrivialTimeDetector — TrivialTimeDetectorFactory — opennms-detector-lineoriented — Rec: **Evaluate**
+> RFC 868 — obsolete?
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### Jsr160Detector — Jsr160DetectorFactory — opennms-detector-jmx — Rec: **Evaluate**
+> JMX detection
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+### Drop
+
+#### SmbDetector — SmbDetectorFactory — opennms-detector-simple — Rec: **Drop**
+> SMB/CIFS — niche
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### MSExchangeDetector — MSExchangeDetectorFactory — opennms-detector-lineoriented — Rec: **Drop**
+> Dead tech
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### CitrixDetector — CitrixDetectorFactory — opennms-detector-lineoriented — Rec: **Drop**
+> Dead tech
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### DominoIIOPDetector — DominoIIOPDetectorFactory — opennms-detector-lineoriented — Rec: **Drop**
+> Lotus Notes — dead tech
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+#### NotesHttpDetector — NotesHttpDetectorFactory — opennms-detector-lineoriented — Rec: **Drop**
+> Lotus Notes — dead tech
+- [ ] indigo423
+- [ ] mhuot
+- [ ] pbrane
+
+---
+
+## Voting Instructions
+
+1. **Check the box** next to your name for each item you want to **keep** in Delta-V
+2. **Leave unchecked** for items you're okay **dropping**
+3. **Comment** on this issue if you want to discuss a specific item or change the recommendation
+4. Items with 2+ votes to keep will be carried forward; items with 0-1 votes will be dropped
+
+## What Happens Next
+
+Once voting is complete, the follow-up spec will:
+1. Replace ServiceLoader + reflection with Spring `@Bean` factory methods for kept items
+2. Remove dropped modules from daemon-boot POMs
+3. Eliminate the SmartLifecycle workaround for SNMP detector factories
+4. Consolidate duplicated POM exclusions

--- a/docs/plans/2026-04-04-spring-native-registry-plan.md
+++ b/docs/plans/2026-04-04-spring-native-registry-plan.md
@@ -1,0 +1,574 @@
+# Spring Boot-Native Registry Registration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ServiceLoader + reflection registry patterns with explicit Spring `@Bean` registration in a dedicated `core/daemon-registry` module.
+
+**Architecture:** Create `core/daemon-registry` with three `@Configuration` classes (monitors, collectors, detectors) that construct registry beans from explicit lists. Refactor `GenericSnmpDetectorFactory` and all 9 subclasses for constructor injection. Boot configs `@Import` only the registries they need. Minion provides a no-op `SnmpAgentConfigFactory`.
+
+**Tech Stack:** Spring Boot 4.x, Spring Framework 7.x, Maven, Java 21
+
+**Spec:** `docs/plans/2026-04-04-spring-native-registry-spec.md`
+
+---
+
+## File Map
+
+### New Files (core/daemon-registry)
+
+| File | Responsibility |
+|------|---------------|
+| `core/daemon-registry/pom.xml` | Module POM — depends on poller-monitors-core, snmp-collector, detector modules, protocols/radius |
+| `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/MonitorRegistryConfiguration.java` | `@Configuration` creating `ServiceMonitorRegistry` with 17 monitors |
+| `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/CollectorRegistryConfiguration.java` | `@Configuration` creating `ServiceCollectorRegistry` with 1 collector |
+| `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/DetectorRegistryConfiguration.java` | `@Configuration` creating `ServiceDetectorRegistry` with 21 detector factories |
+| `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/LocalServiceMonitorRegistry.java` | Moved from daemon-common — accepts `List<ServiceMonitor>` |
+| `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/LocalServiceCollectorRegistry.java` | Moved from daemon-common — accepts `List<ServiceCollector>` |
+| `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/LocalServiceDetectorRegistry.java` | Moved from daemon-common — accepts `List<ServiceDetectorFactory<?>>` |
+| `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/NoOpSnmpAgentConfigFactory.java` | Throws `UnsupportedOperationException` — used only by Minion |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `core/pom.xml` | Add `<module>daemon-registry</module>` |
+| `opennms-provision/opennms-detector-simple/.../GenericSnmpDetectorFactory.java` | Constructor injection for `SnmpAgentConfigFactory` |
+| `opennms-provision/opennms-detector-simple/.../SnmpDetectorFactory.java` | Pass `SnmpAgentConfigFactory` through constructor |
+| `opennms-provision/opennms-detector-simple/.../BgpSessionDetectorFactory.java` | Update constructor (compilation fix) |
+| `opennms-provision/opennms-detector-simple/.../CiscoIpSlaDetectorFactory.java` | Update constructor (compilation fix) |
+| `opennms-provision/opennms-detector-simple/.../DiskUsageDetectorFactory.java` | Update constructor (compilation fix) |
+| `opennms-provision/opennms-detector-simple/.../HostResourceSWRunDetectorFactory.java` | Update constructor (compilation fix) |
+| `opennms-provision/opennms-detector-simple/.../OmsaStorageDetectorFactory.java` | Update constructor (compilation fix) |
+| `opennms-provision/opennms-detector-simple/.../OpenManageChassisDetectorFactory.java` | Update constructor (compilation fix) |
+| `opennms-provision/opennms-detector-simple/.../PercDetectorFactory.java` | Update constructor (compilation fix) |
+| `opennms-provision/opennms-detector-simple/.../Win32ServiceDetectorFactory.java` | Update constructor (compilation fix) |
+| `core/daemon-boot-pollerd/.../PollerdRpcConfiguration.java` | Remove `serviceMonitorRegistry()` bean, `@Import MonitorRegistryConfiguration` |
+| `core/daemon-boot-perspectivepollerd/.../PerspectivePollerdRpcConfiguration.java` | Remove `serviceMonitorRegistry()` bean, `@Import MonitorRegistryConfiguration` |
+| `core/daemon-boot-collectd/.../CollectdRpcConfiguration.java` | Remove `serviceCollectorRegistry()` bean + reflection hack, `@Import CollectorRegistryConfiguration` |
+| `core/daemon-boot-provisiond/.../ProvisiondBootConfiguration.java` | Remove `SmartLifecycle` bean, `@Import DetectorRegistryConfiguration` |
+| `core/daemon-boot-minion/.../PollerConfiguration.java` | Replace `DefaultServiceMonitorRegistry` with `@Import MonitorRegistryConfiguration` |
+| `core/daemon-boot-minion/.../CollectorConfiguration.java` | Replace `DefaultServiceCollectorRegistry` with `@Import CollectorRegistryConfiguration` |
+| `core/daemon-boot-minion/.../DetectorConfiguration.java` | Replace `LocalServiceDetectorRegistry()` with `@Import DetectorRegistryConfiguration`, add no-op `SnmpAgentConfigFactory` bean |
+| `core/daemon-boot-pollerd/pom.xml` | Add `daemon-registry` dependency |
+| `core/daemon-boot-perspectivepollerd/pom.xml` | Add `daemon-registry` dependency |
+| `core/daemon-boot-collectd/pom.xml` | Add `daemon-registry` dependency |
+| `core/daemon-boot-provisiond/pom.xml` | Add `daemon-registry` dependency, remove detector module deps (moved to daemon-registry) |
+| `core/daemon-boot-minion/pom.xml` | Add `daemon-registry` dependency, remove detector module deps (moved to daemon-registry) |
+
+### Deleted Files
+
+| File | Why |
+|------|-----|
+| `core/daemon-common/.../LocalServiceMonitorRegistry.java` | Moved to daemon-registry |
+| `core/daemon-common/.../LocalServiceCollectorRegistry.java` | Moved to daemon-registry |
+| `core/daemon-common/.../LocalServiceDetectorRegistry.java` | Moved to daemon-registry |
+| 6 `META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory` files | ServiceLoader no longer used for detectors |
+
+---
+
+## Task 1: Create `core/daemon-registry` Module
+
+**Files:**
+- Create: `core/daemon-registry/pom.xml`
+- Modify: `core/pom.xml` (add module)
+
+- [ ] **Step 1: Create the module POM**
+
+Create `core/daemon-registry/pom.xml` with dependencies on poller-monitors-core, snmp-collector, all 6 detector modules, and protocols/radius. Include Spring OSGi exclusions (copied from daemon-boot-provisiond for detector modules). Use `jar` packaging.
+
+- [ ] **Step 2: Add module to core/pom.xml**
+
+Add `<module>daemon-registry</module>` to the `<modules>` section in `core/pom.xml`.
+
+- [ ] **Step 3: Verify module compiles**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-registry -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-registry/pom.xml core/pom.xml
+git commit -m "refactor: create core/daemon-registry module skeleton"
+```
+
+---
+
+## Task 2: Refactor GenericSnmpDetectorFactory for Constructor Injection
+
+**Files:**
+- Modify: `opennms-provision/opennms-detector-simple/src/main/java/org/opennms/netmgt/provision/detector/snmp/GenericSnmpDetectorFactory.java`
+- Modify: `opennms-provision/opennms-detector-simple/src/main/java/org/opennms/netmgt/provision/detector/snmp/SnmpDetectorFactory.java`
+- Modify: 8 other `*DetectorFactory.java` files in the same package (BgpSession, CiscoIpSla, DiskUsage, HostResourceSWRun, OmsaStorage, OpenManageChassis, Perc, Win32Service)
+
+- [ ] **Step 1: Refactor GenericSnmpDetectorFactory**
+
+Change the constructor to accept `SnmpAgentConfigFactory`:
+
+```java
+public GenericSnmpDetectorFactory(Class<T> clazz, SnmpAgentConfigFactory agentConfigFactory) {
+    super((Class<SnmpDetector>) clazz);
+    this.m_agentConfigFactory = agentConfigFactory;
+}
+```
+
+Make `m_agentConfigFactory` final. Remove `@Autowired` annotation. Keep the getter (used by `SnmpDetectorFactory.getRuntimeAttributes`). Remove the setter.
+
+- [ ] **Step 2: Update SnmpDetectorFactory**
+
+Change constructor from no-arg to:
+
+```java
+public SnmpDetectorFactory(SnmpAgentConfigFactory agentConfigFactory) {
+    super(SnmpDetector.class, agentConfigFactory);
+}
+```
+
+Remove `@Component` annotation (will be instantiated by `DetectorRegistryConfiguration`).
+
+- [ ] **Step 3: Update all 8 non-kept subclasses**
+
+Each changes from `super(XxxDetector.class)` to `super(XxxDetector.class, agentConfigFactory)`:
+
+```java
+// Example: BgpSessionDetectorFactory
+public BgpSessionDetectorFactory(SnmpAgentConfigFactory agentConfigFactory) {
+    super(BgpSessionDetector.class, agentConfigFactory);
+}
+```
+
+Apply to: BgpSessionDetectorFactory, CiscoIpSlaDetectorFactory, DiskUsageDetectorFactory, HostResourceSWRunDetectorFactory, OmsaStorageDetectorFactory, OpenManageChassisDetectorFactory, PercDetectorFactory, Win32ServiceDetectorFactory.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `./compile.pl -DskipTests --projects :opennms-detector-simple -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add opennms-provision/opennms-detector-simple/
+git commit -m "refactor: convert GenericSnmpDetectorFactory and 9 subclasses to constructor injection"
+```
+
+---
+
+## Task 3: Move and Refactor Registry Classes
+
+**Files:**
+- Create: `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/LocalServiceMonitorRegistry.java`
+- Create: `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/LocalServiceCollectorRegistry.java`
+- Create: `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/LocalServiceDetectorRegistry.java`
+- Delete: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/registry/LocalServiceMonitorRegistry.java`
+- Delete: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/registry/LocalServiceCollectorRegistry.java`
+- Delete: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/registry/LocalServiceDetectorRegistry.java`
+
+- [ ] **Step 1: Create LocalServiceMonitorRegistry in daemon-registry**
+
+New package: `org.opennms.core.daemon.registry`. Constructor accepts `List<ServiceMonitor>`. Remove ServiceLoader, remove `EXPLICIT_MONITORS` array, remove all reflection code.
+
+```java
+package org.opennms.core.daemon.registry;
+
+public class LocalServiceMonitorRegistry implements ServiceMonitorRegistry {
+    private final Map<String, ServiceMonitor> monitorsByClassName = new HashMap<>();
+
+    public LocalServiceMonitorRegistry(List<ServiceMonitor> monitors) {
+        for (ServiceMonitor monitor : monitors) {
+            monitorsByClassName.put(monitor.getClass().getCanonicalName(), monitor);
+            LOG.info("Registered monitor: {}", monitor.getClass().getCanonicalName());
+        }
+        LOG.info("Loaded {} monitors", monitorsByClassName.size());
+    }
+
+    @Override
+    public ServiceMonitor getMonitorByClassName(String className) {
+        return monitorsByClassName.get(className);
+    }
+
+    @Override
+    public Set<String> getMonitorClassNames() {
+        return Collections.unmodifiableSet(monitorsByClassName.keySet());
+    }
+}
+```
+
+- [ ] **Step 2: Create LocalServiceCollectorRegistry in daemon-registry**
+
+Constructor accepts `List<ServiceCollector>`. Same simplification — no ServiceLoader, no OSGi onBind/onUnbind.
+
+```java
+public class LocalServiceCollectorRegistry implements ServiceCollectorRegistry {
+    private final Map<String, ServiceCollector> collectorsByClassName = new HashMap<>();
+
+    public LocalServiceCollectorRegistry(List<ServiceCollector> collectors) {
+        for (ServiceCollector collector : collectors) {
+            collectorsByClassName.put(collector.getClass().getCanonicalName(), collector);
+            LOG.info("Registered collector: {}", collector.getClass().getCanonicalName());
+        }
+        LOG.info("Loaded {} collectors", collectorsByClassName.size());
+    }
+
+    @Override
+    public CompletableFuture<ServiceCollector> getCollectorFutureByClassName(String className) {
+        ServiceCollector collector = collectorsByClassName.get(className);
+        if (collector != null) {
+            return CompletableFuture.completedFuture(collector);
+        }
+        return CompletableFuture.failedFuture(
+                new IllegalArgumentException("Collector not found: " + className));
+    }
+
+    @Override
+    public Set<String> getCollectorClassNames() {
+        return Collections.unmodifiableSet(collectorsByClassName.keySet());
+    }
+}
+```
+
+- [ ] **Step 3: Create LocalServiceDetectorRegistry in daemon-registry**
+
+Constructor accepts `List<ServiceDetectorFactory<?>>`. Keys by `factory.getDetectorClass().getCanonicalName()`. No ServiceLoader, no `EXPLICIT_DETECTOR_FACTORIES`, no reflection.
+
+- [ ] **Step 4: Delete old registry classes from daemon-common**
+
+Delete all three files from `core/daemon-common/src/main/java/org/opennms/core/daemon/common/registry/`.
+
+- [ ] **Step 5: Update imports in all consumers**
+
+Update import statements in these files from `org.opennms.core.daemon.common.registry.*` to `org.opennms.core.daemon.registry.*`:
+- `core/daemon-boot-pollerd/.../PollerdRpcConfiguration.java`
+- `core/daemon-boot-perspectivepollerd/.../PerspectivePollerdRpcConfiguration.java`
+- `core/daemon-boot-collectd/.../CollectdRpcConfiguration.java`
+- `core/daemon-boot-provisiond/.../ProvisiondBootConfiguration.java`
+- `core/daemon-boot-minion/.../DetectorConfiguration.java`
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-registry,:org.opennms.core.daemon-boot-pollerd,:org.opennms.core.daemon-boot-collectd,:org.opennms.core.daemon-boot-provisiond,:org.opennms.core.daemon-boot-minion -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/daemon-registry/src/ core/daemon-common/src/ core/daemon-boot-*/
+git commit -m "refactor: move registry classes to daemon-registry, accept List via constructor"
+```
+
+---
+
+## Task 4: Create Configuration Classes and NoOpSnmpAgentConfigFactory
+
+**Files:**
+- Create: `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/MonitorRegistryConfiguration.java`
+- Create: `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/CollectorRegistryConfiguration.java`
+- Create: `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/DetectorRegistryConfiguration.java`
+- Create: `core/daemon-registry/src/main/java/org/opennms/core/daemon/registry/NoOpSnmpAgentConfigFactory.java`
+
+- [ ] **Step 1: Create MonitorRegistryConfiguration**
+
+```java
+@Configuration
+public class MonitorRegistryConfiguration {
+    @Bean
+    public ServiceMonitorRegistry serviceMonitorRegistry() {
+        return new LocalServiceMonitorRegistry(List.of(
+            new IcmpMonitor(),
+            new SnmpMonitor(),
+            new TcpMonitor(),
+            new HttpMonitor(),
+            new HttpsMonitor(),
+            new DnsMonitor(),
+            new SshMonitor(),
+            new SSLCertMonitor(),
+            new PageSequenceMonitor(),
+            new BgpSessionMonitor(),
+            new DNSResolutionMonitor(),
+            new MinaSshMonitor(),
+            new NtpMonitor(),
+            new StrafePingMonitor(),
+            new WebMonitor(),
+            new PassiveServiceMonitor(),
+            new RadiusAuthMonitor()
+        ));
+    }
+}
+```
+
+- [ ] **Step 2: Create CollectorRegistryConfiguration**
+
+Takes `LocationAwareSnmpClient` as a parameter and injects it into SnmpCollector via setter:
+
+```java
+@Configuration
+public class CollectorRegistryConfiguration {
+    @Bean
+    public ServiceCollectorRegistry serviceCollectorRegistry(LocationAwareSnmpClient snmpClient) {
+        var snmpCollector = new SnmpCollector();
+        snmpCollector.setLocationAwareSnmpClient(snmpClient);
+        return new LocalServiceCollectorRegistry(List.of(snmpCollector));
+    }
+}
+```
+
+- [ ] **Step 3: Create NoOpSnmpAgentConfigFactory**
+
+Implements `SnmpAgentConfigFactory`, throws `UnsupportedOperationException` on all methods. Add a log warning in the constructor so any accidental usage is visible.
+
+- [ ] **Step 4: Create DetectorRegistryConfiguration**
+
+Takes `SnmpAgentConfigFactory` as a parameter:
+
+```java
+@Configuration
+public class DetectorRegistryConfiguration {
+    @Bean
+    public ServiceDetectorRegistry serviceDetectorRegistry(SnmpAgentConfigFactory snmpAgentConfigFactory) {
+        return new LocalServiceDetectorRegistry(List.of(
+            new IcmpDetectorFactory(),
+            new SnmpDetectorFactory(snmpAgentConfigFactory),
+            new SmbDetectorFactory(),
+            new LoopDetectorFactory(),
+            new TcpDetectorFactory(),
+            new HttpDetectorFactory(),
+            new HttpsDetectorFactory(),
+            new FtpDetectorFactory(),
+            new Pop3DetectorFactory(),
+            new SmtpDetectorFactory(),
+            new ImapDetectorFactory(),
+            new ImapsDetectorFactory(),
+            new LdapDetectorFactory(),
+            new LdapsDetectorFactory(),
+            new NrpeDetectorFactory(),
+            new MemcachedDetectorFactory(),
+            new DnsDetectorFactory(),
+            new NtpDetectorFactory(),
+            new SshDetectorFactory(),
+            new WebDetectorFactory(),
+            new Jsr160DetectorFactory()
+        ));
+    }
+}
+```
+
+Note: Only `SnmpDetectorFactory` extends `GenericSnmpDetectorFactory` and needs `snmpAgentConfigFactory`. `SmbDetectorFactory` and `LoopDetectorFactory` extend `GenericServiceDetectorFactory` (not SNMP) and use their existing no-arg constructors.
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `./compile.pl -DskipTests --projects :org.opennms.core.daemon-registry -am install`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/daemon-registry/src/
+git commit -m "refactor: add registry @Configuration classes and NoOpSnmpAgentConfigFactory"
+```
+
+---
+
+## Task 5: Update Daemon Boot Configs to @Import Registries
+
+**Files:**
+- Modify: `core/daemon-boot-pollerd/.../PollerdRpcConfiguration.java`
+- Modify: `core/daemon-boot-perspectivepollerd/.../PerspectivePollerdRpcConfiguration.java`
+- Modify: `core/daemon-boot-collectd/.../CollectdRpcConfiguration.java`
+- Modify: `core/daemon-boot-provisiond/.../ProvisiondBootConfiguration.java`
+- Modify: `core/daemon-boot-minion/.../PollerConfiguration.java`
+- Modify: `core/daemon-boot-minion/.../CollectorConfiguration.java`
+- Modify: `core/daemon-boot-minion/.../DetectorConfiguration.java`
+- Modify: 5 `daemon-boot-*/pom.xml` files
+
+- [ ] **Step 1: Update PollerdRpcConfiguration**
+
+Add `@Import(MonitorRegistryConfiguration.class)` to the class. Remove the `serviceMonitorRegistry()` `@Bean` method (it's now provided by the imported configuration). Keep the `pollerClientRpcModule` bean that consumes the registry.
+
+- [ ] **Step 2: Update PerspectivePollerdRpcConfiguration**
+
+Same pattern as Pollerd — `@Import(MonitorRegistryConfiguration.class)`, remove `serviceMonitorRegistry()`.
+
+- [ ] **Step 3: Update CollectdRpcConfiguration**
+
+`@Import(CollectorRegistryConfiguration.class)`. Remove the `serviceCollectorRegistry()` bean and the reflection-based `setLocationAwareSnmpClient` hack (the `CollectorRegistryConfiguration` handles this cleanly).
+
+- [ ] **Step 4: Update ProvisiondBootConfiguration**
+
+`@Import(DetectorRegistryConfiguration.class)`. Remove the `SmartLifecycle detectorRegistrySnmpConfigInjector` bean entirely. The detector registry already has the SnmpAgentConfigFactory injected via constructor.
+
+- [ ] **Step 5: Update Minion PollerConfiguration**
+
+`@Import(MonitorRegistryConfiguration.class)`. Replace `new DefaultServiceMonitorRegistry()` with removal of the `serviceMonitorRegistry()` bean (now provided by import).
+
+- [ ] **Step 6: Update Minion CollectorConfiguration**
+
+`@Import(CollectorRegistryConfiguration.class)`. Replace `new DefaultServiceCollectorRegistry()` with removal of the `serviceCollectorRegistry()` bean.
+
+- [ ] **Step 7: Update Minion DetectorConfiguration**
+
+`@Import(DetectorRegistryConfiguration.class)`. Replace `new LocalServiceDetectorRegistry()` with removal of the `serviceDetectorRegistry()` bean. Add a `@Bean` for `NoOpSnmpAgentConfigFactory`:
+
+```java
+@Bean
+public SnmpAgentConfigFactory snmpAgentConfigFactory() {
+    return new NoOpSnmpAgentConfigFactory();
+}
+```
+
+- [ ] **Step 8: Update POM dependencies**
+
+Add `<dependency>` on `org.opennms.core.daemon-registry` to:
+- `core/daemon-boot-pollerd/pom.xml`
+- `core/daemon-boot-perspectivepollerd/pom.xml`
+- `core/daemon-boot-collectd/pom.xml`
+- `core/daemon-boot-provisiond/pom.xml`
+- `core/daemon-boot-minion/pom.xml`
+
+Remove detector module dependencies from `daemon-boot-provisiond/pom.xml` and `daemon-boot-minion/pom.xml` (they're now transitive via `daemon-registry`).
+
+- [ ] **Step 9: Verify compilation**
+
+Run: `make build`
+Expected: BUILD SUCCESS (may have pre-existing test failures in graph/integration-tests — ignore those)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add core/daemon-boot-*/
+git commit -m "refactor: replace ServiceLoader with @Import registry configurations in all boot configs"
+```
+
+---
+
+## Task 6: Delete ServiceLoader Artifacts
+
+**Files:**
+- Delete: 6 `META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory` files
+- Delete: `META-INF/services/org.opennms.netmgt.poller.ServiceMonitor` from poller-monitors-core (if only used by ServiceLoader)
+- Delete: `META-INF/services/org.opennms.netmgt.collection.api.ServiceCollector` from snmp-collector (if only used by ServiceLoader)
+
+- [ ] **Step 1: Delete detector ServiceLoader files**
+
+```bash
+rm opennms-provision/opennms-detector-simple/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+rm opennms-provision/opennms-detector-lineoriented/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+rm opennms-provision/opennms-detector-datagram/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+rm opennms-provision/opennms-detector-ssh/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+rm opennms-provision/opennms-detector-web/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+rm opennms-provision/opennms-detector-jmx/src/main/resources/META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory
+```
+
+- [ ] **Step 2: Verify build still works**
+
+Run: `make build`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -u opennms-provision/
+git commit -m "refactor: remove ServiceLoader META-INF/services files for detectors"
+```
+
+---
+
+## Task 7: Build, Deploy, and Run E2E Tests
+
+- [ ] **Step 1: Build Docker images**
+
+```bash
+cd opennms-container/delta-v && bash build.sh deltav
+```
+
+Expected: All 16 images built successfully.
+
+- [ ] **Step 2: Deploy with clean restart**
+
+```bash
+docker compose --profile full down && docker compose --profile full up -d
+```
+
+Wait 45 seconds, verify all 16 services healthy.
+
+- [ ] **Step 3: Verify registry counts in logs**
+
+```bash
+docker logs delta-v-provisiond 2>&1 | grep "Loaded.*detector"
+# Expected: "Loaded 21 detectors"
+
+docker logs delta-v-pollerd 2>&1 | grep "Loaded.*monitor"
+# Expected: "Loaded 17 monitors"
+
+docker logs delta-v-collectd 2>&1 | grep "Loaded.*collector"
+# Expected: "Loaded 1 collectors"
+
+docker logs delta-v-minion 2>&1 | grep "Loaded"
+# Expected: 17 monitors, 1 collector, 21 detectors
+```
+
+- [ ] **Step 4: Verify no ServiceLoader or reflection log lines**
+
+```bash
+docker logs delta-v-provisiond 2>&1 | grep -i "ServiceLoader\|via reflection"
+# Expected: no output
+
+docker logs delta-v-minion 2>&1 | grep -i "ServiceLoader\|via reflection"
+# Expected: no output
+```
+
+- [ ] **Step 5: Verify slim daemons don't contain detector JARs**
+
+```bash
+# Alarmd should NOT have detector modules
+jar tf core/daemon-boot-alarmd/target/*-boot.jar | grep "detector-simple\|detector-lineoriented"
+# Expected: no output
+```
+
+- [ ] **Step 6: Run all 6 E2E test suites**
+
+Run each sequentially from `opennms-container/delta-v/`:
+
+```bash
+./test-e2e.sh --verbose
+./test-minion-e2e.sh --verbose
+./test-syslog-e2e.sh --verbose
+./test-passive-e2e.sh --verbose
+./test-collectd-e2e.sh --verbose
+./test-enlinkd-e2e.sh --verbose
+```
+
+Expected: All suites pass.
+
+- [ ] **Step 7: Push Minion image to labbox and verify**
+
+```bash
+docker tag opennms/minion-boot:36.0.0-SNAPSHOT pbrane/minion-boot:latest
+docker push pbrane/minion-boot:latest
+ssh pbrane@labbox "cd ~/delta-v && docker compose pull && docker compose up -d"
+```
+
+Verify 21 detector factories, 17 monitors, 1 collector on labbox Minion.
+
+- [ ] **Step 8: Commit (if any fixes were needed)**
+
+```bash
+git commit -m "fix: address E2E test failures from registry migration"
+```
+
+---
+
+## Task 8: Create PR
+
+- [ ] **Step 1: Create feature branch and push**
+
+```bash
+git checkout -b refactor/spring-native-registries
+git push -u origin refactor/spring-native-registries
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --repo pbrane/delta-v --base develop --title "refactor: Spring Boot-native monitor/collector/detector registration" --body "..."
+```
+
+Include E2E results table, counts (17 monitors, 1 collector, 21 detectors), and list of deleted patterns (ServiceLoader, EXPLICIT_* arrays, SmartLifecycle, reflection).

--- a/docs/plans/2026-04-04-spring-native-registry-spec.md
+++ b/docs/plans/2026-04-04-spring-native-registry-spec.md
@@ -1,0 +1,326 @@
+# Spec: Spring Boot-Native Monitor, Collector & Detector Registration
+
+> **Date:** 2026-04-04
+> **Status:** Draft
+> **Replaces:** ServiceLoader + reflection pattern from PR #112
+> **Blocked by:** None — inventory decisions finalized (pbrane/delta-v#115)
+
+---
+
+## Problem
+
+PR #112 added detector factory registration using Karaf-era patterns: `ServiceLoader` discovery, `EXPLICIT_DETECTOR_FACTORIES` reflection fallback, and a `SmartLifecycle` workaround to inject `SnmpAgentConfigFactory` into ServiceLoader-created instances. The same patterns exist for monitors (`EXPLICIT_MONITORS` in `LocalServiceMonitorRegistry`). These patterns create instances outside Spring's DI container, requiring manual post-construction wiring.
+
+This conflicts with Delta-V's direction: constructor injection (PR #111), Karaf elimination, and explicit Spring Boot configuration.
+
+## Solution
+
+Replace ServiceLoader + reflection with explicit Spring `@Bean` factory methods. Extract shared `@Configuration` classes in a **new `core/daemon-registry` module** (not `daemon-common`) to avoid classpath bloat. Refactor `GenericSnmpDetectorFactory` and all its subclasses to accept `SnmpAgentConfigFactory` via constructor injection. Provide a no-op `SnmpAgentConfigFactory` bean on Minion since it receives SNMP config via RPC request attributes.
+
+## Inventory (from pbrane/delta-v#115)
+
+### Monitors (17)
+
+| Monitor | Source Module |
+|---------|-------------|
+| IcmpMonitor | poller-monitors-core |
+| SnmpMonitor | poller-monitors-core |
+| TcpMonitor | poller-monitors-core |
+| HttpMonitor | poller-monitors-core |
+| HttpsMonitor | poller-monitors-core |
+| DnsMonitor | poller-monitors-core |
+| SshMonitor | poller-monitors-core |
+| SSLCertMonitor | poller-monitors-core |
+| PageSequenceMonitor | poller-monitors-core |
+| BgpSessionMonitor | poller-monitors-core |
+| DNSResolutionMonitor | poller-monitors-core |
+| MinaSshMonitor | poller-monitors-core |
+| NtpMonitor | poller-monitors-core |
+| StrafePingMonitor | poller-monitors-core |
+| WebMonitor | poller-monitors-core |
+| PassiveServiceMonitor | poller-api |
+| RadiusAuthMonitor | protocols/radius |
+
+### Collectors (1)
+
+| Collector | Source Module |
+|-----------|-------------|
+| SnmpCollector | features/collection/snmp-collector |
+
+### Detectors (21)
+
+| Detector | Factory | Source Module | DI Needs |
+|----------|---------|-------------|----------|
+| IcmpDetector | IcmpDetectorFactory | opennms-detector-simple | None |
+| SnmpDetector | SnmpDetectorFactory | opennms-detector-simple | **SnmpAgentConfigFactory** |
+| SmbDetector | SmbDetectorFactory | opennms-detector-simple | None |
+| LoopDetector | LoopDetectorFactory | opennms-detector-simple | None |
+| TcpDetector | TcpDetectorFactory | opennms-detector-lineoriented | None |
+| HttpDetector | HttpDetectorFactory | opennms-detector-lineoriented | None |
+| HttpsDetector | HttpsDetectorFactory | opennms-detector-lineoriented | None |
+| FtpDetector | FtpDetectorFactory | opennms-detector-lineoriented | None |
+| Pop3Detector | Pop3DetectorFactory | opennms-detector-lineoriented | None |
+| SmtpDetector | SmtpDetectorFactory | opennms-detector-lineoriented | None |
+| ImapDetector | ImapDetectorFactory | opennms-detector-lineoriented | None |
+| ImapsDetector | ImapsDetectorFactory | opennms-detector-lineoriented | None |
+| LdapDetector | LdapDetectorFactory | opennms-detector-lineoriented | None |
+| LdapsDetector | LdapsDetectorFactory | opennms-detector-lineoriented | None |
+| NrpeDetector | NrpeDetectorFactory | opennms-detector-lineoriented | None |
+| MemcachedDetector | MemcachedDetectorFactory | opennms-detector-lineoriented | None |
+| DnsDetector | DnsDetectorFactory | opennms-detector-datagram | None |
+| NtpDetector | NtpDetectorFactory | opennms-detector-datagram | None |
+| SshDetector | SshDetectorFactory | opennms-detector-ssh | None |
+| WebDetector | WebDetectorFactory | opennms-detector-web | None |
+| Jsr160Detector | Jsr160DetectorFactory | opennms-detector-jmx | None |
+
+## Architecture
+
+### New Module: `core/daemon-registry`
+
+A dedicated module containing the three `@Configuration` classes and the registry implementations. This avoids classpath bloat — only daemons that need registries (Pollerd, Collectd, Provisiond, Minion, PerspectivePollerd) depend on this module. Daemons that don't (Alarmd, Syslogd, Trapd, EventTranslator, Discovery, Enlinkd, Bsmd, db-init) remain unaffected.
+
+```
+core/daemon-registry/
+  pom.xml                    — depends on poller-monitors-core, snmp-collector,
+                               detector-simple, detector-lineoriented, detector-datagram,
+                               detector-ssh, detector-web, detector-jmx, protocols/radius
+  src/main/java/org/opennms/core/daemon/registry/
+    MonitorRegistryConfiguration.java
+    CollectorRegistryConfiguration.java
+    DetectorRegistryConfiguration.java
+    LocalServiceMonitorRegistry.java       — moved from daemon-common
+    LocalServiceCollectorRegistry.java     — moved from daemon-common
+    LocalServiceDetectorRegistry.java      — moved from daemon-common
+```
+
+#### MonitorRegistryConfiguration
+
+```java
+@Configuration
+public class MonitorRegistryConfiguration {
+    @Bean
+    public ServiceMonitorRegistry serviceMonitorRegistry() {
+        return new LocalServiceMonitorRegistry(List.of(
+            new IcmpMonitor(),
+            new SnmpMonitor(),
+            new TcpMonitor(),
+            new HttpMonitor(),
+            new HttpsMonitor(),
+            new DnsMonitor(),
+            new SshMonitor(),
+            new SSLCertMonitor(),
+            new PageSequenceMonitor(),
+            new BgpSessionMonitor(),
+            new DNSResolutionMonitor(),
+            new MinaSshMonitor(),
+            new NtpMonitor(),
+            new StrafePingMonitor(),
+            new WebMonitor(),
+            new PassiveServiceMonitor(),
+            new RadiusAuthMonitor()
+        ));
+    }
+}
+```
+
+#### CollectorRegistryConfiguration
+
+```java
+@Configuration
+public class CollectorRegistryConfiguration {
+    @Bean
+    public ServiceCollectorRegistry serviceCollectorRegistry() {
+        return new LocalServiceCollectorRegistry(List.of(
+            new SnmpCollector()
+        ));
+    }
+}
+```
+
+#### DetectorRegistryConfiguration
+
+```java
+@Configuration
+public class DetectorRegistryConfiguration {
+    @Bean
+    public ServiceDetectorRegistry serviceDetectorRegistry(SnmpAgentConfigFactory snmpAgentConfigFactory) {
+        return new LocalServiceDetectorRegistry(List.of(
+            new IcmpDetectorFactory(),
+            new SnmpDetectorFactory(snmpAgentConfigFactory),
+            new SmbDetectorFactory(),
+            new LoopDetectorFactory(),
+            new TcpDetectorFactory(),
+            new HttpDetectorFactory(),
+            new HttpsDetectorFactory(),
+            new FtpDetectorFactory(),
+            new Pop3DetectorFactory(),
+            new SmtpDetectorFactory(),
+            new ImapDetectorFactory(),
+            new ImapsDetectorFactory(),
+            new LdapDetectorFactory(),
+            new LdapsDetectorFactory(),
+            new NrpeDetectorFactory(),
+            new MemcachedDetectorFactory(),
+            new DnsDetectorFactory(),
+            new NtpDetectorFactory(),
+            new SshDetectorFactory(),
+            new WebDetectorFactory(),
+            new Jsr160DetectorFactory()
+        ));
+    }
+}
+```
+
+### Registry Class Changes
+
+The three registry classes move from `daemon-common` to `daemon-registry` and change from self-discovering (ServiceLoader + reflection in constructor) to accepting a pre-built list via constructor injection:
+
+```java
+public class LocalServiceMonitorRegistry implements ServiceMonitorRegistry {
+    private final Map<String, ServiceMonitor> monitorsByClassName;
+
+    public LocalServiceMonitorRegistry(List<ServiceMonitor> monitors) {
+        monitorsByClassName = new HashMap<>();
+        for (ServiceMonitor monitor : monitors) {
+            monitorsByClassName.put(monitor.getClass().getCanonicalName(), monitor);
+            LOG.info("Registered monitor: {}", monitor.getClass().getCanonicalName());
+        }
+        LOG.info("Loaded {} monitors", monitorsByClassName.size());
+    }
+    // ... existing getter methods unchanged
+}
+```
+
+Same pattern for `LocalServiceCollectorRegistry` (accepts `List<ServiceCollector>`) and `LocalServiceDetectorRegistry` (accepts `List<ServiceDetectorFactory<?>>`).
+
+### GenericSnmpDetectorFactory Changes
+
+Refactor to accept `SnmpAgentConfigFactory` via constructor instead of `@Autowired` field + setter:
+
+```java
+public class GenericSnmpDetectorFactory<T extends SnmpDetector> extends GenericServiceDetectorFactory<SnmpDetector> {
+    private final SnmpAgentConfigFactory agentConfigFactory;
+
+    public GenericSnmpDetectorFactory(Class<T> clazz, SnmpAgentConfigFactory agentConfigFactory) {
+        super((Class<SnmpDetector>) clazz);
+        this.agentConfigFactory = agentConfigFactory;
+    }
+    // ... remove @Autowired field, remove setter, remove getter
+}
+```
+
+**All 9 subclasses** must be updated to pass through the factory:
+
+| Subclass | Status |
+|----------|--------|
+| SnmpDetectorFactory | **Keep** — used in Delta-V |
+| BgpSessionDetectorFactory | Not in Delta-V — update constructor for compilation |
+| CiscoIpSlaDetectorFactory | Not in Delta-V — update constructor for compilation |
+| DiskUsageDetectorFactory | Not in Delta-V — update constructor for compilation |
+| HostResourceSWRunDetectorFactory | Not in Delta-V — update constructor for compilation |
+| OmsaStorageDetectorFactory | Not in Delta-V — update constructor for compilation |
+| OpenManageChassisDetectorFactory | Not in Delta-V — update constructor for compilation |
+| PercDetectorFactory | Not in Delta-V — update constructor for compilation |
+| Win32ServiceDetectorFactory | Not in Delta-V — update constructor for compilation |
+
+Each non-kept subclass changes from:
+```java
+public BgpSessionDetectorFactory() {
+    super(BgpSessionDetector.class);
+}
+```
+to:
+```java
+public BgpSessionDetectorFactory(SnmpAgentConfigFactory agentConfigFactory) {
+    super(BgpSessionDetector.class, agentConfigFactory);
+}
+```
+
+### Minion SnmpAgentConfigFactory
+
+Verified: Minion does **not** need a real `SnmpAgentConfigFactory` for detector execution. On the core side (Provisiond), the factory populates `runtimeAttributes` in the RPC request. On the Minion side, `SnmpDetector.getAgentConfig()` reads these attributes from the request — it never calls the factory directly.
+
+`MinionBootConfiguration` provides a no-op bean to satisfy the `DetectorRegistryConfiguration` dependency:
+
+```java
+@Bean
+public SnmpAgentConfigFactory snmpAgentConfigFactory() {
+    // Minion receives SNMP config via RPC request attributes.
+    // This no-op satisfies DetectorRegistryConfiguration's dependency.
+    return new NoOpSnmpAgentConfigFactory();
+}
+```
+
+Create `NoOpSnmpAgentConfigFactory` in `core/daemon-registry` (its only consumer). It throws `UnsupportedOperationException` on all methods — any call to it on Minion indicates a bug. If another service needs it in the future, it can be moved to `daemon-common` at that point.
+
+### Daemon Boot Config Changes
+
+Each boot config adds `@Import` for the registries it needs and a dependency on `core/daemon-registry`:
+
+| Boot Config | @Import | POM dependency |
+|-------------|---------|---------------|
+| PollerdBootConfiguration | `MonitorRegistryConfiguration` | `core/daemon-registry` |
+| PerspectivePollerdBootConfiguration | `MonitorRegistryConfiguration` | `core/daemon-registry` |
+| CollectdBootConfiguration | `CollectorRegistryConfiguration` | `core/daemon-registry` |
+| ProvisiondBootConfiguration | `DetectorRegistryConfiguration` | `core/daemon-registry` |
+| MinionBootConfiguration | All three `*RegistryConfiguration` | `core/daemon-registry` |
+
+**Not affected** (no dependency on `daemon-registry`): Alarmd, Bsmd, Discovery, Enlinkd, EventTranslator, Syslogd, Trapd, Telemetryd, db-init.
+
+## What Gets Deleted
+
+| File/Code | Why |
+|-----------|-----|
+| `EXPLICIT_MONITORS` array + reflection loop in `LocalServiceMonitorRegistry` | Replaced by constructor `List<ServiceMonitor>` |
+| `EXPLICIT_DETECTOR_FACTORIES` array + reflection loop in `LocalServiceDetectorRegistry` | Replaced by constructor `List<ServiceDetectorFactory<?>>` |
+| ServiceLoader calls in all three registry constructors | Replaced by constructor injection |
+| `SmartLifecycle detectorRegistrySnmpConfigInjector` bean in `ProvisiondBootConfiguration` | SnmpAgentConfigFactory now injected via constructor |
+| `@Autowired SnmpAgentConfigFactory` field + setter/getter in `GenericSnmpDetectorFactory` | Replaced by constructor parameter + final field |
+| 6 `META-INF/services/org.opennms.netmgt.provision.ServiceDetectorFactory` files | ServiceLoader no longer used |
+| `META-INF/services/org.opennms.netmgt.poller.ServiceMonitor` in poller-monitors-core | ServiceLoader no longer used |
+| `META-INF/services/org.opennms.netmgt.collection.api.ServiceCollector` in snmp-collector | ServiceLoader no longer used |
+| Karaf/OSGi comments referencing bundle boundaries and DynamicImport-Package | Dead context |
+| Registry classes from `daemon-common` (moved to `daemon-registry`) | Relocated |
+
+## What Gets Removed from POMs
+
+Collector modules no longer needed:
+- `features/collection/collectors` (HttpCollector, Jsr160Collector)
+- `features/prometheus-collector`
+- `features/jdbc-collector`
+- `features/wsman`
+- `opennms-wmi`
+- `protocols/xml`
+- `features/juniper-tca-collector`
+
+Monitor modules no longer needed:
+- `protocols/cifs`
+- `protocols/selenium`
+- `opennms-wmi`
+- `features/wsman`
+
+Spring OSGi exclusion blocks in `daemon-boot-provisiond/pom.xml` and `daemon-boot-minion/pom.xml` can be consolidated since we're trimming the dependency list. The exclusions move to `daemon-registry/pom.xml` — one copy instead of two.
+
+## Testing
+
+1. **Unit tests**: Verify each registry accepts its list and returns correct lookups
+2. **Boot smoke test**: Each daemon starts and logs the expected number of monitors/collectors/detectors
+3. **Slim daemon verification**: Confirm Alarmd, Syslogd, Trapd, etc. do NOT contain monitor/collector/detector JARs in their fat JARs
+4. **E2E suites**: All 6 suites must pass (test-e2e, test-minion-e2e, test-syslog-e2e, test-passive-e2e, test-collectd-e2e, test-enlinkd-e2e)
+5. **Detector verification**: Provisiond logs "21 detector factories", all SNMP detection works
+6. **Minion verification**: Minion logs same counts, RPC detection works end-to-end, no-op SnmpAgentConfigFactory is never called
+
+## Adding a Monitor/Collector/Detector in the Future
+
+To add a new capability (e.g., if voting adds something back):
+
+1. Add the Maven dependency to `core/daemon-registry/pom.xml` (with Spring OSGi exclusions if needed)
+2. Add one line to the appropriate `*RegistryConfiguration.java` — e.g., `new FooMonitor()`
+3. If it needs DI, add it as a parameter to the `@Bean` method
+4. Build and deploy
+
+No ServiceLoader files, no reflection arrays, no SmartLifecycle workarounds.
+
+## Scope Note
+
+This spec covers the registration mechanism only. The underlying monitor/collector/detector implementation classes are not modified (except `GenericSnmpDetectorFactory` and its 9 subclasses for constructor injection). Dropping unused modules from the Maven reactor is a separate future task.

--- a/docs/plans/2026-04-05-next-session-extract-from-horizon.md
+++ b/docs/plans/2026-04-05-next-session-extract-from-horizon.md
@@ -1,0 +1,107 @@
+# Next Session: Brainstorm Phase 3 — Extract Delta-V from Horizon
+
+> Copy everything below the line into the next Claude Code conversation.
+
+---
+
+## Goal
+
+Brainstorm and write a spec for extracting Delta-V completely from the OpenNMS/Horizon codebase, publishing our own Horizon-derived artifacts to GitHub Packages (or similar), so that the `pbrane/delta-v` repo only contains Delta-V-specific code and depends on Horizon JARs as external Maven artifacts.
+
+## Why This Matters
+
+Phase 1 (mvnd + skip flags) made single-module rebuilds take ~3 seconds, but a full build still takes ~10 minutes because we're compiling 219 Horizon modules from source every time. The repo has **780 pom.xml files** — 561 of them are Horizon modules we don't actually need (webapp, Karaf features, RPM/DEB assembly, tests, correlator, vaadin UI, etc.).
+
+Phase 2 (reactor pruning) would drop this to ~220 modules and probably ~4 min build. Phase 3 goes further: extract all Horizon code entirely, depending on it as pre-built JARs, leaving Delta-V with only ~20-30 Delta-V-specific modules. Build time drops to **under 2 minutes**.
+
+## Current State (verified 2026-04-05)
+
+**What Delta-V depends on from Horizon:** ~219 `org.opennms.*:36.0.0-SNAPSHOT` artifacts (all built locally).
+
+**What Delta-V already gets from external repos (maven.opennms.org):**
+- `org.opennms:jicmp-api:3.0.4` — JNI ICMP wrapper (separate project, native libs)
+- `org.opennms:jicmp6-api:3.0.4` — JNI ICMPv6 wrapper
+- `org.opennms.integration.api:api:2.0.0` — Plugin API
+- `org.opennms.integration.api:common:2.0.0` — Plugin API common
+- `org.opennms.newts:newts-*:3.0.0` — Newts timeseries library
+
+**Delta-V-specific modules we'd keep in the repo:**
+- `core/daemon-registry` (new in PR #116)
+- `core/daemon-common`
+- `core/daemon-boot-minion-common`
+- `core/daemon-boot-*` (14 boot JARs)
+- `core/db-init`
+- `opennms-container/delta-v/` (Docker + compose + E2E tests)
+- `docs/plans/` (our planning docs)
+
+That's ~20 Delta-V-specific modules.
+
+## Brainstorming Questions
+
+Before writing the spec, we need to answer:
+
+### Publishing strategy
+1. **Where do we publish the 219 Horizon JARs?**
+   - GitHub Packages (ghcr.io / npm.pkg.github.com for Maven)
+   - GitHub Actions producing a Maven repo site
+   - Self-hosted Nexus / Artifactory
+   - Contribute back to `maven.opennms.org` (unlikely, we're a fork)
+2. **How do we version them?**
+   - Keep `36.0.0-SNAPSHOT` and publish snapshots?
+   - Use semver like `deltav-36.0.0-20260405`?
+   - Tag-driven releases (e.g., `delta-v-horizon-1.0.0`)?
+3. **How do we sync with upstream Horizon?**
+   - When Horizon/OpenNMS releases a new version, we cherry-pick/sync into a separate **horizon-fork** repo, build, and re-publish?
+   - Or we pin to specific Horizon release tags and sync periodically?
+
+### Repo organization options
+
+**Option A: Two repos**
+- `pbrane/delta-v-horizon` — fork of OpenNMS/opennms, pruned to 219 needed modules, publishes JARs via CI
+- `pbrane/delta-v` — Delta-V-specific code only, depends on delta-v-horizon JARs
+
+**Option B: Single repo with separate subtree**
+- `pbrane/delta-v` with two top-level directories: `horizon/` (synced from upstream) and `delta-v/` (our code)
+- Build pipeline publishes horizon JARs on push to master, then builds delta-v using them
+
+**Option C: Submodule / subtree**
+- `pbrane/delta-v` with `pbrane/horizon-fork` as a git submodule
+- Less favored — submodules are painful
+
+### Sync strategy for upstream Horizon updates
+
+When OpenNMS releases a new version (or we want a bugfix from upstream):
+1. How do we detect what changed?
+2. How do we apply it to our Horizon fork (if separate repo)?
+3. How do we test that Delta-V still works against the new JARs?
+4. Do we need a staging area / compatibility matrix?
+
+### CI/CD implications
+- New workflow to publish Horizon JARs (triggered by what?)
+- Existing `delta-v-build-images.yml` workflow (PR #113) would consume these JARs
+- How do we handle auth for private GitHub Packages from Docker builds?
+
+### Migration approach
+- Big-bang vs incremental?
+- Can we test Phase 3 alongside Phase 2 (pruned reactor) before committing?
+- What's the rollback plan if it doesn't work?
+
+## Reference Material
+
+- **Spec for PR #116 (precedent for this kind of refactor):** `docs/plans/2026-04-04-spring-native-registry-spec.md`
+- **Plan for PR #116:** `docs/plans/2026-04-04-spring-native-registry-plan.md`
+- **Current dependency analysis from 2026-04-05 session:** 219 local org.opennms SNAPSHOT modules in daemon-boot transitive closure, 5 external OpenNMS artifact families.
+
+## Suggested Approach for the Session
+
+1. Use `superpowers:brainstorming` skill to work through the questions above
+2. Decide on publishing strategy + repo organization
+3. Write a spec to `docs/plans/2026-04-05-horizon-extraction-spec.md`
+4. Based on user feedback, consider whether to also write an implementation plan, or whether Phase 2 (reactor pruning) should happen first as a stepping stone
+
+## Important Reminders
+
+- **Never create PRs against OpenNMS/opennms** — always `--repo pbrane/delta-v`
+- **Always pull develop before branching**
+- **Feature branches for all work; merge via PR**
+- **Memory index (`MEMORY.md`) must be updated if we add long-lived architectural decisions**


### PR DESCRIPTION
## Summary

Adds four planning documents that were referenced from merged commits and memory but hadn't been tracked in git:

- **\`2026-04-04-delta-v-monitor-collector-detector-inventory.md\`** — Keep/drop inventory for monitors, collectors, and detectors. Also published as pbrane/delta-v#115 for team voting.
- **\`2026-04-04-spring-native-registry-spec.md\`** — Design spec for PR #116 (Spring Boot-native registry refactor).
- **\`2026-04-04-spring-native-registry-plan.md\`** — Task-by-task implementation plan for PR #116.
- **\`2026-04-05-next-session-extract-from-horizon.md\`** — Bootstrap prompt for Phase 3 (Horizon extraction brainstorm).

## Why

These artifacts are the planning trail behind recent work. Keeping them in git makes them grep-able and preserves the rationale behind decisions.

## Test plan
- [x] No code changes — docs only