### PR TITLE
fix: wire Discovery detector registry, purge ServiceMix and ActiveMQ

### DIFF
--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -148,6 +148,8 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <!-- dnsjava-dependencies pulls ServiceMix dnsjava OSGi wrapper — redundant with dnsjava:dnsjava -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.dnsjava</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>

--- a/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
+++ b/core/daemon-boot-discovery/src/main/java/org/opennms/netmgt/discovery/boot/DiscoveryBootConfiguration.java
@@ -14,6 +14,9 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.opennms.core.daemon.common.SpringServiceDaemonSmartLifecycle;
 import org.opennms.core.daemon.common.JdbcDistPollerDao;
 import org.opennms.core.daemon.common.JdbcInterfaceToNodeCache;
+import org.opennms.core.daemon.registry.DetectorRegistryConfiguration;
+import org.opennms.core.daemon.registry.NoOpSnmpAgentConfigFactory;
+import org.opennms.netmgt.config.api.SnmpAgentConfigFactory;
 import org.opennms.netmgt.config.DiscoveryConfigFactory;
 import org.opennms.netmgt.config.api.DiscoveryConfigurationFactory;
 import org.opennms.netmgt.config.discovery.DiscoveryConfiguration;
@@ -41,13 +44,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * Spring Boot @Configuration that wires all Discovery beans.
  *
  * <p>Replaces the Karaf-era {@code applicationContext-daemon-loader-discovery.xml}.</p>
+ *
+ * <p>{@link DetectorRegistryConfiguration} is imported explicitly to provide
+ * the {@link org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry}
+ * bean that {@link DetectorClientRpcModule} requires via {@code @Autowired}.
+ * Discovery doesn't need the collector or monitor registries, so we import
+ * only the detector configuration — the same pattern Minion uses.</p>
  */
 @Configuration
+@Import(DetectorRegistryConfiguration.class)
 public class DiscoveryBootConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(DiscoveryBootConfiguration.class);
