### PR TITLE
fix: bump horizon to 1.0.5 — purge exclusion bloat

### DIFF
--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -50,8 +50,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
-                <!-- Exclude ActiveMQ Camel (brings camel-spring with old Spring dep) -->
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <!-- Exclude Hibernate 3.x -->
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -70,7 +70,6 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
                 <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>org.opennms.core.model-api</artifactId>
         </dependency>
 
+        <!-- SNMP4J implementation (Enlinkd collectors need org.snmp4j classes) -->
+        <dependency>
+            <groupId>org.opennms.core.snmp</groupId>
+            <artifactId>org.opennms.core.snmp.implementations.snmp4j</artifactId>
+        </dependency>
+
         <!-- Shared daemon infrastructure -->
         <dependency>
             <groupId>org.opennms.core</groupId>

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -71,8 +71,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
-                <!-- Exclude ActiveMQ Camel (brings camel-spring with old Spring dep) -->
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <!-- Exclude Hibernate 3.x -->
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
@@ -99,10 +97,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
-                <!-- ServiceMix Kafka wrappers — redundant with kafka-clients from Spring Boot -->
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
@@ -143,7 +137,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
@@ -166,7 +159,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -68,7 +68,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
@@ -143,7 +142,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
@@ -226,7 +224,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
@@ -263,17 +260,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
-                <!-- ActiveMQ is unused — Minion uses Kafka exclusively for IPC -->
-                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>activemq-dependencies</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>*</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq.protobuf</groupId><artifactId>*</artifactId></exclusion>
-                <exclusion><groupId>org.opennms.features.activemq</groupId><artifactId>*</artifactId></exclusion>
-                <!-- ServiceMix Kafka wrappers — redundant with kafka-clients from Spring Boot -->
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
-                <!-- C3P0 — Minion has no database; HikariCP used where needed -->
-                <exclusion><groupId>com.mchange</groupId><artifactId>c3p0</artifactId></exclusion>
-                <exclusion><groupId>com.mchange</groupId><artifactId>mchange-commons-java</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
@@ -373,7 +359,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
@@ -405,7 +390,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aopalliance</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.aspectj</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -78,7 +78,6 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
                 <!-- Exclude legacy Hibernate 3.x DAOs — model-jakarta provides Jakarta JPA DAOs -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-dao</artifactId></exclusion>
@@ -102,7 +101,6 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>
@@ -146,7 +144,6 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -226,9 +226,6 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
-                <!-- ipc.common.kafka pulls ServiceMix Kafka OSGi wrappers — redundant with kafka-clients from Spring Boot -->
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -66,7 +66,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -45,8 +45,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
-                <!-- Exclude ActiveMQ Camel (brings camel-spring with old Spring dep) -->
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <!-- Exclude Hibernate 3.x -->
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>org.opennms.core.model-api</artifactId>
         </dependency>
 
