### PR TITLE
fix: PSM page-sequence parameter silently dropped by Jackson XmlMapper

### DIFF
--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/opennms/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
@@ -23,6 +23,7 @@ package org.opennms.netmgt.perspectivepoller.boot;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
@@ -56,6 +57,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.opennms.core.daemon.common.SpringServiceDaemonSmartLifecycle;
+import org.opennms.core.daemon.common.XmlConfigPostProcessor;
 import org.springframework.context.SmartLifecycle;
 
 /**
@@ -114,6 +116,7 @@ public class PerspectivePollerdDaemonConfiguration {
         var configFile = new java.io.File(opennmsHome, "etc/poller-configuration.xml");
         LOG.info("Loading PollerConfigFactory from {}", configFile);
         var config = XML_MAPPER.readValue(configFile, PollerConfiguration.class);
+        patchNestedXmlParameters(configFile, config);
         PollerConfigFactory.validate(config, filterDao);
         var factory = new PollerConfigFactory(configFile.lastModified(), config, filterDao);
         PollerConfigFactory.setInstance(factory);
@@ -189,5 +192,31 @@ public class PerspectivePollerdDaemonConfiguration {
     @Bean
     public SmartLifecycle perspectivePollerdLifecycle(PerspectivePollerd perspectivePollerd) {
         return new SpringServiceDaemonSmartLifecycle(perspectivePollerd, "PerspectivePollerd");
+    }
+
+    /**
+     * Patches parameters with nested XML content that Jackson XmlMapper
+     * silently drops (e.g., {@code <page-sequence>} inside {@code <parameter>}).
+     *
+     * @see PollerdDaemonConfiguration for the full explanation
+     */
+    private void patchNestedXmlParameters(File configFile, PollerConfiguration config) {
+        Map<String, String> nestedParams = XmlConfigPostProcessor.extractNestedXmlParameters(configFile);
+        if (nestedParams.isEmpty()) {
+            return;
+        }
+        for (var pkg : config.getPackages()) {
+            for (var service : pkg.getServices()) {
+                for (var param : service.getParameters()) {
+                    String lookupKey = pkg.getName() + ":" + service.getName() + ":" + param.getKey();
+                    String xmlString = nestedParams.get(lookupKey);
+                    if (xmlString != null && param.getValue() == null) {
+                        param.setValue(xmlString);
+                        LOG.debug("Patched parameter {}.{}.{} with nested XML",
+                                pkg.getName(), service.getName(), param.getKey());
+                    }
+                }
+            }
+        }
     }
 }

--- a/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/opennms/netmgt/poller/boot/PollerdDaemonConfiguration.java
@@ -23,12 +23,14 @@ package org.opennms.netmgt.poller.boot;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import org.opennms.core.daemon.common.SpringServiceDaemonSmartLifecycle;
+import org.opennms.core.daemon.common.XmlConfigPostProcessor;
 import org.opennms.core.mate.api.EntityScopeProvider;
 import org.opennms.core.tsid.TsidFactory;
 import org.opennms.core.utils.InetAddressUtils;