@@ -59,6 +70,13 @@ public class DiscoveryBootConfiguration {
                 .build();
         XML_MAPPER.registerModule(new JaxbAnnotationModule());
         XML_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    // -- SNMP Config (NoOp — detectors execute on Minion via RPC) --
+
+    @Bean
+    public SnmpAgentConfigFactory snmpAgentConfigFactory() {
+        return new NoOpSnmpAgentConfigFactory();
     }
 
     // -- DAO / Cache --

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -193,6 +193,8 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <!-- dnsjava-dependencies pulls ServiceMix dnsjava OSGi wrapper — redundant with dnsjava:dnsjava -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.dnsjava</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -226,6 +226,9 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <!-- ipc.common.kafka pulls ServiceMix Kafka OSGi wrappers — redundant with kafka-clients from Spring Boot -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -102,6 +102,8 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId></exclusion>
+                <!-- dnsjava-dependencies pulls ServiceMix dnsjava OSGi wrapper — redundant with dnsjava:dnsjava -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.dnsjava</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
@@ -158,6 +160,8 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <!-- dnsjava-dependencies pulls ServiceMix dnsjava OSGi wrapper — redundant with dnsjava:dnsjava -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.dnsjava</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -86,6 +86,8 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
+                <!-- dnsjava-dependencies pulls ServiceMix dnsjava OSGi wrapper — redundant with dnsjava:dnsjava -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.dnsjava</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -216,6 +216,9 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <!-- ipc.common.kafka pulls ServiceMix Kafka OSGi wrappers — redundant with kafka-clients from Spring Boot -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>
@@ -291,6 +294,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- OSGi API — compile-only; AbstractMessageDispatcherFactory declares getBundleContext() -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>7.0.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test -->

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -62,6 +62,7 @@
             <groupId>org.opennms</groupId>
             <artifactId>opennms-config-model</artifactId>
             <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
@@ -116,15 +117,32 @@
         <dependency>
             <groupId>org.opennms.core</groupId>
             <artifactId>org.opennms.core.daemon</artifactId>
+            <exclusions>
+                <!-- spring-dependencies and spring-web-dependencies pull ServiceMix Spring 4.2.x bundles
+                     that conflict with Spring 7 provided by Spring Boot 4 -->
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-web-dependencies</artifactId></exclusion>
+                <!-- ActiveMQ is unused — all daemons use Kafka for messaging -->
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>activemq-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.features.activemq</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>*</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms.features.events</groupId>
             <artifactId>org.opennms.features.events.api</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opennms.core</groupId>
             <artifactId>org.opennms.core.event-forwarder-kafka</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Kafka RPC client (shared by Discovery, Pollerd, Collectd, Enlinkd, etc.) -->
@@ -132,10 +150,14 @@
             <groupId>org.opennms.core.ipc.rpc</groupId>
             <artifactId>org.opennms.core.ipc.rpc.kafka</artifactId>
             <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <!-- ipc.common.kafka pulls ServiceMix Kafka OSGi wrappers — redundant with kafka-clients from Spring Boot -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
@@ -210,11 +232,17 @@
         <dependency>
             <groupId>org.opennms.features.collection</groupId>
             <artifactId>org.opennms.features.collection.api</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+            </exclusions>
         </dependency>
         <!-- Poller API (ServiceMonitorRegistry interface) -->
         <dependency>
             <groupId>org.opennms.features.poller</groupId>
             <artifactId>org.opennms.features.poller.api</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Test -->

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -27,6 +27,8 @@
             <groupId>org.opennms.features.poller.monitors</groupId>
             <artifactId>org.opennms.features.poller.monitors.core</artifactId>
             <exclusions>
+                <!-- dnsjava-dependencies pulls ServiceMix dnsjava OSGi wrapper — redundant with dnsjava:dnsjava -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.dnsjava</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>


### PR DESCRIPTION
## Summary

- **Discovery startup fix**: Wire `DetectorRegistryConfiguration` via `@Import` + `NoOpSnmpAgentConfigFactory` to provide the `ServiceDetectorRegistry` bean that `DetectorClientRpcModule` requires. Follows the same pattern Minion uses.
- **ServiceMix Spring 4.2 purge**: Exclude `spring-dependencies` and `spring-web-dependencies` horizon aggregator POMs from daemon-common, eliminating 16 ServiceMix Spring 4.2.x JARs from all 12 Horizon daemon fat JARs. Fixes `jarmode=tools` extraction.
- **ActiveMQ purge**: Exclude `activemq-dependencies`, `activemq-camel`, and `features.activemq` from daemon-common — ActiveMQ is unused (all daemons use Kafka).
- **OSGi wrapper cleanup**: Exclude redundant ServiceMix OSGi wrappers (josql, kafka-clients, kafka_2.13, dnsjava) — non-wrapped equivalents already on classpath.
- **Telemetryd compile fix**: Add `osgi.core:provided` dependency (AbstractMessageDispatcherFactory declares `getBundleContext()` requiring OSGi API at compile time).

## Verification

- All 21 modules build successfully (16s)
- All 12 Horizon daemons healthy in Docker
- Discovery image: 480 MB (down from 596 MB — 19% reduction)
- Zero ServiceMix Spring JARs in all Horizon daemon fat JARs
- Zero ActiveMQ JARs in all Horizon daemon fat JARs
- `jarmode=tools extract` works cleanly for all daemons
- E2E tests passing:
  - test-e2e.sh: 14/14
  - test-syslog-e2e.sh: 15/15
  - test-passive-e2e.sh: 16/16
  - test-minion-rpc-e2e.sh: 11/11

## Test plan

- [x] `make build` — all 21 modules compile
- [x] `jarmode=tools list-layers` works on Discovery fat JAR
- [x] `jar tf` shows zero ServiceMix Spring JARs across all daemons
- [x] `jar tf` shows zero ActiveMQ JARs across all Horizon daemons
- [x] All 12 daemons healthy in Docker (including Discovery)
- [x] E2E trap → alarm pipeline (test-e2e.sh)
- [x] E2E syslog → alarm pipeline (test-syslog-e2e.sh)
- [x] E2E passive outage detection (test-passive-e2e.sh)
- [x] E2E Minion RPC detector/poller (test-minion-rpc-e2e.sh)