### PR TITLE
test: PR0 Minion RPC canary E2E (Phase 3 gate)

### DIFF
--- a/docs/plans/2026-04-05-horizon-extraction-brainstorm.md
+++ b/docs/plans/2026-04-05-horizon-extraction-brainstorm.md
@@ -1,0 +1,266 @@
+# Brainstorm Transcript: Extract Delta-V from Horizon (Phase 3)
+
+> **Date:** 2026-04-05
+> **Spec:** [2026-04-05-horizon-extraction-spec.md](2026-04-05-horizon-extraction-spec.md)
+> **Format:** Question-by-question summary with options presented, decision made, and reasoning captured for future reference.
+
+This document is the reasoning archaeology artifact for the Phase 3 extraction spec. Each section records a brainstorming question, the options considered, the decision made, and the insights surfaced during discussion. Future contributors reading this can understand *why* the spec took the shape it did, not just *what* was decided.
+
+---
+
+## Q1: Upstream Sync Relationship
+
+**Question:** How will Delta-V relate to upstream OpenNMS/Horizon going forward?
+
+**Context:** The 2026-03-25 upstream sync examined 46 commits and cherry-picked 1. That datapoint suggests architectural divergence — 98% of upstream changes land on code paths Delta-V doesn't use (Karaf, webapp, correlator, Vaadin). The sync relationship shapes every downstream decision (versioning, repo organization, CI complexity).
+
+**Options presented:**
+- **A. Continuous selective sync** — monitor upstream monthly, cherry-pick fitting bugfixes (similar to current practice but formalized)
+- **B. Release-anchored sync** — pin to OpenNMS release tags, sync quarterly
+- **C. Opportunistic / as-needed** — no regular cadence; pull only when needed
+- **D. Hard fork / snapshot** — take today's snapshot, never sync again
+
+**Decision: D (Hard fork)**
+
+**Clarification surfaced during discussion:** User described behavior that sounded between C and D — "learn of a bug, analyze in Delta-V, implement the fix ourselves but doesn't necessarily need to be a cherry-pick." This is structurally D with an upstream-as-reference nuance: OpenNMS GitHub is consulted for bug *intelligence*, but fixes are Delta-V-authored commits with no upstream ancestry.
+
+**Physical distinction between C and D:**
+- Under **C**, the horizon-fork repo has `upstream` as a git remote; cherry-picks preserve upstream commit ancestry.
+- Under **D**, the horizon-fork has no `upstream` remote; all commits are Delta-V-authored; the repo is philosophically separate from OpenNMS.
+
+**Consequences of D locked in:**
+- No sync cadence, no sync tooling, no cherry-pick workflow
+- Version numbers are ours to assign (no implicit alignment with OpenNMS releases)
+- Horizon-fork repo git history is linear and Delta-V-owned
+- Groupwise, the `org.opennms.*` package decision becomes orthogonal to C/D (same answer either way)
+
+**Key insight:** The single configuration choice "does `upstream` exist as a git remote?" encodes the entire philosophy. Without upstream as a remote, the repo can't accidentally drift into being a live fork.
+
+---
+
+## Q2: Repo Organization
+
+**Question:** How should the extracted code be organized across repositories?
+
+**Options presented:**
+- **A. Two repos** — `pbrane/delta-v-horizon` (publishes JARs) + `pbrane/delta-v` (consumes)
+- **B. Single repo with subtree** — `horizon-src/` subdirectory inside `pbrane/delta-v`
+- **C. Git submodule** — rejected upfront by user ("submodules are painful")
+
+**Decision: A (Two repos)**
+
+**Rationale:**
+1. Under D (hard fork), horizon changes are rare. Two-repo setup optimizes for the common case (Delta-V changes only) where horizon JARs are stable cached artifacts.
+2. Conceptual separation matches reality: Delta-V-Horizon is a distinct product (frozen snapshot + Delta-V-owned patches) with its own version cadence.
+3. The `pbrane/delta-v` repo stays small (~20 modules) with a comprehensible POM tree.
+4. The two CI pipelines become genuinely independent — not "independent but coordinated," which is B's hidden cost.
+5. The "API contract" between the repos (published Maven coordinates + version) enforces discipline: horizon changes can't sneak into Delta-V without an explicit publish + version bump.
+
+**Key insights:**
+- Monorepo benefits (coordinated atomic changes) only pay off when you're frequently changing both sides together. Under D, horizon touches are the exception.
+- Two-speed CI economics: delta-v builds in <2 min against cached JARs; horizon CI can take 15 min to produce those JARs, runs maybe once a month.
+
+**Follow-up concern raised by user:** *"How will we know when delta-v-horizon can be pruned?"* Since Delta-V expects to extract functionality rapidly, the set of needed horizon modules will shrink. User wanted to know how two-repo approach handles ongoing pruning.
+
+**Answer — automated pruning-report CI:**
+
+A GitHub Action in `pbrane/delta-v` that runs on every PR and weekly:
+1. Computes `org.opennms:*` transitive closure across Delta-V's daemon-boot modules
+2. Fetches Delta-V-Horizon's module manifest
+3. Classifies each module: **in-use** / **reserved** / **prunable**
+4. Posts results as PR comment / issue update
+
+When Delta-V drops a dependency → pruning report flags modules as newly prunable → human opens delta-v-horizon PR to delete → next delta-v-horizon release bumps major version → automation propagates back to Delta-V.
+
+**Key insight:** The pruning feedback loop is a virtue of two repos, not a cost. In Option B (monorepo), unused horizon modules would silently sit in the reactor forever with no external boundary forcing their notice. Option A makes pruning visible and actionable by construction.
+
+---
+
+## Q3: Publishing Destination
+
+**Question:** Where do the horizon JARs get published?
+
+**Options presented:**
+- **A. GitHub Packages (Maven)**
+- **B. Self-hosted Nexus / Artifactory**
+- **C. Static Maven repo via git branch** (commit JARs to `mvn-repo` branch, served via `raw.githubusercontent.com`)
+- **D. Cloudflare R2 / S3 as Maven repo**
+
+**Decision: A (GitHub Packages)**
+
+**Rationale:**
+1. Unified platform with existing GHCR usage for Delta-V Docker images (`delta-v-build-images.yml`)
+2. CI auth is native: `${{ secrets.GITHUB_TOKEN }}` has both `packages:write` (publisher) and `packages:read` (consumer) out of the box
+3. Free for public repositories with unlimited data transfer
+4. Standard Maven `<repository>` + `<distributionManagement>` configuration
+
+**Known gotcha surfaced:** GitHub Packages Maven requires authentication even for public packages (historical quirk). Mitigation: one-time `~/.m2/settings.xml` + PAT setup, documented in README. Well-understood Maven idiom.
+
+**Fallback kept in pocket:** Option C (static git branch) is available as an emergency exit if GHP auth friction proves excessive. Switching requires only changing the `<repository><url>` value.
+
+**Key insight:** Generalizing an existing pattern, not inventing a new one. Delta-V already consumes `org.opennms:jicmp-api:3.0.4`, `org.opennms.integration.api:api:2.0.0`, etc. as external Maven artifacts from `maven.opennms.org`. Phase 3 extends the same external-artifact pattern to the bulk of horizon.
+
+---
+
+## Q4: Versioning Scheme
+
+**Question:** What version scheme applies to published delta-v-horizon JARs?
+
+**Options presented:**
+- **A. Delta-V semver** — `1.0.0`, `1.0.1`, `2.0.0` (clean, conventional)
+- **B. Lineage-prefixed** — `36.0.0-deltav-1`, `36.0.0-deltav-2` (encodes OpenNMS 36 fork)
+- **C. Date-stamped** — `2026.04.05`, `2026.05.12`
+
+**Decision: A (Delta-V semver)**
+
+**Rationale:**
+1. Simple, standard, every Maven tool understands it
+2. Avoids Maven `ComparableVersion` edge cases (e.g. whether `36.0.0-deltav-10 > 36.0.0-deltav-2` parses correctly)
+3. Semver discipline doubles as change documentation
+4. Lineage doesn't need to live in the version string — README and `<description>` carry it for humans
+
+**Bump semantics:**
+- Patch (`1.0.0 → 1.0.1`): horizon bugfix, no API change
+- Minor (`1.0.0 → 1.1.0`): added/exposed new API, backward compatible
+- Major (`1.0.0 → 2.0.0`): module pruned, API removed
+
+**Downstream mechanics:** Delta-V's root POM declares `<deltav.horizon.version>1.0.0</deltav.horizon.version>` as a property. Every Delta-V `<dependency>` references `${deltav.horizon.version}`. Single line to bump, automatable via post-publish PR from Delta-V-Horizon's CI.
+
+**Key insight:** Pruning-as-major-bump is a feature, not a bug. Delta-V expects rapid horizon shrinkage (~200 → maybe 80 modules). The major version will climb visibly (1.x → 5.x → 10.x), and that climb accurately tracks pruning milestones. Version numbers are free.
+
+---
+
+## Q5: GroupId / Rebrand Strategy
+
+**Question:** Do the published artifacts keep `org.opennms.*` coordinates, or rebrand?
+
+**Initial options presented:**
+- **A. Keep `org.opennms.*` everywhere** — pragmatic, zero refactoring
+- **B. Full rebrand** — `org.deltav.*` across both repos
+
+**Initial recommendation was A**, but user raised a **trademark concern**: continuing to use package names from a trademarked organization can be troublesome.
+
+**Expanded options after trademark concern:**
+- **Strategy 1 (full rebrand)**: rename `org.opennms.*` → `org.deltav.*` in both repos. Weeks-long refactor touching thousands of files, XML configs, META-INF/services descriptors, Protobuf generated code, potentially breaking Kafka serialized data and DB discriminator columns.
+- **Strategy 2 (groupId-only)**: change only Maven `<groupId>` to `org.deltav` while keeping `package org.opennms.*;` Java declarations. Mixed signal — signals awareness of trademark without providing meaningful distance. Not recommended.
+- **Strategy 3 (NOTICE file only)**: keep `org.opennms.*` everywhere, add `NOTICE.md` with trademark attribution. Zero refactor. Precedent: many long-standing forks. Relies on explicit attribution.
+- **Strategy 4 (partial rebrand)**: rename only Delta-V's ~20 modules to `org.deltav.*`, keep delta-v-horizon's ~200 modules as `org.opennms.*`. Spring Boot / Spring precedent.
+
+**User clarification:** *"I was assuming we'd only rebrand the packages in the deltav repo and not the horizon repo."* This is Strategy 4.
+
+**Decision: Strategy 4 (Partial rebrand) + NOTICE.md in both repos**
+
+**What partial rebrand accomplishes:**
+- Asserts Delta-V identity in Delta-V's own work product (bootstrappers, registries, config classes — everything Delta-V wrote)
+- Honest about derivation: horizon code stays in its original namespace as a derivation marker
+- Spring Boot pattern: `org.springframework.boot.*` over `org.springframework.*`
+
+**What partial rebrand does NOT accomplish:**
+- Horizon JARs still publish as `org.opennms:*:1.0.0`
+- Delta-V's Docker images still bundle `org.opennms.*` bytecode (~95% of runtime classes)
+- Strict "zero opennms bytecode" would require full rebrand (deferred to possible future phase)
+
+**Scope of partial rebrand (days, not weeks):**
+- IntelliJ "Rename Package" across ~20 modules
+- Grep verification for Dockerfile ENTRYPOINTs, Spring XML, META-INF/services, CI main-class extraction
+- No runtime serialization risks (Delta-V's main classes aren't over-the-wire)
+
+**Key insights:**
+- Spring Boot analogy: layered-ownership is visible in package names. `org.deltav.*` for bootstrappers + wiring; `org.opennms.*` preserved in horizon-fork as derivation marker.
+- Package namespace as "authorship attribution" is a cleaner mental model than package namespace as "trademark protection." Keeping horizon as `org.opennms.*` is honest: that code came from upstream.
+- Partial rebrand doesn't foreclose full rebrand later. It's an additive change that can be upgraded in a future phase if legal posture tightens.
+
+---
+
+## Q6: Migration Path
+
+**Question:** How do we actually migrate from current state to the target state?
+
+**Options presented:**
+- **Path 1 (Sequential)**: Phase 2 (reactor pruning) delivered as a distinct PR before Phase 3 extraction. 5+ PRs, validation checkpoints at each stage.
+- **Path 2 (Direct)**: Skip Phase 2 as a distinct step; extract straight to delta-v-horizon. 4 PRs, one of which is large.
+
+**Decision: Path 1 (Sequential)**
+
+**Rationale:**
+1. Phase 2 (reactor pruning) is exactly the closure-validation step that Phase 3 extraction depends on. Path 1 makes that proof explicit and shippable.
+2. Phase 2 independently delivers ~4-min builds in roughly a day's work, even if Phase 3 stalls on unforeseen issues (GHP Docker auth, serialization edge cases).
+3. Clean rollback boundaries per PR.
+4. The "redundant work" cost (Phase 2 keeps horizon in-tree briefly) is overstated: Phase 3's "delete horizon source" is a one-command operation.
+
+**Two concerns raised by user that modified the migration plan:**
+
+### Concern 1: Minion RPC E2E Coverage Gap
+
+User observation: All current E2E tests rely on passive monitoring (syslogs, traps, flows). No E2E test exercises active detector/monitor execution via Minion RPC. The user recalled a PerspectivePollerd + PageSequenceMonitor E2E test that existed at one point (introduced alongside `${nodelabel}` hostname resolution), but was removed.
+
+**Impact on plan:** Added **PR0 (NEW)** before Phase 2. PR0 adds one E2E test that provisions a node via Minion RPC exercising a real detector + real monitor. This becomes the canary for every subsequent PR. Without it, Phase 3 validation is flying blind on RPC-execution paths.
+
+**Memory linkage:** `project_e2e_detectors_monitors_minion.md` documented this as a future followup. Phase 3 elevates it from future to prerequisite.
+
+### Concern 2: Capability Recovery for OSGi Services
+
+User observation: Some horizon capabilities are provided via OSGi services that were never formal ServiceDaemons and are not currently consumed by Delta-V daemon-boots. Examples:
+- Telemetry AdapterManager + ListenerManager (Telemetryd migration)
+- Topology GraphProviderManager + GraphService (future UI)
+- Extensions API / AlarmLifecycleListener (ALEC integration)
+
+These would be absent from the transitive closure → pruned from delta-v-horizon under aggressive pruning.
+
+**Question:** If pruned, can they be recovered?
+
+**Answer:** Yes, always. Git history is permanent; published Maven versions are immutable. Recovery path: `git checkout 1.0.0 -- path/to/module/`, restore to reactor, publish next version. Published `1.0.0` JARs don't disappear when `2.0.0` is published — Delta-V could even pin specific old-version modules while using newer versions for everything else.
+
+**But friction matters.** Aggressive initial pruning means every capability addition becomes an archaeology expedition. Asymmetric economics: recovery costs ~1 hour, keeping an unused module costs ~30 seconds build time. Asymmetry favors conservative initial inclusion.
+
+**Impact on plan:** Introduced **Reserved Capabilities allow-list** (spec section 7) for the initial `1.0.0` snapshot:
+1. Telemetry AdapterManager + ListenerManager
+2. Topology GraphProviderManager + GraphService
+3. Extensions API / AlarmLifecycleListener
+4. OpenNMS Integration API infrastructure (added by assistant; confirmed by user)
+
+The pruning-report CI treats reserved modules as an allow-list, not as prunable orphans. Each is documented in delta-v-horizon's README with rationale.
+
+**Key insights:**
+- Reserved modules are "public domain API contracts for future work." Documenting them in README turns tribal knowledge into a repo artifact — a contributor wondering why `graph-provider-manager` is still there gets an immediate answer.
+- Archaeology friction is bounded but real. The failure mode to guard against is: contributor needs a capability, doesn't know it was pruned, reinvents from scratch. The allow-list is defense against that.
+
+**Final migration plan after concerns:**
+
+| PR | Change | Build Time |
+|---|---|---|
+| PR0 | Restore Minion RPC E2E coverage | — |
+| PR1 (Phase 2) | Prune delta-v reactor (780 → ~219) | ~4 min |
+| PR2 | Bootstrap `pbrane/delta-v-horizon`, publish 1.0.0 | — |
+| PR3 (Phase 3a) | Switch delta-v to external JARs; delete horizon source | <2 min |
+| PR4 | Rebrand delta-v modules to `org.deltav.*` | <2 min |
+| PR5 | NOTICE.md + pruning-report CI | — |
+
+---
+
+## Cross-Cutting Insights
+
+**On fork economics:** 97% of the 780 `pom.xml` files in Delta-V are horizon plumbing Delta-V never touches. The JVM equivalent of shipping `node_modules` in every deploy. Phase 3 is structurally about stopping that.
+
+**On trademark mitigation asymmetry:** The cost of the four trademark strategies (NOTICE only / partial rebrand / groupId-only / full rebrand) varies by ~100x. Partial rebrand is the inflection point — meaningful trademark distance at days-of-work cost.
+
+**On what two repos buy you:** Not simplicity (monorepos are simpler per se) but **visible coupling**. The published Maven coordinate is an enforced API boundary. You can't accidentally modify horizon and ship it in delta-v — you have to publish and version-bump.
+
+**On recoverability:** Git history + immutable published versions means no architecture decision is irreversible. The spec can be aggressive about pruning because the recovery path is always `git checkout <tag> -- path/`. This reduces the cost of wrong decisions.
+
+**On sequencing:** Phase 2 before Phase 3 looks like "extra work" but is actually free validation. The closure computation Phase 2 performs is exactly what Phase 3 depends on. Doing it separately makes the proof shippable and rollback-able.
+
+---
+
+## What the Spec Captures (That This Transcript Doesn't)
+
+The spec document adds implementation detail derived from these decisions but not separately brainstormed:
+
+- **Bootstrap mechanism**: directory copy vs `git subtree split` for populating `pbrane/delta-v-horizon`
+- **CI workflow YAML structure**: publish-on-tag-push pattern for delta-v-horizon
+- **Docker build auth**: `--secret` mount vs env-based settings.xml in `delta-v-build-images.yml`
+- **Local dev onboarding**: `~/.m2/settings.xml` + PAT setup documentation
+- **Per-PR rollback procedures**: explicit revert paths for each of PR0–PR5
+- **Risk table**: likelihood + mitigation for eight identified risks
+
+These were treated as implementation details that follow from the architecture, not decisions requiring separate brainstorming.