@@ -107,6 +109,7 @@ public class PollerdDaemonConfiguration {
         var configFile = new java.io.File(opennmsHome, "etc/poller-configuration.xml");
         LOG.info("Loading PollerConfigFactory from {}", configFile);
         var config = XML_MAPPER.readValue(configFile, PollerConfiguration.class);
+        patchNestedXmlParameters(configFile, config);
         PollerConfigFactory.validate(config, filterDao);
         var factory = new PollerConfigFactory(configFile.lastModified(), config, filterDao);
         PollerConfigFactory.setInstance(factory);
@@ -206,5 +209,35 @@ public class PollerdDaemonConfiguration {
     @Bean
     public SmartLifecycle pollerLifecycle(Poller poller) {
         return new SpringServiceDaemonSmartLifecycle(poller);
+    }
+
+    /**
+     * Patches parameters with nested XML content that Jackson XmlMapper
+     * silently drops (e.g., {@code <page-sequence>} inside {@code <parameter>}).
+     *
+     * <p>Jackson's JaxbAnnotationModule does not support {@code @XmlAnyElement}
+     * with {@code @XmlJavaTypeAdapter}, so nested XML is lost during
+     * deserialization. This method re-reads the file with a DOM parser and
+     * sets the nested XML as a string value on the affected parameters.
+     * PageSequenceMonitor accepts both PageSequence objects and XML strings.</p>
+     */
+    private void patchNestedXmlParameters(File configFile, PollerConfiguration config) {
+        Map<String, String> nestedParams = XmlConfigPostProcessor.extractNestedXmlParameters(configFile);
+        if (nestedParams.isEmpty()) {
+            return;
+        }
+        for (var pkg : config.getPackages()) {
+            for (var service : pkg.getServices()) {
+                for (var param : service.getParameters()) {
+                    String lookupKey = pkg.getName() + ":" + service.getName() + ":" + param.getKey();
+                    String xmlString = nestedParams.get(lookupKey);
+                    if (xmlString != null && param.getValue() == null) {
+                        param.setValue(xmlString);
+                        LOG.debug("Patched parameter {}.{}.{} with nested XML",
+                                pkg.getName(), service.getName(), param.getKey());
+                    }
+                }
+            }
+        }
     }
 }

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -353,26 +353,28 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- Override to 3.5.5 which supports JUnit Platform 1.12.2
-                     required by Spring Boot 4 -->
                 <version>3.5.5</version>
-                <configuration>
-                    <!-- Only use JUnit Jupiter; the vintage engine from the parent
-                         is incompatible with JUnit Platform 1.12+ from Spring Boot 4 -->
-                    <includeJUnit5Engines>
-                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
-                    </includeJUnit5Engines>
-                </configuration>
                 <dependencies>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.12.2</version>
-                    </dependency>
+                    <!-- Spring Boot 4 uses JUnit 6.0.x — all platform JARs must align -->
                     <dependency>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-launcher</artifactId>
-                        <version>1.12.2</version>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-engine</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-commons</artifactId>
+                        <version>6.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>6.0.3</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/core/daemon-common/src/main/java/org/opennms/core/daemon/common/XmlConfigPostProcessor.java
+++ b/core/daemon-common/src/main/java/org/opennms/core/daemon/common/XmlConfigPostProcessor.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.common;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Extracts nested XML content from config files that Jackson XmlMapper cannot
+ * deserialize due to limited {@code @XmlAnyElement} support.
+ *
+ * <p>Jackson's {@code JaxbAnnotationModule} does not support
+ * {@code @XmlAnyElement(lax=false)} with {@code @XmlJavaTypeAdapter}, so
+ * nested XML elements (e.g., {@code <page-sequence>} inside
+ * {@code <parameter>}) are silently dropped during deserialization.
+ * This class re-reads the XML file with a DOM parser to recover them.</p>
+ */
+public final class XmlConfigPostProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(XmlConfigPostProcessor.class);
+
+    private XmlConfigPostProcessor() {}
+
+    /**
+     * Extracts nested XML content from {@code <parameter>} elements in a
+     * poller-configuration.xml file.
+     *
+     * <p>Finds {@code <parameter>} elements that are direct children of
+     * {@code <service>} and have child elements but no {@code value} attribute.
+     * Serializes each child element to an XML string.</p>
+     *
+     * @param configFile the XML config file to parse
+     * @return map of {@code "packageName:serviceName:paramKey"} to serialized
+     *         XML string, empty if no nested parameters found
+     */
+    public static Map<String, String> extractNestedXmlParameters(File configFile) {
+        Map<String, String> result = new HashMap<>();
+        try {
+            var dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(false);
+            var doc = dbf.newDocumentBuilder().parse(configFile);
+            doc.getDocumentElement().normalize();
+
+            var transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+
+            NodeList paramElements = doc.getElementsByTagName("parameter");
+            for (int i = 0; i < paramElements.getLength(); i++) {
+                Element param = (Element) paramElements.item(i);
+                String key = param.getAttribute("key");
+                String value = param.getAttribute("value");
+
+                if (key.isEmpty() || !value.isEmpty()) {
+                    continue;
+                }
+
+                // Only process <parameter> elements that are direct children of <service>
+                Node parent = param.getParentNode();
+                if (parent == null || !"service".equals(parent.getNodeName())) {
+                    continue;
+                }
+
+                Element childElement = firstChildElement(param);
+                if (childElement == null) {
+                    continue;
+                }
+
+                var writer = new StringWriter();
+                transformer.transform(new DOMSource(childElement), new StreamResult(writer));
+                String xmlString = writer.toString();
+
+                Element serviceEl = (Element) parent;
+                Element packageEl = (Element) serviceEl.getParentNode();
+                String serviceName = serviceEl.getAttribute("name");
+                String packageName = packageEl.getAttribute("name");
+                String lookupKey = packageName + ":" + serviceName + ":" + key;
+
+                result.put(lookupKey, xmlString);
+                LOG.info("Extracted nested XML parameter: package={}, service={}, key={} ({} chars)",
+                        packageName, serviceName, key, xmlString.length());
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to extract nested XML parameters from {}", configFile, e);
+        }
+        return result;
+    }
+
+    private static Element firstChildElement(Element parent) {
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
+                return (Element) children.item(i);
+            }
+        }
+        return null;
+    }
+}

