### PR TITLE
fix: purge ActiveMQ, ServiceMix Kafka, and C3P0 from daemon classpaths

### DIFF
--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -100,6 +100,9 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <!-- ServiceMix Kafka wrappers — redundant with kafka-clients from Spring Boot -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -263,7 +263,17 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
+                <!-- ActiveMQ is unused — Minion uses Kafka exclusively for IPC -->
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>activemq-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.apache.activemq.protobuf</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.features.activemq</groupId><artifactId>*</artifactId></exclusion>
+                <!-- ServiceMix Kafka wrappers — redundant with kafka-clients from Spring Boot -->
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
+                <!-- C3P0 — Minion has no database; HikariCP used where needed -->
+                <exclusion><groupId>com.mchange</groupId><artifactId>c3p0</artifactId></exclusion>
+                <exclusion><groupId>com.mchange</groupId><artifactId>mchange-commons-java</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -132,6 +132,9 @@
                      AbstractServiceDaemon and SpringServiceDaemon (the only classes we use
                      from core/daemon) reference ServiceDaemon from model-api, not opennms-model. -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <!-- C3P0 connection pool — replaced by HikariCP via Spring Boot -->
+                <exclusion><groupId>com.mchange</groupId><artifactId>c3p0</artifactId></exclusion>
+                <exclusion><groupId>com.mchange</groupId><artifactId>mchange-commons-java</artifactId></exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Excludes ActiveMQ (17 JARs), ServiceMix Kafka wrappers (2 JARs), and C3P0 (2 JARs) from all daemon classpaths
- Minion: exclusions on `events.traps` and `ipc.rpc.kafka` dependencies
- All Horizon daemons: C3P0 exclusion on `core.daemon` in daemon-common (Spring Boot provides HikariCP)

## Test plan
- [x] Maven build: 21/21 modules
- [x] Dependency verification: 0 ActiveMQ, 0 ServiceMix Kafka, 0 C3P0 across all daemons
- [x] Docker images rebuilt
- [x] Full regression: 119/119 E2E tests across 8 suites