### PR TITLE
refactor: remove last @Autowired from production code

### DIFF
--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/CollectorsEndpoint.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/CollectorsEndpoint.java
@@ -21,9 +21,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -38,8 +38,7 @@ public class CollectorsEndpoint {
 
     private final ServiceCollectorRegistry registry;
 
-    @Autowired(required = false)
-    public CollectorsEndpoint(ServiceCollectorRegistry registry) {
+    public CollectorsEndpoint(@Nullable ServiceCollectorRegistry registry) {
         this.registry = registry;
     }
 

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/DetectorsEndpoint.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/DetectorsEndpoint.java
@@ -21,9 +21,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -38,8 +38,7 @@ public class DetectorsEndpoint {
 
     private final ServiceDetectorRegistry registry;
 
-    @Autowired(required = false)
-    public DetectorsEndpoint(ServiceDetectorRegistry registry) {
+    public DetectorsEndpoint(@Nullable ServiceDetectorRegistry registry) {
         this.registry = registry;
     }
 


### PR DESCRIPTION
## Summary
Replace `@Autowired(required = false)` with `@Nullable` constructor parameter in two Minion actuator endpoints. Spring Boot 4 auto-wires the sole constructor; `@Nullable` signals the optional dependency.

**Zero `@Autowired` annotations remain in delta-v production code.** (9 remain in test classes — standard Spring test injection practice.)

## Files changed
- `CollectorsEndpoint.java` — `@Autowired(required = false)` → `@Nullable`
- `DetectorsEndpoint.java` — `@Autowired(required = false)` → `@Nullable`

## Test plan
- [x] `mvn clean compile -DskipTests` — BUILD SUCCESS