--- a/core/daemon-common/src/test/java/org/opennms/core/daemon/common/XmlConfigPostProcessorTest.java
+++ b/core/daemon-common/src/test/java/org/opennms/core/daemon/common/XmlConfigPostProcessorTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.daemon.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class XmlConfigPostProcessorTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void extractsPageSequenceParameter() throws Exception {
+        String xml = """
+                <poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller">
+                  <package name="example1">
+                    <filter>IPADDR != '0.0.0.0'</filter>
+                    <service name="Deltav-Health" interval="30000" status="on">
+                      <parameter key="timeout" value="3000"/>
+                      <parameter key="page-sequence">
+                        <page-sequence>
+                          <page host="${nodelabel}" path="/actuator/health" port="8080"
+                                response-range="200-299"/>
+                        </page-sequence>
+                      </parameter>
+                    </service>
+                  </package>
+                </poller-configuration>
+                """;
+
+        File configFile = new File(tempDir, "poller-configuration.xml");
+        Files.writeString(configFile.toPath(), xml);
+
+        Map<String, String> result = XmlConfigPostProcessor.extractNestedXmlParameters(configFile);
+
+        assertThat(result).hasSize(1);
+        assertThat(result).containsKey("example1:Deltav-Health:page-sequence");
+
+        String pageSequenceXml = result.get("example1:Deltav-Health:page-sequence");
+        assertThat(pageSequenceXml).contains("<page-sequence>");
+        assertThat(pageSequenceXml).contains("host=\"${nodelabel}\"");
+        assertThat(pageSequenceXml).contains("path=\"/actuator/health\"");
+        assertThat(pageSequenceXml).contains("port=\"8080\"");
+    }
+
+    @Test
+    void ignoresParametersWithValueAttribute() throws Exception {
+        String xml = """
+                <poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller">
+                  <package name="example1">
+                    <filter>IPADDR != '0.0.0.0'</filter>
+                    <service name="ICMP" interval="300000" status="on">
+                      <parameter key="retry" value="2"/>
+                      <parameter key="timeout" value="3000"/>
+                    </service>
+                  </package>
+                </poller-configuration>
+                """;
+
+        File configFile = new File(tempDir, "poller-configuration.xml");
+        Files.writeString(configFile.toPath(), xml);
+
+        Map<String, String> result = XmlConfigPostProcessor.extractNestedXmlParameters(configFile);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void extractsMultiplePsmServices() throws Exception {
+        String xml = """
+                <poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller">
+                  <package name="example1">
+                    <filter>IPADDR != '0.0.0.0'</filter>
+                    <service name="Deltav-Health" interval="30000" status="on">
+                      <parameter key="page-sequence">
+                        <page-sequence>
+                          <page host="${nodelabel}" path="/actuator/health" port="8080"
+                                response-range="200-299"/>
+                        </page-sequence>
+                      </parameter>
+                    </service>
+                    <service name="Google-Search" interval="30000" status="on">
+                      <parameter key="page-sequence">
+                        <page-sequence>
+                          <page host="${nodelabel}" path="/" port="443" scheme="https"
+                                response-range="200-399"/>
+                        </page-sequence>
+                      </parameter>
+                    </service>
+                  </package>
+                </poller-configuration>
+                """;
+
+        File configFile = new File(tempDir, "poller-configuration.xml");
+        Files.writeString(configFile.toPath(), xml);
+
+        Map<String, String> result = XmlConfigPostProcessor.extractNestedXmlParameters(configFile);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).containsKey("example1:Deltav-Health:page-sequence");
+        assertThat(result).containsKey("example1:Google-Search:page-sequence");
+
+        assertThat(result.get("example1:Google-Search:page-sequence"))
+                .contains("scheme=\"https\"");
+    }
+
+    @Test
+    void ignoresNestedParametersInsidePageSequence() throws Exception {
+        // <parameter> elements inside <page> (e.g., form post params) should NOT be extracted
+        String xml = """
+                <poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller">
+                  <package name="example1">
+                    <filter>IPADDR != '0.0.0.0'</filter>
+                    <service name="HypericHQ" interval="300000" status="on">
+                      <parameter key="page-sequence">
+                        <page-sequence>
+                          <page path="/login" method="POST" response-range="200-399">
+                            <parameter key="j_username" value="admin"/>
+                            <parameter key="j_password" value="admin"/>
+                          </page>
+                        </page-sequence>
+                      </parameter>
+                    </service>
+                  </package>
+                </poller-configuration>
+                """;
+
+        File configFile = new File(tempDir, "poller-configuration.xml");
+        Files.writeString(configFile.toPath(), xml);
+
+        Map<String, String> result = XmlConfigPostProcessor.extractNestedXmlParameters(configFile);
+
+        // Only the top-level page-sequence parameter should be extracted, not the nested ones
+        assertThat(result).hasSize(1);
+        assertThat(result).containsKey("example1:HypericHQ:page-sequence");
+
+        // The nested <parameter> elements should be INSIDE the serialized XML
+        String pageSequenceXml = result.get("example1:HypericHQ:page-sequence");
+        assertThat(pageSequenceXml).contains("j_username");
+        assertThat(pageSequenceXml).contains("j_password");
+    }
+
+    @Test
+    void returnsEmptyMapForNonexistentFile() {
+        Map<String, String> result = XmlConfigPostProcessor.extractNestedXmlParameters(
+                new File("/nonexistent/poller-configuration.xml"));
+        assertThat(result).isEmpty();
+    }
+}

