### PR TITLE
feat: wire event expansion pipeline for logmsg/descr

### DIFF
--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventConfEnrichmentService.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventConfEnrichmentService.java
@@ -34,6 +34,7 @@ import org.opennms.netmgt.xml.event.Parm;
 import org.opennms.netmgt.xml.event.UpdateField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,7 @@ import org.springframework.stereotype.Service;
  * classic OpenNMS would generate.</p>
  */
 @Service
+@ConditionalOnProperty("spring.datasource.url")
 public class EventConfEnrichmentService {
 
     private static final Logger LOG = LoggerFactory.getLogger(EventConfEnrichmentService.class);

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventConfEnrichmentService.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventConfEnrichmentService.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.eventd.AbstractEventUtil;
 import org.opennms.netmgt.model.EventConfEvent;
 import org.opennms.netmgt.model.EventConfSource;
 import org.opennms.netmgt.xml.event.AlarmData;
@@ -34,6 +35,7 @@ import org.opennms.netmgt.xml.event.UpdateField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -55,9 +57,12 @@ public class EventConfEnrichmentService {
     private static final Logger LOG = LoggerFactory.getLogger(EventConfEnrichmentService.class);
 
     private final DaemonEventConfDao eventConfDao;
+    @Nullable
+    private final AbstractEventUtil eventUtil;
 
-    public EventConfEnrichmentService(DataSource dataSource) {
+    public EventConfEnrichmentService(DataSource dataSource, @Nullable AbstractEventUtil eventUtil) {
         this.eventConfDao = new DaemonEventConfDao();
+        this.eventUtil = eventUtil;
         List<EventConfEvent> events = loadEventConfFromDb(new JdbcTemplate(dataSource));
         if (!events.isEmpty()) {
             eventConfDao.loadEventsFromDB(events);
@@ -109,6 +114,41 @@ public class EventConfEnrichmentService {
                 eventLogmsg.setDest(confLogmsg.getDest().toString());
             }
             event.setLogmsg(eventLogmsg);
+        }
+
+        if (event.getDescr() == null && matched.getDescr() != null) {
+            event.setDescr(matched.getDescr());
+        }
+
+        // Expand DB-backed tokens (%nodelabel%, %ifalias%, %foreignsource%, etc.)
+        // in logmsg and descr using JdbcEventUtil's JDBC lookups.
+        expandTemplateTokens(event);
+    }
+
+    /**
+     * Expands DB-backed parameter tokens in the event's logmsg and descr fields
+     * using {@link AbstractEventUtil#expandParms(String, Event)}.
+     *
+     * <p>This resolves tokens like {@code %nodelabel%}, {@code %ifalias%},
+     * {@code %foreignsource%}, {@code %foreignid%}, {@code %nodelocation%},
+     * {@code %primaryinterface%}, and {@code %asset[field]%} by querying
+     * PostgreSQL via {@link JdbcEventUtil}.</p>
+     */
+    private void expandTemplateTokens(Event event) {
+        if (eventUtil == null) {
+            return;
+        }
+        try {
+            if (event.getLogmsg() != null && event.getLogmsg().getContent() != null) {
+                String expanded = eventUtil.expandParms(event.getLogmsg().getContent(), event);
+                event.getLogmsg().setContent(expanded);
+            }
+            if (event.getDescr() != null) {
+                event.setDescr(eventUtil.expandParms(event.getDescr(), event));
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to expand template tokens for event {}: {}",
+                    event.getUei(), e.getMessage());
         }
     }
 

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventConfEnrichmentService.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventConfEnrichmentService.java
@@ -112,10 +112,15 @@ public class EventConfEnrichmentService {
             org.opennms.netmgt.xml.event.Logmsg eventLogmsg = new org.opennms.netmgt.xml.event.Logmsg();
             org.opennms.netmgt.xml.eventconf.Logmsg confLogmsg = matched.getLogmsg();
             eventLogmsg.setContent(confLogmsg.getContent());
-            if (confLogmsg.getDest() != null) {
-                eventLogmsg.setDest(confLogmsg.getDest().toString());
-            }
+            eventLogmsg.setDest("logndisplay");
             event.setLogmsg(eventLogmsg);
+        }
+
+        // Delta-V has no events table — force logndisplay so AlarmPersisterImpl
+        // always processes the event. Legacy "donotpersist" dest values from
+        // EventTranslator or trap eventconf are meaningless without an events table.
+        if (event.getLogmsg() != null) {
+            event.getLogmsg().setDest("logndisplay");
         }
 
         if (event.getDescr() == null && matched.getDescr() != null) {

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventIpcManagerEnrichingWrapper.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/EventIpcManagerEnrichingWrapper.java
@@ -28,12 +28,14 @@ import org.opennms.netmgt.xml.event.Log;
 
 /**
  * Delegating {@link EventIpcManager} wrapper that enriches events with
- * alarm-data, severity, and logmsg from the event configuration before
- * forwarding them to the real {@link EventIpcManager}.
+ * alarm-data, severity, logmsg, and descr from the event configuration
+ * before forwarding them to the real {@link EventIpcManager}.
  *
- * <p>Used by EventTranslator so that translated events are enriched before
- * being published to Kafka, ensuring downstream Alarmd sees fully-populated
- * alarm-data without needing to re-enrich on the alarm side.</p>
+ * <p>Wired as the primary {@link EventIpcManager} by
+ * {@link KafkaEventTransportConfiguration} so that ALL events from ALL
+ * daemons pass through {@link EventConfEnrichmentService#enrichEvent}
+ * before reaching Kafka. This replaces the role of Eventd's EventExpander
+ * in classic OpenNMS.</p>
  */
 public class EventIpcManagerEnrichingWrapper implements EventIpcManager {
 

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
@@ -25,6 +25,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * JDBC-backed {@link org.opennms.netmgt.eventd.EventUtil} for Spring Boot daemons.
@@ -44,7 +46,8 @@ public class JdbcEventUtil extends AbstractEventUtil {
 
     private final JdbcTemplate jdbc;
 
-    public JdbcEventUtil(DataSource dataSource) {
+    public JdbcEventUtil(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        super(null, new TransactionTemplate(transactionManager));
         this.jdbc = new JdbcTemplate(dataSource);
     }
 

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import org.opennms.netmgt.eventd.AbstractEventUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -38,8 +39,12 @@ import org.springframework.transaction.support.TransactionTemplate;
  * <p>{@link AbstractEventUtil} provides the {@code expandParms()} template method
  * that calls these lookup methods to resolve {@code %nodelabel%}, {@code %ifalias%},
  * {@code %foreignsource%}, etc. tokens in event descriptions and logmsg.</p>
+ *
+ * <p>Only created in daemons that have a database (i.e., where
+ * {@code spring.datasource.url} is configured). Not available in Minion.</p>
  */
 @Component
+@ConditionalOnProperty("spring.datasource.url")
 public class JdbcEventUtil extends AbstractEventUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcEventUtil.class);

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -110,8 +110,14 @@ public class KafkaEventTransportConfiguration {
     @Bean
     @org.springframework.context.annotation.Primary
     public EventIpcManager eventIpcManager(KafkaEventForwarder forwarder,
-                                           KafkaEventSubscriptionService subscriptionService) {
-        return new KafkaEventIpcManagerAdapter(forwarder, subscriptionService);
+                                           KafkaEventSubscriptionService subscriptionService,
+                                           @org.springframework.beans.factory.annotation.Autowired(required = false)
+                                           EventConfEnrichmentService eventConfEnrichmentService) {
+        EventIpcManager base = new KafkaEventIpcManagerAdapter(forwarder, subscriptionService);
+        if (eventConfEnrichmentService != null) {
+            return new EventIpcManagerEnrichingWrapper(base, eventConfEnrichmentService);
+        }
+        return base;
     }
 
     /**

--- a/opennms-container/delta-v/test-minion-e2e.sh
+++ b/opennms-container/delta-v/test-minion-e2e.sh
@@ -297,6 +297,30 @@ else
     fail "No linkDown alarm found in PostgreSQL"
 fi
 
+# Verify alarm logmsg is expanded (not empty, no raw %tokens%)
+ALARM_LOGMSG=$(psql_query "SELECT logmsg FROM alarms WHERE eventuei = 'uei.opennms.org/translator/traps/SNMP_Link_Down' AND logmsg IS NOT NULL AND logmsg != '' LIMIT 1")
+if [ -n "$ALARM_LOGMSG" ]; then
+    if echo "$ALARM_LOGMSG" | grep -q '%nodelabel%'; then
+        fail "Alarm logmsg contains unexpanded %nodelabel% token: $ALARM_LOGMSG"
+    else
+        ok "Alarm logmsg expanded: $ALARM_LOGMSG"
+    fi
+else
+    fail "Alarm logmsg is empty — event template expansion not working"
+fi
+
+# Verify alarm description is expanded (not empty, no raw %tokens%)
+ALARM_DESCR=$(psql_query "SELECT description FROM alarms WHERE eventuei = 'uei.opennms.org/translator/traps/SNMP_Link_Down' AND description IS NOT NULL AND description != '' LIMIT 1")
+if [ -n "$ALARM_DESCR" ]; then
+    if echo "$ALARM_DESCR" | grep -q '%nodelabel%'; then
+        fail "Alarm description contains unexpanded %nodelabel% token"
+    else
+        ok "Alarm description expanded (non-empty, tokens resolved)"
+    fi
+else
+    fail "Alarm description is empty — event template expansion not working"
+fi
+
 # ══════════════════════════════════════════════════════════════════
 # Phase 3: Alarm Clearing via linkUp Trap (through Minion)
 # ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- **Fix empty alarm logmsg/description columns** for SNMP trap events. `EventConfEnrichmentService` applied logmsg templates but never expanded DB-backed tokens (`%nodelabel%`, `%ifalias%`, etc.) and never applied `<descr>` templates. `AlarmPersisterImpl` expects these pre-expanded.
- **JdbcEventUtil**: Accept `PlatformTransactionManager`, pass `TransactionTemplate` to `AbstractEventUtil` — enables `expandParms()` for DB-backed tokens (previously NPE on `Objects.requireNonNull(transactionOperations)`).
- **EventConfEnrichmentService**: Inject `AbstractEventUtil`, apply `descr` template, call `expandParms()` on both logmsg and descr.
- **KafkaEventTransportConfiguration**: Wrap `KafkaEventIpcManagerAdapter` with `EventIpcManagerEnrichingWrapper` as primary `EventIpcManager` — all events from all daemons now pass through `enrichEvent()` before Kafka.

## Test plan

- [ ] Deploy to Docker Compose stack
- [ ] Trigger SNMP trap alarms (link down/up on labbox cEOS)
- [ ] Verify `SELECT logmsg, description FROM alarms WHERE eventuei LIKE '%SNMP_Link%'` returns expanded text (not empty, no raw `%tokens%`)
- [ ] Verify syslog-sourced alarms still work (regression check)
- [ ] Verify all 12 daemons start healthy
- [ ] Run full E2E test suite