+        <!-- SNMP4J implementation (Telemetryd protocols may need org.snmp4j classes) -->
+        <dependency>
+            <groupId>org.opennms.core.snmp</groupId>
+            <artifactId>org.opennms.core.snmp.implementations.snmp4j</artifactId>
+        </dependency>
+
         <!-- Shared daemon infrastructure.
              Exclude ALL ServiceMix Spring bundles (spring-dependencies POM pulls in
              Spring 4.2.x through multiple transitive paths via opennms-core-daemon,

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -73,7 +73,6 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>
@@ -216,9 +215,6 @@
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
-                <!-- ipc.common.kafka pulls ServiceMix Kafka OSGi wrappers — redundant with kafka-clients from Spring Boot -->
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
             </exclusions>
         </dependency>

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -45,8 +45,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-web</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-webmvc</artifactId></exclusion>
-                <!-- Exclude ActiveMQ Camel (brings camel-spring with old Spring dep) -->
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
                 <!-- Exclude Hibernate 3.x -->
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -144,6 +144,12 @@
             <artifactId>org.opennms.core.model-api</artifactId>
         </dependency>
 
+        <!-- SNMP4J implementation (TrapSinkModule needs org.snmp4j.PDU) -->
+        <dependency>
+            <groupId>org.opennms.core.snmp</groupId>
+            <artifactId>org.opennms.core.snmp.implementations.snmp4j</artifactId>
+        </dependency>
+
         <!-- javax.persistence API (legacy classes need it loadable) -->
         <dependency>
             <groupId>javax.persistence</groupId>

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -122,19 +122,11 @@
                      that conflict with Spring 7 provided by Spring Boot 4 -->
                 <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
                 <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-web-dependencies</artifactId></exclusion>
-                <!-- ActiveMQ is unused — all daemons use Kafka for messaging -->
-                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>activemq-dependencies</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>activemq-camel</artifactId></exclusion>
-                <exclusion><groupId>org.opennms.features.activemq</groupId><artifactId>*</artifactId></exclusion>
-                <exclusion><groupId>org.apache.activemq</groupId><artifactId>*</artifactId></exclusion>
                 <!-- opennms-model contains javax.persistence entities that clash with
                      model-jakarta (jakarta.persistence) under Hibernate 7 entity scanning.
                      AbstractServiceDaemon and SpringServiceDaemon (the only classes we use
                      from core/daemon) reference ServiceDaemon from model-api, not opennms-model. -->
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
-                <!-- C3P0 connection pool — replaced by HikariCP via Spring Boot -->
-                <exclusion><groupId>com.mchange</groupId><artifactId>c3p0</artifactId></exclusion>
-                <exclusion><groupId>com.mchange</groupId><artifactId>mchange-commons-java</artifactId></exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -163,9 +155,6 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
-                <!-- ipc.common.kafka pulls ServiceMix Kafka OSGi wrappers — redundant with kafka-clients from Spring Boot -->
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.kafka_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -62,25 +62,10 @@
             <artifactId>org.opennms.features.events.kafka-consumer</artifactId>
         </dependency>
 
-        <!-- Kafka client -->
+        <!-- Kafka client (standard, not ServiceMix OSGi bundle) -->
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.lz4</groupId>
-                    <artifactId>lz4-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
 
         <!-- Logging -->

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -79,6 +79,17 @@
         <!-- Enlinkd enum types are now defined as inner classes in our Jakarta entities.
              No dependency on enlinkd-persistence-api needed. -->
 
+        <!-- javax.xml.bind — compile-only for PrimaryTypeAdapter (extends XmlAdapter).
+             Horizon's RequisitionInterface has @XmlJavaTypeAdapter(PrimaryTypeAdapter.class)
+             baked into its bytecode; the adapter must extend the javax XmlAdapter at runtime.
+             jaxb-api-2.3.1.jar is already on the Docker classpath (external layer). -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Jackson for @JsonIgnoreProperties -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/AbstractEntityVisitor.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/AbstractEntityVisitor.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+/**
+ * <p>
+ * AbstractEntityVisitor class.
+ * </p>
+ */
+public class AbstractEntityVisitor implements EntityVisitor {
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitNode(final OnmsNode node) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitSnmpInterface(final OnmsEntity snmpIface) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitIpInterface(final OnmsIpInterface iface) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitMonitoredService(final OnmsMonitoredService monSvc) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitNodeComplete(final OnmsNode node) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitSnmpInterfaceComplete(final OnmsEntity snmpIface) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitIpInterfaceComplete(final OnmsIpInterface iface) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitMonitoredServiceComplete(final OnmsMonitoredService monSvc) {
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsCriteria.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/OnmsCriteria.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+/**
+ * Classloading stub for the legacy OnmsCriteria type.
+ *
+ * The {@link org.opennms.netmgt.dao.api.OnmsDao} interface declares deprecated
+ * default methods whose signatures reference this class. Those defaults throw
+ * {@link UnsupportedOperationException} and are never called in Delta-V — but
+ * the JVM must still resolve the parameter type when loading the interface.
+ *
+ * This empty stub satisfies that resolution without pulling in the full
+ * opennms-model JAR (which carries javax.persistence entities that conflict
+ * with the jakarta.persistence entities in this module).
+ */
+public class OnmsCriteria {
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/PrimaryTypeAdapter.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/PrimaryTypeAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+public class PrimaryTypeAdapter extends XmlAdapter<String, PrimaryType> {
+
+    @Override
+    public String marshal(final PrimaryType type) throws Exception {
+        return type == null? null : type.getCode();
+    }
+
+    @Override
+    public PrimaryType unmarshal(final String typeCode) throws Exception {
+        return typeCode == null? null : PrimaryType.get(typeCode);
+    }
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/discovery/IPAddrRange.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/discovery/IPAddrRange.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.discovery;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.opennms.core.network.IPAddress;
+import org.opennms.core.utils.ByteArrayComparator;
+import org.opennms.core.utils.InetAddressUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Encapsulates a contiguous IPv4/IPv6 address range with iteration support.
+ *
+ * Copied from opennms-model to model-jakarta because opennms-model is excluded
+ * from the Spring Boot classpath (javax/jakarta persistence split-package).
+ */
+public final class IPAddrRange implements Iterable<InetAddress>, Serializable {
+
+    private static final long serialVersionUID = -106414771861377679L;
+    private static final Logger LOG = LoggerFactory.getLogger(IPAddrRange.class);
+
+    private final byte[] m_begin;
+    private byte[] m_end;
+
+    static class IPAddressRangeGenerator implements Enumeration<InetAddress>, Iterator<InetAddress> {
+        private BigInteger m_next;
+        private final BigInteger m_end;
+
+        static InetAddress make(BigInteger addr) {
+            try {
+                return InetAddressUtils.convertBigIntegerIntoInetAddress(addr);
+            } catch (UnknownHostException e) {
+                return null;
+            }
+        }
+
+        IPAddressRangeGenerator(byte[] start, byte[] end) {
+            if (new ByteArrayComparator().compare(start, end) > 0)
+                throw new IllegalArgumentException("start must be less than or equal to end");
+            m_next = new BigInteger(1, Arrays.copyOf(start, start.length));
+            m_end = new BigInteger(1, Arrays.copyOf(end, end.length));
+        }
+
+        @Override
+        public boolean hasMoreElements() {
+            return (m_next.compareTo(m_end) <= 0);
+        }
+
+        @Override
+        public InetAddress nextElement() {
+            if (!hasMoreElements())
+                throw new NoSuchElementException("End of Range");
+            InetAddress element = make(m_next);
+            m_next = m_next.add(BigInteger.ONE);
+            return element;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return hasMoreElements();
+        }
+
+        @Override
+        public InetAddress next() {
+            return nextElement();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("remove not supported");
+        }
+    }
+
+    IPAddrRange(String fromIP, String toIP) throws java.net.UnknownHostException {
+        this(InetAddressUtils.addr(fromIP), InetAddressUtils.addr(toIP));
+    }
+
+    IPAddrRange(InetAddress start, InetAddress end) {
+        byte[] from = start.getAddress();
+        byte[] to = end.getAddress();
+        if (new ByteArrayComparator().compare(from, to) > 0) {
+            LOG.warn("Beginning of address range is greater than end ({} - {}), swapping",
+                    InetAddressUtils.str(start), InetAddressUtils.str(end));
+            m_end = from;
+            m_begin = to;
+        } else {
+            m_begin = from;
+            m_end = to;
+        }
+    }
+
+    public byte[] getBegin() { return m_begin; }
+    public byte[] getEnd() { return m_end; }
+
+    public void incrementEnd() {
+        m_end = new IPAddress(m_end).incr().toOctets();
+    }
+
+    boolean contains(InetAddress ipAddr) {
+        return InetAddressUtils.isInetAddressInRange(ipAddr.getAddress(), m_begin, m_end);
+    }
+
+    boolean contains(String ipAddr) throws java.net.UnknownHostException {
+        return InetAddressUtils.isInetAddressInRange(ipAddr, m_begin, m_end);
+    }
+
+    @Override
+    public Iterator<InetAddress> iterator() {
+        return new IPAddressRangeGenerator(m_begin, m_end);
+    }
+
+    Enumeration<InetAddress> elements() {
+        return new IPAddressRangeGenerator(m_begin, m_end);
+    }
+
+    @Override
+    public String toString() {
+        return "IPAddrRange[begin=" + InetAddressUtils.getInetAddress(m_begin)
+                + ",end=" + InetAddressUtils.getInetAddress(m_end) + "]";
+    }
+
+    public BigInteger size() {
+        return InetAddressUtils.difference(
+                InetAddressUtils.getInetAddress(m_end),
+                InetAddressUtils.getInetAddress(m_begin)).add(BigInteger.ONE);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/discovery/IPPollAddress.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/discovery/IPPollAddress.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.discovery;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+
+/**
+ * Polling information used by the discovery process and PingSweepRpcModule.
+ * Each instance encapsulates an internet address, timeout in milliseconds,
+ * and a retry count.
+ *
+ * Copied from opennms-model to model-jakarta because opennms-model is excluded
+ * from the Spring Boot classpath (javax/jakarta persistence split-package).
+ */
+public class IPPollAddress implements Serializable {
+
+    private static final long serialVersionUID = -4162816651553193934L;
+
+    private final String m_foreignSource;
+    private final String m_location;
+    private final InetAddress m_address;
+    private final long m_timeout;
+    private final int m_retries;
+
+    public IPPollAddress(final String foreignSource, final String location,
+                         final InetAddress ipAddress, final long timeout, final int retries) {
+        m_foreignSource = foreignSource;
+        m_location = location;
+        m_address = ipAddress;
+        m_timeout = timeout;
+        m_retries = retries;
+    }
+
+    public String getForeignSource() {
+        return m_foreignSource;
+    }
+
+    public String getLocation() {
+        return m_location;
+    }
+
+    public long getTimeout() {
+        return m_timeout;
+    }
+
+    public int getRetries() {
+        return m_retries;
+    }
+
+    public InetAddress getAddress() {
+        return m_address;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (object instanceof IPPollAddress) {
+            IPPollAddress other = (IPPollAddress) object;
+            return other.getAddress().equals(m_address)
+                    && other.getRetries() == m_retries
+                    && other.getTimeout() == m_timeout;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(m_address, m_retries, m_timeout);
+    }
+
+    @Override
+    public String toString() {
+        return "IPPollAddress[address=" + m_address
+                + ",retries=" + m_retries
+                + ",timeout=" + m_timeout + "]";
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/discovery/IPPollRange.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/discovery/IPPollRange.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.discovery;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.Enumeration;
+import java.util.Iterator;
+
+/**
+ * Encapsulates an address range plus retry/timeout information for discovery.
+ *
+ * Copied from opennms-model to model-jakarta because opennms-model is excluded
+ * from the Spring Boot classpath (javax/jakarta persistence split-package).
+ */
+public class IPPollRange implements Iterable<IPPollAddress>, Serializable {
+    private static final long serialVersionUID = -287583115922481242L;
+
+    private final IPAddrRange m_range;
+    private final String m_foreignSource;
+    private final String m_location;
+    private final long m_timeout;
+    private final int m_retries;
+
+    final class IPPollRangeGenerator implements Enumeration<IPPollAddress>, Iterator<IPPollAddress> {
+        private final Enumeration<InetAddress> m_range;
+
+        public IPPollRangeGenerator(Enumeration<InetAddress> en) {
+            m_range = en;
+        }
+
+        @Override public boolean hasMoreElements() { return m_range.hasMoreElements(); }
+        @Override public IPPollAddress nextElement() {
+            return new IPPollAddress(m_foreignSource, m_location, m_range.nextElement(), m_timeout, m_retries);
+        }
+        @Override public boolean hasNext() { return hasMoreElements(); }
+        @Override public IPPollAddress next() { return nextElement(); }
+        @Override public void remove() { throw new UnsupportedOperationException("remove not supported"); }
+    }
+
+    public IPPollRange(String foreignSource, String location, String fromIP, String toIP,
+                       long timeout, int retries) throws java.net.UnknownHostException {
+        m_range = new IPAddrRange(fromIP, toIP);
+        m_foreignSource = foreignSource;
+        m_location = location;
+        m_timeout = timeout;
+        m_retries = retries;
+    }
+
+    public IPPollRange(String foreignSource, String location, InetAddress start, InetAddress end,
+                       long timeout, int retries) {
+        this(foreignSource, location, new IPAddrRange(start, end), timeout, retries);
+    }
+
+    IPPollRange(String foreignSource, String location, IPAddrRange range, long timeout, int retries) {
+        m_range = range;
+        m_foreignSource = foreignSource;
+        m_location = location;
+        m_timeout = timeout;
+        m_retries = retries;
+    }
+
+    public String getForeignSource() { return m_foreignSource; }
+    public String getLocation() { return m_location; }
+    public long getTimeout() { return m_timeout; }
+    public int getRetries() { return m_retries; }
+    public IPAddrRange getAddressRange() { return m_range; }
+
+    public Enumeration<IPPollAddress> elements() {
+        return new IPPollRangeGenerator(m_range.elements());
+    }
+
+    @Override
+    public Iterator<IPPollAddress> iterator() {
+        return new IPPollRangeGenerator(m_range.elements());
+    }
+
+    @Override
+    public String toString() {
+        return "IPPollRange[foreignSource=" + m_foreignSource
+                + ",location=" + m_location
+                + ",range=" + m_range
+                + ",timeout=" + m_timeout
+                + ",retries=" + m_retries + "]";
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/AddEventVisitor.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/AddEventVisitor.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.events;
+
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.AbstractEntityVisitor;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.xml.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AddEventVisitor extends AbstractEntityVisitor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AddEventVisitor.class);
+
+    private static final String m_eventSource = "Provisiond";
+    private final EventForwarder m_eventForwarder;
+    private String monitorKey;
+
+    public AddEventVisitor(EventForwarder eventForwarder) {
+        this(eventForwarder, null);
+    }
+
+    /**
+     * <p>Constructor for AddEventVisitor.</p>
+     *
+     * @param eventForwarder a {@link org.opennms.netmgt.model.events.EventForwarder} object.
+     * @param monitorKey a {@link java.lang.String} object. (optional)
+     */
+    public AddEventVisitor(EventForwarder eventForwarder, String monitorKey) {
+        m_eventForwarder = eventForwarder;
+        this.monitorKey = monitorKey;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitNode(OnmsNode node) {
+        LOG.info("Sending nodeAdded Event for {}\n", node);
+        m_eventForwarder.sendNow(createNodeAddedEvent(node));
+        if (node.getCategories().size() > 0) {
+            // Collect the category names into an array
+            String[] categoriesAdded = node.getCategories().stream().map(OnmsCategory::getName).toArray(String[]::new);
+            m_eventForwarder.sendNow(createNodeCategoryMembershipChangedEvent(node, categoriesAdded, new String[0]));
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitIpInterface(OnmsIpInterface iface) {
+        LOG.info("Sending nodeGainedInterface Event for {}\n", iface);
+        m_eventForwarder.sendNow(createNodeGainedInterfaceEvent(iface));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitMonitoredService(OnmsMonitoredService monSvc) {
+        LOG.info("Sending nodeGainedService Event for {}\n", monSvc);
+        m_eventForwarder.sendNow(createNodeGainedServiceEvent(monSvc));
+    }
+
+    /**
+     * <p>createNodeAddedEvent</p>
+     *
+     * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    protected Event createNodeAddedEvent(OnmsNode node) {
+        return EventUtils.createNodeAddedEvent(m_eventSource, node.getId(), node.getLabel(), node.getLabelSource(), monitorKey);
+    }
+
+    private Event createNodeCategoryMembershipChangedEvent(final OnmsNode node, String[] categoriesAdded, String[] categoriesDeleted) {
+        return EventUtils.createNodeCategoryMembershipChangedEvent(m_eventSource, node.getId(), node.getLabel(), categoriesAdded, categoriesDeleted);
+    }
+
+    /**
+     * <p>createNodeGainedInterfaceEvent</p>
+     *
+     * @param iface a {@link org.opennms.netmgt.model.OnmsIpInterface} object.
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    protected Event createNodeGainedInterfaceEvent(OnmsIpInterface iface) {
+        return EventUtils.createNodeGainedInterfaceEvent(m_eventSource, iface.getNode().getId(), iface.getIpAddress());
+    }
+
+    /**
+     * <p>createNodeGainedServiceEvent</p>
+     *
+     * @param monSvc a {@link org.opennms.netmgt.model.OnmsMonitoredService} object.
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    protected Event createNodeGainedServiceEvent(final OnmsMonitoredService monSvc) {
+        final OnmsIpInterface iface = monSvc.getIpInterface();
+        final OnmsNode node = iface.getNode();
+        LOG.debug("ipinterface = {}", iface);
+        LOG.debug("snmpinterface = {}", iface.getSnmpInterface());
+        LOG.debug("node = {}", node);
+        return EventUtils.createNodeGainedServiceEvent(m_eventSource, monSvc.getNodeId(), iface.getIpAddress(), monSvc.getServiceType().getName(), node.getLabel(), node.getLabelSource(), node.getSysName(), node.getSysDescription());
+    }
+
+
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/DeleteEventVisitor.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/DeleteEventVisitor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.events;
+
+
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.AbstractEntityVisitor;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
+
+public class DeleteEventVisitor extends AbstractEntityVisitor {
+    private final EventForwarder m_eventForwarder;
+    private static final String m_eventSource = "Provisiond";
+
+    public DeleteEventVisitor(EventForwarder eventForwarder) {
+        m_eventForwarder = eventForwarder;
+    }
+
+    @Override
+    public void visitMonitoredServiceComplete(final OnmsMonitoredService monSvc) {
+        m_eventForwarder.sendNow(EventUtils.createServiceDeletedEvent(m_eventSource, monSvc.getNodeId(), monSvc.getIpAddress(), monSvc.getServiceType().getName()));
+    }
+
+    @Override
+    public void visitIpInterfaceComplete(final OnmsIpInterface iface) {
+        m_eventForwarder.sendNow(EventUtils.createInterfaceDeletedEvent(m_eventSource, iface.getNode().getId(), iface.getIpAddress(), iface.getId()));
+    }
+
+    @Override
+    public void visitNodeComplete(final OnmsNode node) {
+        m_eventForwarder.sendNow(EventUtils.createNodeDeletedEvent(m_eventSource, node.getId(), node.getLabel(), node.getLabel(), node.getLocation(), node.getForeignId(), node.getForeignSource(), node.getPrimaryInterface()));
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
@@ -1,0 +1,970 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.events;
+
+import static org.opennms.core.utils.InetAddressUtils.addr;
+import static org.opennms.core.utils.InetAddressUtils.str;
+import static org.opennms.netmgt.events.api.EventConstants.APPLICATION_DELETED_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.INTERFACE_DELETED_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.NODE_ADDED_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.NODE_CATEGORY_MEMBERSHIP_CHANGED_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.NODE_DELETED_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.NODE_GAINED_INTERFACE_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.NODE_GAINED_SERVICE_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.NODE_LOCATION_CHANGED_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.NODE_UPDATED_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_APPLICATION_ID;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_APPLICATION_NAME;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_FOREIGN_ID;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_FOREIGN_SOURCE;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_INTERFACE;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_IPINTERFACE_ID;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_IP_HOSTNAME;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_LOCATION;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_NODE_CURRENT_LOCATION;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_NODE_LABEL;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_NODE_LABEL_SOURCE;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_NODE_PREV_LOCATION;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_NODE_SYSDESCRIPTION;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_NODE_SYSNAME;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_RESCAN_EXISTING;
+import static org.opennms.netmgt.events.api.EventConstants.PARM_MONITOR_KEY;
+import static org.opennms.netmgt.events.api.EventConstants.SERVICE_DELETED_EVENT_UEI;
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Objects;
+
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.core.utils.InsufficientInformationException;
+import org.opennms.core.utils.WebSecurityUtils;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
+import org.opennms.netmgt.events.api.model.IValue;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode.NodeLabelSource;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.opennms.netmgt.xml.event.Autoaction;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Forward;
+import org.opennms.netmgt.xml.event.Operaction;
+import org.opennms.netmgt.xml.event.Parm;
+import org.opennms.netmgt.xml.event.Script;
+import org.opennms.netmgt.xml.event.Snmp;
+import org.opennms.netmgt.xml.event.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>Abstract EventUtils class.</p>
+ *
+ * @author ranger
+ * @version $Id: $
+ */
+public abstract class EventUtils {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(EventUtils.class);
+
+    
+    /**
+     * <p>createNodeAddedEvent</p>
+     *
+     * @param source a {@link java.lang.String} object.
+     * @param nodeId a int.
+     * @param nodeLabel a {@link java.lang.String} object.
+     * @param labelSource a {@link java.lang.String} object.
+     * @param monitorKey a {@link java.lang.String} object. (optional)
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    public static Event createNodeAddedEvent(String source, int nodeId, String nodeLabel, NodeLabelSource labelSource, String monitorKey) {
+        debug("CreateNodeAddedEvent: nodedId: %d", nodeId);
+        
+        EventBuilder bldr = new EventBuilder(NODE_ADDED_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.addParam(PARM_NODE_LABEL, WebSecurityUtils.sanitizeString(nodeLabel));
+        if (labelSource != null) {
+            bldr.addParam(PARM_NODE_LABEL_SOURCE, labelSource.toString());
+        }
+        if (monitorKey != null) {
+            bldr.addParam(PARM_MONITOR_KEY, monitorKey);
+        }
+        return bldr.getEvent();
+    }
+
+    /**
+     * <p>createNodeGainedInterfaceEvent</p>
+     *
+     * @param source a {@link java.lang.String} object.
+     * @param nodeId a int.
+     * @param ifaddr a {@link java.net.InetAddress} object.
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    public static Event createNodeGainedInterfaceEvent(String source, int nodeId, InetAddress ifaddr) {
+        
+        debug("createNodeGainedInterfaceEvent:  %d / %s", nodeId, str(ifaddr));
+        
+        EventBuilder bldr = new EventBuilder(NODE_GAINED_INTERFACE_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.setInterface(ifaddr);
+        bldr.addParam(PARM_IP_HOSTNAME, ifaddr.getHostName());
+
+        return bldr.getEvent();
+    }
+    
+    /**
+     * <p>createNodeGainedServiceEvent</p>
+     *
+     * @param source a {@link java.lang.String} object.
+     * @param nodeId a int.
+     * @param ifaddr a {@link java.net.InetAddress} object.
+     * @param service a {@link java.lang.String} object.
+     * @param nodeLabel a {@link java.lang.String} object.
+     * @param labelSource a {@link java.lang.String} object.
+     * @param sysName a {@link java.lang.String} object.
+     * @param sysDescr a {@link java.lang.String} object.
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    public static Event createNodeGainedServiceEvent(String source, int nodeId, InetAddress ifaddr, String service, String nodeLabel, NodeLabelSource labelSource, String sysName, String sysDescr) {
+        
+        debug("createAndSendNodeGainedServiceEvent:  nodeId/interface/service  %d/%s/%s", nodeId, str(ifaddr), service);
+
+        EventBuilder bldr = new EventBuilder(NODE_GAINED_SERVICE_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.setInterface(ifaddr);
+        bldr.setService(service);
+        bldr.setParam(PARM_IP_HOSTNAME, ifaddr.getHostName());
+        bldr.setParam(PARM_NODE_LABEL, nodeLabel);
+        if (labelSource != null) {
+            bldr.setParam(PARM_NODE_LABEL_SOURCE, labelSource.toString());
+        }
+
+        // Add sysName if available
+        if (sysName != null) {
+            bldr.setParam(PARM_NODE_SYSNAME, sysName);
+        }
+
+        // Add sysDescr if available
+        if (sysDescr != null) {
+            bldr.setParam(PARM_NODE_SYSDESCRIPTION, sysDescr);
+        }
+
+        return bldr.getEvent();
+    }
+
+    /**
+     * This method is responsible for generating a nodeDeleted event and sending
+     * it to eventd..
+     *
+     * @param source
+     *            A string representing the source of the event
+     * @param nodeId
+     *            Nodeid of the node got deleted.
+     * @param hostName
+     *            the Host server name.
+     * @param nodeLabel
+     *            the node label of the deleted node.
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    public static Event createNodeDeletedEvent(final String source, final int nodeId, final String hostName, final String nodeLabel, final OnmsMonitoringLocation nodeLocation, final String nodeForeignId, final String nodeForeignSource, final OnmsIpInterface nodePrimaryInterface) {
+        
+        debug("createNodeDeletedEvent for nodeid:  %d", nodeId);
+
+        final EventBuilder bldr = new EventBuilder(NODE_DELETED_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.setHost(hostName);
+
+        if (nodeLabel != null) {
+            bldr.addParam(PARM_NODE_LABEL, nodeLabel);
+        }
+
+        if (nodeLocation != null) {
+            bldr.addParam(PARM_LOCATION, nodeLocation.getLocationName());
+        }
+
+        if (nodeForeignId != null) {
+            bldr.addParam(PARM_FOREIGN_ID, nodeForeignId);
+        }
+
+        if (nodeForeignSource != null) {
+            bldr.addParam(PARM_FOREIGN_SOURCE, nodeForeignSource);
+        }
+
+        if (nodePrimaryInterface != null && nodePrimaryInterface.getIpAddress() != null) {
+            bldr.addParam(PARM_INTERFACE, InetAddressUtils.str(nodePrimaryInterface.getIpAddress()));
+        }
+
+        return bldr.getEvent();
+    }
+
+    /**
+     * Construct an interfaceDeleted event for an interface.
+     *
+     * @param source
+     *            the source of the event
+     * @param nodeId
+     *            the nodeId of the node the interface resides in
+     * @param addr
+     *            the ipAdddr of the event
+     * @param ipInterfaceId
+     *            the  id of IpInterface
+     * @return an Event represent an interfaceDeleted event for the given
+     *         interface
+     */
+    public static Event createInterfaceDeletedEvent(String source, int nodeId, InetAddress addr, Integer ipInterfaceId) {
+        debug("createInterfaceDeletedEvent for nodeid/ipaddr:  %d/%s", nodeId, str(addr));
+
+        EventBuilder bldr = new EventBuilder(INTERFACE_DELETED_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.setInterface(addr);
+        if(ipInterfaceId != null) {
+            bldr.addParam(PARM_IPINTERFACE_ID, ipInterfaceId);
+        }
+        return bldr.getEvent();
+    }
+
+    /**
+     * Constructs a serviceDeleted Event for the nodeId, ipAddr, serviceName
+     * triple
+     *
+     * @param source
+     *            the source of the event
+     * @param nodeId
+     *            the nodeId that the service resides on
+     * @param ipAddr
+     *            the interface that the service resides on
+     * @param service
+     *            the name of the service that was deleted
+     * @return an Event that represents the serviceDeleted event for the give
+     *         triple
+     */
+    public static Event createServiceDeletedEvent(String source, int nodeId, InetAddress addr, String service) {
+        debug("createServiceDeletedEvent for nodeid/ipaddr/service:  %d/%s/%s", nodeId, str(addr), service);
+
+        EventBuilder bldr = new EventBuilder(SERVICE_DELETED_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.setInterface(addr);
+        bldr.setService(service);
+
+        return bldr.getEvent();
+    }
+
+    /**
+     * Constructs a applicationDeleted Event for a given application id and name
+     * @param source
+     *              the source of the event
+     * @param applicationId
+     *              the id of the deleted application
+     * @param applicationName
+     *              the name of the deleted application
+     * @return an Event that represents the applicationDeleted event for the given id and name
+     */
+    public static Event createApplicationDeletedEvent(String source, int applicationId, String applicationName) {
+        debug("createApplicationDeletedEvent for nodeid:  %d", applicationId);
+
+        final EventBuilder bldr = new EventBuilder(APPLICATION_DELETED_EVENT_UEI, source);
+        bldr.addParam(PARM_APPLICATION_ID, applicationId);
+        bldr.addParam(PARM_APPLICATION_NAME, applicationName);
+
+        return bldr.getEvent();
+    }
+
+
+    /**
+     * Retrieve the value associated with an event parameter and parse it to a
+     * long. If the value can not be found, return a default value.
+     *
+     * @param e
+     *            the Event to retrieve the parameter from
+     * @param parmName
+     *            the name of the parameter to retrieve
+     * @param defaultValue
+     *            the value to return if the paramter can not be retrieved or
+     *            parsed
+     * @return the value of the parameter as a long
+     */
+    public static long getLongParm(Event e, String parmName, long defaultValue) {
+        String longVal = EventUtils.getParm(e, parmName);
+    
+        if (longVal == null)
+            return defaultValue;
+    
+        try {
+            return Long.parseLong(longVal);
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Retrieve the value associated with an event parameter and parse it to an
+     * int. If the value can not be found, return a default value.
+     *
+     * @param e
+     *            the Event to retrieve the parameter from
+     * @param parmName
+     *            the name of the parameter to retrieve
+     * @param defaultValue
+     *            the value to return if the paramter can not be retrieved or
+     *            parsed
+     * @return the value of the parameter as a long
+     */
+    public static int getIntParm(Event e, String parmName, int defaultValue) {
+        String intVal = EventUtils.getParm(e, parmName);
+    
+        if (intVal == null)
+            return defaultValue;
+    
+        try {
+            return Integer.parseInt(intVal);
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Retrieve a parameter from and event, returning defaultValue of the
+     * parameter is not set.
+     *
+     * @param e
+     *            The Event to retrieve the parameter from
+     * @param parmName
+     *            the name of the parameter to retrieve
+     * @param defaultValue
+     *            the default value to return if the parameter is not set
+     * @return the value of the parameter, or defalutValue if the parameter is
+     *         not set
+     */
+    public static String getParm(Event e, String parmName, String defaultValue) {
+        if (e.getParmCollection().size() < 1)
+            return defaultValue;
+    
+        for (Parm parm : e.getParmCollection()) {
+            if (parmName.equals(parm.getParmName())) {
+                if (parm.getValue() != null && parm.getValue().getContent() != null) {
+                    return parm.getValue().getContent();
+                } else {
+                    return defaultValue;
+                }
+            }
+        }
+    
+        return defaultValue;
+    
+    }
+
+    /**
+     * Return the value of an event parameter of null if it does not exist.
+     *
+     * @param e
+     *            the Event to get the parameter for
+     * @param parmName
+     *            the name of the parameter to retrieve
+     * @return the value of the parameter, or null of the parameter is not set
+     */
+    public static String getParm(Event e, String parmName) {
+        return EventUtils.getParm(e, parmName, null);
+    }
+    
+    private static void debug(String format, Object... args) {
+            LOG.debug(String.format(format, args));
+    }
+
+
+    /**
+     * <p>createNodeUpdatedEvent</p>
+     *
+     * @param source a {@link java.lang.String} object.
+     * @param nodeId a {@link java.lang.Integer} object.
+     * @param nodeLabel a {@link java.lang.String} object.
+     * @param labelSource a {@link java.lang.String} object.
+     * @param rescanExisting a {@link java.lang.String} object.
+     * @param monitorKey a {@link java.lang.String} object. (optional)
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    public static Event createNodeUpdatedEvent(String source, Integer nodeId, String nodeLabel, NodeLabelSource labelSource, String rescanExisting, String monitorKey) {
+        debug("CreateNodeUpdatedEvent: nodedId: %d", nodeId);
+        EventBuilder bldr = new EventBuilder(NODE_UPDATED_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.addParam(PARM_NODE_LABEL, nodeLabel);
+        if (labelSource != null) {
+            bldr.addParam(PARM_NODE_LABEL_SOURCE, labelSource.toString());
+        }
+        if (rescanExisting != null) {
+            bldr.addParam(PARM_RESCAN_EXISTING, rescanExisting);
+        }
+        if (monitorKey != null) {
+            bldr.addParam(PARM_MONITOR_KEY, monitorKey);
+        }
+        return bldr.getEvent();
+    }
+    
+    public static Event createNodeRescanEvent(String source, Integer nodeId) {
+        debug("CreateNodeUpdatedEvent: nodedId: %d", nodeId);
+        EventBuilder bldr = new EventBuilder(EventConstants.RELOAD_IMPORT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.addParam(PARM_RESCAN_EXISTING, Boolean.TRUE.toString());
+        return bldr.getEvent();
+    }
+
+
+    /**
+     * <p>createNodeLocationChangedEvent</p>
+     *
+     * @param source a {@link java.lang.String} object.
+     * @param nodeId a {@link java.lang.Integer} object.
+     * @param nodeLabel a {@link java.lang.String} object.
+     * @param prevLocation a {@link java.lang.String} object.
+     * @param currentLocation a {@link java.lang.String} object.
+     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     */
+    public static Event createNodeLocationChangedEvent(String source, Integer nodeId, String nodeLabel, String prevLocation, String currentLocation) {
+        debug("createNodeLocationChangedEvent: nodedId: %d", nodeId);
+        EventBuilder bldr = new EventBuilder(NODE_LOCATION_CHANGED_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.addParam(PARM_NODE_LABEL, nodeLabel);
+        bldr.addParam(PARM_NODE_PREV_LOCATION, prevLocation);
+        bldr.addParam(PARM_NODE_CURRENT_LOCATION, currentLocation);
+        return bldr.getEvent();
+    }
+
+
+    public static Event createNodeCategoryMembershipChangedEvent(final String source, final Integer nodeId, final String nodeLabel, String[] categoriesAdded, String[] categoriesDeleted) {
+        EventBuilder bldr = new EventBuilder(NODE_CATEGORY_MEMBERSHIP_CHANGED_EVENT_UEI, source);
+        bldr.setNodeid(nodeId);
+        bldr.addParam(PARM_NODE_LABEL, nodeLabel);
+        if (categoriesAdded != null && categoriesAdded.length > 0) {
+            bldr.addParam(EventConstants.PARM_CATEGORIES_ADDED, String.join(",", categoriesAdded));
+        }
+        if (categoriesDeleted != null && categoriesDeleted.length > 0) {
+            bldr.addParam(EventConstants.PARM_CATEGORIES_DELETED, String.join(",", categoriesDeleted));
+        }
+        return bldr.getEvent();
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @return a {@link java.lang.String} object.
+     */
+    public static String toString(Event event) {
+        final StringBuilder b = new StringBuilder("Event: ");
+        b.append("\n");
+        if (event.getAutoacknowledge() != null) {
+            b.append(" Autoacknowledge: " + event.getAutoacknowledge() + "\n");
+        }
+        if (event.getAutoactionCount() > 0) {
+            b.append(" Autoactions:");
+            for (Iterator<Autoaction> i = event.getAutoactionCollection().iterator(); i.hasNext(); ) {
+                b.append(" " + i.next().toString());
+            }
+            b.append("\n");
+        }
+        if (event.getCreationTime() != null) {
+            b.append(" CreationTime: " + event.getCreationTime() + "\n");
+        }
+        b.append(" Dbid: " + event.getDbid() + "\n");
+        if (event.getDescr() != null) {
+            b.append(" Descr: " + event.getDescr() + "\n");
+        }
+        if (event.getDistPoller() != null) {
+            b.append(" DistPoller: " + event.getDistPoller() + "\n");
+        }
+        if (event.getForwardCount() > 0) {
+            b.append(" Forwards:");
+            for (Iterator<Forward> i = event.getForwardCollection().iterator(); i.hasNext(); ) {
+                b.append(" " + i.next().toString());
+            }
+            b.append("\n");
+        }
+        if (event.getHost() != null) {
+            b.append(" Host: " + event.getHost() + "\n");
+        }
+        if (event.getInterface() != null) {
+            b.append(" Interface: " + event.getInterface() + "\n");
+        }
+        if (event.getLoggroupCount() > 0) {
+            b.append(" Loggroup:");
+            for (Iterator<String> i = event.getLoggroupCollection().iterator(); i.hasNext(); ) {
+                b.append(" " + i.next());
+            }
+            b.append("\n");
+        }
+        if (event.getLogmsg() != null) {
+            b.append(" Logmsg: " + event.getLogmsg() + "\n");
+        }
+        if (event.getMask() != null) {
+            b.append(" Mask: " + event.getMask() + "\n");
+        }
+        if (event.getMasterStation() != null) {
+            b.append(" MasterStation: " + event.getMasterStation() + "\n");
+        }
+        if (event.getMouseovertext() != null) {
+            b.append(" Mouseovertext: " + event.getMouseovertext() + "\n");
+        }
+        b.append(" Nodeid: " + event.getNodeid() + "\n");
+        if (event.getOperactionCount() > 0) {
+            b.append(" Operaction:");
+            for (Iterator<Operaction> i = event.getOperactionCollection().iterator(); i.hasNext(); ) {
+                b.append(" " + i.next().toString());
+            }
+            b.append("\n");
+        }
+        if (event.getOperinstruct() != null) {
+            b.append(" Operinstruct: " + event.getOperinstruct() + "\n");
+        }
+        if (event.getParmCollection().size() > 0) {
+            b.append(" Parms: " + toString(event.getParmCollection()) + "\n");
+        }
+        if (event.getScriptCount() > 0) {
+            b.append(" Script:");
+            for (Iterator<Script> i = event.getScriptCollection().iterator(); i.hasNext(); ) {
+                b.append(" " + i.next().toString());
+            }
+            b.append("\n");
+        }
+        if (event.getService() != null) {
+            b.append(" Service: " + event.getService() + "\n");
+        }
+        if (event.getSeverity() != null) {
+            b.append(" Severity: " + event.getSeverity() + "\n");
+        }
+        if (event.getSnmp() != null) {
+            b.append(" Snmp: " + toString(event.getSnmp()) + "\n");
+        }
+        if (event.getSnmphost() != null) {
+            b.append(" Snmphost: " + event.getSnmphost() + "\n");
+        }
+        if (event.getSource() != null) {
+            b.append(" Source: " + event.getSource() + "\n");
+        }
+        if (event.getTime() != null) {
+            b.append(" Time: " + event.getTime() + "\n");
+        }
+        if (event.getTticket() != null) {
+            b.append(" Tticket: " + event.getTticket() + "\n");
+        }
+        if (event.getUei() != null) {
+            b.append(" Uei: " + event.getUei() + "\n");
+        }
+        if (event.getUuid() != null) {
+            b.append(" Uuid: " + event.getUuid() + "\n");
+        }
+        
+        b.append("End Event\n");
+        return b.toString();
+    }
+
+    public static String toString(Collection<Parm> parms) {
+        if (parms.size() == 0) {
+            return "{}\n";
+        }
+        
+        final StringBuilder b = new StringBuilder();
+        b.append("{\n");
+        for (Parm p : parms) {
+            b.append("  ");
+            b.append(p.getParmName());
+            b.append(" = ");
+            b.append(toString(p.getValue()));
+            b.append("\n");
+        }
+        b.append(" }");
+        return b.toString();
+    }
+    
+    /**
+     * <p>toString</p>
+     *
+     * @param value a {@link org.opennms.netmgt.xml.event.Value} object.
+     * @return a {@link java.lang.String} object.
+     */
+    public static String toString(Value value) {
+        return value.getType() + "(" + value.getEncoding() + "): " + value.getContent();
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @param snmp a {@link org.opennms.netmgt.xml.event.Snmp} object.
+     * @return a {@link java.lang.String} object.
+     */
+    public static String toString(Snmp snmp) {
+        StringBuffer b = new StringBuffer("Snmp: ");
+    
+        if (snmp.getVersion() != null) {
+            b.append("Version: " + snmp.getVersion() + "\n");
+        }
+        
+        b.append("TimeStamp: " + new Date(snmp.getTimeStamp()) + "\n");
+        
+        if (snmp.getCommunity() != null) {
+            b.append("Community: " + snmp.getCommunity() + "\n");
+        }
+    
+        b.append("Generic: " + snmp.getGeneric() + "\n");
+        b.append("Specific: " + snmp.getSpecific() + "\n");
+        
+        if (snmp.getId() != null) {
+            b.append("Id: " + snmp.getId() + "\n");
+        }
+        if (snmp.getIdtext() != null) {
+            b.append("Idtext: " + snmp.getIdtext() + "\n");
+        }
+        
+        b.append("End Snmp\n");
+        return b.toString();
+    }
+
+
+    /**
+     * <p>eventsMatch</p>
+     *
+     * @param e1 a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e2 a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @return a boolean.
+     */
+    public static boolean eventsMatch(final Event e1, final Event e2) {
+        if (e1 == e2) {
+            return true;
+        }
+        if (e1 == null || e2 == null) {
+            return false;
+        }
+        if (!Objects.equals(e1.getUei(), e2.getUei())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getNodeid(), e2.getNodeid())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getInterface(), e2.getInterface())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getService(), e2.getService())) {
+            return false;
+        }
+    
+        return true;
+    }
+
+    /**
+     * <p>eventsMatch</p>
+     *
+     * @param e1 a {@link org.opennms.netmgt.events.api.model.IEvent} object.
+     * @param e2 a {@link org.opennms.netmgt.events.api.model.IEvent} object.
+     * @return a boolean.
+     */
+    public static boolean eventsMatch(final IEvent e1, final IEvent e2) {
+        if (e1 == e2) {
+            return true;
+        }
+        if (e1 == null || e2 == null) {
+            return false;
+        }
+        if (!Objects.equals(e1.getUei(), e2.getUei())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getNodeid(), e2.getNodeid())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getInterface(), e2.getInterface())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getService(), e2.getService())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Ensures the given event has an interface
+     *
+     * @param e
+     *            the event
+     * @throws org.opennms.netmgt.capsd.InsufficientInformationException
+     *             if an interface is not available
+     */
+    static public void checkInterface(Event e) throws InsufficientInformationException {
+        if (e == null) {
+            throw new NullPointerException("Event is null");
+        } else if (e.getInterface() == null) {
+            throw new InsufficientInformationException("ipaddr for event is unavailable");
+        }
+    }
+    
+    /**
+     * Is the given interface a non-IP interface
+     *
+     * @param intf
+     *            the interface
+     * @return true/false
+     */
+    static public boolean isNonIpInterface(String intf) {
+        if (intf == null || intf.length() == 0 || "0.0.0.0".equals(intf) ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Ensures that the given Event has a node id
+     *
+     * @param e
+     *            the event
+     * @throws org.opennms.netmgt.capsd.InsufficientInformationException
+     *             if a node id is not available
+     */
+    static public void checkNodeId(Event e) throws InsufficientInformationException {
+        if (e == null) {
+            throw new NullPointerException("e is null");
+        } else if (!e.hasNodeid()) {
+            throw new InsufficientInformationException("nodeid for event is unavailable");
+        }
+    }
+
+    /**
+     * Ensures that the given event has a service parameter
+     *
+     * @param e
+     *            the event to check
+     * @throws org.opennms.netmgt.capsd.InsufficientInformationException
+     *             if the event does not have a service
+     */
+    public static void checkService(Event e) throws InsufficientInformationException {
+        if (e == null) {
+            throw new NullPointerException("e is null");
+        } else if (e.getService() == null || e.getService().length() == 0) {
+            throw new InsufficientInformationException("service for event is unavailable");
+        }
+    }
+
+    /**
+     * Constructs a deleteInterface event for the given nodeId, ipAddress (or ifIndex) pair.
+     *
+     * @param source
+     *            the source for the event
+     * @param nodeId
+     *            the nodeId of the node that owns the interface
+     * @param ipAddr
+     *            the ipAddress of the interface being deleted
+     * @param ifIndex
+     *            the ifIndex of the interface being deleted
+     * @param txNo
+     *            the transaction number to use for processing this event
+     * @return an Event representing a deleteInterface event for the given
+     *         nodeId, ipaddr
+     */
+    public static Event createDeleteInterfaceEvent(String source, long nodeId, String ipAddr, int ifIndex, long txNo) {
+        return createInterfaceEventBuilder(EventConstants.DELETE_INTERFACE_EVENT_UEI, source, nodeId, ipAddr, ifIndex, txNo).getEvent();
+    }
+
+    private static EventBuilder createInterfaceEventBuilder(String uei, String source, long nodeId, String ipAddr, int ifIndex, long txNo) {
+        EventBuilder bldr = new EventBuilder(uei, source);
+        
+        if (ipAddr != null && ipAddr.length() != 0) {
+            bldr.setInterface(addr(ipAddr));
+        }
+        
+        bldr.setNodeid(nodeId);
+
+        if (ifIndex != -1) {
+            bldr.setIfIndex(ifIndex);
+        }
+
+        bldr.addParam(EventConstants.PARM_TRANSACTION_NO, txNo);
+
+        return bldr;
+    }
+
+    public static Event createDeleteNodeEvent(String source, long nodeId, long txNo) {
+        return createNodeEventBuilder(EventConstants.DELETE_NODE_EVENT_UEI, source, nodeId, txNo).getEvent();
+    }
+
+    private static EventBuilder createNodeEventBuilder(String uei, String source, long nodeId, long txNo) {
+        EventBuilder bldr = new EventBuilder(uei, source);
+        
+        bldr.setNodeid(nodeId);
+        
+        if (txNo >= 0) {
+            bldr.addParam(EventConstants.PARM_TRANSACTION_NO, txNo);
+        }
+        return bldr;
+    }
+
+    /**
+     * Construct a deleteNode event for the given nodeId.
+     *
+     * @param source
+     *            the source for the event
+     * @param nodeId
+     *            the node to be deleted.
+     * @param txNo
+     *            the transaction number associated with deleting the node
+     * @return an Event object representing a delete node event.
+     */
+    public static Event createAssetInfoChangedEvent(String source, long nodeId, long txNo) {
+        return createNodeEventBuilder(EventConstants.ASSET_INFO_CHANGED_EVENT_UEI, source, nodeId, txNo).getEvent();
+    }
+
+    private static EventBuilder createServiceEventBuilder(String uei, String source, long nodeId, String ipAddr, String service, long txNo) {
+        EventBuilder bldr = new EventBuilder(uei, source);
+
+        bldr.setNodeid(nodeId);
+        bldr.setInterface(addr(ipAddr));
+        bldr.setService(service);
+        
+        bldr.addParam(EventConstants.PARM_TRANSACTION_NO, txNo);
+
+        return bldr;
+    }
+
+    /**
+     * Constructs a deleteService event for the given nodeId, ipAddress,
+     * serviceName triple.
+     *
+     * @param source
+     *            the source for the event
+     * @param nodeId
+     *            the nodeId of the node that service resides on
+     * @param ipAddr
+     *            the ipAddress of the interface the service resides on
+     * @param service
+     *            the service that is being deleted
+     * @param txNo
+     *            the transaction number to use for processing this event
+     * @return an Event representing a deleteInterface event for the given
+     *         nodeId, ipaddr
+     */
+    public static Event createDeleteServiceEvent(String source, long nodeId, String ipAddr, String service, long txNo) {
+        
+        return createServiceEventBuilder(EventConstants.DELETE_SERVICE_EVENT_UEI, source, nodeId, ipAddr, service, txNo).getEvent();
+        
+    }
+
+    /**
+     * Throw an exception if an event does have the required parameter
+     *
+     * @param e
+     *            the event the parameter must reside on
+     * @throws org.opennms.netmgt.capsd.InsufficientInformationException
+     *             if the paramter is not set on the event or if its value has
+     *             no content
+     * @param parmName a {@link java.lang.String} object.
+     */
+    public static void requireParm(Event e, String parmName) throws InsufficientInformationException {
+        for (Parm parm : e.getParmCollection()) {
+            if (parmName.equals(parm.getParmName())) {
+                if (parm.getValue() != null && parm.getValue().getContent() != null) {
+                    // we found a matching parm
+                    return;
+                } else {
+                    throw new InsufficientInformationException("parameter " + parmName + " required but only null valued parms available");
+                }
+            }
+        }
+
+        throw new InsufficientInformationException("parameter " + parmName + " required but was not available");
+
+    }
+
+    public static String getParm(IEvent e, String parmName) {
+        return getParm(e, parmName, null);
+    }
+
+    public static String getParm(IEvent e, String parmName, String defaultValue) {
+        if (e.getParmCollection().isEmpty()) {
+            return defaultValue;
+        }
+
+        IParm parm = e.getParmCollection()
+                .stream()
+                .filter(p -> Objects.equals(p.getParmName(), parmName))
+                .findFirst()
+                .orElse(null);
+
+        if (parm != null && parm.getValue() != null) {
+            return parm.getValue().getContent();
+        }
+
+        return defaultValue;
+    }
+
+    public static void requireParm(IEvent e, String parmName) throws InsufficientInformationException {
+        IParm parm = e.getParmCollection()
+                .stream()
+                .filter(p -> Objects.equals(p.getParmName(), parmName))
+                .findFirst()
+                .orElse(null);
+
+        if (parm != null) {
+            IValue value = parm.getValue();
+            if (value != null && value.getContent() != null) {
+                return;
+            }
+            throw new InsufficientInformationException("parameter " + parmName +
+                    " required but only null valued parms available");
+        }
+
+        throw new InsufficientInformationException("parameter " + parmName + " required but was not available");
+    }
+
+    public static void checkInterface(IEvent e) throws InsufficientInformationException {
+        if (e == null) {
+            throw new NullPointerException("Event is null");
+        } else if (e.getInterface() == null) {
+            throw new InsufficientInformationException("ipaddr for event is unavailable");
+        }
+    }
+
+    public static void checkNodeId(IEvent e) throws InsufficientInformationException {
+        if (e == null) {
+            throw new NullPointerException("e is null");
+        } else if (!e.hasNodeid()) {
+            throw new InsufficientInformationException("nodeid for event is unavailable");
+        }
+    }
+
+    public static void checkService(IEvent e) throws InsufficientInformationException {
+        if (e == null) {
+            throw new NullPointerException("e is null");
+        } else if (e.getService() == null || e.getService().isEmpty()) {
+            throw new InsufficientInformationException("service for event is unavailable");
+        }
+    }
+
+    public static int getIntParm(IEvent e, String parmName, int defaultValue) {
+        String intVal = getParm(e, parmName);
+
+        if (intVal == null)
+            return defaultValue;
+
+        try {
+            return Integer.parseInt(intVal);
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
@@ -251,7 +251,7 @@ public abstract class EventUtils {
      *            the source of the event
      * @param nodeId
      *            the nodeId that the service resides on
-     * @param ipAddr
+     * @param addr
      *            the interface that the service resides on
      * @param service
      *            the name of the service that was deleted

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/UpdateEventVisitor.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/UpdateEventVisitor.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.events;
+
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.AbstractEntityVisitor;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.xml.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>UpdateEventVisitor class.</p>
+ *
+ * @author ranger
+ * @version $Id: $
+ */
+public class UpdateEventVisitor extends AbstractEntityVisitor {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(UpdateEventVisitor.class);
+
+    
+    private static final String m_eventSource = "Provisiond";
+    private EventForwarder m_eventForwarder;
+    private String m_rescanExisting;
+    private String monitorKey;
+
+    /**
+     * <p>Constructor for UpdateEventVisitor.</p>
+     *
+     * @param eventForwarder a {@link org.opennms.netmgt.events.api.EventForwarder} object.
+     * @param rescanExisting a {@link String} object.
+     * @param monitorKey a {@link String} object. (optional)
+     */
+    public UpdateEventVisitor(EventForwarder eventForwarder, String rescanExisting, String monitorKey) {
+        m_eventForwarder = eventForwarder;
+        m_rescanExisting = rescanExisting;
+        this.monitorKey = monitorKey;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void visitNode(OnmsNode node) {
+        LOG.info("Sending nodeUpdated Event for {}\n", node);
+        m_eventForwarder.sendNow(createNodeUpdatedEvent(node));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitIpInterface(OnmsIpInterface iface) {
+        //TODO decide what to do here and when to do it
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void visitMonitoredService(OnmsMonitoredService monSvc) {
+        //TODO decide what to do here and when to do it
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void visitSnmpInterface(org.opennms.netmgt.model.OnmsEntity snmpIface) {
+        //TODO decide what to do here and when to do it
+    }
+
+    private Event createNodeUpdatedEvent(OnmsNode node) {
+        return EventUtils.createNodeUpdatedEvent(m_eventSource, node.getId(), node.getLabel(), node.getLabelSource(), m_rescanExisting, monitorKey);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/snmp/SyntaxToEvent.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/events/snmp/SyntaxToEvent.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.model.events.snmp;
+
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.snmp.SnmpValue;
+import org.opennms.netmgt.xml.event.Parm;
+import org.opennms.netmgt.xml.event.Value;
+
+/**
+ * <p>SyntaxToEvent class.</p>
+ */
+public class SyntaxToEvent {
+    int m_typeId;
+
+    String m_type;
+
+    /** Constant <code>m_syntaxToEvents</code> */
+    public static SyntaxToEvent[] m_syntaxToEvents;
+
+    static {
+        setupSyntax();
+    }
+
+    /**
+     * <p>Constructor for SyntaxToEvent.</p>
+     *
+     * @param typeId a int.
+     * @param type a {@link java.lang.String} object.
+     */
+    private SyntaxToEvent(int typeId, String type) {
+        m_typeId = typeId;
+        m_type = type;
+    }
+
+    /**
+     * <p>getTypeId</p>
+     *
+     * @return a int.
+     */
+    private int getTypeId() {
+        return m_typeId;
+    }
+
+    /**
+     * <p>getType</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    private String getType() {
+        return m_type;
+    }
+
+    /**
+     * <p>setupSyntax</p>
+     */
+    public static void setupSyntax() {
+        m_syntaxToEvents = new SyntaxToEvent[] { 
+                new SyntaxToEvent(SnmpValue.SNMP_INT32,             EventConstants.TYPE_SNMP_INT32),
+                new SyntaxToEvent(SnmpValue.SNMP_NULL,              EventConstants.TYPE_SNMP_NULL), 
+                new SyntaxToEvent(SnmpValue.SNMP_OBJECT_IDENTIFIER, EventConstants.TYPE_SNMP_OBJECT_IDENTIFIER), 
+                new SyntaxToEvent(SnmpValue.SNMP_IPADDRESS,         EventConstants.TYPE_SNMP_IPADDRESS), 
+                new SyntaxToEvent(SnmpValue.SNMP_TIMETICKS,         EventConstants.TYPE_SNMP_TIMETICKS), 
+                new SyntaxToEvent(SnmpValue.SNMP_COUNTER32,         EventConstants.TYPE_SNMP_COUNTER32),
+                new SyntaxToEvent(SnmpValue.SNMP_GAUGE32,           EventConstants.TYPE_SNMP_GAUGE32), 
+                new SyntaxToEvent(SnmpValue.SNMP_OCTET_STRING,      EventConstants.TYPE_SNMP_OCTET_STRING), 
+                new SyntaxToEvent(SnmpValue.SNMP_OPAQUE,            EventConstants.TYPE_SNMP_OPAQUE), 
+                new SyntaxToEvent(SnmpValue.SNMP_COUNTER64,         EventConstants.TYPE_SNMP_COUNTER64),
+                new SyntaxToEvent(-1,                               EventConstants.TYPE_STRING) 
+        };
+    }
+
+    /**
+     * <p>processSyntax</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param value a {@link org.opennms.netmgt.snmp.SnmpValue} object.
+     * @return a {@link org.opennms.netmgt.xml.event.Parm} object.
+     */
+    public static Parm processSyntax(final String name, final SnmpValue value) {
+    	final Value val = new Value();
+
+        boolean found = false;
+        for (int i = 0; i < m_syntaxToEvents.length; i++) {
+            if (m_syntaxToEvents[i].getTypeId() == -1 || m_syntaxToEvents[i].getTypeId() == value.getType()) {
+                val.setType(m_syntaxToEvents[i].getType());
+                String encoding = null;
+                if (value.isDisplayable()) {
+                    if (name.matches(".*[Mm][Aa][Cc].*")) {
+                        encoding = EventConstants.XML_ENCODING_MAC_ADDRESS;
+                    } else {
+                        encoding = EventConstants.XML_ENCODING_TEXT;
+                    }
+                } else {
+                    if (value.getBytes().length == 6) {
+                        encoding = EventConstants.XML_ENCODING_MAC_ADDRESS;
+                    } else {
+                        encoding = EventConstants.XML_ENCODING_BASE64;
+                    }
+                }
+                val.setEncoding(encoding);
+                val.setContent(EventConstants.toString(encoding, value));
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            throw new IllegalStateException("Internal error: fell through the " + "bottom of the loop.  The syntax-to-events array might not have a " + "catch-all for Object");
+        }
+
+        final Parm parm = new Parm();
+        parm.setParmName(name);
+        parm.setValue(val);
+
+        return parm;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Horizon JAR version (published by pbrane/delta-v-horizon) -->
-    <deltav.horizon.version>1.0.4</deltav.horizon.version>
+    <deltav.horizon.version>1.0.5</deltav.horizon.version>
 
     <!-- Plugin versions not inherited from spring-boot-starter-parent -->
     <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>


### PR DESCRIPTION
## Summary
- Bump `deltav.horizon.version` to 1.0.5 (ActiveMQ, C3P0, ServiceMix Kafka removed at source)
- Remove all ActiveMQ, C3P0, and ServiceMix Kafka `<exclusion>` tags from 11 daemon POMs
- Replace ServiceMix `kafka-clients` bundle with standard `kafka-clients` in `event-forwarder-kafka`
- Add `OnmsCriteria` stub to `model-jakarta` — classloading shim for `OnmsDao` default methods
- Copy discovery model classes (`IPPollAddress`, `IPPollRange`, `IPAddrRange`) to model-jakarta
- Add explicit `snmp4j` dependency to trapd, enlinkd, telemetryd
- Port 7 opennms-model utility classes to model-jakarta:
  - `PrimaryTypeAdapter` — JAXB adapter referenced by `RequisitionInterface` via `@XmlJavaTypeAdapter`
  - `AbstractEntityVisitor` — base visitor for provisioning entity graph
  - `AddEventVisitor`, `DeleteEventVisitor`, `UpdateEventVisitor` — provisioning lifecycle events
  - `EventUtils` — factory methods for provisioning event creation
  - `SyntaxToEvent` — SNMP value→event parameter mapping for Trapd

Depends on: pbrane/delta-v-horizon#1

## Test plan
- [x] `mvn clean install -DskipTests` — 22/22 modules pass
- [x] No target exclusions remain (grep verified)
- [x] `build.sh deltav` + `deploy.sh up full` — all 12 daemons + Minion healthy
- [x] Zero `ClassNotFoundException` across all daemons
- [x] E2E suites: 119/120 pass (1 timing flake in perspective restart check)