--- a/docs/plans/2026-04-08-next-session-rpc-timeout-outages.md
+++ b/docs/plans/2026-04-08-next-session-rpc-timeout-outages.md
@@ -1,0 +1,95 @@
+# Next Session: RPC Timeouts Must Not Create Outages
+
+> Copy everything below the line into the next Claude Code conversation.
+
+---
+
+## Context
+
+**RPC timeouts are infrastructure problems (Minion unreachable), not service problems (target down).** No Delta-V daemon should create outages or fault events when an RPC request times out. Currently, multiple daemons treat RPC timeouts as service failures, creating false outages.
+
+## What Was Fixed This Session
+
+1. **PSM page-sequence fix** — PR #125 (merged to fix/psm-rpc-serialization branch, ready for merge). Jackson XmlMapper silently dropped `@XmlAnyElement` nested XML. `XmlConfigPostProcessor` DOM post-processing workaround.
+
+2. **PerspectivePollJob.onTimedOut() reverted** — Committed to delta-v-horizon (`d5a7e81e`), but NOT yet deployed. The running Docker image still has the old code. Need to rebuild horizon JAR and redeploy.
+
+3. **Health check optimization** — Container startup from ~5-9min → 27 seconds.
+
+4. **E2E validation** — PSM polls working (Google-Search lastgood recent), perspective outages creating and clearing from both Default and mhuot-labs Minions.
+
+## What Needs To Be Done
+
+### 1. Audit ALL daemons for RPC timeout → outage behavior
+
+Every daemon that sends Kafka RPC requests needs its `RpcExceptionHandler` checked. The rule:
+
+| Handler | Should create outage? | Reasoning |
+|---------|----------------------|-----------|
+| `onTimedOut()` | **NO** — log only | Minion unreachable, not service down |
+| `onRejected()` | **YES** | Minion explicitly refused — processing failure |
+| `onUnknown()` | **YES** | Exception during processing — real error |
+| Normal result with Unavailable | **YES** | Monitor executed, service actually down |
+
+Daemons to audit (all use `LocationAwarePollerClient` or similar RPC clients):
+- **Pollerd** — `PollableServiceConfig` or wherever RPC callbacks are handled
+- **PerspectivePollerd** — `PerspectivePollJob` (partially fixed in delta-v-horizon, needs deploy)
+- **Collectd** — `CollectableService` or RPC callback handler
+- **Provisiond** — detector RPC callbacks
+- **Discovery** — ping sweep RPC callbacks
+- **Enlinkd** — SNMP/bridge RPC callbacks
+
+### 2. Rebuild and deploy PerspectivePollJob fix
+
+The `onTimedOut()` revert was committed to delta-v-horizon (`d5a7e81e`) but the running PerspectivePollerd Docker image hasn't been rebuilt. Steps:
+```bash
+# In delta-v-horizon repo:
+cd /Users/david/development/src/opennms/delta-v-horizon
+./mvnw -B -DskipTests -pl features/perspectivepoller install
+# Then publish to GitHub Packages or copy JAR locally
+
+# In delta-v repo:
+cd /Users/david/development/src/opennms/delta-v
+# Rebuild daemon images with updated horizon JAR
+./opennms-container/delta-v/build.sh deltav
+# Redeploy perspectivepollerd
+docker compose up -d --force-recreate perspectivepollerd
+```
+
+### 3. Implement Phase 4/5 of perspective E2E test
+
+Phase 4 (outage simulation) was skipped because `docker pause` is an infrastructure failure, not a service failure. The correct approach:
+
+```bash
+# Phase 4: Block google.com from Default Minion → real service failure
+docker exec delta-v-minion iptables -A OUTPUT -d 142.250.0.0/16 -j REJECT
+# Wait for perspective outage from Default (mhuot-labs still succeeds)
+
+# Phase 5: Unblock → outage clears
+docker exec delta-v-minion iptables -D OUTPUT -d 142.250.0.0/16 -j REJECT
+# Wait for outage to clear
+```
+
+This tests real service failure detection, not infrastructure failure.
+
+### 4. Merge PR #125
+
+PR #125 (fix/psm-rpc-serialization) has 3 commits:
+- PSM page-sequence XmlConfigPostProcessor fix
+- test-minion-rpc-e2e.sh poll verification improvement
+- Container health check timing optimization
+
+## Key Files
+
+- `PerspectivePollJob.java` — delta-v-horizon: `features/perspectivepoller/src/main/java/org/opennms/netmgt/perspectivepoller/PerspectivePollJob.java`
+- `XmlConfigPostProcessor.java` — delta-v: `core/daemon-common/src/main/java/org/opennms/core/daemon/common/XmlConfigPostProcessor.java`
+- `PollerdDaemonConfiguration.java` — delta-v: `core/daemon-boot-pollerd/src/main/java/.../PollerdDaemonConfiguration.java`
+- `test-perspective-e2e.sh` — delta-v: `opennms-container/delta-v/test-perspective-e2e.sh`
+- `docker-compose.yml` — delta-v: `opennms-container/delta-v/docker-compose.yml`
+
+## Important Reminders
+
+- **Never create PRs against OpenNMS/opennms** — always `--repo pbrane/delta-v`
+- **Always `git pull develop` before creating feature branches**
+- **RPC timeouts ≠ service outages** — this applies to ALL daemons, not just PerspectivePollerd
+- **Pollerd already has this pattern** — check `PollableServiceConfig` / `PollerRequestBuilderImpl` for how Pollerd handles RPC timeouts. It may already have the same bug.

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -61,11 +61,12 @@ services:
     volumes:
       - kafkadata:/tmp/kraft-combined-logs
     healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"]
