### PR TITLE
feat: add ifAlias lookup by ifIndex for SNMP trap events

### DIFF
--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/JdbcEventUtil.java
@@ -94,6 +94,13 @@ public class JdbcEventUtil extends AbstractEventUtil {
     }
 
     @Override
+    public String getIfAliasByNodeAndIfIndex(long nodeId, int ifIndex) throws SQLException {
+        return queryString(
+                "SELECT snmpifalias FROM snmpinterface WHERE nodeid = ? AND snmpifindex = ?",
+                nodeId, ifIndex);
+    }
+
+    @Override
     public String getPrimaryInterface(long nodeId) throws SQLException {
         return queryString(
                 "SELECT ipaddr FROM ipinterface WHERE nodeid = ? AND issnmpprimary = 'P' LIMIT 1",

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Horizon JAR version (published by pbrane/delta-v-horizon) -->
-    <deltav.horizon.version>1.0.5</deltav.horizon.version>
+    <deltav.horizon.version>1.0.7</deltav.horizon.version>
 
     <!-- Plugin versions not inherited from spring-boot-starter-parent -->
     <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>


### PR DESCRIPTION
## Summary

- Cherry-picked NMS-19631 into delta-v-horizon (1.0.7) — adds `getIfAliasByNodeAndIfIndex(nodeId, ifIndex)` to the `EventUtil` interface
- Added JDBC implementation in `JdbcEventUtil` — direct query on `snmpinterface` by `(nodeid, snmpifindex)`
- Bumped `deltav.horizon.version` from 1.0.5 to 1.0.7

When expanding `%ifalias%` in event templates (logmsg, descr, reduction keys), if the event has an `ifIndex` (common for SNMP traps), the lookup now uses `(nodeId, ifIndex)` instead of `(nodeId, ipAddr)`. This is more reliable because SNMP trap events always carry ifIndex but may not have a matching IP address for the interface.

## Test plan

- [ ] Deploy and verify `%ifalias%` resolves in SNMP trap alarm descriptions
- [ ] Run E2E test suite