### PR TITLE
feat(flow-enricher): Phase 1 skeleton — Spring Cloud Stream pipeline

### DIFF
--- a/core/flow-enricher/Dockerfile
+++ b/core/flow-enricher/Dockerfile
@@ -1,0 +1,16 @@
+FROM eclipse-temurin:21-jre-alpine
+
+# curl is needed by the docker-compose healthcheck.
+RUN apk add --no-cache curl && \
+    addgroup -g 10001 deltav && \
+    adduser -u 10001 -G deltav -D deltav
+
+COPY --chown=deltav:deltav target/flow-enricher-*.jar /app/flow-enricher.jar
+
+USER deltav
+
+EXPOSE 8080
+
+# JAVA_TOOL_OPTIONS is read natively by the JVM — override heap via the
+# docker-compose environment block (e.g. JAVA_TOOL_OPTIONS=-Xms256m -Xmx512m).
+ENTRYPOINT ["java", "-jar", "/app/flow-enricher.jar"]

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -157,13 +157,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <!-- repackage execution is inherited from spring-boot-starter-parent -->
             </plugin>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.flows</groupId>
+    <artifactId>org.deltav.flows.flow-enricher</artifactId>
+    <name>Delta-V :: Flows :: Enricher</name>
+    <description>Spring Cloud Stream service that consumes raw flow telemetry from Kafka Sink topics, enriches it with node/locality information, and publishes enriched FlowDocument protobuf messages to the deltav-flows topic.</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <!-- protoc artifact version: must match the protobuf-java version managed by the horizon BOM -->
+        <protoc.version>3.25.5</protoc.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Spring Cloud Stream + Kafka binder -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-binder-kafka</artifactId>
+        </dependency>
+
+        <!-- Protocol Buffers -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protoc.version}</version>
+        </dependency>
+
+        <!-- Caffeine cache (for JdbcNodeInfoLookup) -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <!-- PostgreSQL JDBC driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Horizon: Sink IPC model (SinkMessage protobuf class) -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.sink</groupId>
+            <artifactId>org.opennms.core.ipc.sink.common</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-security-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Horizon: Telemetry common (TelemetryProtos.TelemetryMessageLog protobuf class) -->
+        <dependency>
+            <groupId>org.opennms.features.telemetry</groupId>
+            <artifactId>org.opennms.features.telemetry.common</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-security-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-test-binder</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>flow-enricher-${project.version}</finalName>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -124,6 +124,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Required by maven-surefire-plugin 3.5.4 to discover JUnit Platform 6.x tests.
+             spring-boot-starter-test brings junit-jupiter (which transitively includes
+             junit-platform-engine), but not junit-platform-launcher. -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream-test-binder</artifactId>

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherApplication.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherApplication.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Entry point for the Delta-V flow-enricher service.
+ *
+ * <p>Spring Boot 4.0 + Spring Cloud Stream (Kafka binder) consumer that reads
+ * raw flow telemetry from OpenNMS Sink topics, enriches each flow with node
+ * lookup, locality, and SNMP-interface marking, and publishes enriched
+ * FlowDocument protobuf messages to the {@code deltav-flows} topic — the
+ * public contract topic for community downstream consumers.
+ */
+@SpringBootApplication
+@EnableScheduling
+public class FlowEnricherApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FlowEnricherApplication.class, args);
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import javax.sql.DataSource;
+
+import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
+import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/**
+ * Bean wiring for the flow-enricher service. Beans are constructed with
+ * constructor injection rather than field {@code @Autowired} per the
+ * delta-v project convention.
+ */
+@Configuration
+public class FlowEnricherConfiguration {
+
+    @Bean
+    JdbcTemplate flowEnricherJdbcTemplate(DataSource dataSource) {
+        return new JdbcTemplate(dataSource);
+    }
+
+    @Bean
+    JdbcNodeInfoLookup jdbcNodeInfoLookup(
+            JdbcTemplate flowEnricherJdbcTemplate,
+            @Value("${deltav.flows.node-lookup.cache-ttl:5m}") Duration cacheTtl) {
+        return new JdbcNodeInfoLookup(flowEnricherJdbcTemplate, cacheTtl);
+    }
+
+    @Bean
+    FlowLocalityCalculator flowLocalityCalculator() {
+        return new FlowLocalityCalculator();
+    }
+
+    @Bean
+    InterfaceMarkingCache interfaceMarkingCache(
+            JdbcTemplate flowEnricherJdbcTemplate,
+            @Value("${deltav.flows.interface-marking.cache-ttl:24h}") Duration cacheTtl) {
+        return new InterfaceMarkingCache(flowEnricherJdbcTemplate, cacheTtl);
+    }
+
+    @Bean
+    SinkMessageDeserializer sinkMessageDeserializer() {
+        return new SinkMessageDeserializer();
+    }
+
+    @Bean
+    FlowEnrichmentFunction flowEnrichmentFunction(
+            SinkMessageDeserializer deserializer,
+            JdbcNodeInfoLookup nodeInfoLookup,
+            FlowLocalityCalculator localityCalculator,
+            InterfaceMarkingCache interfaceMarkingCache) {
+        return new FlowEnrichmentFunction(
+                deserializer, nodeInfoLookup, localityCalculator, interfaceMarkingCache);
+    }
+
+    /**
+     * Spring Cloud Stream function binding. The bean name {@code enrichFlows}
+     * matches the {@code spring.cloud.function.definition} value in
+     * application.yml; the suffixes {@code -in-0} / {@code -out-0} are
+     * generated automatically by Spring Cloud Function.
+     *
+     * <p>Returning {@code null} from the inner function discards the message
+     * (it does not become an output record).
+     */
+    @Bean
+    Function<byte[], byte[]> enrichFlows(FlowEnrichmentFunction enrichmentFunction) {
+        return enrichmentFunction::processMessage;
+    }
+
+    /**
+     * Periodically purges TTL-expired entries from the InterfaceMarkingCache
+     * to bound memory growth.
+     */
+    @Bean
+    InterfaceMarkingCacheCleaner interfaceMarkingCacheCleaner(InterfaceMarkingCache cache) {
+        return new InterfaceMarkingCacheCleaner(cache);
+    }
+
+    /**
+     * Trivial bean wrapper that owns the {@link Scheduled} hook. Defining the
+     * scheduled method on the {@code @Configuration} class itself is awkward
+     * because Spring proxies it; an explicit holder bean keeps the wiring
+     * straightforward and easy to mock in tests.
+     */
+    public static class InterfaceMarkingCacheCleaner {
+        private final InterfaceMarkingCache cache;
+
+        InterfaceMarkingCacheCleaner(InterfaceMarkingCache cache) {
+            this.cache = cache;
+        }
+
+        @Scheduled(fixedRateString = "${deltav.flows.interface-marking.clean-interval-ms:3600000}")
+        public void clean() {
+            cache.cleanExpired();
+        }
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher;
+
+import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
+import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Phase 1 (skeleton) flow enrichment pipeline. The processing path is:
+ *
+ * <ol>
+ *   <li>Deserialize the Kafka payload into a {@link TelemetryProtos.TelemetryMessageLog}
+ *       via {@link SinkMessageDeserializer}.</li>
+ *   <li>Look up the exporter NodeInfo by the message source address (the
+ *       Minion-reported IP that received the original UDP packet).</li>
+ *   <li>Build a {@link FlowDocumentProtos.FlowDocument} envelope with timestamp,
+ *       host, location, and exporter_node populated.</li>
+ *   <li>Serialize and emit to the {@code deltav-flows} output binding.</li>
+ * </ol>
+ *
+ * <p><strong>Phase 1 limitations (intentional):</strong>
+ * <ul>
+ *   <li>Per-flow protocol parsing (Netflow5/9, IPFIX, sFlow records inside
+ *       the {@code TelemetryMessage} payload bytes) is NOT performed in this
+ *       skeleton. The horizon protocol adapters will be wired in a follow-up
+ *       PR once this Spring Cloud Stream pipeline is proven end-to-end.</li>
+ *   <li>Application classification, src/dst node lookup, and locality
+ *       calculation depend on per-flow parsed records and are similarly
+ *       deferred. The {@link InterfaceMarkingCache},
+ *       {@link FlowLocalityCalculator}, and {@link JdbcNodeInfoLookup#lookupByIpAddress}
+ *       beans are wired through the constructor so the follow-up PR can use
+ *       them without further bean changes.</li>
+ *   <li>The unused fields are deliberately left in the constructor signature
+ *       so this skeleton compiles to the same bean wiring the full pipeline
+ *       will use; removing them now would just churn the configuration class
+ *       in the next PR.</li>
+ * </ul>
+ *
+ * <p>The output of this skeleton is a near-empty FlowDocument: callers
+ * receive a real protobuf message they can deserialize, with the topic
+ * contract proven, but the meaningful fields populated only by the follow-up
+ * adapter integration.
+ */
+public class FlowEnrichmentFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlowEnrichmentFunction.class);
+
+    private final SinkMessageDeserializer deserializer;
+    private final JdbcNodeInfoLookup nodeInfoLookup;
+    @SuppressWarnings("unused") // wired now; consumed in the follow-up adapter PR
+    private final FlowLocalityCalculator localityCalculator;
+    @SuppressWarnings("unused") // wired now; consumed in the follow-up adapter PR
+    private final InterfaceMarkingCache interfaceMarkingCache;
+
+    public FlowEnrichmentFunction(
+            SinkMessageDeserializer deserializer,
+            JdbcNodeInfoLookup nodeInfoLookup,
+            FlowLocalityCalculator localityCalculator,
+            InterfaceMarkingCache interfaceMarkingCache) {
+        this.deserializer = deserializer;
+        this.nodeInfoLookup = nodeInfoLookup;
+        this.localityCalculator = localityCalculator;
+        this.interfaceMarkingCache = interfaceMarkingCache;
+    }
+
+    /**
+     * Spring Cloud Stream function entry point. Returns the protobuf bytes of
+     * an enriched FlowDocument, or {@code null} to drop the input message
+     * without producing an output record.
+     */
+    public byte[] processMessage(byte[] kafkaBytes) {
+        TelemetryProtos.TelemetryMessageLog messageLog = deserializer.deserialize(kafkaBytes);
+        if (messageLog == null || messageLog.getMessageCount() == 0) {
+            return null;
+        }
+
+        try {
+            FlowDocumentProtos.FlowDocument.Builder builder =
+                    FlowDocumentProtos.FlowDocument.newBuilder()
+                            .setTimestamp(System.currentTimeMillis())
+                            .setHost(messageLog.getSourceAddress())
+                            .setLocation(messageLog.getLocation());
+
+            JdbcNodeInfoLookup.NodeInfo exporter =
+                    nodeInfoLookup.lookupByIpAddress(messageLog.getSourceAddress());
+            if (exporter != null) {
+                FlowDocumentProtos.NodeInfo.Builder exporterBuilder =
+                        FlowDocumentProtos.NodeInfo.newBuilder().setNodeId(exporter.nodeId());
+                if (exporter.foreignSource() != null) {
+                    exporterBuilder.setForeignSource(exporter.foreignSource());
+                }
+                if (exporter.foreignId() != null) {
+                    exporterBuilder.setForeignId(exporter.foreignId());
+                }
+                builder.setExporterNode(exporterBuilder.build());
+            }
+
+            return builder.build().toByteArray();
+        } catch (Exception e) {
+            LOG.warn("Failed to enrich flow message from {}: {}",
+                    messageLog.getSourceAddress(), e.getMessage());
+            return null;
+        }
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher;
+
+import org.opennms.core.ipc.sink.model.SinkMessage;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unwraps the two-layer protobuf encoding used on Kafka Sink topics:
+ * Kafka bytes → {@link SinkMessage} envelope → {@link TelemetryProtos.TelemetryMessageLog}.
+ *
+ * <p>The Sink IPC framework (OpenNMS Minion) supports message chunking for
+ * payloads that exceed the Kafka message size limit. Flow telemetry messages
+ * are typically small (single UDP packet payload) so this deserializer takes
+ * the simpler path of dropping any chunked message it encounters and logging
+ * a warning. Reassembly across chunks can be added later if it proves
+ * necessary in production.
+ */
+public class SinkMessageDeserializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SinkMessageDeserializer.class);
+
+    /**
+     * Deserializes a Kafka payload into a {@link TelemetryProtos.TelemetryMessageLog}.
+     * Returns {@code null} if the payload is null, malformed, or chunked. Callers
+     * should treat null as "drop and continue".
+     */
+    public TelemetryProtos.TelemetryMessageLog deserialize(byte[] kafkaBytes) {
+        if (kafkaBytes == null) {
+            return null;
+        }
+        try {
+            SinkMessage sinkMessage = SinkMessage.parseFrom(kafkaBytes);
+            if (sinkMessage.getTotalChunks() > 1) {
+                LOG.warn("Chunked SinkMessage not supported (messageId={}, totalChunks={}); dropping",
+                        sinkMessage.getMessageId(), sinkMessage.getTotalChunks());
+                return null;
+            }
+            return TelemetryProtos.TelemetryMessageLog.parseFrom(sinkMessage.getContent());
+        } catch (Exception e) {
+            LOG.warn("Failed to deserialize SinkMessage payload ({} bytes): {}",
+                    kafkaBytes.length, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/FlowLocalityCalculator.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/FlowLocalityCalculator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Classifies IPv4/IPv6 addresses as PRIVATE (RFC1918, loopback, link-local,
+ * site-local) or PUBLIC for flow locality enrichment.
+ *
+ * <p>Stateless and thread-safe.
+ */
+public class FlowLocalityCalculator {
+
+    public enum Locality {
+        UNKNOWN,
+        PRIVATE,
+        PUBLIC
+    }
+
+    public Locality classify(String ipAddress) {
+        if (ipAddress == null || ipAddress.isEmpty()) {
+            return Locality.UNKNOWN;
+        }
+        final InetAddress addr;
+        try {
+            addr = InetAddress.getByName(ipAddress);
+        } catch (UnknownHostException e) {
+            return Locality.UNKNOWN;
+        }
+        if (addr.isLoopbackAddress() || addr.isLinkLocalAddress() || addr.isSiteLocalAddress()) {
+            return Locality.PRIVATE;
+        }
+        // InetAddress.isSiteLocalAddress() covers 10/8 and 192.168/16 but only
+        // covers 172.16/12 partially in some JDK versions; check explicitly.
+        byte[] bytes = addr.getAddress();
+        if (bytes.length == 4
+                && (bytes[0] & 0xFF) == 172
+                && (bytes[1] & 0xFF) >= 16
+                && (bytes[1] & 0xFF) <= 31) {
+            return Locality.PRIVATE;
+        }
+        return Locality.PUBLIC;
+    }
+
+    public Locality flowLocality(String srcAddress, String dstAddress) {
+        Locality src = classify(srcAddress);
+        Locality dst = classify(dstAddress);
+        if (src == Locality.UNKNOWN || dst == Locality.UNKNOWN) {
+            return Locality.UNKNOWN;
+        }
+        if (src == Locality.PUBLIC || dst == Locality.PUBLIC) {
+            return Locality.PUBLIC;
+        }
+        return Locality.PRIVATE;
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/InterfaceMarkingCache.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/InterfaceMarkingCache.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Marks SNMP interfaces as flow-enabled in the database, deduplicated by a
+ * TTL cache so that high-volume flow streams do not flood the database with
+ * UPDATE statements.
+ *
+ * <p>Each (nodeId, ifIndex) pair is marked once per TTL window. The cache is
+ * intentionally process-local — if the service restarts, the first flow on
+ * each interface will re-mark, which is harmless.
+ *
+ * <p>{@link #evictNode(long)} should be called when a node is deleted (e.g.
+ * via a {@code nodeDeleted} event subscription) so that the next flow with
+ * a recycled nodeId triggers a fresh DB write rather than relying on stale
+ * cache state.
+ */
+public class InterfaceMarkingCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InterfaceMarkingCache.class);
+
+    static final String UPDATE_SQL =
+            "UPDATE snmpinterface SET hasflows = true WHERE nodeid = ? AND snmpifindex = ?";
+
+    private final JdbcTemplate jdbc;
+    private final Duration ttl;
+    private final Map<Long, Map<Integer, Instant>> cache = new ConcurrentHashMap<>();
+
+    public InterfaceMarkingCache(JdbcTemplate jdbc, Duration ttl) {
+        this.jdbc = jdbc;
+        this.ttl = ttl;
+    }
+
+    public void markIfNeeded(long nodeId, int ifIndex) {
+        Map<Integer, Instant> nodeCache = cache.computeIfAbsent(nodeId, k -> new ConcurrentHashMap<>());
+        Instant lastMarked = nodeCache.get(ifIndex);
+        Instant now = Instant.now();
+        if (lastMarked != null && lastMarked.plus(ttl).isAfter(now)) {
+            return;
+        }
+        try {
+            jdbc.update(UPDATE_SQL, nodeId, ifIndex);
+            nodeCache.put(ifIndex, now);
+        } catch (Exception e) {
+            LOG.debug("Failed to mark interface hasflows for node {} ifIndex {}: {}",
+                    nodeId, ifIndex, e.getMessage());
+        }
+    }
+
+    public void evictNode(long nodeId) {
+        cache.remove(nodeId);
+    }
+
+    /**
+     * Removes cache entries whose last-marked timestamp is older than the TTL.
+     * Intended to be called periodically (e.g. hourly) to bound memory growth
+     * for nodes whose interfaces have stopped emitting flows.
+     */
+    public void cleanExpired() {
+        Instant cutoff = Instant.now().minus(ttl);
+        cache.forEach((nodeId, interfaces) -> {
+            interfaces.entrySet().removeIf(entry -> entry.getValue().isBefore(cutoff));
+            if (interfaces.isEmpty()) {
+                cache.remove(nodeId);
+            }
+        });
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookup.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookup.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * JDBC-based node lookup for flow enrichment. Resolves IP addresses and node
+ * IDs to {@link NodeInfo} via the OpenNMS {@code node} and {@code ipinterface}
+ * tables.
+ *
+ * <p>Backed by a Caffeine cache to avoid hitting the database on every flow.
+ * High-volume flow streams (10k+ flows/sec) routinely repeat the same
+ * exporter/src/dst IP addresses; without this cache the lookup would saturate
+ * the connection pool. Negative results are cached too — a flow whose src
+ * address belongs to no monitored node should not retry the lookup until the
+ * TTL expires.
+ *
+ * <p>Cached values are wrapped in {@link Optional} so the cache can store
+ * "looked up, came back empty" without needing a sentinel value.
+ */
+public class JdbcNodeInfoLookup {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcNodeInfoLookup.class);
+
+    private static final String SQL_BY_IP =
+            "SELECT n.nodeid, n.foreignsource, n.foreignid, n.location " +
+            "FROM node n JOIN ipinterface i ON n.nodeid = i.nodeid " +
+            "WHERE i.ipaddr = ? LIMIT 1";
+
+    private static final String SQL_BY_NODE_ID =
+            "SELECT nodeid, foreignsource, foreignid, location FROM node WHERE nodeid = ?";
+
+    private static final RowMapper<NodeInfo> ROW_MAPPER = (rs, rowNum) -> new NodeInfo(
+            rs.getInt("nodeid"),
+            rs.getString("foreignsource"),
+            rs.getString("foreignid"),
+            rs.getString("location"));
+
+    public record NodeInfo(int nodeId, String foreignSource, String foreignId, String location) {}
+
+    private final JdbcTemplate jdbc;
+    private final Cache<String, Optional<NodeInfo>> ipCache;
+    private final Cache<Integer, Optional<NodeInfo>> nodeIdCache;
+
+    public JdbcNodeInfoLookup(JdbcTemplate jdbc, Duration cacheTtl) {
+        this.jdbc = jdbc;
+        this.ipCache = Caffeine.newBuilder()
+                .expireAfterWrite(cacheTtl)
+                .maximumSize(50_000)
+                .build();
+        this.nodeIdCache = Caffeine.newBuilder()
+                .expireAfterWrite(cacheTtl)
+                .maximumSize(50_000)
+                .build();
+    }
+
+    public NodeInfo lookupByIpAddress(String ipAddress) {
+        if (ipAddress == null || ipAddress.isEmpty()) {
+            return null;
+        }
+        return ipCache.get(ipAddress, this::queryByIpAddress).orElse(null);
+    }
+
+    public NodeInfo lookupByNodeId(int nodeId) {
+        return nodeIdCache.get(nodeId, this::queryByNodeId).orElse(null);
+    }
+
+    private Optional<NodeInfo> queryByIpAddress(String ipAddress) {
+        try {
+            List<NodeInfo> results = jdbc.query(SQL_BY_IP, ROW_MAPPER, ipAddress);
+            return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
+        } catch (Exception e) {
+            LOG.debug("Node lookup failed for IP {}: {}", ipAddress, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<NodeInfo> queryByNodeId(int nodeId) {
+        try {
+            List<NodeInfo> results = jdbc.query(SQL_BY_NODE_ID, ROW_MAPPER, nodeId);
+            return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
+        } catch (Exception e) {
+            LOG.debug("Node lookup failed for nodeId {}: {}", nodeId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/core/flow-enricher/src/main/proto/deltav-flows.proto
+++ b/core/flow-enricher/src/main/proto/deltav-flows.proto
@@ -1,0 +1,127 @@
+// Copyright (C) 2026 BeaconStrategists, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// API version: 1
+//
+// Public contract for the deltav-flows Kafka topic.
+//
+// Community consumers: generate client code from this file.
+//
+// Versioning: additive changes (new fields with new tag numbers) are
+// backward-compatible. Renaming or removing existing fields, changing
+// tag numbers, or changing field types are breaking changes that
+// require a major version bump.
+//
+// Field tag numbers are intentionally aligned with the historical
+// org.opennms.netmgt.flows.persistence.model.FlowDocument numbering
+// to ease migration of existing consumers; tag 25 and tag 44 are
+// reserved (formerly src_node_identifier and convo_key respectively).
+
+syntax = "proto3";
+
+package org.deltav.flows;
+
+option java_package = "org.deltav.flows.proto";
+option java_outer_classname = "FlowDocumentProtos";
+
+import "google/protobuf/wrappers.proto";
+
+message NodeInfo {
+    uint32 node_id = 1;
+    string foreign_source = 2;
+    string foreign_id = 3;
+    repeated string categories = 4;
+}
+
+enum Direction {
+    DIRECTION_UNKNOWN = 0;
+    INGRESS = 1;
+    EGRESS = 2;
+}
+
+enum Locality {
+    LOCALITY_UNKNOWN = 0;
+    PRIVATE = 1;
+    PUBLIC = 2;
+}
+
+enum NetflowVersion {
+    NETFLOW_VERSION_UNKNOWN = 0;
+    V5 = 1;
+    V9 = 2;
+    IPFIX = 3;
+    SFLOW = 4;
+}
+
+enum SamplingAlgorithm {
+    SAMPLING_ALGORITHM_UNKNOWN = 0;
+    SYSTEMATIC_COUNT_BASED_SAMPLING = 1;
+    SYSTEMATIC_TIME_BASED_SAMPLING = 2;
+    RANDOM_N_OUT_OF_N_SAMPLING = 3;
+    UNIFORM_PROBABILISTIC_SAMPLING = 4;
+    PROPERTY_MATCH_FILTERING = 5;
+    HASH_BASED_FILTERING = 6;
+    FLOW_STATE_DEPENDENT_INTERMEDIATE_FLOW_SELECTION_PROCESS = 7;
+}
+
+message FlowDocument {
+    uint64 timestamp = 1;
+    google.protobuf.UInt64Value num_bytes = 2;
+    Direction direction = 3;
+    string dst_address = 4;
+    string dst_hostname = 5;
+    google.protobuf.UInt64Value dst_as = 6;
+    google.protobuf.UInt32Value dst_mask_len = 7;
+    google.protobuf.UInt32Value dst_port = 8;
+    google.protobuf.UInt32Value engine_id = 9;
+    google.protobuf.UInt32Value engine_type = 10;
+    google.protobuf.UInt64Value delta_switched = 11;
+    google.protobuf.UInt64Value first_switched = 12;
+    google.protobuf.UInt64Value last_switched = 13;
+    google.protobuf.UInt32Value num_flow_records = 14;
+    google.protobuf.UInt64Value num_packets = 15;
+    google.protobuf.UInt64Value flow_seq_num = 16;
+    google.protobuf.UInt32Value input_snmp_ifindex = 17;
+    google.protobuf.UInt32Value output_snmp_ifindex = 18;
+    google.protobuf.UInt32Value ip_protocol_version = 19;
+    string next_hop_address = 20;
+    string next_hop_hostname = 21;
+    google.protobuf.UInt32Value protocol = 22;
+    SamplingAlgorithm sampling_algorithm = 23;
+    google.protobuf.DoubleValue sampling_interval = 24;
+    // field 25 reserved (formerly src_node_identifier)
+    string src_address = 26;
+    string src_hostname = 27;
+    google.protobuf.UInt64Value src_as = 28;
+    google.protobuf.UInt32Value src_mask_len = 29;
+    google.protobuf.UInt32Value src_port = 30;
+    google.protobuf.UInt32Value tcp_flags = 31;
+    google.protobuf.UInt32Value tos = 32;
+    NetflowVersion netflow_version = 33;
+    string vlan = 34;
+    NodeInfo src_node = 35;
+    NodeInfo exporter_node = 36;
+    NodeInfo dest_node = 37;
+    string application = 38;
+    string host = 39;
+    string location = 40;
+    Locality src_locality = 41;
+    Locality dst_locality = 42;
+    Locality flow_locality = 43;
+    // field 44 reserved (formerly convo_key)
+    uint64 clock_correction = 45;
+    google.protobuf.UInt32Value dscp = 46;
+    google.protobuf.UInt32Value ecn = 47;
+}

--- a/core/flow-enricher/src/main/resources/application.yml
+++ b/core/flow-enricher/src/main/resources/application.yml
@@ -1,0 +1,55 @@
+spring:
+  application:
+    name: flow-enricher
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
+    username: ${SPRING_DATASOURCE_USERNAME:opennms}
+    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+  cloud:
+    function:
+      definition: enrichFlows
+    stream:
+      bindings:
+        # Multi-topic input: comma-separated destinations let one binding
+        # consume from all four flow Sink topics in parallel. Defaults to the
+        # legacy OpenNMS.Sink.* prefix until the DeltaV.Sink.* rename lands;
+        # operators can override the whole list via DELTAV_FLOWS_SINK_TOPICS.
+        enrichFlows-in-0:
+          destination: ${DELTAV_FLOWS_SINK_TOPICS:OpenNMS.Sink.Telemetry-Netflow-5,OpenNMS.Sink.Telemetry-Netflow-9,OpenNMS.Sink.Telemetry-IPFIX,OpenNMS.Sink.Telemetry-SFlow}
+          group: deltav-flow-enricher
+        enrichFlows-out-0:
+          destination: ${DELTAV_FLOWS_OUTPUT_TOPIC:deltav-flows}
+      kafka:
+        binder:
+          brokers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+          auto-create-topics: true
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always
+
+deltav:
+  flows:
+    interface-marking:
+      cache-ttl: ${DELTAV_FLOWS_INTERFACE_MARKING_CACHE_TTL:24h}
+      clean-interval-ms: ${DELTAV_FLOWS_INTERFACE_MARKING_CLEAN_INTERVAL_MS:3600000}
+    node-lookup:
+      cache-ttl: ${DELTAV_FLOWS_NODE_LOOKUP_CACHE_TTL:5m}
+
+logging:
+  level:
+    org.deltav: INFO
+    org.opennms: INFO
+    org.springframework.cloud.stream: INFO

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.model.SinkMessage;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
+class SinkMessageDeserializerTest {
+
+    private final SinkMessageDeserializer deserializer = new SinkMessageDeserializer();
+
+    @Test
+    void deserializesSingleChunkMessage() {
+        TelemetryProtos.TelemetryMessageLog messageLog = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("Default")
+                .setSystemId("minion-01")
+                .setSourceAddress("192.168.1.1")
+                .setSourcePort(4729)
+                .build();
+
+        SinkMessage sinkMessage = SinkMessage.newBuilder()
+                .setMessageId("test-1")
+                .setContent(ByteString.copyFrom(messageLog.toByteArray()))
+                .setCurrentChunkNumber(0)
+                .setTotalChunks(1)
+                .build();
+
+        TelemetryProtos.TelemetryMessageLog result = deserializer.deserialize(sinkMessage.toByteArray());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getLocation()).isEqualTo("Default");
+        assertThat(result.getSystemId()).isEqualTo("minion-01");
+        assertThat(result.getSourceAddress()).isEqualTo("192.168.1.1");
+        assertThat(result.getSourcePort()).isEqualTo(4729);
+    }
+
+    @Test
+    void chunkedMessageIsDroppedAndReturnsNull() {
+        TelemetryProtos.TelemetryMessageLog messageLog = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("Default")
+                .setSystemId("minion-01")
+                .setSourceAddress("192.168.1.1")
+                .setSourcePort(4729)
+                .build();
+
+        SinkMessage sinkMessage = SinkMessage.newBuilder()
+                .setMessageId("test-chunked")
+                .setContent(ByteString.copyFrom(messageLog.toByteArray()))
+                .setCurrentChunkNumber(0)
+                .setTotalChunks(3)
+                .build();
+
+        assertThat(deserializer.deserialize(sinkMessage.toByteArray())).isNull();
+    }
+
+    @Test
+    void garbageBytesReturnNull() {
+        assertThat(deserializer.deserialize(new byte[]{0x01, 0x02, 0x03, 0x04})).isNull();
+    }
+
+    @Test
+    void nullBytesReturnNull() {
+        assertThat(deserializer.deserialize(null)).isNull();
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/FlowLocalityCalculatorTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/FlowLocalityCalculatorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FlowLocalityCalculatorTest {
+
+    private final FlowLocalityCalculator calculator = new FlowLocalityCalculator();
+
+    @Test
+    void rfc1918AddressesArePrivate() {
+        assertThat(calculator.classify("10.0.0.1")).isEqualTo(FlowLocalityCalculator.Locality.PRIVATE);
+        assertThat(calculator.classify("172.16.5.1")).isEqualTo(FlowLocalityCalculator.Locality.PRIVATE);
+        assertThat(calculator.classify("172.31.255.254")).isEqualTo(FlowLocalityCalculator.Locality.PRIVATE);
+        assertThat(calculator.classify("192.168.1.1")).isEqualTo(FlowLocalityCalculator.Locality.PRIVATE);
+    }
+
+    @Test
+    void loopbackIsPrivate() {
+        assertThat(calculator.classify("127.0.0.1")).isEqualTo(FlowLocalityCalculator.Locality.PRIVATE);
+    }
+
+    @Test
+    void publicAddressesArePublic() {
+        assertThat(calculator.classify("8.8.8.8")).isEqualTo(FlowLocalityCalculator.Locality.PUBLIC);
+        assertThat(calculator.classify("1.1.1.1")).isEqualTo(FlowLocalityCalculator.Locality.PUBLIC);
+        // Just outside the 172.16.0.0/12 range — must be PUBLIC, not PRIVATE
+        assertThat(calculator.classify("172.32.0.1")).isEqualTo(FlowLocalityCalculator.Locality.PUBLIC);
+    }
+
+    @Test
+    void nullOrEmptyOrInvalidIsUnknown() {
+        assertThat(calculator.classify(null)).isEqualTo(FlowLocalityCalculator.Locality.UNKNOWN);
+        assertThat(calculator.classify("")).isEqualTo(FlowLocalityCalculator.Locality.UNKNOWN);
+        assertThat(calculator.classify("not-an-ip")).isEqualTo(FlowLocalityCalculator.Locality.UNKNOWN);
+    }
+
+    @Test
+    void flowLocalityIsPublicIfEitherEndpointIsPublic() {
+        assertThat(calculator.flowLocality("10.0.0.1", "8.8.8.8"))
+                .isEqualTo(FlowLocalityCalculator.Locality.PUBLIC);
+        assertThat(calculator.flowLocality("8.8.8.8", "10.0.0.1"))
+                .isEqualTo(FlowLocalityCalculator.Locality.PUBLIC);
+    }
+
+    @Test
+    void flowLocalityIsPrivateWhenBothEndpointsArePrivate() {
+        assertThat(calculator.flowLocality("10.0.0.1", "192.168.1.1"))
+                .isEqualTo(FlowLocalityCalculator.Locality.PRIVATE);
+    }
+
+    @Test
+    void flowLocalityIsUnknownIfEitherEndpointIsUnknown() {
+        assertThat(calculator.flowLocality(null, "10.0.0.1"))
+                .isEqualTo(FlowLocalityCalculator.Locality.UNKNOWN);
+        assertThat(calculator.flowLocality("10.0.0.1", "garbage"))
+                .isEqualTo(FlowLocalityCalculator.Locality.UNKNOWN);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/InterfaceMarkingCacheTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/InterfaceMarkingCacheTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class InterfaceMarkingCacheTest {
+
+    private static final String EXPECTED_SQL =
+            "UPDATE snmpinterface SET hasflows = true WHERE nodeid = ? AND snmpifindex = ?";
+
+    @Test
+    void firstMarkingExecutesDbUpdate() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        InterfaceMarkingCache cache = new InterfaceMarkingCache(jdbc, Duration.ofHours(24));
+
+        cache.markIfNeeded(5L, 12);
+
+        verify(jdbc).update(eq(EXPECTED_SQL), eq(5L), eq(12));
+    }
+
+    @Test
+    void secondMarkingWithinTtlSkipsDbUpdate() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        InterfaceMarkingCache cache = new InterfaceMarkingCache(jdbc, Duration.ofHours(24));
+
+        cache.markIfNeeded(5L, 12);
+        cache.markIfNeeded(5L, 12);
+
+        verify(jdbc, times(1)).update(anyString(), anyLong(), anyInt());
+    }
+
+    @Test
+    void differentInterfacesAreTrackedSeparately() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        InterfaceMarkingCache cache = new InterfaceMarkingCache(jdbc, Duration.ofHours(24));
+
+        cache.markIfNeeded(5L, 12);
+        cache.markIfNeeded(5L, 13);
+
+        verify(jdbc, times(2)).update(anyString(), anyLong(), anyInt());
+    }
+
+    @Test
+    void differentNodesAreTrackedSeparately() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        InterfaceMarkingCache cache = new InterfaceMarkingCache(jdbc, Duration.ofHours(24));
+
+        cache.markIfNeeded(5L, 12);
+        cache.markIfNeeded(6L, 12);
+
+        verify(jdbc, times(2)).update(anyString(), anyLong(), anyInt());
+    }
+
+    @Test
+    void evictNodeClearsAllInterfacesForThatNode() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        InterfaceMarkingCache cache = new InterfaceMarkingCache(jdbc, Duration.ofHours(24));
+
+        cache.markIfNeeded(5L, 12);
+        cache.markIfNeeded(5L, 13);
+        cache.evictNode(5L);
+        cache.markIfNeeded(5L, 12);
+
+        // 3 calls total: initial 12, initial 13, re-mark 12 after eviction
+        verify(jdbc, times(3)).update(anyString(), anyLong(), anyInt());
+    }
+
+    @Test
+    void evictNodeDoesNotAffectOtherNodes() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        InterfaceMarkingCache cache = new InterfaceMarkingCache(jdbc, Duration.ofHours(24));
+
+        cache.markIfNeeded(5L, 12);
+        cache.markIfNeeded(6L, 12);
+        cache.evictNode(5L);
+        cache.markIfNeeded(6L, 12); // still cached, no DB call
+
+        verify(jdbc, times(2)).update(anyString(), anyLong(), anyInt());
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookupTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookupTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class JdbcNodeInfoLookupTest {
+
+    private static final JdbcNodeInfoLookup.NodeInfo SAMPLE =
+            new JdbcNodeInfoLookup.NodeInfo(5, "delta-v", "router-1", "Default");
+
+    @Test
+    void lookupByIpAddressReturnsNodeInfo() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.query(contains("ipaddr"), any(RowMapper.class), eq("192.168.1.1")))
+                .thenReturn(List.of(SAMPLE));
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+
+        JdbcNodeInfoLookup.NodeInfo result = lookup.lookupByIpAddress("192.168.1.1");
+
+        assertThat(result).isNotNull();
+        assertThat(result.nodeId()).isEqualTo(5);
+        assertThat(result.foreignSource()).isEqualTo("delta-v");
+        assertThat(result.foreignId()).isEqualTo("router-1");
+        assertThat(result.location()).isEqualTo("Default");
+    }
+
+    @Test
+    void lookupByIpAddressReturnsNullWhenNotFound() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.query(anyString(), any(RowMapper.class), anyString())).thenReturn(List.of());
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+
+        assertThat(lookup.lookupByIpAddress("1.2.3.4")).isNull();
+    }
+
+    @Test
+    void lookupByIpAddressReturnsNullWhenJdbcThrows() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.query(anyString(), any(RowMapper.class), anyString()))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+
+        assertThat(lookup.lookupByIpAddress("1.2.3.4")).isNull();
+    }
+
+    @Test
+    void lookupByIpAddressIsCached() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.query(contains("ipaddr"), any(RowMapper.class), eq("192.168.1.1")))
+                .thenReturn(List.of(SAMPLE));
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+
+        lookup.lookupByIpAddress("192.168.1.1");
+        lookup.lookupByIpAddress("192.168.1.1");
+        lookup.lookupByIpAddress("192.168.1.1");
+
+        verify(jdbc, times(1)).query(anyString(), any(RowMapper.class), anyString());
+    }
+
+    @Test
+    void lookupByIpAddressNegativeResultIsAlsoCached() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.query(anyString(), any(RowMapper.class), anyString())).thenReturn(List.of());
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+
+        assertThat(lookup.lookupByIpAddress("1.2.3.4")).isNull();
+        assertThat(lookup.lookupByIpAddress("1.2.3.4")).isNull();
+
+        // Cache should suppress the second DB call even though the first returned null.
+        verify(jdbc, times(1)).query(anyString(), any(RowMapper.class), anyString());
+    }
+
+    @Test
+    void lookupByNodeIdReturnsNodeInfo() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.query(contains("nodeid"), any(RowMapper.class), eq(5))).thenReturn(List.of(SAMPLE));
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+
+        assertThat(lookup.lookupByNodeId(5)).isEqualTo(SAMPLE);
+    }
+
+    @Test
+    void lookupByNodeIdIsCached() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.query(contains("nodeid"), any(RowMapper.class), anyInt())).thenReturn(List.of(SAMPLE));
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+
+        lookup.lookupByNodeId(5);
+        lookup.lookupByNodeId(5);
+        lookup.lookupByNodeId(5);
+
+        verify(jdbc, times(1)).query(anyString(), any(RowMapper.class), any(Object[].class));
+    }
+}

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -79,6 +79,14 @@ do_db_init_image() {
     docker build -t "opennms/db-init:$VERSION" -t "opennms/db-init:latest" .
 }
 
