### PR TITLE
feat: replace EventUtil stubs with JDBC-backed JdbcEventUtil

### DIFF
--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -20,7 +20,6 @@ package org.deltav.netmgt.alarmd.boot;
 
 import org.deltav.core.daemon.common.SpringServiceDaemonSmartLifecycle;
 import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
-import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.alarmd.Alarmd;
 import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
@@ -182,35 +181,6 @@ public class AlarmdConfiguration {
             @Override public void didUpdateLastAutomationTime(OnmsAlarm a, java.util.Date d) {}
             @Override public void didUpdateRelatedAlarms(OnmsAlarm a, java.util.Set<OnmsAlarm> s) {}
             @Override public void didChangeTicketStateForAlarm(OnmsAlarm a, org.opennms.netmgt.model.TroubleTicketState s) {}
-        };
-    }
-
-    /**
-     * Minimal EventUtil implementation for alarm parameter expansion.
-     * The full EventUtilDaoImpl depends on the legacy Hibernate DAO layer.
-     * This pass-through implementation handles the expandParms() calls that
-     * AlarmPersisterImpl makes — returning the input unchanged when no
-     * database-backed token resolution is available.
-     */
-    @Bean
-    public EventUtil eventUtil() {
-        return new EventUtil() {
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
-            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
-            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
-            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
-            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getForeignId(long nodeId) { return ""; }
-            @Override public String getForeignSource(long nodeId) { return ""; }
-            @Override public String getNodeLabel(long nodeId) { return ""; }
-            @Override public String getNodeLocation(long nodeId) { return ""; }
-            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
-            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
-            @Override public String getPrimaryInterface(long nodeId) { return ""; }
         };
     }
 

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/netmgt/collectd/boot/CollectdJpaConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/netmgt/collectd/boot/CollectdJpaConfiguration.java
@@ -29,7 +29,6 @@ import org.opennms.core.tsid.TsidFactory;
 import org.opennms.netmgt.config.api.DefaultDatabaseSchemaConfig;
 import org.opennms.netmgt.config.filter.DatabaseSchema;
 import org.opennms.netmgt.dao.api.SessionUtils;
-import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.JdbcFilterDao;
 import org.opennms.netmgt.model.OnmsApplication;
@@ -62,8 +61,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  * Spring Boot @Configuration for Collectd JPA entities, DAOs, and infrastructure beans.
  *
  * <p>Follows the same pattern as PollerdJpaConfiguration: explicit entity listing
- * (not @EntityScan), SessionUtils for transaction management, and a minimal no-op
- * EventUtil stub for parameter expansion.</p>
+ * (not @EntityScan) and SessionUtils for transaction management.</p>
  *
  * <p>Entity classes are listed explicitly via a custom {@link PersistenceManagedTypes}
  * bean instead of using package-based {@code @EntityScan} because the legacy
@@ -221,35 +219,4 @@ public class CollectdJpaConfiguration {
         return new TsidFactory(nodeId);
     }
 
-    // ===================================================================
-    // Section 5: No-op stubs
-    // ===================================================================
-
-    /**
-     * Minimal EventUtil implementation for parameter expansion.
-     * The full EventUtilDaoImpl depends on the legacy Hibernate DAO layer.
-     * This pass-through implementation returns inputs unchanged when no
-     * database-backed token resolution is available.
-     */
-    @Bean
-    public EventUtil eventUtil() {
-        return new EventUtil() {
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
-            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
-            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
-            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
-            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getForeignId(long nodeId) { return ""; }
-            @Override public String getForeignSource(long nodeId) { return ""; }
-            @Override public String getNodeLabel(long nodeId) { return ""; }
-            @Override public String getNodeLocation(long nodeId) { return ""; }
-            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
-            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
-            @Override public String getPrimaryInterface(long nodeId) { return ""; }
-        };
-    }
 }

