### PR TITLE
fix: exclude opennms-model from JPA daemon classpaths

### DIFF
--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -127,6 +127,11 @@
                 <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms.features.activemq</groupId><artifactId>*</artifactId></exclusion>
                 <exclusion><groupId>org.apache.activemq</groupId><artifactId>*</artifactId></exclusion>
+                <!-- opennms-model contains javax.persistence entities that clash with
+                     model-jakarta (jakarta.persistence) under Hibernate 7 entity scanning.
+                     AbstractServiceDaemon and SpringServiceDaemon (the only classes we use
+                     from core/daemon) reference ServiceDaemon from model-api, not opennms-model. -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -234,6 +239,7 @@
             <artifactId>org.opennms.features.collection.api</artifactId>
             <exclusions>
                 <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>
         <!-- Poller API (ServiceMonitorRegistry interface) -->

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -105,6 +105,7 @@
             <exclusions>
                 <!-- Brings in ServiceMix Spring 4.2.9 bundles which conflict with Spring Boot 4 -->
                 <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Summary
- Excludes `opennms-model` (javax.persistence entities) from all 13 JPA daemon classpaths, resolving the split-package conflict with `model-jakarta` (jakarta.persistence) under Hibernate 7
- Three exclusions across two POMs: `core/daemon` and `collection.api` in `daemon-common`, `collection.api` in `daemon-registry`
- Minion retains its deliberate runtime-scope `opennms-model` dependency (no JPA/Hibernate entity scanning)

## Context
`opennms-model` leaked into every daemon via `daemon-common → core/daemon → opennms-model` and `collection.api → opennms-model`. Since `model-jakarta` provides the same entities in the same package with `jakarta.persistence` annotations, Hibernate 7 would scan both and fail. Bytecode analysis confirmed that `AbstractServiceDaemon` and `SpringServiceDaemon` (the only classes used from `core/daemon`) reference `ServiceDaemon` from `model-api`, not `opennms-model`.

## Test plan
- [x] Maven build: 21/21 modules compile clean
- [x] Dependency verification: `opennms-model` absent from all 13 JPA daemons, present only in Minion (runtime scope)
- [x] Docker images rebuilt for all 12 daemons
- [x] E2E: 107/107 tests pass across 8 suites (test-e2e, test-syslog-e2e, test-passive-e2e, test-minion-rpc-e2e, test-collectd-e2e, test-minion-e2e, test-perspective-e2e, test-enlinkd-e2e)