+do_flow_enricher_image() {
+    log "Building flow-enricher image (opennms/flow-enricher:$VERSION)..."
+    cd "$REPO_ROOT"
+    ./mvnw -B -f core/flow-enricher/pom.xml -DskipTests package
+    cd "$REPO_ROOT/core/flow-enricher"
+    docker build -t "opennms/flow-enricher:$VERSION" -t "opennms/flow-enricher:latest" .
+}
+
 do_jre_image() {
     log "Building opennms/jre-deltav:21..."
     cd "$SCRIPT_DIR"
@@ -153,8 +161,16 @@ do_deltav_images() {
     # Clean up staging
     rm -rf "$SCRIPT_DIR/staging"
 
+    # --- Build flow-enricher (standalone Spring Cloud Stream service) ---
+    # flow-enricher does not share daemon-base because its dependency
+    # profile is fundamentally different from the 12 horizon-derived
+    # daemons (Spring Cloud Stream + Kafka binder + Caffeine + protobuf,
+    # vs. legacy Spring 4.2 / Hibernate / Karaf-era libs). Build it as a
+    # standalone image, like db-init.
+    do_flow_enricher_image
+
     log "Delta-V images built:"
-    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot" | sort | head -20
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher" | sort | head -20
 }
 
 

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -502,6 +502,32 @@ services:
       retries: 12
       start_period: 20s
 
+  flow-enricher:
+    profiles: [full]
+    image: ${IMAGE_PREFIX:-opennms}/flow-enricher:${VERSION}
+    container_name: delta-v-flow-enricher
+    hostname: flow-enricher
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+    environment:
+      JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m"
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
+      SPRING_DATASOURCE_USERNAME: opennms
+      SPRING_DATASOURCE_PASSWORD: opennms
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      # Sink topic prefix is OpenNMS.* until the DeltaV.* rename PR lands.
+      DELTAV_FLOWS_SINK_TOPICS: "OpenNMS.Sink.Telemetry-Netflow-5,OpenNMS.Sink.Telemetry-Netflow-9,OpenNMS.Sink.Telemetry-IPFIX,OpenNMS.Sink.Telemetry-SFlow"
+      DELTAV_FLOWS_OUTPUT_TOPIC: deltav-flows
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
 volumes:
   pgdata:
   kafkadata:

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,9 @@
 
     <!-- Standalone tools -->
     <module>core/db-init</module>
+
+    <!-- Flow processing services (Spring Cloud Stream) -->
+    <module>core/flow-enricher</module>
   </modules>
 
   <!-- ============================================================ -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,9 @@
     <!-- Horizon JAR version (published by pbrane/delta-v-horizon) -->
     <deltav.horizon.version>1.0.7</deltav.horizon.version>
 
+    <!-- Spring Cloud release train (for flow-enricher / flow-aggregator) -->
+    <spring-cloud.version>2025.1.1</spring-cloud.version>
+
     <!-- Plugin versions not inherited from spring-boot-starter-parent -->
     <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
   </properties>
@@ -101,7 +104,9 @@
   <!-- BOM import precedence: first declared wins.
        spring-boot-dependencies must come BEFORE the horizon BOM so that
        modern Jackson, SLF4J, logback, etc. are not downgraded by the
-       horizon POM's older managed versions. -->
+       horizon POM's older managed versions. Spring Cloud BOM sits between
+       so that it cannot override Boot's managed versions but still wins
+       over horizon for Spring Framework / Reactor / Micrometer. -->
   <dependencyManagement>
     <dependencies>
       <!-- Spring Boot BOM — must be first to ensure modern dep versions win -->
@@ -109,6 +114,15 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>4.0.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Spring Cloud BOM — for flow-enricher / flow-aggregator (Spring Cloud Stream) -->
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring-cloud.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Summary

Phase 1 of the Nephron (Apache Beam/Flink) replacement: a new
**flow-enricher** Spring Cloud Stream service that consumes raw flow
telemetry from the four Kafka Sink topics, runs a skeleton enrichment
pipeline, and publishes enriched FlowDocument protobuf messages to
the new public **`deltav-flows`** topic.

This PR delivers the **plumbing** end-to-end so the harder work
(horizon protocol adapter integration, classification engine wiring,
clock-skew correction) can land in focused follow-up PRs against a
proven foundation. The deployed service produces near-empty
FlowDocuments by design — the value of this PR is proving the
Spring Cloud Stream + Spring Boot 4.0.3 + Kafka binder stack works
end-to-end against the live delta-v Compose stack.

### What landed
- **Spring Cloud 2025.1.1 BOM** added between Spring Boot 4.0.3 and the
  horizon BOM (first-declared-wins precedence preserved)
- **`core/flow-enricher/`** new Maven module — `org.deltav.flows.flow-enricher`
- **`deltav-flows.proto`** — public protobuf contract for the new topic,
  with field tag numbers intentionally aligned with horizon
  FlowDocument so future migration is non-breaking
- **`FlowLocalityCalculator`** — RFC1918/loopback/172.16-12 classifier (TDD)
- **`InterfaceMarkingCache`** — TTL-deduplicated `snmpinterface.hasflows` writer (TDD)
- **`SinkMessageDeserializer`** — two-layer protobuf unwrap (`SinkMessage` → `TelemetryMessageLog`) (TDD)
- **`JdbcNodeInfoLookup`** — JDBC node lookup with **Caffeine cache**
  (5 min TTL, positive + negative caching) (TDD)
- **`FlowEnrichmentFunction`** — skeleton pipeline emitting timestamp +
  host + location + exporter_node only (per-flow Netflow/IPFIX/sFlow
  parsing deferred to follow-up adapter PR)
- **`FlowEnricherApplication` + `FlowEnricherConfiguration`** —
  Spring Boot 4.0.3 entry point with constructor-injected beans
- **`application.yml`** — multi-topic comma-separated input binding:
  ```
  ${DELTAV_FLOWS_SINK_TOPICS:OpenNMS.Sink.Telemetry-Netflow-5,OpenNMS.Sink.Telemetry-Netflow-9,OpenNMS.Sink.Telemetry-IPFIX,OpenNMS.Sink.Telemetry-SFlow}
  ```
  Default uses the legacy `OpenNMS.Sink.*` prefix until the
  `DeltaV.Sink.*` rename PR lands; operators can override the entire
  list via the `DELTAV_FLOWS_SINK_TOPICS` environment variable.
- **Standalone Dockerfile** (eclipse-temurin:21-jre-alpine + curl for
  the actuator healthcheck) following the db-init pattern — does NOT
  share `daemon-base` because the Spring Cloud Stream / Kafka binder /
  Caffeine / protobuf dep profile is fundamentally different from
  the 12 horizon-derived daemons that compute their shared layer via
  strict-intersection deduplication
- **`docker-compose.yml`** — flow-enricher service in the `[full]`
  profile, depends on `db-init` (postgres + schema) and `kafka` (healthy)
- **`build.sh`** — `do_flow_enricher_image()` invoked from
  `do_deltav_images()` so `./build.sh deltav` builds it alongside
  the existing daemons

### Tests

24 unit tests, all green:

| Suite | Tests |
|---|---|
| `FlowLocalityCalculatorTest` | 7 |
| `InterfaceMarkingCacheTest` | 6 |
| `SinkMessageDeserializerTest` | 4 |
| `JdbcNodeInfoLookupTest` | 7 |

All written test-first. The `JdbcNodeInfoLookupTest` covers positive,
negative, exception → null, IP cache hit, **negative IP cache hit**,
nodeId lookup, and nodeId cache.

### End-to-end verification (against the live delta-v Compose stack)

Brought `flow-enricher` up against the running 17-service stack:

- Container reaches `(healthy)` in ~30 s (Spring Boot start ~3 s)
- All four `OpenNMS.Sink.Telemetry-*` partitions assigned to consumer
  group `deltav-flow-enricher`
- `deltav-flows` topic auto-created on producer registration
- Actuator `/actuator/health` returns `UP`:
  ```json
  {
    "binders": {"kafka": {"status": "UP",
      "topicsInUse": ["OpenNMS.Sink.Telemetry-IPFIX",
                      "OpenNMS.Sink.Telemetry-SFlow",
                      "OpenNMS.Sink.Telemetry-Netflow-9",
                      "OpenNMS.Sink.Telemetry-Netflow-5",
                      "deltav-flows"]}},
    "db": {"status": "UP", "details": {"database": "PostgreSQL"}}
  }
  ```

### Notable gotchas this PR uncovered

- **`junit-platform-launcher` is no longer transitive in Boot 4.0** —
  every new Boot 4.0 module in this repo will need it added
  explicitly until the parent POM manages it (see commit 5e4ec90503c).
  Symptom: `OutputDirectoryCreator not available; probably due to
  unaligned versions of the junit-platform-engine and junit-platform-launcher`.
- **`protobuf-java-util` is not BOM-managed** by either Boot or horizon
  — pinned inline to match `protoc.version` (3.25.5)
- **`TelemetryProtos` package is `org.opennms.netmgt.telemetry.common.ipc`**,
  not the older `org.opennms.netmgt.telemetry.ipc` path used in some
  historical docs
- **Spring Cloud 2025.1.1 targets Spring Boot 4.0.2** but resolves
  cleanly against our 4.0.3 (binary-stable patch series, BOM order
  guarantees Boot 4.0.3 wins for any conflicting Boot artifacts)

### Out of scope (deliberate, follow-up PRs)

1. **Horizon protocol adapter integration** — wire `Netflow5Adapter`,
   `Netflow9Adapter`, `IpfixAdapter`, `SFlowAdapter` so per-flow records
   actually populate src/dst/ports/bytes/etc. The skeleton currently
   emits only timestamp + host + exporter_node.
2. **Classification engine** — load classification rules from
   PostgreSQL and apply application classification to enriched flows
3. **Clock-skew correction** — adjust timestamps based on
   received-vs-reported delta
4. **`nodeDeleted` event listener** — invalidate `InterfaceMarkingCache`
   and `JdbcNodeInfoLookup` cache entries when a node is removed
5. **flow-aggregator (Phase 2)** — Kafka Streams windowed aggregation
   of `deltav-flows` → Elasticsearch
6. **`OpenNMS.Sink.* → DeltaV.Sink.*` rename** — separate PR
   (configurable via `DELTAV_FLOWS_SINK_TOPICS` until then)

## Test plan

- [x] `./mvnw -B -pl :org.deltav.flows.flow-enricher test` → 24/24 green
- [x] `./mvnw -B -pl :org.deltav.flows.flow-enricher package` → fat JAR builds, manifest correct
- [x] `docker build` produces `opennms/flow-enricher:0.0.1-SNAPSHOT` (499MB)
- [x] Smoke test: container boots Spring Boot in ~3 s with no Kafka/DB
- [x] Live integration: `docker compose --profile full up -d flow-enricher`
      against the running delta-v stack reaches `(healthy)`, joins
      consumer group, assigns all 4 input partitions, auto-creates
      `deltav-flows` output topic
- [ ] Reviewer: confirm the multi-topic `DELTAV_FLOWS_SINK_TOPICS`
      override works for the eventual `DeltaV.Sink.*` rename without
      modifying the module