### PR TITLE
fix: port ResourceTypeUtils, NetworkBuilder, SnmpInterfaceBuilder to model-jakarta

### DIFF
--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
@@ -233,9 +233,9 @@ public class NetworkBuilder {
             m_currentMonSvc = new OnmsMonitoredService(m_currentIf, serviceType);
             m_currentMonSvc.setStatus("A");
             return m_currentMonSvc;
-        } else {
+        } else if (m_currentSnmpIf != null) {
             final Set<OnmsIpInterface> ipInterfaces = m_currentSnmpIf.getIpInterfaces();
-            if (m_currentSnmpIf != null && ipInterfaces != null && ipInterfaces.size() > 0) {
+            if (ipInterfaces != null && ipInterfaces.size() > 0) {
                 final OnmsIpInterface current = ipInterfaces.toArray(new OnmsIpInterface[]{})[ipInterfaces.size() - 1];
                 m_currentMonSvc = new OnmsMonitoredService(current, serviceType);
                 m_currentMonSvc.setStatus("A");

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ * Copyright (C) 2026 BeaconStrategists, Inc. (Modifications)
+ *
+ * This file is part of OpenNMS(R) / Delta-V.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opennms.netmgt.model;
+
+import static org.opennms.core.utils.InetAddressUtils.addr;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.opennms.netmgt.model.OnmsNode.NodeLabelSource;
+import org.opennms.netmgt.model.OnmsNode.NodeType;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyAccessorFactory;
+
+/**
+ * Builder for constructing OnmsNode/interface/service hierarchies.
+ * Used by provisioning adapters and test infrastructure.
+ */
+public class NetworkBuilder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NetworkBuilder.class);
+
+    private final OnmsMonitoringLocation m_location;
+
+    private final OnmsDistPoller m_distPoller;
+
+    OnmsNode m_currentNode;
+
+    BeanWrapper m_assetBean;
+
+    OnmsIpInterface m_currentIf;
+
+    OnmsSnmpInterface m_currentSnmpIf;
+
+    OnmsMonitoredService m_currentMonSvc;
+
+    private Map<String, OnmsServiceType> m_serviceTypeCache = new HashMap<String, OnmsServiceType>();
+
+    private Map<String, OnmsCategory> m_categoryCache = new HashMap<String, OnmsCategory>();
+
+    public NetworkBuilder(final OnmsDistPoller distPoller) {
+        m_location = new OnmsMonitoringLocation("Default", "Default");
+        m_distPoller = distPoller;
+    }
+
+    public NetworkBuilder() {
+        m_location = new OnmsMonitoringLocation("Default", "Default");
+        m_distPoller = new OnmsDistPoller("00000000-0000-0000-0000-000000000000");
+        m_distPoller.setLabel("localhost");
+        m_distPoller.setLocation("Default");
+        m_distPoller.setType(OnmsMonitoringSystem.TYPE_OPENNMS);
+    }
+
+    public OnmsMonitoringLocation getLocation() {
+        return m_location;
+    }
+
+    public OnmsDistPoller getDistPoller() {
+        return m_distPoller;
+    }
+
+    public NodeBuilder addNode(String label) {
+        m_currentNode = new OnmsNode(m_location, label);
+        m_assetBean = PropertyAccessorFactory.forBeanPropertyAccess(m_currentNode.getAssetRecord());
+        return new NodeBuilder(m_currentNode);
+    }
+
+    public static class NodeBuilder {
+        OnmsNode m_node;
+
+        NodeBuilder(final OnmsNode node) {
+            m_node = node;
+        }
+
+        public OnmsNode getNode() {
+            return m_node;
+        }
+
+        public NodeBuilder setId(final Integer id) {
+            m_node.setId(id);
+            return this;
+        }
+
+        public NodeBuilder setForeignSource(final String foreignSource) {
+            m_node.setForeignSource(foreignSource);
+            return this;
+        }
+
+        public NodeBuilder setForeignId(final String foreignId) {
+            m_node.setForeignId(foreignId);
+            return this;
+        }
+
+        public NodeBuilder setLocation(final String locationName) {
+            if (locationName != null) {
+                final OnmsMonitoringLocation location = new OnmsMonitoringLocation();
+                location.setLocationName(locationName);
+                m_node.setLocation(location);
+            } else {
+                m_node.setLocation(null);
+            }
+            return this;
+        }
+
+        public OnmsAssetRecord getAssetRecord() {
+            return m_node.getAssetRecord();
+        }
+
+        public NodeBuilder setLabelSource(final NodeLabelSource labelSource) {
+            m_node.setLabelSource(labelSource);
+            return this;
+        }
+
+        public NodeBuilder setType(final NodeType type) {
+            m_node.setType(type);
+            return this;
+        }
+
+        public NodeBuilder setSysObjectId(final String sysObjectId) {
+            m_node.setSysObjectId(sysObjectId);
+            return this;
+        }
+
+        public NodeBuilder setSysName(final String nodesysname) {
+            m_node.setSysName(nodesysname);
+            return this;
+        }
+
+        public NodeBuilder setParent(final OnmsNode parent) {
+            m_node.setParent(parent);
+            return this;
+        }
+
+        public NodeBuilder setNodeParentId(Integer id) {
+            m_node.setNodeParentId(id);
+            return this;
+        }
+    }
+
+    public InterfaceBuilder addInterface(final String ipAddr) {
+        return addInterface(addr(ipAddr));
+    }
+
+    public InterfaceBuilder addInterface(final InetAddress ipAddr) {
+        m_currentIf = new OnmsIpInterface(ipAddr, m_currentNode);
+        return new InterfaceBuilder(m_currentIf);
+    }
+
+    public static class InterfaceBuilder {
+        final OnmsIpInterface m_iface;
+
+        InterfaceBuilder(final OnmsIpInterface iface) {
+            m_iface = iface;
+        }
+
+        public InterfaceBuilder setNetMask(final InetAddress mask) {
+            m_iface.setNetMask(mask);
+            return this;
+        }
+
+        public InterfaceBuilder setNetMask(final String mask) {
+            return this.setNetMask(addr(mask));
+        }
+
+        public InterfaceBuilder setIsManaged(final String managed) {
+            m_iface.setIsManaged(managed);
+            return this;
+        }
+
+        public InterfaceBuilder setIsSnmpPrimary(final String isSnmpPrimary) {
+            m_iface.setIsSnmpPrimary(PrimaryType.get(isSnmpPrimary));
+            return this;
+        }
+
+        public OnmsIpInterface getInterface() {
+            return m_iface;
+        }
+
+        @Deprecated
+        public SnmpInterfaceBuilder addSnmpInterface(final int ifIndex) {
+            final OnmsSnmpInterface snmpIf = new OnmsSnmpInterface(m_iface.getNode(), ifIndex);
+            m_iface.setSnmpInterface(snmpIf);
+            snmpIf.getIpInterfaces().add(m_iface);
+            return new SnmpInterfaceBuilder(snmpIf);
+        }
+
+        public InterfaceBuilder setId(final int id) {
+            m_iface.setId(id);
+            return this;
+        }
+    }
+
+    public InterfaceBuilder addInterface(final String ipAddr, final OnmsSnmpInterface snmpInterface) {
+        m_currentIf = new OnmsIpInterface(addr(ipAddr), m_currentNode);
+        m_currentIf.setSnmpInterface(snmpInterface);
+        return new InterfaceBuilder(m_currentIf);
+    }
+
+    public SnmpInterfaceBuilder addSnmpInterface(final int ifIndex) {
+        final OnmsSnmpInterface snmp = new OnmsSnmpInterface(m_currentNode, ifIndex);
+        if (m_currentIf != null) snmp.getIpInterfaces().add(m_currentIf);
+        final SnmpInterfaceBuilder snmpInterfaceBuilder = new SnmpInterfaceBuilder(snmp);
+        m_currentSnmpIf = snmp;
+        return snmpInterfaceBuilder;
+    }
+
+    public OnmsMonitoredService addService(final OnmsServiceType serviceType) {
+        m_serviceTypeCache.put(serviceType.getName(), serviceType);
+        if (m_currentIf != null) {
+            m_currentMonSvc = new OnmsMonitoredService(m_currentIf, serviceType);
+            m_currentMonSvc.setStatus("A");
+            return m_currentMonSvc;
+        } else {
+            final Set<OnmsIpInterface> ipInterfaces = m_currentSnmpIf.getIpInterfaces();
+            if (m_currentSnmpIf != null && ipInterfaces != null && ipInterfaces.size() > 0) {
+                final OnmsIpInterface current = ipInterfaces.toArray(new OnmsIpInterface[]{})[ipInterfaces.size() - 1];
+                m_currentMonSvc = new OnmsMonitoredService(current, serviceType);
+                m_currentMonSvc.setStatus("A");
+                return m_currentMonSvc;
+            }
+        }
+        m_currentMonSvc = null;
+        return null;
+    }
+
+    public void setDisplayCategory(final String displayCategory) {
+        m_currentNode.getAssetRecord().setDisplayCategory(displayCategory);
+    }
+
+    public void setBuilding(final String building) {
+        m_currentNode.getAssetRecord().setBuilding(building);
+    }
+
+    public OnmsNode getCurrentNode() {
+        return m_currentNode;
+    }
+
+    public void addCategory(final OnmsCategory cat) {
+        m_categoryCache.put(cat.getName(), cat);
+        m_currentNode.addCategory(cat);
+    }
+
+    public void addCategory(final String categoryName) {
+        addCategory(getCategory(categoryName));
+    }
+
+    public void clearInterface() {
+        m_currentIf = null;
+        m_currentMonSvc = null;
+    }
+
+    public OnmsMonitoredService addService(final String serviceName) {
+        return addService(getServiceType(serviceName));
+    }
+
+    public void setAssetAttribute(final String name, final String value) {
+        try {
+            m_assetBean.setPropertyValue(name, value);
+        } catch (final BeansException e) {
+            LOG.warn("Could not set property '{}' on asset '{}'", value, name, e);
+        }
+    }
+
+    public void setNodeMetaDataEntry(final String context, final String key, final String value) {
+        if (m_currentNode != null) {
+            m_currentNode.addMetaData(context, key, value);
+        }
+    }
+
+    public void setInterfaceMetaDataEntry(final String context, final String key, final String value) {
+        if (m_currentIf != null) {
+            m_currentIf.addMetaData(context, key, value);
+        }
+    }
+
+    public void setServiceMetaDataEntry(final String context, final String key, final String value) {
+        if (m_currentMonSvc != null) {
+            m_currentMonSvc.addMetaData(context, key, value);
+        }
+    }
+
+    public OnmsServiceType getServiceType(final String serviceName) {
+        if (!m_serviceTypeCache.containsKey(serviceName)) {
+            m_serviceTypeCache.put(serviceName, new OnmsServiceType(serviceName));
+        }
+        return m_serviceTypeCache.get(serviceName);
+    }
+
+    public OnmsCategory getCategory(final String categoryName) {
+        if (!m_categoryCache.containsKey(categoryName)) {
+            m_categoryCache.put(categoryName, new OnmsCategory(categoryName));
+        }
+        return m_categoryCache.get(categoryName);
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/ResourceTypeUtils.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/ResourceTypeUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ * Copyright (C) 2026 BeaconStrategists, Inc. (Modifications)
+ *
+ * This file is part of OpenNMS(R) / Delta-V.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opennms.netmgt.model;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for resource type path resolution and storage configuration.
+ *
+ * <p>Ported from opennms-model to model-jakarta. Methods referencing
+ * OnmsResource/OnmsEntity/RrdRepository are omitted — those classes are
+ * not in the delta-v classpath and the methods are not called by any daemon.</p>
+ */
+public abstract class ResourceTypeUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceTypeUtils.class);
+
+    /**
+     * Default folder where RRD files are stored.
+     *
+     * Working directory defaults to $OPENNMS_HOME, so we can find these in $OPENNMS_HOME/share/rrd.
+     */
+    public static final File DEFAULT_RRD_ROOT = Paths.get("share", "rrd").toAbsolutePath().toFile();
+
+    /** Directory name of where latency data is stored. */
+    public static final String RESPONSE_DIRECTORY = "response";
+
+    /** Directory name of where status data is stored. */
+    public static final String STATUS_DIRECTORY = "status";
+
+    /** Directory name of where all other collected data is stored. */
+    public static final String SNMP_DIRECTORY = "snmp";
+
+    /** Directory name of where stored-by-foreign-source data is stored. */
+    public static final String FOREIGN_SOURCE_DIRECTORY = "fs";
+
+    private static final Pattern s_responseDirectoryPattern = Pattern.compile("^" + RESPONSE_DIRECTORY + ".+$");
+    private static final Pattern s_statusDirectoryPattern = Pattern.compile("^" + STATUS_DIRECTORY + ".+$");
+
+    public static boolean isStoreByGroup() {
+        return Boolean.getBoolean("org.opennms.rrd.storeByGroup");
+    }
+
+    public static boolean isStoreByForeignSource() {
+        return Boolean.getBoolean("org.opennms.rrd.storeByForeignSource");
+    }
+
+    public static boolean isResponseTime(String relativePath) {
+        return s_responseDirectoryPattern.matcher(relativePath).matches();
+    }
+
+    public static boolean isStatus(String relativePath) {
+        return s_statusDirectoryPattern.matcher(relativePath).matches();
+    }
+
+    public static File getRelativeNodeSourceDirectory(String nodeSource) {
+        String[] ident = getFsAndFidFromNodeSource(nodeSource);
+        return new File(FOREIGN_SOURCE_DIRECTORY, File.separator + ident[0] + File.separator + ident[1]);
+    }
+
+    public static String[] getFsAndFidFromNodeSource(String nodeSource) {
+        final String[] ident = nodeSource.split(":", 2);
+        if (!(ident.length == 2)) {
+            LOG.warn("'{}' is not in the format foreignSource:foreignId.", nodeSource);
+            throw new IllegalArgumentException("Node definition '" + nodeSource
+                    + "' is invalid, it should be in the format: 'foreignSource:foreignId'.");
+        }
+        return ident;
+    }
+
+    /**
+     * Returns the number of elements that correspond to the "node resource" for the given path.
+     *
+     * @param path resource path
+     * @return number of elements or -1 if the given path does not map to a node
+     */
+    public static int getNumPathElementsToNodeLevel(ResourcePath path) {
+        final String[] elements = path.elements();
+        if (elements == null) return -1;
+        if (elements.length >= 2
+                && SNMP_DIRECTORY.equals(elements[0])
+                && !FOREIGN_SOURCE_DIRECTORY.equals(elements[1])) {
+            return 2;
+        } else if (elements.length >= 4
+                && SNMP_DIRECTORY.equals(elements[0])
+                && FOREIGN_SOURCE_DIRECTORY.equals(elements[1])) {
+            return 4;
+        }
+        return -1;
+    }
+}

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/SnmpInterfaceBuilder.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/SnmpInterfaceBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 1999-2024 The OpenNMS Group, Inc.
+ * Copyright (C) 2026 BeaconStrategists, Inc. (Modifications)
+ *
+ * This file is part of OpenNMS(R) / Delta-V.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opennms.netmgt.model;
+
+import java.net.InetAddress;
+
+import org.opennms.netmgt.model.NetworkBuilder.InterfaceBuilder;
+
+import static org.opennms.core.utils.InetAddressUtils.addr;
+
+/**
+ * Builder for constructing OnmsSnmpInterface entities with IP interface associations.
+ */
+public class SnmpInterfaceBuilder {
+
+    private final OnmsSnmpInterface m_snmpIf;
+
+    public SnmpInterfaceBuilder(OnmsSnmpInterface snmpIf) {
+        m_snmpIf = snmpIf;
+    }
+
+    public SnmpInterfaceBuilder setIfSpeed(long ifSpeed) {
+        m_snmpIf.setIfSpeed(Long.valueOf(ifSpeed));
+        return this;
+    }
+
+    public SnmpInterfaceBuilder setIfDescr(String ifDescr) {
+        m_snmpIf.setIfDescr(ifDescr);
+        return this;
+    }
+
+    public SnmpInterfaceBuilder setIfAlias(String ifAlias) {
+        m_snmpIf.setIfAlias(ifAlias);
+        return this;
+    }
+
+    public SnmpInterfaceBuilder setIfName(String ifName) {
+        m_snmpIf.setIfName(ifName);
+        return this;
+    }
+
+    public SnmpInterfaceBuilder setIfType(Integer ifType) {
+        m_snmpIf.setIfType(ifType);
+        return this;
+    }
+
+    public OnmsSnmpInterface getSnmpInterface() {
+        return m_snmpIf;
+    }
+
+    public SnmpInterfaceBuilder setIfOperStatus(Integer ifOperStatus) {
+        m_snmpIf.setIfOperStatus(ifOperStatus);
+        return this;
+    }
+
+    public SnmpInterfaceBuilder setCollectionEnabled(boolean collect) {
+        m_snmpIf.setCollectionEnabled(collect);
+        return this;
+    }
+
+    public SnmpInterfaceBuilder setPhysAddr(String physAddr) {
+        m_snmpIf.setPhysAddr(physAddr);
+        return this;
+    }
+
+    public InterfaceBuilder addIpInterface(final String ipAddress) {
+        return addIpInterface(addr(ipAddress));
+    }
+
+    public InterfaceBuilder addIpInterface(final InetAddress ipAddress) {
+        final OnmsIpInterface iface = new OnmsIpInterface(ipAddress, m_snmpIf.getNode());
+        m_snmpIf.addIpInterface(iface);
+        return new InterfaceBuilder(iface);
+    }
+}


### PR DESCRIPTION
## Summary
Port three utility classes from horizon `opennms-model` to `model-jakarta` to fix runtime ClassNotFoundException errors in Collectd and Provisiond.

- **ResourceTypeUtils** — called by `DefaultCollectionAgentService.isStoreByForeignSource()` in Collectd. Ported without `OnmsResource`/`OnmsEntity`/`RrdRepository` methods (not called by any daemon, deps not on classpath).
- **NetworkBuilder** + **SnmpInterfaceBuilder** — called by `OnmsNodeRequisition.constructOnmsNodeFromRequisition()` in Provisiond during node scans. All entity deps already in model-jakarta. Ported as-is.

All three files get dual copyright headers (horizon-derived, blatant copy).

## Test plan
- [x] `mvn clean install -DskipTests` — BUILD SUCCESS
- [x] All 16 containers healthy
- [x] Zero `ClassNotFoundException` for ResourceTypeUtils and NetworkBuilder
- [x] test-e2e: **12/12** (was 3/4 — nodeScanCompleted now passes)
- [x] test-minion-rpc-e2e: 8/9 (same as before — Pollerd poll timing unrelated)

### Known remaining
- `SiblingColumnStorageStrategy` ClassNotFoundException in Collectd — dynamically loaded storage strategy, newly surfaced now that ResourceTypeUtils is fixed. Follow-up item.