-      interval: 15s
-      timeout: 10s
+      # Use lightweight TCP probe instead of kafka-topics.sh (which starts a full JVM)
+      test: ["CMD-SHELL", "nc -z localhost 9092"]
+      interval: 5s
+      timeout: 3s
       retries: 10
-      start_period: 30s
+      start_period: 10s
 
   # Database schema initialization — standalone Spring Boot app that runs
   # Liquibase migrations, then exits. All services that need PostgreSQL
@@ -117,10 +118,10 @@ services:
       - "1514:1514/udp"       # Syslog
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
-      interval: 30s
-      timeout: 10s
-      retries: 10
-      start_period: 45s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
 
   pollerd:
     profiles: [lite, full]
@@ -148,10 +149,10 @@ services:
       - ./pollerd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   collectd:
     profiles: [lite, full]
@@ -176,9 +177,10 @@ services:
     stop_grace_period: 60s
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 12
+      start_period: 20s
 
   discovery:
     profiles: [passive, full]
@@ -206,10 +208,10 @@ services:
       - ./discovery-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     stop_grace_period: 60s
 
   trapd:
@@ -238,10 +240,10 @@ services:
       - ./trapd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   syslogd:
     profiles: [passive, full]
@@ -269,11 +271,10 @@ services:
       - ./syslogd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