--- a/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/EnlinkdJpaConfiguration.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/EnlinkdJpaConfiguration.java
@@ -48,7 +48,6 @@ import org.opennms.netmgt.enlinkd.persistence.impl.OspfAreaDaoJpa;
 import org.opennms.netmgt.enlinkd.persistence.impl.OspfElementDaoJpa;
 import org.opennms.netmgt.enlinkd.persistence.impl.OspfLinkDaoJpa;
 import org.opennms.netmgt.enlinkd.persistence.impl.UserDefinedLinkDaoJpa;
-import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.model.OnmsApplication;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsDistPoller;
@@ -255,29 +254,4 @@ public class EnlinkdJpaConfiguration {
         return new UserDefinedLinkDaoJpa();
     }
 
-    // ===================================================================
-    // Section 4: No-op stubs
-    // ===================================================================
-
-    @Bean
-    public EventUtil eventUtil() {
-        return new EventUtil() {
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
-            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
-            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
-            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
-            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getForeignId(long nodeId) { return ""; }
-            @Override public String getForeignSource(long nodeId) { return ""; }
-            @Override public String getNodeLabel(long nodeId) { return ""; }
-            @Override public String getNodeLocation(long nodeId) { return ""; }
-            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
-            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
-            @Override public String getPrimaryInterface(long nodeId) { return ""; }
-        };
-    }
 }

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/CollectorsEndpoint.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/CollectorsEndpoint.java
@@ -21,9 +21,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -38,8 +38,7 @@ public class CollectorsEndpoint {
 
     private final ServiceCollectorRegistry registry;
 
-    @Autowired(required = false)
-    public CollectorsEndpoint(ServiceCollectorRegistry registry) {
+    public CollectorsEndpoint(@Nullable ServiceCollectorRegistry registry) {
         this.registry = registry;
     }
 

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/DetectorsEndpoint.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/actuator/DetectorsEndpoint.java
@@ -21,9 +21,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -38,8 +38,7 @@ public class DetectorsEndpoint {
 
     private final ServiceDetectorRegistry registry;
 
-    @Autowired(required = false)
-    public DetectorsEndpoint(ServiceDetectorRegistry registry) {
+    public DetectorsEndpoint(@Nullable ServiceDetectorRegistry registry) {
         this.registry = registry;
     }
 

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdJpaConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdJpaConfiguration.java
@@ -36,7 +36,6 @@ import org.opennms.netmgt.collection.api.ServiceParameters;
 import org.opennms.netmgt.config.api.DefaultDatabaseSchemaConfig;
 import org.opennms.netmgt.config.filter.DatabaseSchema;
 import org.opennms.netmgt.dao.api.SessionUtils;
-import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.JdbcFilterDao;
 import org.opennms.netmgt.model.OnmsApplication;
@@ -297,31 +296,4 @@ public class PerspectivePollerdJpaConfiguration {
         };
     }
 
-    /**
-     * Minimal EventUtil implementation for parameter expansion.
-     * The full EventUtilDaoImpl depends on the legacy Hibernate DAO layer.
-     * This pass-through implementation returns inputs unchanged when no
-     * database-backed token resolution is available.
-     */
-    @Bean
-    public EventUtil eventUtil() {
-        return new EventUtil() {
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
-            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
-            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
-            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
-            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getForeignId(long nodeId) { return ""; }
-            @Override public String getForeignSource(long nodeId) { return ""; }
-            @Override public String getNodeLabel(long nodeId) { return ""; }
-            @Override public String getNodeLocation(long nodeId) { return ""; }
-            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
-            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
-            @Override public String getPrimaryInterface(long nodeId) { return ""; }
-        };
-    }
 }

--- a/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdJpaConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdJpaConfiguration.java
@@ -40,7 +40,6 @@ import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.dao.api.SessionUtils;
-import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.JdbcFilterDao;
 import org.opennms.netmgt.model.OnmsCategory;
@@ -306,31 +305,4 @@ public class PollerdJpaConfiguration {
         };
     }
 
-    /**
-     * Minimal EventUtil implementation for parameter expansion.
-     * The full EventUtilDaoImpl depends on the legacy Hibernate DAO layer.
-     * This pass-through implementation returns inputs unchanged when no
-     * database-backed token resolution is available.
-     */
-    @Bean
-    public EventUtil eventUtil() {
-        return new EventUtil() {
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
-            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
-            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
-            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
-            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getForeignId(long nodeId) { return ""; }
-            @Override public String getForeignSource(long nodeId) { return ""; }
-            @Override public String getNodeLabel(long nodeId) { return ""; }
-            @Override public String getNodeLocation(long nodeId) { return ""; }
-            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
-            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
-            @Override public String getPrimaryInterface(long nodeId) { return ""; }
-        };
-    }
 }

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydJpaConfiguration.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydJpaConfiguration.java
@@ -18,7 +18,6 @@ package org.deltav.netmgt.telemetry.boot;
 
 import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
 import org.opennms.netmgt.dao.api.SessionUtils;