--- a/docs/plans/2026-04-05-horizon-extraction-spec.md
+++ b/docs/plans/2026-04-05-horizon-extraction-spec.md
@@ -100,6 +100,10 @@ Both repos ship `NOTICE.md` files with:
 
 **Why not groupId-only rebrand:** Changing only the Maven groupId while keeping `package org.opennms.netmgt.*;` declarations creates a confusing split personality and provides weak trademark coverage. Either commit to package rebrand or don't — not halfway.
 
+**Artifact ID naming:** Delta-V-Horizon modules keep their existing `opennms-*` artifact IDs unchanged (e.g., `org.opennms:opennms-dao:1.0.0`, `org.opennms:opennms-provision:1.0.0`). This minimizes POM churn in Delta-V — only the `<version>` needs to change to `${deltav.horizon.version}`, not `<artifactId>`. Artifact IDs live under the groupId namespace, so the `org.opennms:opennms-dao` coordinate is unambiguous.
+
+**Leaf-repository constraint (critical):** `pbrane/delta-v-horizon` MUST remain a leaf — it MUST NOT depend on any `org.deltav:*` artifacts. If a future Delta-V-Horizon patch needs a utility currently in Delta-V (e.g., a shared logging helper), the utility must either be duplicated into Delta-V-Horizon or moved *down* into Delta-V-Horizon and consumed by Delta-V. Any attempt to import `org.deltav:*` into Delta-V-Horizon creates a circular repo dependency that breaks the two-speed CI economics (Delta-V-Horizon would need Delta-V published first, which needs Delta-V-Horizon published first).
+
 ### 6. Migration Path: Sequential (Path 1)
 
 Six PRs (PR0 through PR5), each individually testable against the full E2E suite. The sequential path optimizes for safety: each PR has a clear rollback boundary, and PR1's reactor pruning validates the module closure that PR3's extraction depends on.
@@ -125,7 +129,7 @@ The exact module paths will be confirmed during PR2's bootstrap work; the table 
 
 A GitHub Action in `pbrane/delta-v` runs on every PR and weekly on schedule. It performs reachability analysis from Delta-V's daemon-boot modules into the Delta-V-Horizon module set, producing a trinary classification:
 
-- **In use** — transitively referenced by a Delta-V daemon-boot (via `mvn dependency:list -DincludeGroupIds=org.opennms`)
+- **In use** — transitively referenced by a Delta-V daemon-boot (via `mvn dependency:list -DincludeGroupIds=org.opennms`). Transitive traversal MUST be enabled (it is by default — do not pass `-DexcludeTransitive=true`) because horizon modules are typically only referenced 2–3 levels deep.
 - **Reserved** — in the capabilities allow-list
 - **Prunable** — neither; flagged for human review
 
@@ -144,10 +148,10 @@ All PRs run the full E2E suite (93 tests) as baseline validation plus PR-specifi
 Historical note: a PerspectivePollerd + PageSequenceMonitor E2E test existed at one point (during the introduction of `${nodelabel}` hostname resolution). It was removed at some point and the coverage has not been restored.
 
 **Change:** Add one E2E test that provisions a node via Minion RPC exercising:
-- A real detector (e.g., `SnmpDetector` against labbox cEOS)
+- A real detector (e.g., `SnmpDetector` against labbox cEOS — verify cEOS SNMP community string config matches the test's `read-community` attribute)
 - A real monitor (e.g., `IcmpMonitor` or `SnmpMonitor`)
 
-The test runs on the existing labbox Containerlab cEOS topology (see `reference_labbox_setup.md`).
+The test runs on the existing labbox Containerlab cEOS topology (see `reference_labbox_setup.md`). New suite location: `integration-tests/test-minion-rpc-e2e/` — distinct from the passive `test-minion-e2e` suite so "active RPC execution" coverage is separately discoverable.
 
 **Validation:** test passes against the current `develop` baseline *before* any Phase 3 work begins. This establishes the canary — every subsequent PR re-runs this test to catch RPC path regressions.
 
@@ -195,9 +199,12 @@ The test runs on the existing labbox Containerlab cEOS topology (see `reference_
 
 ### PR3 (Phase 3a): Switch Delta-V to External Horizon JARs
 
+**Pre-PR3 audit:** Run `mvn dependency:tree -Dverbose` across all 16 daemon-boot modules. Confirm no daemon-boot requires a *different* version of the same `org.opennms:*` artifact than another daemon-boot. If divergences exist (unlikely — everything currently pins to `36.0.0-SNAPSHOT`), resolve them via `<dependencyManagement>` in the delta-v root POM pinning single horizon versions.
+
 **Change:** In `pbrane/delta-v`:
 - Add `<repositories>` entry for GitHub Packages Maven
 - Add `<properties><deltav.horizon.version>1.0.0</deltav.horizon.version></properties>` to root POM
+- Add `<dependencyManagement>` section in root POM pinning all `org.opennms:*` artifacts to `${deltav.horizon.version}`
 - Update all `org.opennms:*` dependencies in daemon-boot POMs to use `${deltav.horizon.version}` (currently `36.0.0-SNAPSHOT`)
 - Delete the ~200 horizon module directories from the repo (now dead code, not in reactor since PR1)
 - Update `.github/workflows/delta-v-build-images.yml` to authenticate to GitHub Packages during dependency resolution
@@ -242,6 +249,7 @@ The test runs on the existing labbox Containerlab cEOS topology (see `reference_
 - PR0's Minion RPC test passes
 - Docker images build and daemons start (validates ENTRYPOINT + main class updates)
 - `grep -r "org.opennms.core.daemon" core/` returns only unavoidable import statements (no residual package declarations)
+- **XML configuration audit:** `grep -rn 'class="org.opennms.core.daemon' core/ opennms-container/` returns zero hits. Covers both Spring (`META-INF/spring/*.xml`) and Blueprint (`OSGI-INF/blueprint/*.xml`) configs — hardcoded FQCNs in XML are the highest-risk miss during package renames because IDE refactoring doesn't traverse XML files reliably.
 
 **Rollback:** Revert the PR. Package rename is idempotent.
 
@@ -302,6 +310,8 @@ Before merging PR3, validate the published-JAR path works end-to-end:
 | `ComparableVersion` surprises with semver | Low | Plain semver (1.0.0) dodges Maven version-parsing edge cases |
 | Reserved capability missed in `1.0.0` | Medium | Allow-list lives in README; adding a module later is a routine PR bumping to next minor version |
 | Published `1.0.0` has a bug, needs immediate replacement | Low | Publish `1.0.1`; previous version immutably remains on GHP for reproducibility |
+| Circular repo dependency (delta-v-horizon imports `org.deltav:*`) | Low | Leaf-repo constraint enforced in Section 5; delta-v-horizon's CI could lint pom.xml files to reject any `org.deltav:*` dependency |
+| Daemon-boots require *different* versions of same horizon module | Medium | Pre-PR3 convergence audit: `mvn dependency:tree -Dverbose` across all daemon-boots; add `<dependencyManagement>` to delta-v root POM to pin single horizon version per artifact |
 
 ## Rollback Procedures
 
@@ -321,8 +331,9 @@ These will be resolved during the implementation plan phase, not the spec phase:
 1. **Exact module paths for reserved capabilities** — indicative paths in section 7 need verification against current horizon source layout
 2. **Docker build auth pattern** — whether `--secret` mount or env-based `settings.xml` is cleaner for `delta-v-build-images.yml`
 3. **Automated version-bump PR mechanics** — whether to use `peter-evans/create-pull-request` GitHub Action or a custom script
-4. **PR0 test location** — which existing E2E suite directory should host the new Minion RPC test (likely `test-minion-e2e` or `test-e2e`)
-5. **Initial bootstrap mechanism** — `git subtree split` vs. directory copy for populating `pbrane/delta-v-horizon` (directory copy is simpler; subtree split preserves Delta-V-side commit attribution)
+4. **Initial bootstrap mechanism** — `git subtree split` vs. directory copy for populating `pbrane/delta-v-horizon` (directory copy is simpler; subtree split preserves Delta-V-side commit attribution)
+5. **Dependency convergence audit outcome** — whether the pre-PR3 `mvn dependency:tree -Dverbose` audit surfaces any horizon version divergences requiring explicit `<dependencyManagement>` pins beyond the global version property
+6. **Leaf-repo enforcement mechanism** — whether a lint script in delta-v-horizon's CI is needed to reject `org.deltav:*` imports, or if the constraint stays a documented convention
 
 ## Decision Journal
 
@@ -339,3 +350,5 @@ Summary of the brainstorming decisions that produced this spec. Full transcript 
 | 6a | PR0 added (Minion RPC E2E) | Deferred to future task | Phase 3 extraction cannot be safely validated without Minion RPC execution coverage; gap existed before Phase 3 but becomes blocking |
 | 7 | Reserved capabilities allow-list | Prune aggressively, recover from git | Aggressive pruning creates recovery friction; asymmetric economics favor conservative initial inclusion (~1 hour recovery cost vs. ~30 seconds build cost) |
 | 8 | Automated pruning-report CI | Manual inspection per refactor | Operational sustainability of two-repo approach depends on visible pruning signals; CI comment on every PR makes it automatic |
+| 9 | Keep `opennms-*` artifactId prefixes | Rename to `deltav-*` | Minimizes POM churn in delta-v consumer (only `<version>` changes, not `<artifactId>`); artifactId lives under groupId namespace so coordinate stays unambiguous |
+| 10 | Leaf-repo constraint on delta-v-horizon | Allow bidirectional deps | Circular repo dependency would break two-speed CI economics; leaf constraint preserves independent publish cadence |

--- a/docs/plans/2026-04-05-horizon-extraction-spec.md
+++ b/docs/plans/2026-04-05-horizon-extraction-spec.md
@@ -1,0 +1,341 @@
+# Spec: Extract Delta-V from Horizon (Phase 3)
+
+> **Date:** 2026-04-05
+> **Status:** Draft
+> **Precedes:** PR0 (RPC E2E coverage) through PR5 (NOTICE + pruning-report CI)
+> **Companion:** [2026-04-05-horizon-extraction-brainstorm.md](2026-04-05-horizon-extraction-brainstorm.md) (full Q&A transcript + rationale)
+> **Precedent:** [2026-04-04-spring-native-registry-spec.md](2026-04-04-spring-native-registry-spec.md) (PR #116 pattern)
+
+---
+
+## Problem
+
+Delta-V's repository contains 780 `pom.xml` files. Only ~219 of them are actually built: ~20 Delta-V-specific modules (daemon-boot, daemon-registry, db-init, etc.) plus ~200 Horizon modules transitively referenced by Delta-V's daemon-boots. The other ~561 (webapp, Karaf features, RPM/DEB assembly, correlator, Vaadin UI, legacy tests) are dead weight compiled from source on every build.
+
+Phase 1 (mvnd + skip flags, PR #117) brought single-module rebuilds to ~3 seconds, but a clean full build still takes ~10 minutes because all ~219 modules in the current reactor closure are compiled from source every time.
+
+**Goal:** Reduce a clean Delta-V full build to under 2 minutes by consuming Horizon as pre-built external Maven artifacts, leaving only Delta-V-specific modules in the `pbrane/delta-v` repository.
+
+## Solution
+
+Extract the ~200 needed Horizon modules into a new `pbrane/delta-v-horizon` repository. Publish them as versioned Maven artifacts to GitHub Packages. Update `pbrane/delta-v`'s POMs to consume those published artifacts as normal Maven dependencies. Rebrand Delta-V's own modules to `org.deltav.*` to assert authorship while preserving the horizon-derived code in its original `org.opennms.*` namespace.
+
+## Architecture
+
+### 1. Upstream Relationship: Hard Fork
+
+Delta-V-Horizon is a **frozen snapshot** of OpenNMS Horizon 36, owned entirely by Delta-V going forward. No `upstream` remote is configured on `pbrane/delta-v-horizon`. OpenNMS GitHub remains a read-only reference consulted for bug intelligence — when a Horizon bug is relevant to Delta-V, the fix is reimplemented as a new Delta-V commit, not cherry-picked.
+
+**Consequences:**
+- No sync cadence, no sync tooling, no cherry-pick workflow
+- Delta-V-Horizon's git history is linear and Delta-V-owned from day one
+- Version numbers are ours to assign; they carry no implicit alignment with OpenNMS releases
+- Recovery of pruned functionality happens from Delta-V-Horizon's own git history, not from upstream
+
+### 2. Repo Organization: Two Repos
+
+| Repo | Contents | Role |
+|---|---|---|
+| `pbrane/delta-v-horizon` | ~200 horizon modules + reserved capabilities | Publishes JARs to GitHub Packages |
+| `pbrane/delta-v` | ~20 Delta-V modules (daemon-boot, daemon-registry, db-init, container) | Consumes horizon JARs as Maven deps |
+
+**Why two repos rather than a monorepo:**
+Under a hard fork, horizon-source changes are rare (only when Delta-V fixes a bug). A two-repo setup optimizes for the common case — Delta-V changes only — where horizon JARs are stable artifacts pulled from a registry. The `pbrane/delta-v` repo stays small (~20 modules), with fast clones and a comprehensible POM tree. The two CI pipelines are genuinely independent (not "independent-but-coordinated"), which simplifies each pipeline.
+
+The "API contract" between the two repos — a published Maven coordinate + version — enforces discipline. A horizon change can't sneak into Delta-V without an explicit publish + version bump.
+
+### 3. Publishing Destination: GitHub Packages
+
+Registry URL: `maven.pkg.github.com/pbrane/delta-v-horizon/*`
+
+**Rationale:**
+- Unified platform with GHCR (already used for Delta-V Docker images in `delta-v-build-images.yml`)
+- CI auth is native: `${{ secrets.GITHUB_TOKEN }}` has `packages:write` and `packages:read` out of the box
+- Free for public repositories, unlimited data transfer
+- Standard Maven `<repository>` + `<distributionManagement>` configuration
+
+**Known limitation (mitigated):** GitHub Packages Maven requires authentication even for public packages. Mitigation: document one-time `~/.m2/settings.xml` + PAT setup in Delta-V-Horizon's README.
+
+**Fallback option (not chosen initially):** A static Maven repo served from an `mvn-repo` branch via `raw.githubusercontent.com` would require no auth but is unconventional. Available as an emergency exit if GHP auth friction proves excessive — switching requires only changing the `<repository><url>` value.
+
+### 4. Versioning: Delta-V Semver
+
+Scheme: `1.0.0`, `1.0.1`, `2.0.0`. No lineage prefix in the version string.
+
+| Change type | Bump | Examples |
+|---|---|---|
+| Bugfix, no API change | Patch | `1.0.0` → `1.0.1` |
+| New API, backward compatible | Minor | `1.0.0` → `1.1.0` |
+| Module pruning, API removal | Major | `1.0.0` → `2.0.0` |
+
+Lineage to OpenNMS 36 lives in `delta-v-horizon/README.md` and each `pom.xml`'s `<description>`. The version string is for Maven resolution and ordering; lineage is for humans.
+
+**Downstream mechanics:** Delta-V's root `pom.xml` declares:
+
+```xml
+<properties>
+  <deltav.horizon.version>1.0.0</deltav.horizon.version>
+</properties>
+```
+
+Every Delta-V dependency on `org.opennms:*` references `${deltav.horizon.version}`. A single property edit propagates the bump. Delta-V-Horizon's publish CI opens an automated PR in Delta-V to bump this property after each release.
+
+**Pruning as major bump is intentional:** over the coming weeks as Delta-V extracts functionality natively, Delta-V-Horizon is expected to shrink rapidly (~200 → maybe 80 modules). The major-version climbs will track that progress visibly.
+
+### 5. GroupId Strategy: Partial Rebrand
+
+| Repo | Java Packages | Maven groupIds | Rationale |
+|---|---|---|---|
+| `pbrane/delta-v` (~20 modules) | `org.deltav.*` (rebranded) | `org.deltav:*` | Delta-V-authored code; asserts Delta-V identity |
+| `pbrane/delta-v-horizon` (~200 modules) | `org.opennms.*` (unchanged) | `org.opennms:*` | Honest derivation marker — this code came from OpenNMS |
+
+Both repos ship `NOTICE.md` files with:
+- Trademark attribution: *"'OpenNMS' is a trademark of The OpenNMS Group, Inc."*
+- Non-affiliation: *"Delta-V is not affiliated with, endorsed by, or sponsored by The OpenNMS Group, Inc."*
+- Derivation: *"Delta-V is a fork of OpenNMS Horizon, snapshotted 2026-04-05 from OpenNMS 36.0.0-SNAPSHOT."*
+
+**Precedent:** This is the Spring Boot / Spring pattern. Spring Boot lives in `org.springframework.boot.*` while Spring stays `org.springframework.*`. Layered-ownership is visible in package names.
+
+**Why not full rebrand:** Rebranding all ~200 horizon modules' Java packages is a weeks-long refactor touching thousands of files, XML configs, META-INF/services descriptors, Protobuf generated code, and potentially serialized data on the wire. Partial rebrand asserts Delta-V identity where it matters (Delta-V's own code) and can be upgraded to full rebrand in a future phase if legal posture tightens.
+
+**Why not groupId-only rebrand:** Changing only the Maven groupId while keeping `package org.opennms.netmgt.*;` declarations creates a confusing split personality and provides weak trademark coverage. Either commit to package rebrand or don't — not halfway.
+
+### 6. Migration Path: Sequential (Path 1)
+
+Six PRs (PR0 through PR5), each individually testable against the full E2E suite. The sequential path optimizes for safety: each PR has a clear rollback boundary, and PR1's reactor pruning validates the module closure that PR3's extraction depends on.
+
+### 7. Reserved Capabilities
+
+These modules are included in the initial `1.0.0` snapshot even though no current Delta-V daemon-boot references them. They provide capabilities Delta-V expects to adopt in the near-to-medium term.
+
+| Module (indicative path) | Reserved for | Rationale |
+|---|---|---|
+| `features/telemetry/adapter-manager` | Telemetryd migration | OSGi→Spring conversion of AdapterManager |
+| `features/telemetry/listener-manager` | Telemetryd migration | OSGi→Spring conversion of ListenerManager |
+| `features/topology/graph-service` | Future UI work | Topology Graph API surface |
+| `features/topology/graph-provider-manager` | Future UI work | Topology Graph plugin registration |
+| `features/distributed/extensions-api` (or equivalent) | ALEC integration | AlarmLifecycleListener plugin SPI |
+| OpenNMS Integration API infrastructure | Plugin registration | Bundled-plugin support beyond the external `org.opennms.integration.api:api:2.0.0` artifact |
+
+The exact module paths will be confirmed during PR2's bootstrap work; the table above captures intent. Each entry is documented in `delta-v-horizon/README.md` with the same rationale.
+
+**Effect on pruning-report CI:** Reserved modules are treated as an allow-list, not as orphans. They do not appear in the "prunable" category even when no Delta-V module references them.
+
+### 8. Pruning-Report CI
+
+A GitHub Action in `pbrane/delta-v` runs on every PR and weekly on schedule. It performs reachability analysis from Delta-V's daemon-boot modules into the Delta-V-Horizon module set, producing a trinary classification:
+
+- **In use** — transitively referenced by a Delta-V daemon-boot (via `mvn dependency:list -DincludeGroupIds=org.opennms`)
+- **Reserved** — in the capabilities allow-list
+- **Prunable** — neither; flagged for human review
+
+Output: a PR comment (or issue update on schedule runs) summarizing the diff since the previous report, e.g. *"2 modules newly prunable: `features/legacy-foo`, `opennms-bar`"*.
+
+**Workflow integration:** when the report surfaces prunable modules, a human opens a PR in `pbrane/delta-v-horizon` to delete the modules, which produces a new major version bump (e.g., `2.0.0`), which automation propagates back to `pbrane/delta-v` via a version-bump PR.
+
+## Migration Plan
+
+All PRs run the full E2E suite (93 tests) as baseline validation plus PR-specific additional checks.
+
+### PR0: Restore Minion RPC E2E Coverage
+
+**Problem:** Current E2E suites exercise passive monitoring (syslog, traps, flows), enlinkd topology, collection, and passive outages. No E2E test exercises *active* detector or monitor execution via Minion RPC. This gap existed before Phase 3 and is not introduced by it, but Phase 3 cannot be safely validated without closing it.
+
+Historical note: a PerspectivePollerd + PageSequenceMonitor E2E test existed at one point (during the introduction of `${nodelabel}` hostname resolution). It was removed at some point and the coverage has not been restored.
+
+**Change:** Add one E2E test that provisions a node via Minion RPC exercising:
+- A real detector (e.g., `SnmpDetector` against labbox cEOS)
+- A real monitor (e.g., `IcmpMonitor` or `SnmpMonitor`)
+
+The test runs on the existing labbox Containerlab cEOS topology (see `reference_labbox_setup.md`).
+
+**Validation:** test passes against the current `develop` baseline *before* any Phase 3 work begins. This establishes the canary — every subsequent PR re-runs this test to catch RPC path regressions.
+
+**Rollback:** N/A (purely additive test).
+
+### PR1 (Phase 2): Prune Delta-V Reactor
+
+**Change:** In `pbrane/delta-v`'s root `pom.xml`, remove the ~561 `<module>` entries for horizon modules Delta-V does not transitively reference. Horizon source remains on the filesystem but is no longer built.
+
+**Identifying the closure:** Run `mvn dependency:list -DincludeGroupIds=org.opennms` on each of the 16 daemon-boot modules (+ db-init + minion-boot). Union the results. Any `org.opennms:*` artifact in that union is in the closure and stays in the reactor. Everything else is prunable from the reactor.
+
+**Validation:**
+- `make build` succeeds with the pruned reactor
+- Full E2E suite passes (93/93)
+- PR0's new Minion RPC test passes
+- Build time measured and recorded (~4 min expected)
+
+**Rollback:** Revert the PR. Horizon source was never moved.
+
+### PR2: Bootstrap `pbrane/delta-v-horizon`
+
+**Change:** Create `pbrane/delta-v-horizon`. Seed with:
+- The ~200 horizon module directories copied from `pbrane/delta-v` (post-PR1, preserving any Delta-V-side fixes already applied)
+- Reserved capability modules from section 7
+- Root `pom.xml` with `<distributionManagement>` pointing to GitHub Packages
+- `.github/workflows/publish.yml` triggered on tag push (`delta-v-horizon-*`)
+- `README.md` with lineage declaration
+- `NOTICE.md` with trademark attribution
+- First tag: `1.0.0`
+
+**Publish CI workflow:** pattern-matched to `delta-v-build-images.yml`. On tag push:
+1. Checkout with full history
+2. Set up JDK 17
+3. Authenticate to GitHub Packages via `GITHUB_TOKEN`
+4. `mvn deploy -DskipTests` for all modules
+5. Open automated PR in `pbrane/delta-v` bumping `deltav.horizon.version`
+
+**Validation:**
+- `mvn install -DskipTests` succeeds in the new repo (local build sanity)
+- Publish workflow runs successfully on `1.0.0` tag
+- `mvn dependency:get -Dartifact=org.opennms:opennms-dao:1.0.0` resolves from a clean `~/.m2/repository`
+- Published artifact list matches expectation (~200 + reserved)
+
+**Rollback:** Delete the repo (or leave unpublished). Delta-V is unaffected.
+
+### PR3 (Phase 3a): Switch Delta-V to External Horizon JARs
+
+**Change:** In `pbrane/delta-v`:
+- Add `<repositories>` entry for GitHub Packages Maven
+- Add `<properties><deltav.horizon.version>1.0.0</deltav.horizon.version></properties>` to root POM
+- Update all `org.opennms:*` dependencies in daemon-boot POMs to use `${deltav.horizon.version}` (currently `36.0.0-SNAPSHOT`)
+- Delete the ~200 horizon module directories from the repo (now dead code, not in reactor since PR1)
+- Update `.github/workflows/delta-v-build-images.yml` to authenticate to GitHub Packages during dependency resolution
+- Update local dev documentation (`README.md`): `~/.m2/settings.xml` PAT setup instructions
+
+**Validation:**
+- `mvn -o clean install -DskipTests` fails from a clean `~/.m2/repository` (proves we're not accidentally using cached local artifacts)
+- `mvn clean install -DskipTests` succeeds when online (proves JAR resolution from GHP)
+- Full E2E suite passes
+- PR0's Minion RPC test passes
+- Docker images build successfully (including GHP auth during build)
+- Docker images run successfully and daemons start
+- Build time measured and recorded (<2 min expected)
+
+**Rollback:** Revert the PR. Delta-V-Horizon JARs remain published but unused.
+
+### PR4: Rebrand Delta-V Modules to `org.deltav.*`
+
+**Change:** IntelliJ "Rename Package" across all ~20 Delta-V modules:
+- `org.opennms.core.daemon.boot.*` → `org.deltav.core.daemon.boot.*`
+- `org.opennms.core.daemon.registry` → `org.deltav.core.daemon.registry`
+- `org.opennms.core.daemon.common` → `org.deltav.core.daemon.common`
+- All other Delta-V-authored packages under `core/`
+
+**Also updated:**
+- `<groupId>org.opennms</groupId>` → `<groupId>org.deltav</groupId>` in Delta-V's own POMs
+- `@SpringBootApplication` main class references in:
+  - Dockerfile ENTRYPOINTs (`opennms-container/delta-v/Dockerfile.daemon-per` etc.)
+  - `delta-v-build-images.yml` workflow (MAIN_CLASS extraction)
+  - `compute-shared-libs.sh` (if it references classnames)
+- Spring XML `class="..."` references to Delta-V classes
+- `META-INF/services/` filenames where Delta-V registers its own SPI
+- Logback `<logger name="org.opennms.core.daemon.*"/>` patterns
+
+**Unchanged (intentionally):**
+- `import org.opennms.*` statements referencing horizon classes (unavoidable — Delta-V daemons extend horizon base classes)
+- `extends` / `implements` clauses pointing at horizon types
+
+**Validation:**
+- All modules compile after the rename
+- Full E2E suite passes
+- PR0's Minion RPC test passes
+- Docker images build and daemons start (validates ENTRYPOINT + main class updates)
+- `grep -r "org.opennms.core.daemon" core/` returns only unavoidable import statements (no residual package declarations)
+
+**Rollback:** Revert the PR. Package rename is idempotent.
+
+### PR5: NOTICE Files + Pruning-Report CI
+
+**Change:**
+- Add `NOTICE.md` to both `pbrane/delta-v` and `pbrane/delta-v-horizon` with trademark attribution and non-affiliation statement
+- Update root `README.md` in both repos to reference `NOTICE.md`
+- Add `.github/workflows/pruning-report.yml` to `pbrane/delta-v`:
+  - Triggers: pull_request, schedule (weekly)
+  - Computes closure of `org.opennms:*` transitive deps across daemon-boot modules
+  - Fetches Delta-V-Horizon's module manifest
+  - Classifies each Delta-V-Horizon module: in-use / reserved / prunable
+  - Posts PR comment (or creates/updates tracking issue on schedule)
+
+**Validation:**
+- Workflow runs successfully on a test PR
+- Output format is readable (markdown comment with clear classification table)
+- Reserved modules from section 7 appear as reserved, not prunable
+
+**Rollback:** Revert. Workflow removal is clean.
+
+## Testing Strategy
+
+### Per-PR
+
+Every PR runs:
+- Unit tests (JUnit) for changed modules
+- Integration tests (IT) for changed modules
+- Full E2E suite: test-e2e, test-minion-e2e, test-syslog-e2e, test-passive-e2e, test-collectd-e2e, test-enlinkd-e2e (+ new Minion RPC test from PR0)
+- Docker image build and smoke-test startup
+
+### Build-Time Regression Tracking
+
+Each PR records the measured clean-build time in its description:
+- Baseline (pre-PR0): ~10 min
+- PR1 target: ~4 min
+- PR3 target: <2 min
+- PR4/PR5: <2 min maintained
+
+### Cross-Repo Validation (PR3 only)
+
+Before merging PR3, validate the published-JAR path works end-to-end:
+1. Clear `~/.m2/repository/org/opennms/`
+2. `mvn clean install -DskipTests` (forces fetch from GHP)
+3. All JARs resolve successfully
+4. Full E2E suite passes
+5. Docker images build successfully *from CI* (validates GHP auth in CI context)
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| GitHub Packages auth friction in Docker builds | Medium | Mirror existing GHCR auth pattern in `delta-v-build-images.yml`; fallback to static `mvn-repo` branch if unworkable |
+| Module closure missing a transitive dep → build fails at PR1 | Medium | `dependency:list` closure computation is deterministic; PR1 catches this before PR3 |
+| PR3 Docker build fails on private package auth | Medium | `docker buildx --secret` pattern for `GITHUB_TOKEN` injection; documented in workflow |
+| Rebrand (PR4) misses a Spring XML / META-INF reference | Low-Medium | Grep verification step + E2E tests catch runtime failures; rollback is a single revert |
+| `ComparableVersion` surprises with semver | Low | Plain semver (1.0.0) dodges Maven version-parsing edge cases |
+| Reserved capability missed in `1.0.0` | Medium | Allow-list lives in README; adding a module later is a routine PR bumping to next minor version |
+| Published `1.0.0` has a bug, needs immediate replacement | Low | Publish `1.0.1`; previous version immutably remains on GHP for reproducibility |
+
+## Rollback Procedures
+
+Path 1 (sequential) provides clean rollback at each PR boundary:
+
+- **PR0**: purely additive test — no rollback needed
+- **PR1**: revert restores all 561 modules to the reactor; horizon source was never moved
+- **PR2**: delete or ignore `pbrane/delta-v-horizon`; Delta-V is unaffected
+- **PR3**: revert restores local horizon source dependencies; `deltav.horizon.version` property reverts to `36.0.0-SNAPSHOT`
+- **PR4**: revert restores `org.opennms.core.daemon.*` package names; rebrand is idempotent
+- **PR5**: revert removes NOTICE and CI workflow; no runtime impact
+
+## Open Questions (for Implementation Plan)
+
+These will be resolved during the implementation plan phase, not the spec phase:
+
+1. **Exact module paths for reserved capabilities** — indicative paths in section 7 need verification against current horizon source layout
+2. **Docker build auth pattern** — whether `--secret` mount or env-based `settings.xml` is cleaner for `delta-v-build-images.yml`
+3. **Automated version-bump PR mechanics** — whether to use `peter-evans/create-pull-request` GitHub Action or a custom script
+4. **PR0 test location** — which existing E2E suite directory should host the new Minion RPC test (likely `test-minion-e2e` or `test-e2e`)
+5. **Initial bootstrap mechanism** — `git subtree split` vs. directory copy for populating `pbrane/delta-v-horizon` (directory copy is simpler; subtree split preserves Delta-V-side commit attribution)
+
+## Decision Journal
+
+Summary of the brainstorming decisions that produced this spec. Full transcript with reasoning is in the companion brainstorm document.
+
+| # | Decision | Rejected Alternatives | Why |
+|---|---|---|---|
+| 1 | Hard fork (no upstream remote) | Continuous sync (A), Release-anchored (B), Opportunistic cherry-pick (C) | 2026-03-25 sync showed 1/46 commits were picked; Delta-V has architecturally diverged from upstream |
+| 2 | Two repos | Single repo with subtree; Git submodule | Horizon changes are rare under hard fork; two-repo separation reflects reality and keeps delta-v surgical |
+| 3 | GitHub Packages (Maven) | Self-hosted Nexus; Static git branch; Cloudflare R2 | Unified platform with GHCR; native CI auth via `GITHUB_TOKEN`; free for public repos |
+| 4 | Delta-V semver (`1.0.0`) | Lineage-prefixed (`36.0.0-deltav-N`); Date-stamped | Simple, conventional, dodges Maven `ComparableVersion` edge cases; lineage lives in README |
+| 5 | Partial rebrand (delta-v only) | Full rebrand (both repos); groupId-only rebrand; keep `org.opennms.*` everywhere | Full rebrand is a weeks-long refactor; groupId-only is mixed-signal; partial rebrand asserts identity where it matters and defers larger scope to future phase |
+| 6 | Sequential migration (Path 1) | Direct (Path 2) — single large PR | Phase 2 independently delivers 4-min builds; PR1's closure validation is prerequisite to PR3's extraction; clean per-PR rollback boundaries |
+| 6a | PR0 added (Minion RPC E2E) | Deferred to future task | Phase 3 extraction cannot be safely validated without Minion RPC execution coverage; gap existed before Phase 3 but becomes blocking |
+| 7 | Reserved capabilities allow-list | Prune aggressively, recover from git | Aggressive pruning creates recovery friction; asymmetric economics favor conservative initial inclusion (~1 hour recovery cost vs. ~30 seconds build cost) |
+| 8 | Automated pruning-report CI | Manual inspection per refactor | Operational sustainability of two-repo approach depends on visible pruning signals; CI comment on every PR makes it automatic |

--- a/docs/plans/2026-04-05-next-session-pr1-reactor-pruning.md
+++ b/docs/plans/2026-04-05-next-session-pr1-reactor-pruning.md
@@ -1,0 +1,77 @@
+# Next Session: PR1 — Phase 2 Reactor Pruning
+
+> Copy everything below the line into the next Claude Code conversation.
+
+---
+
+## Goal
+
+Start PR1 of the Phase 3 horizon-extraction migration. PR1 is **Phase 2 (reactor pruning)** — remove ~561 unneeded `<module>` entries from `pbrane/delta-v`'s root `pom.xml`, leaving ~219 modules in the reactor (the transitive closure of the 16 daemon-boot modules + db-init + minion-boot).
+
+**Target build time after PR1:** ~4 minutes clean full build (down from ~10 min).
+
+## Prerequisites (verify before starting)
+
+- PR #119 must be merged to `develop` (adds the Phase 3 spec + PR0 plan docs)
+- PR #120 must be merged to `develop` (adds `test-minion-rpc-e2e.sh`, the canary)
+- Running the canary locally should produce **11 assertions pass / 0 fail**:
+  ```bash
+  cd opennms-container/delta-v && ./deploy.sh up lite
+  ./test-minion-rpc-e2e.sh --pre-clean --verbose
+  ```
+
+If either PR is unmerged, stop and address that first.
+
+## What PR1 Does
+
+### Changes
+- Edit `pbrane/delta-v/pom.xml` (root): remove ~561 `<module>` entries for horizon modules Delta-V does NOT transitively reference
+- Horizon source stays on the filesystem (not deleted) — just no longer built
+- The ~219 modules that stay in the reactor = ~20 Delta-V-authored modules + ~199 horizon modules in the transitive closure
+
+### How to compute the closure
+For each of the 18 entry points (16 daemon-boots + db-init + minion-boot):
+```bash
+mvn dependency:list -DincludeGroupIds=org.opennms -f <entry-point-pom>
+```
+Union all the results → that's the closure. Anything not in the union is prunable.
+
+### Validation (critical)
+- `make build` succeeds with the pruned reactor
+- `./test-minion-rpc-e2e.sh --pre-clean --verbose` → **11 passed / 0 failed**
+- Full E2E suite (93 tests) passes
+- Measured build time is recorded in the PR description (~4 min expected)
+
+### Rollback
+Revert the PR — horizon source was never moved, so revert restores the reactor immediately.
+
+## Reference Documents
+
+- **Spec:** `docs/plans/2026-04-05-horizon-extraction-spec.md` (PR1 detailed in Section 6 Migration Plan)
+- **Brainstorm transcript:** `docs/plans/2026-04-05-horizon-extraction-brainstorm.md` (Q6 explains why Path 1 sequential migration was chosen)
+- **Canary test:** `opennms-container/delta-v/test-minion-rpc-e2e.sh` (must not regress)
+
+## Suggested Approach for the Session
+
+1. **Verify prerequisites** — confirm #119 and #120 are merged; run canary locally to establish baseline
+2. **Use `superpowers:brainstorming` briefly** to surface any risks in the closure calculation (e.g., modules provided via runtime classpath rather than `<dependency>` declarations, plugins that load classes reflectively, etc.)
+3. **Use `superpowers:writing-plans`** to create a step-by-step implementation plan that includes:
+   - Closure computation script
+   - POM editing strategy (how to remove 561 `<module>` entries safely)
+   - Validation checkpoints after each major change
+4. **Execute via `superpowers:subagent-driven-development`** — brand-new feature branch from latest develop
+5. **Use `superpowers:finishing-a-development-branch`** to open PR1 against `develop`
+
+## Risks to Consider
+
+- **Runtime-only dependencies**: some horizon modules may contribute via classpath assembly without appearing in `dependency:list`. If a daemon fails to start after PR1, that's the likely culprit.
+- **Plugin-provided modules**: Maven plugins (assembly, shade, etc.) may reference modules that don't appear in dependency trees.
+- **Test-scope gaps**: `mvn dependency:list` with `-DincludeGroupIds=org.opennms` may or may not include test-scope deps — verify by checking whether test-only modules end up in the closure.
+- **Incremental vs. big-bang pruning**: consider pruning in phases (e.g., delete obviously-dead modules first, re-validate, then narrow closer to the closure). Reduces blast radius per commit.
+
+## Important Reminders
+
+- **Never create PRs against OpenNMS/opennms** — always `--repo pbrane/delta-v`
+- **Always `git pull develop` before creating feature branches**
+- **Feature branches for all work; merge via PR**
+- **Run the canary test after every significant change** — it's the Phase 3 gate

--- a/docs/plans/2026-04-05-pr0-minion-rpc-canary-plan.md
+++ b/docs/plans/2026-04-05-pr0-minion-rpc-canary-plan.md
@@ -1,0 +1,807 @@
+# PR0: Minion RPC Canary E2E Test — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `test-minion-rpc-e2e.sh` — a new shell-based E2E test that provisions a node against the Docker-internal Minion (location="Default"), verifies SnmpDetector + IcmpDetector executed via Minion RPC, and verifies Pollerd is actively polling the node's services via Minion RPC. This is the canary test that gates all subsequent Phase 3 PRs.
+
+**Architecture:** Follows the existing shell-script E2E pattern (`test-collectd-e2e.sh`, `test-passive-e2e.sh`). Writes a requisition targeting the existing `snmp-agent` mock container at a Docker-resolved IP, triggers Provisiond import, then asserts:
+1. Both ICMP and SNMP appear in `ifservices` for the canary node (detectors executed on Minion)
+2. Pollerd logs show poll activity for the canary node's services within a timeout (monitor executing via Minion RPC)
+
+**Tech Stack:** Bash, Docker Compose, PostgreSQL (`psql`), OpenNMS requisition XML, existing `test-lib.sh` helpers.
+
+**Reference implementations to model after:**
+- `opennms-container/delta-v/test-collectd-e2e.sh` — provisioning + DB assertion pattern
+- `opennms-container/delta-v/test-enlinkd-e2e.sh` — SNMP detector assertion on multiple nodes
+- `opennms-container/delta-v/test-passive-e2e.sh` — outages table queries and `wait_for_db` usage
+
+**File location note:** The spec mentions `integration-tests/test-minion-rpc-e2e/` as a possible location. The existing Delta-V convention places E2E tests as shell scripts at `opennms-container/delta-v/test-*-e2e.sh`. This plan follows the existing convention; the filename `test-minion-rpc-e2e.sh` preserves the "distinct from passive test-minion-e2e" distinction the user requested.
+
+---
+
+## File Structure
+
+**Files to create:**
+
+| Path | Purpose | Approximate size | Committed to git? |
+|---|---|---|---|
+| `opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml` | Foreign-source config restricting detectors to ICMP + SNMP only | ~15 lines | Yes (static, no runtime values) |
+| `opennms-container/delta-v/test-minion-rpc-e2e.sh` | Test script with prereq checks, runtime requisition generation, detector assertion, monitor assertion | ~300 lines | Yes |
+
+**Files written at test runtime (NOT committed):** `provisiond-overlay/etc/imports/rpc-canary.xml` — the requisition targets snmp-agent at a Docker-assigned IP that can only be resolved at runtime. The test script generates this file fresh on every run, matching the pattern in `test-collectd-e2e.sh` which generates `delta-v.xml` inline.
+
+**Files NOT modified:** `docker-compose.yml` (snmp-agent and minion already exist and are sufficient).
+
+---
+
+## Task 1: Create the canary foreign-source config
+
+**Files:**
+- Create: `opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml`
+
+Why a separate foreign-source (`rpc-canary`) rather than reusing `delta-v`: keeping the canary node segregated lets `--post-cleanup` target only the canary's data without disturbing other tests, and makes DB assertions trivially node-scoped by `foreignsource = 'rpc-canary'`.
+
+Why an explicit foreign-source config: restricting detectors to ICMP + SNMP only makes the test deterministic. If we fell back to the default foreign-source config, unexpected detectors might run, slowing provisioning and making failure modes ambiguous.
+
+- [ ] **Step 1: Create the foreign-source config**
+
+```bash
+mkdir -p opennms-container/delta-v/provisiond-overlay/etc/foreign-sources
+```
+
+```xml
+<!-- opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="rpc-canary">
+    <scan-interval>1d</scan-interval>
+    <detectors>
+        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+        <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector"/>
+    </detectors>
+    <policies/>
+</foreign-source>
+```
+
+- [ ] **Step 2: Verify the file was created**
+
+Run:
+```bash
+grep -c "SnmpDetector\|IcmpDetector" opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml
+```
+
+Expected: `2` (one line per detector).
+
+- [ ] **Step 3: Commit the foreign-source config**
+
+```bash
+git add opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml
+git commit -m "test: add rpc-canary foreign-source config (ICMP + SNMP detectors)"
+```
+
+---
+
+## Task 2: Create test script skeleton with header, flags, and configuration
+
+**Files:**
+- Create: `opennms-container/delta-v/test-minion-rpc-e2e.sh`
+
+- [ ] **Step 1: Write the script header (shebang, doc comment, set flags, cd, source test-lib.sh)**
+
+```bash
+#!/usr/bin/env bash
+#
+# test-minion-rpc-e2e.sh — End-to-end Minion RPC canary for Delta-V
+#
+# Provisions a canary node at location="Default" targeting the snmp-agent
+# mock container. Verifies that SnmpDetector + IcmpDetector executed via
+# Minion RPC (evidence: services in ifservices table) and that Pollerd
+# is actively polling those services via Minion RPC (evidence: poll
+# activity in Pollerd logs).
+#
+# This test is the CANARY for Phase 3 horizon-extraction. Any PR that
+# regresses Minion RPC detection or monitoring will fail this test.
+#
+# Usage:
+#   ./test-minion-rpc-e2e.sh              Run the test
+#   ./test-minion-rpc-e2e.sh --verbose    Show diagnostic queries on failure
+#   ./test-minion-rpc-e2e.sh --pre-clean  Full pre-run cleanup (DB + restart daemons)
+#   ./test-minion-rpc-e2e.sh --post-cleanup  Delete canary node and alarms after run
+#
+# Prerequisites:
+#   - Delta-V deployed with lite or full profile: ./deploy.sh up lite
+#   - snmp-agent, minion, provisiond, pollerd, postgres, kafka running
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = test failure
+#   2 = prerequisite failure
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
+
+# ── Configuration ──────────────────────────────────────────────────
+FOREIGN_SOURCE="rpc-canary"
+EXPECTED_NODES=1
+PROVISION_TIMEOUT=120        # 2 min — wait for node provisioning via Minion
+DETECT_TIMEOUT=180           # 3 min — wait for detectors to complete via RPC
+POLL_TIMEOUT=180             # 3 min — wait for Pollerd to start polling via RPC
+POLL_INTERVAL=10             # seconds between DB checks
+
+# ── Parse flags ────────────────────────────────────────────────────
+VERBOSE=false
+PRE_CLEAN=false
+POST_CLEANUP=false
+for arg in "$@"; do
+    case "$arg" in
+        --verbose) VERBOSE=true ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
+        --help|-h)
+            sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
+            exit 0
+            ;;
+    esac
+done
+```
+
+- [ ] **Step 2: Verify the script parses as valid bash**
+
+Run:
+```bash
+bash -n opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: no output (successful syntax check).
+
+- [ ] **Step 3: Make the script executable**
+
+```bash
+chmod +x opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+---
+
+## Task 3: Add helper functions and snmp-agent IP resolution
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-minion-rpc-e2e.sh` (append)
+
+- [ ] **Step 1: Append logging helpers, `psql_query`, `wait_for_db`, and `resolve_snmp_agent_ip`**
+
+Append the following to `test-minion-rpc-e2e.sh`:
+
+```bash
+# ── Helpers ────────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+log()  { echo "==> $*"; }
+ok()   { echo "  [PASS] $*"; PASS=$((PASS + 1)); }
+fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
+err()  { echo "ERROR: $*" >&2; exit 2; }
+
+cleanup() {
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing canary node..."
+        psql_query "DELETE FROM outages WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+        psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'))" || true
+        psql_query "DELETE FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+        psql_query "DELETE FROM events WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+        psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
+        log "  Canary node deleted"
+    fi
+}
+trap cleanup EXIT
+
+psql_query() {
+    docker compose exec -T -e PGPASSWORD=opennms postgres \
+        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+}
+
+wait_for_db() {
+    local query="$1"
+    local timeout="$2"
+    local description="$3"
+    local poll_interval="${4:-$POLL_INTERVAL}"
+    local elapsed=0
+
+    log "Waiting for $description (timeout: ${timeout}s)..."
+    while [ $elapsed -lt "$timeout" ]; do
+        local result
+        result=$(psql_query "$query" 2>/dev/null || echo "")
+        if [ -n "$result" ] && [ "$result" != "0" ]; then
+            return 0
+        fi
+        sleep "$poll_interval"
+        elapsed=$((elapsed + poll_interval))
+        if [ $((elapsed % 60)) -eq 0 ]; then
+            log "  ... ${elapsed}s elapsed"
+        fi
+    done
+    return 1
+}
+
+wait_for_health() {
+    local container="$1"
+    local health_url="$2"
+    local timeout="${3:-120}"
+    local elapsed=0
+
+    log "Waiting for $container health check (timeout: ${timeout}s)..."
+    while [ $elapsed -lt "$timeout" ]; do
+        if docker compose exec -T "$container" curl -sf "$health_url" >/dev/null 2>&1; then
+            log "  ... $container is healthy"
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    return 1
+}
+
+# Resolves the snmp-agent container's IP on the Docker internal network.
+# Uses docker inspect from the host — more reliable than exec'ing into Minion
+# (Alpine-based Minion container lacks ping, nslookup, and may lack getent).
+# The IP returned is the container's IP on the shared Docker network, which
+# is exactly what Minion will use to reach snmp-agent.
+resolve_snmp_agent_ip() {
+    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{"\n"}}{{end}}' delta-v-snmp-agent 2>/dev/null | grep -v '^$' | head -1
+}
+
+show_diagnostics() {
+    if ! $VERBOSE; then
+        log "Hint: re-run with --verbose for diagnostic output"
+        return
+    fi
+    log ""
+    log "── Diagnostic Queries ──"
+    log ""
+    log "Canary node:"
+    psql_query "SELECT nodeid, nodelabel, foreignid, location, lastcapsdpoll FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
+    log ""
+    log "IP Interfaces:"
+    psql_query "SELECT n.nodelabel, ip.ipaddr, ip.issnmpprimary FROM ipinterface ip JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}'" || true
+    log ""
+    log "Services detected:"
+    psql_query "SELECT n.nodelabel, svc.servicename, s.status FROM ifservices s JOIN service svc ON s.serviceid = svc.serviceid JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' ORDER BY svc.servicename" || true
+    log ""
+    log "Recent Pollerd log lines mentioning canary node:"
+    docker compose logs --tail=100 pollerd 2>/dev/null | grep -i "snmp-agent-canary" || log "  (no matches)"
+}
+```
+
+- [ ] **Step 2: Verify script still parses**
+
+Run:
+```bash
+bash -n opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: no output.
+
+---
+
+## Task 4: Add prerequisite checks and pre-clean logic
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-minion-rpc-e2e.sh` (append)
+
+- [ ] **Step 1: Append prerequisite checks section**
+
+Append:
+
+```bash
+# ── Prerequisite Checks ───────────────────────────────────────────
+log "Checking prerequisites..."
+
+REQUIRED_SERVICES="postgres kafka provisiond pollerd minion snmp-agent"
+for svc in $REQUIRED_SERVICES; do
+    if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw "$svc"; then
+        err "Service '$svc' is not running. Deploy with: ./deploy.sh up lite"
+    fi
+done
+ok "Required services running (postgres, kafka, provisiond, pollerd, minion, snmp-agent)"
+
+# Resolve snmp-agent IP via Minion's DNS view (this is the IP Minion will use)
+SNMP_AGENT_IP=$(resolve_snmp_agent_ip)
+if [ -z "${SNMP_AGENT_IP:-}" ]; then
+    err "Could not resolve snmp-agent IP from Minion's perspective. Is Docker DNS working?"
+fi
+ok "Resolved snmp-agent IP (from Minion's perspective): ${SNMP_AGENT_IP}"
+
+# Quick sanity check — Minion can reach the SNMP port
+if ! docker compose exec -T minion sh -c "nc -uzvw 2 snmp-agent 161" >/dev/null 2>&1; then
+    log "  [WARN] Minion could not reach snmp-agent:161/udp (may still work; netcat may be unavailable)"
+else
+    ok "Minion can reach snmp-agent:161/udp"
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Pre-run cleanup (--pre-clean): remove any prior canary data
+# ══════════════════════════════════════════════════════════════════
+if $PRE_CLEAN; then
+    log ""
+    log "Pre-run cleanup (--pre-clean): removing existing canary data..."
+
+    psql_query "DELETE FROM outages WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+    psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'))" || true
+    psql_query "DELETE FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+    psql_query "DELETE FROM events WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+    psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
+    ok "Prior canary data cleaned"
+fi
+```
+
+- [ ] **Step 2: Verify script still parses**
+
+Run:
+```bash
+bash -n opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: no output.
+
+---
+
+## Task 5: Add Phase 1 — provisioning (requisition import + wait for node)
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-minion-rpc-e2e.sh` (append)
+
+- [ ] **Step 1: Append Phase 1 provisioning logic**
+
+Append:
+
+```bash
+# ══════════════════════════════════════════════════════════════════
+# Phase 1: Provision the canary node via Minion
+# ══════════════════════════════════════════════════════════════════
+log ""
+log "Phase 1: Provisioning canary node targeting snmp-agent (${SNMP_AGENT_IP}) at location=Default..."
+
+# Generate the requisition inline with the resolved IP. This file is overwritten
+# on each test run — not committed to git (matches the delta-v.xml pattern
+# used by test-collectd-e2e.sh).
+mkdir -p provisiond-overlay/etc/imports
+CANARY_REQ="provisiond-overlay/etc/imports/${FOREIGN_SOURCE}.xml"
+cat > "$CANARY_REQ" <<REQEOF
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
+              date-stamp="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+              foreign-source="${FOREIGN_SOURCE}">
+   <node location="Default" foreign-id="snmp-agent-canary" node-label="snmp-agent-canary">
+      <interface ip-addr="${SNMP_AGENT_IP}" status="1" snmp-primary="P">
+         <monitored-service service-name="ICMP"/>
+         <monitored-service service-name="SNMP"/>
+      </interface>
+   </node>
+</model-import>
+REQEOF
+ok "Requisition generated at ${CANARY_REQ}"
+
+# Update provisiond-configuration.xml to auto-import this foreign source.
+# If an existing config has other requisition-defs (e.g., delta-v, mhuot-labs),
+# we need to append ours without destroying theirs.
+PROV_CONFIG="provisiond-overlay/etc/provisiond-configuration.xml"
+mkdir -p provisiond-overlay/etc
+PROVISIOND_NEEDS_RESTART=false
+if [ ! -f "$PROV_CONFIG" ]; then
+    log "  Writing new provisiond-configuration.xml with ${FOREIGN_SOURCE} import"
+    cat > "$PROV_CONFIG" <<PROVEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
+  foreign-source-dir="/opt/deltav/etc/foreign-sources"
+  requistion-dir="/opt/deltav/etc/imports"
+  importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
+  <requisition-def import-name="${FOREIGN_SOURCE}"
+                   import-url-resource="file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
+</provisiond-configuration>
+PROVEOF
+    PROVISIOND_NEEDS_RESTART=true
+elif ! grep -q "import-name=\"${FOREIGN_SOURCE}\"" "$PROV_CONFIG"; then
+    log "  Adding ${FOREIGN_SOURCE} requisition-def to existing provisiond-configuration.xml"
+    # Insert the rpc-canary requisition-def before the closing </provisiond-configuration>
+    sed -i.bak "s|</provisiond-configuration>|  <requisition-def import-name=\"${FOREIGN_SOURCE}\" import-url-resource=\"file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml\">\n    <cron-schedule>0/30 * * * * ?</cron-schedule>\n  </requisition-def>\n</provisiond-configuration>|" "$PROV_CONFIG"
+    rm -f "${PROV_CONFIG}.bak"
+    PROVISIOND_NEEDS_RESTART=true
+fi
+
+if $PROVISIOND_NEEDS_RESTART; then
+    log "  Restarting Provisiond to pick up requisition-def..."
+    docker compose restart provisiond
+    if wait_for_health "provisiond" "http://localhost:8080/actuator/health" 120; then
+        ok "Provisiond restarted and healthy"
+    else
+        fail "Provisiond not healthy after restart"
+        exit 1
+    fi
+else
+    ok "Provisiond configuration already includes ${FOREIGN_SOURCE}"
+fi
+
+# Wait for node to appear in DB
+if wait_for_db \
+    "SELECT count(*) FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" \
+    "$PROVISION_TIMEOUT" "canary node in database" 10; then
+    ok "Canary node provisioned"
+else
+    fail "Canary node not provisioned within ${PROVISION_TIMEOUT}s"
+    show_diagnostics
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+```
+
+- [ ] **Step 2: Verify script still parses**
+
+```bash
+bash -n opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: no output.
+
+---
+
+## Task 6: Add Phase 2 — detector assertion (ICMP + SNMP in ifservices)
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-minion-rpc-e2e.sh` (append)
+
+**Why this assertion proves Minion RPC detection worked:**
+- Under Delta-V architecture (memory: `feedback_no_local_polling`), daemons NEVER poll directly — all detection requests for nodes at location="Default" route through the Minion container via Kafka RPC
+- If both ICMP and SNMP services appear in `ifservices` for the canary node, it proves:
+  - The detection RPC request was sent to Minion's location topic
+  - Minion received and dispatched the request to its local IcmpDetector and SnmpDetector
+  - Detectors successfully reached snmp-agent (for SNMP) and the network stack (for ICMP)
+  - Results were serialized and sent back to Provisiond via Kafka
+  - Provisiond wrote the results to `ifservices`
+- If either assertion fails, the Minion RPC detection path is broken
+
+- [ ] **Step 1: Append Phase 2 detector assertion**
+
+Append:
+
+```bash
+# ══════════════════════════════════════════════════════════════════
+# Phase 2: Detector Assertion — ICMP and SNMP both detected via Minion RPC
+# ══════════════════════════════════════════════════════════════════
+log ""
+log "Phase 2: Verifying detectors executed on Minion via RPC..."
+
+# Assertion: ICMP service detected
+ICMP_QUERY="SELECT count(*) FROM ifservices s JOIN service svc ON s.serviceid = svc.serviceid JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND svc.servicename = 'ICMP'"
+if wait_for_db "$ICMP_QUERY" "$DETECT_TIMEOUT" "ICMP service detected (proves IcmpDetector ran via Minion RPC)" 10; then
+    ok "ICMP service detected via Minion RPC"
+else
+    fail "ICMP service NOT detected within ${DETECT_TIMEOUT}s — IcmpDetector RPC path broken"
+    show_diagnostics
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Assertion: SNMP service detected
+SNMP_QUERY="SELECT count(*) FROM ifservices s JOIN service svc ON s.serviceid = svc.serviceid JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND svc.servicename = 'SNMP'"
+if wait_for_db "$SNMP_QUERY" "$DETECT_TIMEOUT" "SNMP service detected (proves SnmpDetector ran via Minion RPC)" 10; then
+    ok "SNMP service detected via Minion RPC"
+else
+    fail "SNMP service NOT detected within ${DETECT_TIMEOUT}s — SnmpDetector RPC path broken OR snmp-agent community string mismatch"
+    show_diagnostics
+    log ""
+    log "Hint: mock-snmp-agent default community is 'public'. If SnmpConfig overrides this,"
+    log "      check that the community string in the SNMP config matches."
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Confirm the node's lastcapsdpoll timestamp is recent (detection actually completed)
+LASTPOLL_EPOCH=$(psql_query "SELECT EXTRACT(EPOCH FROM lastcapsdpoll) FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" | head -1 | cut -d. -f1)
+NOW_EPOCH=$(date +%s)
+if [ -n "${LASTPOLL_EPOCH:-}" ] && [ "${LASTPOLL_EPOCH:-0}" -gt 0 ]; then
+    AGE=$((NOW_EPOCH - LASTPOLL_EPOCH))
+    if [ "$AGE" -lt 600 ]; then
+        ok "Node lastcapsdpoll is recent (${AGE}s ago) — full detection scan completed"
+    else
+        log "  [WARN] Node lastcapsdpoll is stale (${AGE}s ago)"
+    fi
+else
+    log "  [WARN] Node lastcapsdpoll is NULL — detection may not have completed"
+fi
+```
+
+- [ ] **Step 2: Verify script still parses**
+
+```bash
+bash -n opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: no output.
+
+---
+
+## Task 7: Add Phase 3 — monitor assertion (Pollerd polling via Minion RPC)
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-minion-rpc-e2e.sh` (append)
+
+**Why this assertion proves Minion RPC monitoring works:**
+- When Provisiond writes a service into `ifservices`, it fires a `nodeGainedService` event
+- Pollerd consumes that event and schedules the service for polling
+- Polls for the canary node route through Minion (force-remote=true in pollerd config per docker-compose.yml)
+- Pollerd logs the poll request when it dispatches to Minion
+- A log entry mentioning the canary node's IP or label proves the poll attempt reached Minion
+
+- [ ] **Step 1: Append Phase 3 monitor assertion**
+
+Append:
+
+```bash
+# ══════════════════════════════════════════════════════════════════
+# Phase 3: Monitor Assertion — Pollerd is polling via Minion RPC
+# ══════════════════════════════════════════════════════════════════
+log ""
+log "Phase 3: Verifying Pollerd is polling canary services via Minion RPC..."
+
+# Wait for Pollerd to schedule the newly-detected services and make first poll attempts.
+# Pollerd reacts to nodeGainedService events; first poll typically happens within 30-60s.
+log "Waiting up to ${POLL_TIMEOUT}s for Pollerd to poll canary services..."
+
+POLL_EVIDENCE_FOUND=false
+ELAPSED=0
+while [ $ELAPSED -lt "$POLL_TIMEOUT" ]; do
+    # Look for Pollerd log entries mentioning the canary node or its IP.
+    # Delta-V Pollerd's log format includes service + IP on poll dispatches.
+    if docker compose logs --since="5m" pollerd 2>/dev/null | grep -qE "(snmp-agent-canary|${SNMP_AGENT_IP//./\\.})" ; then
+        POLL_EVIDENCE_FOUND=true
+        break
+    fi
+    sleep "$POLL_INTERVAL"
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+    if [ $((ELAPSED % 60)) -eq 0 ]; then
+        log "  ... ${ELAPSED}s elapsed"
+    fi
+done
+
+if $POLL_EVIDENCE_FOUND; then
+    ok "Pollerd poll activity observed for canary node (proves polling dispatched to Minion RPC)"
+else
+    fail "No Pollerd poll activity observed for canary node within ${POLL_TIMEOUT}s — Monitor RPC path may be broken"
+    show_diagnostics
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Secondary assertion: no service should be in a stuck-open outage state immediately after detection.
+# If the monitor IS running but cannot reach the service, an open outage would appear.
+# If the monitor is running AND the service is reachable, the service is up and no open outage exists.
+STUCK_OUTAGE_QUERY="SELECT count(*) FROM outages o JOIN ifservices s ON o.ifserviceid = s.id JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND o.ifregainedservice IS NULL"
+STUCK_OUTAGES=$(psql_query "$STUCK_OUTAGE_QUERY" || echo "0")
+if [ "${STUCK_OUTAGES:-0}" -eq 0 ]; then
+    ok "No stuck-open outages for canary services (services are reachable via Minion RPC)"
+else
+    fail "${STUCK_OUTAGES} stuck-open outage(s) on canary services — Monitor reports service unreachable via Minion RPC"
+    show_diagnostics
+    log ""
+    log "Hint: If outages are for SNMP, verify mock-snmp-agent responds on UDP/161"
+    log "      If outages are for ICMP, verify Minion has NET_RAW capability (docker-compose.yml minion.cap_add)"
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+```
+
+- [ ] **Step 2: Verify script still parses**
+
+```bash
+bash -n opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: no output.
+
+---
+
+## Task 8: Add summary + exit handling
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-minion-rpc-e2e.sh` (append)
+
+- [ ] **Step 1: Append summary section**
+
+Append:
+
+```bash
+# ══════════════════════════════════════════════════════════════════
+# Summary
+# ══════════════════════════════════════════════════════════════════
+if $VERBOSE; then
+    show_diagnostics
+fi
+
+log ""
+log "══════════════════════════════════════════════════════════════"
+log "Results: $PASS passed, $FAIL failed"
+log ""
+log "Validated:"
+log "  Phase 1: Canary node provisioned at location=Default"
+log "  Phase 2: ICMP + SNMP detectors executed via Minion RPC"
+log "  Phase 3: Pollerd actively polling canary services via Minion RPC"
+log "══════════════════════════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1
+```
+
+- [ ] **Step 2: Verify final script parses**
+
+```bash
+bash -n opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Confirm script is executable**
+
+```bash
+ls -l opennms-container/delta-v/test-minion-rpc-e2e.sh
+```
+
+Expected: `-rwxr-xr-x` permissions.
+
+---
+
+## Task 9: Run test against current develop baseline
+
+**Files:**
+- None modified; executing the test.
+
+**Objective:** Prove the canary passes against current `develop` **before** any Phase 3 migration PRs are merged. This establishes the baseline that PR1–PR5 must continue to pass.
+
+- [ ] **Step 1: Ensure Delta-V is deployed with at least `lite` profile**
+
+```bash
+cd opennms-container/delta-v
+./deploy.sh status
+```
+
+Expected: shows `postgres`, `kafka`, `provisiond`, `pollerd`, `minion`, `snmp-agent` as running. If not, run `./deploy.sh up lite`.
+
+- [ ] **Step 2: Run the canary test with pre-clean and verbose**
+
+```bash
+cd opennms-container/delta-v
+./test-minion-rpc-e2e.sh --pre-clean --verbose
+```
+
+Expected output (last few lines):
+```
+Results: 5 passed, 0 failed
+
+Validated:
+  Phase 1: Canary node provisioned at location=Default
+  Phase 2: ICMP + SNMP detectors executed via Minion RPC
+  Phase 3: Pollerd actively polling canary services via Minion RPC
+```
+
+Expected exit code: `0`.
+
+- [ ] **Step 3: If the test fails, diagnose before proceeding**
+
+Run the script with `--verbose` to see diagnostic queries. Common failure modes:
+
+| Failure | Likely cause | Debug step |
+|---|---|---|
+| Phase 1 timeout (node not provisioned) | Provisiond did not import requisition | Check Provisiond logs: `docker compose logs provisiond \| grep -i 'rpc-canary'` |
+| Phase 2 timeout on SNMP | SnmpDetector cannot reach snmp-agent OR community mismatch | Run `docker compose exec minion snmpwalk -v2c -c public snmp-agent system` |
+| Phase 2 timeout on ICMP | Minion lacks NET_RAW capability | Check docker-compose.yml has `cap_add: NET_RAW` on minion service |
+| Phase 3 timeout (no poll evidence) | Pollerd is not forced-remote OR Minion RPC broken | Check `docker compose logs pollerd \| grep -i 'force-remote'` |
+| Stuck-open outages | Monitor polling but service unreachable | Same as Phase 2 debug (reachability issue) |
+
+Do NOT proceed to Task 10 if the test fails. The canary must pass on current develop before being committed.
+
+---
+
+## Task 10: Document the test and commit
+
+**Files:**
+- Modify: `opennms-container/delta-v/README.md` (append to test list if present)
+- Commit all changes
+
+- [ ] **Step 1: Check whether README has a test-scripts table and add an entry if so**
+
+```bash
+grep -l "test-minion-e2e\|test-collectd-e2e" opennms-container/delta-v/README.md 2>/dev/null || echo "No test list in README"
+```
+
+If README lists the existing tests, add:
+```markdown
+| `test-minion-rpc-e2e.sh` | Minion RPC canary — verifies SnmpDetector + IcmpDetector + Pollerd polling all execute via Minion RPC (Kafka roundtrip). Gates Phase 3 horizon-extraction PRs. |
+```
+
+If README doesn't list existing tests, skip this step (no change needed).
+
+- [ ] **Step 2: Verify the canary node was cleaned up from prior test run**
+
+```bash
+cd opennms-container/delta-v
+docker compose exec -T -e PGPASSWORD=opennms postgres psql -U opennms -d opennms -t -A -c "SELECT count(*) FROM node WHERE foreignsource = 'rpc-canary'"
+```
+
+Expected: `0` or `1` (one canary node from Task 9's run is acceptable and expected).
+
+- [ ] **Step 3: Stage and commit**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+git status --short
+git add opennms-container/delta-v/test-minion-rpc-e2e.sh
+# Only add README if it was modified
+git add opennms-container/delta-v/README.md 2>/dev/null || true
+git commit -m "$(cat <<'EOF'
+test: add Minion RPC canary E2E for Phase 3 gate
+
+Adds test-minion-rpc-e2e.sh — a new shell-based E2E that provisions a
+canary node targeting the snmp-agent mock container at location=Default,
+then asserts:
+
+Phase 1: Node provisioned
+Phase 2: ICMP + SNMP detectors executed via Minion RPC (services in
+         ifservices table)
+Phase 3: Pollerd actively polling canary services via Minion RPC
+         (poll activity in Pollerd logs, no stuck-open outages)
+
+This is the canary for Phase 3 horizon-extraction. It establishes a
+baseline against current develop. PRs 1-5 of the extraction migration
+must not regress this test.
+
+Restores coverage lost when a PerspectivePollerd + PageSequenceMonitor
+E2E test was removed at some point prior (historical note from
+2026-04-05 spec brainstorm).
+EOF
+)"
+```
+
+Expected: commit created on the branch.
+
+- [ ] **Step 4: Verify commit**
+
+```bash
+git log --oneline -1
+git show --stat HEAD
+```
+
+Expected: commit shows 1-2 files changed (test script; README only if it was modified).
+
+---
+
+## Self-Review Checklist (run before handoff)
+
+Before presenting the plan as complete, walk through:
+
+- [ ] **Spec coverage:** All three assertions the spec calls for (detector via RPC, monitor via RPC, canary baseline on current develop) are covered by tasks 6, 7, and 9 respectively.
+- [ ] **Placeholder scan:** No "TBD", no "similar to task N", no "add error handling" — all shell code is literal and complete.
+- [ ] **Variable consistency:** `FOREIGN_SOURCE`, `SNMP_AGENT_IP`, `POLL_TIMEOUT`, etc. are defined in Task 2 and used consistently in Tasks 3–8.
+- [ ] **Idempotency:** `--pre-clean` removes prior canary data; `--post-cleanup` removes canary after run. Re-runs are safe.
+- [ ] **Failure diagnostics:** Each `fail` path calls `show_diagnostics` and provides hints before exit.
+
+---
+
+## Notes for the Implementing Engineer
+
+1. **Do not run `--post-cleanup` during the baseline run.** You want the canary node to remain in the DB briefly so the commit message can reference observed DB state if needed.
+
+2. **The `snmp-agent` image (`./mock-snmp-agent`) uses community string `public` by default.** If your local SNMP config overrides this, SnmpDetector will fail in Phase 2. Verify by checking `docker compose exec minion snmpwalk -v2c -c public snmp-agent system` returns output.
+
+3. **The test runs for up to 8 minutes** (provision 2m + detect 3m + poll 3m = 8m max). On a successful run it completes in ~2-3 minutes.
+
+4. **If Pollerd does not log the service name or IP explicitly,** the Phase 3 log-grep assertion may need to use a different pattern. Inspect a few seconds of Pollerd logs after a poll to confirm the log format:
+   ```bash
+   docker compose logs --since=2m pollerd | head -50
+   ```
+   If the log format is different, adjust the `grep -qE "(snmp-agent-canary|...)"` pattern in Task 7 accordingly.
+
+5. **No rollback needed.** This PR is purely additive — it adds one test script + one requisition fixture. Reverting the commit is the only rollback.

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -133,6 +133,7 @@ cd opennms-container/delta-v
 
 bash test-collectd-e2e.sh        # SNMP data collection via Minion
 bash test-minion-e2e.sh          # Trap → Minion → Kafka → Alarmd lifecycle
+bash test-minion-rpc-e2e.sh      # Detector + Monitor via Minion RPC (Phase 3 canary)
 bash test-syslog-e2e.sh          # Syslog → Minion → Kafka → Alarmd lifecycle
 bash test-passive-e2e.sh         # Passive status via EventTranslator + Pollerd
 bash test-enlinkd-e2e.sh         # LLDP/CDP link discovery on Containerlab cEOS

--- a/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="rpc-canary">
+    <scan-interval>1d</scan-interval>
+    <detectors>
+        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+        <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector"/>
+    </detectors>
+    <policies/>
+</foreign-source>

--- a/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -15,4 +15,7 @@
                    import-url-resource="file:///opt/deltav/etc/imports/mhuot-labs.xml">
     <cron-schedule>0/30 * * * * ?</cron-schedule>
   </requisition-def>
+  <requisition-def import-name="rpc-canary" import-url-resource="file:///opt/deltav/etc/imports/rpc-canary.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
 </provisiond-configuration>

--- a/opennms-container/delta-v/test-minion-rpc-e2e.sh
+++ b/opennms-container/delta-v/test-minion-rpc-e2e.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+#
+# test-minion-rpc-e2e.sh — End-to-end Minion RPC canary for Delta-V
+#
+# Provisions a canary node at location="Default" targeting the snmp-agent
+# mock container. Verifies that SnmpDetector + IcmpDetector executed via
+# Minion RPC (evidence: services in ifservices table) and that Pollerd
+# is actively polling those services via Minion RPC (evidence: poll
+# activity in Pollerd logs).
+#
+# This test is the CANARY for Phase 3 horizon-extraction. Any PR that
+# regresses Minion RPC detection or monitoring will fail this test.
+#
+# Usage:
+#   ./test-minion-rpc-e2e.sh              Run the test
+#   ./test-minion-rpc-e2e.sh --verbose    Show diagnostic queries on failure
+#   ./test-minion-rpc-e2e.sh --pre-clean  Full pre-run cleanup (DB + restart daemons)
+#   ./test-minion-rpc-e2e.sh --post-cleanup  Delete canary node and alarms after run
+#
+# Prerequisites:
+#   - Delta-V deployed with lite or full profile: ./deploy.sh up lite
+#   - snmp-agent, minion, provisiond, pollerd, postgres, kafka running
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = test failure
+#   2 = prerequisite failure
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
+
+# ── Configuration ──────────────────────────────────────────────────
+FOREIGN_SOURCE="rpc-canary"
+EXPECTED_NODES=1
+PROVISION_TIMEOUT=120        # 2 min — wait for node provisioning via Minion
+DETECT_TIMEOUT=180           # 3 min — wait for detectors to complete via RPC
+POLL_TIMEOUT=180             # 3 min — wait for Pollerd to start polling via RPC
+POLL_INTERVAL=10             # seconds between DB checks
+
+# ── Parse flags ────────────────────────────────────────────────────
+VERBOSE=false
+PRE_CLEAN=false
+POST_CLEANUP=false
+for arg in "$@"; do
+    case "$arg" in
+        --verbose) VERBOSE=true ;;
+        --pre-clean) PRE_CLEAN=true ;;
+        --post-cleanup) POST_CLEANUP=true ;;
+        --help|-h)
+            sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
+            exit 0
+            ;;
+    esac
+done
+# ── Helpers ────────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+log()  { echo "==> $*"; }
+ok()   { echo "  [PASS] $*"; PASS=$((PASS + 1)); }
+fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
+err()  { echo "ERROR: $*" >&2; exit 2; }
+
+cleanup() {
+    if $POST_CLEANUP; then
+        log "Post-run cleanup (--post-cleanup): removing canary node..."
+        psql_query "DELETE FROM outages WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+        psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'))" || true
+        psql_query "DELETE FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+        psql_query "DELETE FROM events WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+        psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
+        log "  Canary node deleted"
+    fi
+}
+trap cleanup EXIT
+
+psql_query() {
+    docker compose exec -T -e PGPASSWORD=opennms postgres \
+        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+}
+
+wait_for_db() {
+    local query="$1"
+    local timeout="$2"
+    local description="$3"
+    local poll_interval="${4:-$POLL_INTERVAL}"
+    local elapsed=0
+
+    log "Waiting for $description (timeout: ${timeout}s)..."
+    while [ $elapsed -lt "$timeout" ]; do
+        local result
+        result=$(psql_query "$query" 2>/dev/null || echo "")
+        if [ -n "$result" ] && [ "$result" != "0" ]; then
+            return 0
+        fi
+        sleep "$poll_interval"
+        elapsed=$((elapsed + poll_interval))
+        if [ $((elapsed % 60)) -eq 0 ]; then
+            log "  ... ${elapsed}s elapsed"
+        fi
+    done
+    return 1
+}
+
+wait_for_health() {
+    local container="$1"
+    local health_url="$2"
+    local timeout="${3:-120}"
+    local elapsed=0
+
+    log "Waiting for $container health check (timeout: ${timeout}s)..."
+    while [ $elapsed -lt "$timeout" ]; do
+        if docker compose exec -T "$container" curl -sf "$health_url" >/dev/null 2>&1; then
+            log "  ... $container is healthy"
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    return 1
+}
+
+# Resolves the snmp-agent container's IP on the Docker internal network.
+# Uses docker inspect from the host — more reliable than exec'ing into Minion
+# (Alpine-based Minion container lacks ping, nslookup, and may lack getent).
+# The IP returned is the container's IP on the shared Docker network, which
+# is exactly what Minion will use to reach snmp-agent.
+resolve_snmp_agent_ip() {
+    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{"\n"}}{{end}}' delta-v-snmp-agent 2>/dev/null | grep -v '^$' | head -1
+}
+
+show_diagnostics() {
+    if ! $VERBOSE; then
+        log "Hint: re-run with --verbose for diagnostic output"
+        return
+    fi
+    log ""
+    log "── Diagnostic Queries ──"
+    log ""
+    log "Canary node:"
+    psql_query "SELECT nodeid, nodelabel, foreignid, location, lastcapsdpoll FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
+    log ""
+    log "IP Interfaces:"
+    psql_query "SELECT n.nodelabel, ip.ipaddr, ip.issnmpprimary FROM ipinterface ip JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}'" || true
+    log ""
+    log "Services detected:"
+    psql_query "SELECT n.nodelabel, svc.servicename, s.status FROM ifservices s JOIN service svc ON s.serviceid = svc.serviceid JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' ORDER BY svc.servicename" || true
+    log ""
+    log "Recent Pollerd log lines mentioning canary node:"
+    docker compose logs --tail=100 pollerd 2>/dev/null | grep -i "snmp-agent-canary" || log "  (no matches)"
+}
+# ── Prerequisite Checks ───────────────────────────────────────────
+log "Checking prerequisites..."
+
+REQUIRED_SERVICES="postgres kafka provisiond pollerd minion snmp-agent"
+for svc in $REQUIRED_SERVICES; do
+    if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw "$svc"; then
+        err "Service '$svc' is not running. Deploy with: ./deploy.sh up lite"
+    fi
+done
+ok "Required services running (postgres, kafka, provisiond, pollerd, minion, snmp-agent)"
+
+# Resolve snmp-agent IP via Minion's DNS view (this is the IP Minion will use)
+SNMP_AGENT_IP=$(resolve_snmp_agent_ip)
+if [ -z "${SNMP_AGENT_IP:-}" ]; then
+    err "Could not resolve snmp-agent IP from Minion's perspective. Is Docker DNS working?"
+fi
+ok "Resolved snmp-agent IP (from Minion's perspective): ${SNMP_AGENT_IP}"
+
+# Quick sanity check — Minion can reach the SNMP port
+if ! docker compose exec -T minion sh -c "nc -uzvw 2 snmp-agent 161" >/dev/null 2>&1; then
+    log "  [WARN] Minion could not reach snmp-agent:161/udp (may still work; netcat may be unavailable)"
+else
+    ok "Minion can reach snmp-agent:161/udp"
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Pre-run cleanup (--pre-clean): remove any prior canary data
+# ══════════════════════════════════════════════════════════════════
+if $PRE_CLEAN; then
+    log ""
+    log "Pre-run cleanup (--pre-clean): removing existing canary data..."
+
+    psql_query "DELETE FROM outages WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+    psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'))" || true
+    psql_query "DELETE FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+    psql_query "DELETE FROM events WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+    psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
+    ok "Prior canary data cleaned"
+fi
+# ══════════════════════════════════════════════════════════════════
+# Phase 1: Provision the canary node via Minion
+# ══════════════════════════════════════════════════════════════════
+log ""
+log "Phase 1: Provisioning canary node targeting snmp-agent (${SNMP_AGENT_IP}) at location=Default..."
+
+# Generate the requisition inline with the resolved IP. This file is overwritten
+# on each test run — not committed to git (matches the delta-v.xml pattern
+# used by test-collectd-e2e.sh).
+mkdir -p provisiond-overlay/etc/imports
+CANARY_REQ="provisiond-overlay/etc/imports/${FOREIGN_SOURCE}.xml"
+cat > "$CANARY_REQ" <<REQEOF
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
+              date-stamp="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+              foreign-source="${FOREIGN_SOURCE}">
+   <node location="Default" foreign-id="snmp-agent-canary" node-label="snmp-agent-canary">
+      <interface ip-addr="${SNMP_AGENT_IP}" status="1" snmp-primary="P">
+         <monitored-service service-name="ICMP"/>
+         <monitored-service service-name="SNMP"/>
+      </interface>
+   </node>
+</model-import>
+REQEOF
+ok "Requisition generated at ${CANARY_REQ}"
+
+# Update provisiond-configuration.xml to auto-import this foreign source.
+# If an existing config has other requisition-defs (e.g., delta-v, mhuot-labs),
+# we need to append ours without destroying theirs.
+PROV_CONFIG="provisiond-overlay/etc/provisiond-configuration.xml"
+mkdir -p provisiond-overlay/etc
+PROVISIOND_NEEDS_RESTART=false
+if [ ! -f "$PROV_CONFIG" ]; then
+    log "  Writing new provisiond-configuration.xml with ${FOREIGN_SOURCE} import"
+    cat > "$PROV_CONFIG" <<PROVEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
+  foreign-source-dir="/opt/deltav/etc/foreign-sources"
+  requistion-dir="/opt/deltav/etc/imports"
+  importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
+  <requisition-def import-name="${FOREIGN_SOURCE}"
+                   import-url-resource="file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
+</provisiond-configuration>
+PROVEOF
+    PROVISIOND_NEEDS_RESTART=true
+elif ! grep -q "import-name=\"${FOREIGN_SOURCE}\"" "$PROV_CONFIG"; then
+    log "  Adding ${FOREIGN_SOURCE} requisition-def to existing provisiond-configuration.xml"
+    # Insert the rpc-canary requisition-def before the closing </provisiond-configuration>
+    sed -i.bak "s|</provisiond-configuration>|  <requisition-def import-name=\"${FOREIGN_SOURCE}\" import-url-resource=\"file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml\">\n    <cron-schedule>0/30 * * * * ?</cron-schedule>\n  </requisition-def>\n</provisiond-configuration>|" "$PROV_CONFIG"
+    rm -f "${PROV_CONFIG}.bak"
+    PROVISIOND_NEEDS_RESTART=true
+fi
+
+if $PROVISIOND_NEEDS_RESTART; then
+    log "  Restarting Provisiond to pick up requisition-def..."
+    docker compose restart provisiond
+    if wait_for_health "provisiond" "http://localhost:8080/actuator/health" 120; then
+        ok "Provisiond restarted and healthy"
+    else
+        fail "Provisiond not healthy after restart"
+        exit 1
+    fi
+else
+    ok "Provisiond configuration already includes ${FOREIGN_SOURCE}"
+fi
+
+# Wait for node to appear in DB
+if wait_for_db \
+    "SELECT count(*) FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" \
+    "$PROVISION_TIMEOUT" "canary node in database" 10; then
+    ok "Canary node provisioned"
+else
+    fail "Canary node not provisioned within ${PROVISION_TIMEOUT}s"
+    show_diagnostics
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 2: Detector Assertion — ICMP and SNMP both detected via Minion RPC
+# ══════════════════════════════════════════════════════════════════
+log ""
+log "Phase 2: Verifying detectors executed on Minion via RPC..."
+
+# Assertion: ICMP service detected
+ICMP_QUERY="SELECT count(*) FROM ifservices s JOIN service svc ON s.serviceid = svc.serviceid JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND svc.servicename = 'ICMP'"
+if wait_for_db "$ICMP_QUERY" "$DETECT_TIMEOUT" "ICMP service detected (proves IcmpDetector ran via Minion RPC)" 10; then
+    ok "ICMP service detected via Minion RPC"
+else
+    fail "ICMP service NOT detected within ${DETECT_TIMEOUT}s — IcmpDetector RPC path broken"
+    show_diagnostics
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Assertion: SNMP service detected
+SNMP_QUERY="SELECT count(*) FROM ifservices s JOIN service svc ON s.serviceid = svc.serviceid JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND svc.servicename = 'SNMP'"
+if wait_for_db "$SNMP_QUERY" "$DETECT_TIMEOUT" "SNMP service detected (proves SnmpDetector ran via Minion RPC)" 10; then
+    ok "SNMP service detected via Minion RPC"
+else
+    fail "SNMP service NOT detected within ${DETECT_TIMEOUT}s — SnmpDetector RPC path broken OR snmp-agent community string mismatch"
+    show_diagnostics
+    log ""
+    log "Hint: mock-snmp-agent default community is 'public'. If SnmpConfig overrides this,"
+    log "      check that the community string in the SNMP config matches."
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Confirm the node's lastcapsdpoll timestamp is recent (detection actually completed)
+LASTPOLL_EPOCH=$(psql_query "SELECT EXTRACT(EPOCH FROM lastcapsdpoll) FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" | head -1 | cut -d. -f1)
+NOW_EPOCH=$(date +%s)
+if [ -n "${LASTPOLL_EPOCH:-}" ] && [ "${LASTPOLL_EPOCH:-0}" -gt 0 ]; then
+    AGE=$((NOW_EPOCH - LASTPOLL_EPOCH))
+    if [ "$AGE" -lt 600 ]; then
+        ok "Node lastcapsdpoll is recent (${AGE}s ago) — full detection scan completed"
+    else
+        log "  [WARN] Node lastcapsdpoll is stale (${AGE}s ago)"
+    fi
+else
+    log "  [WARN] Node lastcapsdpoll is NULL — detection may not have completed"
+fi
+# ══════════════════════════════════════════════════════════════════
+# Phase 3: Monitor Assertion — Pollerd is polling via Minion RPC
+# ══════════════════════════════════════════════════════════════════
+log ""
+log "Phase 3: Verifying Pollerd is polling canary services via Minion RPC..."
+
+# Wait for Pollerd to schedule the newly-detected services and make first poll attempts.
+# Pollerd reacts to nodeGainedService events; first poll typically happens within 30-60s.
+log "Waiting up to ${POLL_TIMEOUT}s for Pollerd to poll canary services..."
+
+POLL_EVIDENCE_FOUND=false
+ELAPSED=0
+while [ $ELAPSED -lt "$POLL_TIMEOUT" ]; do
+    # Look for Pollerd log entries mentioning the canary node or its IP.
+    # Delta-V Pollerd's log format includes service + IP on poll dispatches.
+    if docker compose logs --since="5m" pollerd 2>/dev/null | grep -qE "(snmp-agent-canary|${SNMP_AGENT_IP//./\\.})" ; then
+        POLL_EVIDENCE_FOUND=true
+        break
+    fi
+    sleep "$POLL_INTERVAL"
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+    if [ $((ELAPSED % 60)) -eq 0 ]; then
+        log "  ... ${ELAPSED}s elapsed"
+    fi
+done
+
+if $POLL_EVIDENCE_FOUND; then
+    ok "Pollerd poll activity observed for canary node (proves polling dispatched to Minion RPC)"
+else
+    fail "No Pollerd poll activity observed for canary node within ${POLL_TIMEOUT}s — Monitor RPC path may be broken"
+    show_diagnostics
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Secondary assertion: no service should be in a stuck-open outage state immediately after detection.
+# If the monitor IS running but cannot reach the service, an open outage would appear.
+# If the monitor is running AND the service is reachable, the service is up and no open outage exists.
+STUCK_OUTAGE_QUERY="SELECT count(*) FROM outages o JOIN ifservices s ON o.ifserviceid = s.id JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND o.ifregainedservice IS NULL"
+STUCK_OUTAGES=$(psql_query "$STUCK_OUTAGE_QUERY" || echo "0")
+if [ "${STUCK_OUTAGES:-0}" -eq 0 ]; then
+    ok "No stuck-open outages for canary services (services are reachable via Minion RPC)"
+else
+    fail "${STUCK_OUTAGES} stuck-open outage(s) on canary services — Monitor reports service unreachable via Minion RPC"
+    show_diagnostics
+    log ""
+    log "Hint: If outages are for SNMP, verify mock-snmp-agent responds on UDP/161"
+    log "      If outages are for ICMP, verify Minion has NET_RAW capability (docker-compose.yml minion.cap_add)"
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+# ══════════════════════════════════════════════════════════════════
+# Summary
+# ══════════════════════════════════════════════════════════════════
+if $VERBOSE; then
+    show_diagnostics
+fi
+
+log ""
+log "══════════════════════════════════════════════════════════════"
+log "Results: $PASS passed, $FAIL failed"
+log ""
+log "Validated:"
+log "  Phase 1: Canary node provisioned at location=Default"
+log "  Phase 2: ICMP + SNMP detectors executed via Minion RPC"
+log "  Phase 3: Pollerd actively polling canary services via Minion RPC"
+log "══════════════════════════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/opennms-container/delta-v/test-minion-rpc-e2e.sh
+++ b/opennms-container/delta-v/test-minion-rpc-e2e.sh
@@ -69,6 +69,8 @@ cleanup() {
         log "Post-run cleanup (--post-cleanup): removing canary node..."
         psql_query "DELETE FROM outages WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
         psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'))" || true
+        psql_query "UPDATE ipinterface SET snmpinterfaceid = NULL WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+        psql_query "DELETE FROM snmpinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
         psql_query "DELETE FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
         psql_query "DELETE FROM events WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
         psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true
@@ -186,6 +188,8 @@ if $PRE_CLEAN; then
 
     psql_query "DELETE FROM outages WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
     psql_query "DELETE FROM ifservices WHERE ipinterfaceid IN (SELECT id FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'))" || true
+    psql_query "UPDATE ipinterface SET snmpinterfaceid = NULL WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
+    psql_query "DELETE FROM snmpinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
     psql_query "DELETE FROM ipinterface WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
     psql_query "DELETE FROM events WHERE nodeid IN (SELECT nodeid FROM node WHERE foreignsource = '${FOREIGN_SOURCE}')" || true
     psql_query "DELETE FROM node WHERE foreignsource = '${FOREIGN_SOURCE}'" || true


### PR DESCRIPTION
## Summary

Implements **PR0** — the canary E2E test that gates all subsequent Phase 3 horizon-extraction PRs (PR1–PR5).

Adds `opennms-container/delta-v/test-minion-rpc-e2e.sh` — a new shell-based E2E test that provisions a node targeting the `snmp-agent` mock container at `location=Default`, then asserts in three phases:

- **Phase 1**: Canary node provisioned via Provisiond
- **Phase 2**: ICMP + SNMP services detected via Minion RPC (proven by rows in `ifservices` DB table)
- **Phase 3**: Pollerd actively polling canary services via Minion RPC (proven by poll activity in Pollerd logs + no stuck-open outages)

**Baseline established:** 11 assertions pass / 0 fail, ~2 min wall-clock on current develop.

Restores test coverage lost when a PerspectivePollerd + PageSequenceMonitor E2E test was removed at some point (historical note surfaced during the 2026-04-05 spec brainstorm).

## Files Added / Modified

| File | Change | Purpose |
|---|---|---|
| `opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/rpc-canary.xml` | NEW (9 lines) | Foreign-source config — restricts detectors to ICMP + SNMP |
| `opennms-container/delta-v/test-minion-rpc-e2e.sh` | NEW (393 lines, executable) | The canary test script |
| `opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml` | MODIFIED (+3 lines) | Adds `rpc-canary` requisition-def (matches existing pattern for `delta-v`, `mhuot-labs`) |
| `opennms-container/delta-v/README.md` | MODIFIED (+1 line) | Adds test to list of E2E tests |

## Related

- **Depends on:** #119 (Phase 3 spec + PR0 plan)
- **Spec:** `docs/plans/2026-04-05-horizon-extraction-spec.md`
- **Implementation plan:** `docs/plans/2026-04-05-pr0-minion-rpc-canary-plan.md`
- **Gates:** PR1 (Phase 2 reactor pruning) through PR5 (NOTICE + pruning-report CI)

Until #119 merges, this PR's diff will show all 6 commits. After #119 merges, GitHub will auto-update the diff to show only the 3 PR0 commits.

## Test Plan

- [x] Script parses (`bash -n` passes)
- [x] Script executable
- [x] First run: **11/0 assertions pass**, ~2 min wall-clock
- [x] Cleanup fix verified: re-run with `--pre-clean` produces zero orphan `snmpinterface` rows
- [x] Second run with existing canary data: cleanup works, new canary provisioned, **11/0 assertions pass**
- [x] Code review: approved with one fix applied (snmpinterface cleanup)
- [ ] Reviewer verifies test passes on their local Delta-V deployment (`./deploy.sh up lite` → `./test-minion-rpc-e2e.sh --pre-clean --verbose`)

## Known Future Improvements (not blocking)

- **Cron timing flakiness**: when Provisiond is busy with long-running scans (e.g., mhuot-labs), the 30s cron-based import of rpc-canary can be delayed beyond the 120s PROVISION_TIMEOUT. Consider switching to on-demand REST import. Doesn't affect clean CI environments.
- **Phase 3 log-grep fragility**: pollerd log format may change; consider adding a DB-based positive assertion of monitor activity as secondary evidence.