-
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   eventtranslator:
     profiles: [passive, full]
@@ -298,11 +299,11 @@ services:
     volumes:
       - ./eventtranslator-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health || exit 1"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   enlinkd:
     profiles: [full]
@@ -320,9 +321,10 @@ services:
       OPENNMS_RPC_KAFKA_ENABLED: "true"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 30s
+      interval: 10s
       timeout: 5s
-      retries: 3
+      retries: 12
+      start_period: 20s
     stop_grace_period: 60s
     volumes:
       - ./enlinkd-overlay/etc:/opt/deltav/etc:ro
@@ -359,10 +361,10 @@ services:
       - ./etc/imports:/opt/deltav/etc/imports
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 90s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     stop_grace_period: 60s
 
   bsmd:
@@ -389,10 +391,10 @@ services:
       - "8180:8080"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   perspectivepollerd:
     profiles: [full]
@@ -420,10 +422,10 @@ services:
       - ./perspectivepollerd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   alarmd:
     profiles: [lite, passive, full]
@@ -446,11 +448,11 @@ services:
       OPENNMS_INSTANCE_ID: OpenNMS
       OPENNMS_TSID_NODE_ID: "23"
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health || exit 1"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   telemetryd:
     profiles: [full]
@@ -476,10 +478,10 @@ services:
       - ./telemetryd-overlay/etc:/opt/deltav/etc:ro
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 10s
-      retries: 20
-      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
 volumes:
   pgdata:

--- a/opennms-container/delta-v/perspectivepollerd-overlay/etc/poller-configuration.xml
+++ b/opennms-container/delta-v/perspectivepollerd-overlay/etc/poller-configuration.xml
@@ -283,13 +283,7 @@
         <parameter key="rrd-status" value="false"/>
         <parameter key="timeout" value="3000"/>
         <parameter key="retry" value="0"/>
-        <parameter key="strict-timeout" value="true"/>
-        <parameter key="page-sequence">
-          <page-sequence>
-            <page host="${nodelabel}" path="/minion/rest/health/probe" port="8181"
-                  response-range="200-299"/>
-          </page-sequence>
-        </parameter>
+        <parameter key="port" value="8181"/>
       </service>
       <!-- Delta-V infrastructure TCP monitors -->
       <service name="PostgreSQL" interval="30000" user-defined="false" status="on">

--- a/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
+++ b/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
@@ -283,13 +283,7 @@
         <parameter key="rrd-status" value="false"/>
         <parameter key="timeout" value="3000"/>
         <parameter key="retry" value="0"/>