-import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
@@ -127,35 +126,4 @@ public class TelemetrydJpaConfiguration {
         return new TransactionTemplate(txManager);
     }
 
-    // ===================================================================
-    // Section 3: No-op stubs
-    // ===================================================================
-
-    /**
-     * Minimal EventUtil implementation for parameter expansion.
-     * The full EventUtilDaoImpl depends on the legacy Hibernate DAO layer.
-     * This pass-through implementation returns inputs unchanged when no
-     * database-backed token resolution is available.
-     */
-    @Bean
-    public EventUtil eventUtil() {
-        return new EventUtil() {
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event) { return inp; }
-            @Override public String expandParms(String inp, org.opennms.netmgt.xml.event.Event event, java.util.Map<String, java.util.Map<String, String>> decode) { return inp; }
-            @Override public String getNamedParmValue(String string, org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public void expandMapValues(java.util.Map<String, String> parmMap, org.opennms.netmgt.xml.event.Event event) {}
-            @Override public String getHardwareFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getHostName(int nodeId, String hostip) { return hostip; }
-            @Override public String getEventHost(org.opennms.netmgt.xml.event.Event event) { return ""; }
-            @Override public String getIfAlias(long nodeId, String ipAddr) { return ""; }
-            @Override public String getAssetFieldValue(String parm, long nodeId) { return ""; }
-            @Override public String getForeignId(long nodeId) { return ""; }
-            @Override public String getForeignSource(long nodeId) { return ""; }
-            @Override public String getNodeLabel(long nodeId) { return ""; }
-            @Override public String getNodeLocation(long nodeId) { return ""; }
-            @Override public org.opennms.netmgt.eventd.processor.expandable.ExpandableParameterResolver getResolver(String token) { return null; }
-            @Override public java.util.Date decodeSnmpV2TcDateAndTime(java.math.BigInteger value) { return new java.util.Date(); }
-            @Override public String getPrimaryInterface(long nodeId) { return ""; }
-        };
-    }
 }

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.core.daemon.common;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.opennms.netmgt.eventd.AbstractEventUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * JDBC-backed {@link org.opennms.netmgt.eventd.EventUtil} for Spring Boot daemons.
+ *
+ * <p>Replaces the Hibernate-backed {@code EventUtilDaoImpl} that depends on the
+ * full DAO layer. This implementation uses direct SQL queries against PostgreSQL,
+ * consistent with Delta-V's JDBC-first approach in daemon-common.</p>
+ *
+ * <p>{@link AbstractEventUtil} provides the {@code expandParms()} template method
+ * that calls these lookup methods to resolve {@code %nodelabel%}, {@code %ifalias%},
+ * {@code %foreignsource%}, etc. tokens in event descriptions and logmsg.</p>
+ */
+@Component
+public class JdbcEventUtil extends AbstractEventUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcEventUtil.class);
+
+    private final JdbcTemplate jdbc;
+
+    public JdbcEventUtil(DataSource dataSource) {
+        this.jdbc = new JdbcTemplate(dataSource);
+    }
+
+    @Override
+    public String getNodeLabel(long nodeId) throws SQLException {
+        return queryString("SELECT nodelabel FROM node WHERE nodeid = ?", nodeId);
+    }
+
+    @Override
+    public String getNodeLocation(long nodeId) throws SQLException {
+        return queryString("SELECT location FROM node WHERE nodeid = ?", nodeId);
+    }
+
+    @Override
+    public String getForeignSource(long nodeId) throws SQLException {
+        return queryString("SELECT foreignsource FROM node WHERE nodeid = ?", nodeId);
+    }
+
+    @Override
+    public String getForeignId(long nodeId) throws SQLException {
+        return queryString("SELECT foreignid FROM node WHERE nodeid = ?", nodeId);
+    }
+
+    @Override
+    public String getHostName(int nodeId, String hostip) throws SQLException {
+        String hostname = queryString(
+                "SELECT iphostname FROM ipinterface WHERE nodeid = ? AND ipaddr = ?",
+                nodeId, hostip);
+        return hostname != null ? hostname : hostip;
+    }
+
+    @Override
+    public String getIfAlias(long nodeId, String ipAddr) throws SQLException {
+        return queryString(
+                "SELECT s.snmpifalias FROM snmpinterface s " +
+                "JOIN ipinterface i ON s.id = i.snmpinterfaceid " +
+                "WHERE i.nodeid = ? AND i.ipaddr = ?",
+                nodeId, ipAddr);
+    }
+
+    @Override
+    public String getPrimaryInterface(long nodeId) throws SQLException {
+        return queryString(
+                "SELECT ipaddr FROM ipinterface WHERE nodeid = ? AND issnmpprimary = 'P' LIMIT 1",
+                nodeId);
+    }
+
+    @Override
+    public String getAssetFieldValue(String parm, long nodeId) {
+        try {
+            // Asset fields are column names on the assets table, joined via node.assetrecordid
+            // Validate column name to prevent SQL injection
+            if (!parm.matches("[a-zA-Z_]+")) {
+                LOG.warn("Invalid asset field name: {}", parm);
+                return "";
+            }
+            String lowerParm = parm.toLowerCase();
+            return queryString(
+                    "SELECT a." + lowerParm + " FROM assets a " +
+                    "JOIN node n ON n.assetrecordid = a.id WHERE n.nodeid = ?",
+                    nodeId);
+        } catch (Exception e) {
+            LOG.debug("Failed to lookup asset field '{}' for node {}: {}", parm, nodeId, e.getMessage());
+            return "";
+        }
+    }
+
+    @Override
+    public String getHardwareFieldValue(String parm, long nodeId) {
+        // Hardware entity lookup — rarely used, return empty for now
+        LOG.debug("Hardware field lookup not implemented: {} for node {}", parm, nodeId);
+        return "";
+    }
+
+    private String queryString(String sql, Object... args) {
+        try {
+            return jdbc.query(sql, rs -> rs.next() ? rs.getString(1) : null, args);
+        } catch (Exception e) {
+            LOG.debug("EventUtil query failed [{}]: {}", sql, e.getMessage());
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add `JdbcEventUtil` in `daemon-common` — a JDBC-backed implementation of the `EventUtil` interface that resolves `%nodelabel%`, `%ifalias%`, `%foreignsource%`, `%foreignid%`, `%nodelocation%`, `%primaryinterface%`, `%asset[field]%`, and `%hostname%` tokens in event descriptions and logmsg.

Removes 6 identical anonymous `EventUtil` stubs from Alarmd, Collectd, Enlinkd, PerspectivePollerd, Pollerd, and Telemetryd. The shared `@Component` is auto-discovered via `org.deltav.core.daemon.common` component scanning.

**Before:** Alarm descriptions showed raw `%nodelabel%` / `%ifalias%` tokens.
**After:** Tokens expand to actual node labels, interface aliases, foreign sources, etc. from PostgreSQL.

`AbstractEventUtil` (from the horizon JAR) provides the `expandParms()` template method that calls these lookup methods. `JdbcEventUtil` extends it with direct SQL queries, avoiding the full Hibernate DAO layer.

## Test plan
- [x] `mvn clean compile -DskipTests` — BUILD SUCCESS (all 22 modules)
- [ ] Docker build + deploy + verify alarm descriptions show expanded values