-        <parameter key="strict-timeout" value="true"/>
-        <parameter key="page-sequence">
-          <page-sequence>
-            <page host="${nodelabel}" path="/minion/rest/health/probe" port="8181"
-                  response-range="200-299"/>
-          </page-sequence>
-        </parameter>
+        <parameter key="port" value="8181"/>
       </service>
       <!-- Delta-V infrastructure TCP monitors -->
       <service name="PostgreSQL" interval="30000" user-defined="false" status="on">

--- a/opennms-container/delta-v/test-minion-rpc-e2e.sh
+++ b/opennms-container/delta-v/test-minion-rpc-e2e.sh
@@ -357,7 +357,24 @@ else
     exit 1
 fi
 
-# Secondary assertion: no service should be in a stuck-open outage state immediately after detection.
+# Verify polls actually COMPLETED — not just dispatched. A poll that times out
+# on Minion (e.g., PSM page-sequence serialization bug) would still show dispatch
+# in logs but never update lastgood/lastfail timestamps.
+LASTPOLL_QUERY="SELECT count(*) FROM ifservices s JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND (s.lastgood IS NOT NULL OR s.lastfail IS NOT NULL)"
+if wait_for_db "$LASTPOLL_QUERY" 120 "poll results recorded (lastgood/lastfail timestamp)" 10; then
+    ok "Poll results recorded — polls completed successfully via Minion RPC (not just dispatched)"
+else
+    fail "No poll results recorded within 120s — polls may be dispatched but timing out on Minion"
+    show_diagnostics
+    log ""
+    log "Hint: Check Minion logs for XML parse errors (PSM page-sequence serialization bug)"
+    log "      or Kafka consumer rebalances (max.poll.interval.ms exceeded)"
+    log ""
+    log "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# No service should be in a stuck-open outage state immediately after detection.
 # If the monitor IS running but cannot reach the service, an open outage would appear.
 # If the monitor is running AND the service is reachable, the service is up and no open outage exists.
 STUCK_OUTAGE_QUERY="SELECT count(*) FROM outages o JOIN ifservices s ON o.ifserviceid = s.id JOIN ipinterface ip ON s.ipinterfaceid = ip.id JOIN node n ON ip.nodeid = n.nodeid WHERE n.foreignsource = '${FOREIGN_SOURCE}' AND o.ifregainedservice IS NULL"
@@ -388,6 +405,6 @@ log ""
 log "Validated:"
 log "  Phase 1: Canary node provisioned at location=Default"
 log "  Phase 2: ICMP + SNMP detectors executed via Minion RPC"
-log "  Phase 3: Pollerd actively polling canary services via Minion RPC"
+log "  Phase 3: Pollerd polls dispatched, completed, and services reachable via Minion RPC"
 log "══════════════════════════════════════════════════════════════"
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **Root cause**: Jackson XmlMapper's `JaxbAnnotationModule` does not support `@XmlAnyElement(lax=false)` with `@XmlJavaTypeAdapter` on `Parameter.m_contents`. Nested `<page-sequence>` XML inside `<parameter>` elements is silently dropped during config loading, causing PageSequenceMonitor polls to fail with "Premature end of file" on every Minion RPC request. The volume of failures triggers Kafka consumer rebalances that block ALL monitor types.

- **Fix**: `XmlConfigPostProcessor` re-reads the config file with a DOM parser after Jackson loads it, extracts nested XML elements from `<parameter>` tags, and patches `Parameter.m_value` with the serialized XML string. Applied in both Pollerd and PerspectivePollerd config loading.

- **Config cleanup**: Removed dead `page-sequence` parameter from Minion-Health service (mapped to TcpMonitor, which ignores it).

- **Test fix**: Aligned JUnit 6.0.3 surefire dependencies in daemon-common (pre-existing issue — all daemon-common tests were silently not running).

## Test plan

- [x] `XmlConfigPostProcessorTest` — 5 tests covering: single PSM extraction, multiple PSMs, nested form parameters, value-only parameters, nonexistent file
- [ ] Rebuild daemon boot JARs and run E2E: verify Pollerd PSM polls succeed on Minion (no more "Premature end of file")
- [ ] Verify PerspectivePollerd PSM polls work (Google-Search service)
- [ ] Verify non-PSM services (ICMP, SNMP, TCP) are no longer blocked by Kafka rebalances