### PR TITLE
feat(flow-enricher): Phase 1.5 horizon adapter integration

### DIFF
--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -165,8 +165,20 @@
             <groupId>org.opennms.features.flows</groupId>
             <artifactId>org.opennms.features.flows.api</artifactId>
             <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-security-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.features.jest</groupId><artifactId>jest-complete-osgi</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -118,6 +118,85 @@
             </exclusions>
         </dependency>
 
+        <!-- Horizon: Netflow protocol adapters (Netflow-5, Netflow-9, IPFIX in one JAR) -->
+        <dependency>
+            <groupId>org.opennms.features.telemetry.protocols.netflow</groupId>
+            <artifactId>org.opennms.features.telemetry.protocols.netflow.adapter</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-security-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Horizon: sFlow protocol adapter -->
+        <dependency>
+            <groupId>org.opennms.features.telemetry.protocols.sflow</groupId>
+            <artifactId>org.opennms.features.telemetry.protocols.sflow.adapter</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-security-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Horizon: Flow API (Flow interface, FlowSource, etc.) -->
+        <dependency>
+            <groupId>org.opennms.features.flows</groupId>
+            <artifactId>org.opennms.features.flows.api</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Horizon: Flow processing (Pipeline interface; PipelineImpl is bundled but unused) -->
+        <dependency>
+            <groupId>org.opennms.features.flows</groupId>
+            <artifactId>org.opennms.features.flows.processing</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-security-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+                <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Dropwizard Metrics (required by horizon adapter constructors) -->
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -251,6 +251,25 @@
                 <!-- repackage execution is inherited from spring-boot-starter-parent -->
             </plugin>
             <plugin>
+                <!--
+                    Include Spring Boot stream-binder integration tests (suffix *IT)
+                    in the surefire 'test' phase so they run alongside the unit tests
+                    without requiring a separate failsafe/verify phase. The flow-enricher
+                    integration tests use the in-memory TestChannelBinder, so they have
+                    no external dependencies and behave like unit tests from a CI
+                    perspective.
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher;
+
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
+/**
+ * Result of deserializing a Kafka Sink topic record. Carries both the Sink
+ * module identifier (used for protocol dispatch in
+ * {@link FlowEnrichmentFunction}) and the decoded
+ * {@link TelemetryProtos.TelemetryMessageLog} payload (passed to the protocol
+ * adapter).
+ *
+ * <p><strong>Note on moduleId source:</strong> the {@code SinkMessage}
+ * protobuf envelope on the Kafka wire (class
+ * {@code org.opennms.core.ipc.sink.model.SinkMessage}) does <em>not</em>
+ * carry a {@code moduleId} field &mdash; its fields are {@code messageId},
+ * {@code content}, {@code currentChunkNumber}, {@code totalChunks}, and
+ * {@code tracingInfo}. The Sink IPC framework derives the module identifier
+ * from the Kafka topic name ({@code OpenNMS.Sink.{moduleId}}; see
+ * {@code KafkaSinkBridge} in {@code core/daemon-sink-kafka}).
+ *
+ * <p>The single-argument {@link SinkMessageDeserializer#deserialize(byte[])}
+ * overload therefore populates {@code moduleId} as {@code null}. Callers that
+ * know the topic name (e.g. the Spring Cloud Stream binding layer) should
+ * use the two-argument
+ * {@link SinkMessageDeserializer#deserialize(String, byte[])} overload to
+ * supply the moduleId explicitly. Wiring topic headers through the Spring
+ * Cloud Stream function signature happens in a later commit of the Phase 1.5
+ * effort.
+ *
+ * @param moduleId the Sink module identifier (e.g. {@code "Telemetry-Netflow-5"}),
+ *                 or {@code null} when the deserializer cannot determine it
+ *                 from the payload alone
+ * @param messageLog the decoded telemetry payload
+ */
+public record DeserializedSinkMessage(String moduleId, TelemetryProtos.TelemetryMessageLog messageLog) {
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java
@@ -46,7 +46,17 @@ import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
  * @param moduleId the Sink module identifier (e.g. {@code "Telemetry-Netflow-5"}),
  *                 or {@code null} when the deserializer cannot determine it
  *                 from the payload alone
- * @param messageLog the decoded telemetry payload
+ * @param messageLog the decoded telemetry payload; must not be {@code null}
  */
 public record DeserializedSinkMessage(String moduleId, TelemetryProtos.TelemetryMessageLog messageLog) {
+
+    /**
+     * Compact constructor enforcing a non-null {@code messageLog}. The
+     * deserializer returns {@code null} in place of this record when the
+     * payload is unparseable, so callers can rely on any non-null
+     * {@code DeserializedSinkMessage} carrying a usable message log.
+     */
+    public DeserializedSinkMessage {
+        java.util.Objects.requireNonNull(messageLog, "messageLog");
+    }
 }

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -23,13 +23,25 @@ import java.util.function.Function;
 
 import javax.sql.DataSource;
 
+import com.codahale.metrics.MetricRegistry;
+
+import org.deltav.flows.enricher.classification.ApplicationClassifier;
+import org.deltav.flows.enricher.classification.PortBasedApplicationClassifier;
 import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.enricher.mapping.FlowToDocumentMapper;
+import org.deltav.flows.enricher.protocol.IpfixMessageProcessor;
+import org.deltav.flows.enricher.protocol.Netflow5MessageProcessor;
+import org.deltav.flows.enricher.protocol.Netflow9MessageProcessor;
+import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
+import org.deltav.flows.enricher.protocol.SFlowMessageProcessor;
+import org.deltav.flows.enricher.protocol.SimpleAdapterDefinition;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.messaging.Message;
 import org.springframework.scheduling.annotation.Scheduled;
 
 /**
@@ -70,18 +82,78 @@ public class FlowEnricherConfiguration {
     }
 
     @Bean
+    ApplicationClassifier applicationClassifier() {
+        return new PortBasedApplicationClassifier();
+    }
+
+    @Bean
+    FlowToDocumentMapper flowToDocumentMapper() {
+        return new FlowToDocumentMapper();
+    }
+
+    /**
+     * A process-local Dropwizard {@link MetricRegistry} shared across the
+     * four horizon flow adapters. Phase 1.5 does not publish these metrics
+     * anywhere; the registry exists solely because horizon's
+     * {@code AbstractFlowAdapter} constructor requires one for timer/meter
+     * registration. A later phase can wire this to an actuator endpoint.
+     */
+    @Bean
+    MetricRegistry flowEnricherMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    Netflow5MessageProcessor netflow5Processor(MetricRegistry flowEnricherMetricRegistry) {
+        return new Netflow5MessageProcessor(
+                new SimpleAdapterDefinition("Netflow-5"), flowEnricherMetricRegistry);
+    }
+
+    @Bean
+    Netflow9MessageProcessor netflow9Processor(MetricRegistry flowEnricherMetricRegistry) {
+        return new Netflow9MessageProcessor(
+                new SimpleAdapterDefinition("Netflow-9"), flowEnricherMetricRegistry);
+    }
+
+    @Bean
+    IpfixMessageProcessor ipfixProcessor(MetricRegistry flowEnricherMetricRegistry) {
+        return new IpfixMessageProcessor(
+                new SimpleAdapterDefinition("IPFIX"), flowEnricherMetricRegistry);
+    }
+
+    @Bean
+    SFlowMessageProcessor sflowProcessor(MetricRegistry flowEnricherMetricRegistry) {
+        return new SFlowMessageProcessor(
+                new SimpleAdapterDefinition("SFlow"), flowEnricherMetricRegistry);
+    }
+
+    @Bean
     FlowEnrichmentFunction flowEnrichmentFunction(
             SinkMessageDeserializer deserializer,
             JdbcNodeInfoLookup nodeInfoLookup,
             FlowLocalityCalculator localityCalculator,
-            InterfaceMarkingCache interfaceMarkingCache) {
-        // The dispatch map is empty in Commit 3 (splitter refactor). Commit 5
-        // (Task 12) replaces Map.of() with the real ProtocolMessageProcessor
-        // beans keyed by moduleId (Telemetry-Netflow-5, Telemetry-Netflow-9,
-        // Telemetry-IPFIX, Telemetry-SFlow).
+            InterfaceMarkingCache interfaceMarkingCache,
+            ApplicationClassifier applicationClassifier,
+            FlowToDocumentMapper flowToDocumentMapper,
+            Netflow5MessageProcessor netflow5Processor,
+            Netflow9MessageProcessor netflow9Processor,
+            IpfixMessageProcessor ipfixProcessor,
+            SFlowMessageProcessor sflowProcessor) {
+
+        Map<String, ProtocolMessageProcessor> dispatchMap = Map.of(
+                "Telemetry-Netflow-5", netflow5Processor,
+                "Telemetry-Netflow-9", netflow9Processor,
+                "Telemetry-IPFIX",     ipfixProcessor,
+                "Telemetry-SFlow",     sflowProcessor);
+
         return new FlowEnrichmentFunction(
-                deserializer, nodeInfoLookup, localityCalculator, interfaceMarkingCache,
-                Map.of());
+                deserializer,
+                nodeInfoLookup,
+                localityCalculator,
+                interfaceMarkingCache,
+                applicationClassifier,
+                flowToDocumentMapper,
+                dispatchMap);
     }
 
     /**
@@ -90,12 +162,15 @@ public class FlowEnricherConfiguration {
      * application.yml; the suffixes {@code -in-0} / {@code -out-0} are
      * generated automatically by Spring Cloud Function.
      *
-     * <p>The splitter signature {@code Function<byte[], List<byte[]>>} emits
-     * zero or more output records per input record; an empty list discards
-     * the message entirely.
+     * <p>The splitter signature {@code Function<Message<byte[]>, List<byte[]>>}
+     * emits zero or more output records per input record; an empty list
+     * discards the message entirely. The {@code Message<byte[]>} envelope
+     * carries the Kafka {@code kafka_receivedTopic} header, which
+     * {@link FlowEnrichmentFunction} uses to extract the module ID for
+     * protocol dispatch.
      */
     @Bean
-    Function<byte[], List<byte[]>> enrichFlows(FlowEnrichmentFunction enrichmentFunction) {
+    Function<Message<byte[]>, List<byte[]>> enrichFlows(FlowEnrichmentFunction enrichmentFunction) {
         return enrichmentFunction::processMessage;
     }
 

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -17,6 +17,8 @@
 package org.deltav.flows.enricher;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import javax.sql.DataSource;
@@ -73,8 +75,13 @@ public class FlowEnricherConfiguration {
             JdbcNodeInfoLookup nodeInfoLookup,
             FlowLocalityCalculator localityCalculator,
             InterfaceMarkingCache interfaceMarkingCache) {
+        // The dispatch map is empty in Commit 3 (splitter refactor). Commit 5
+        // (Task 12) replaces Map.of() with the real ProtocolMessageProcessor
+        // beans keyed by moduleId (Telemetry-Netflow-5, Telemetry-Netflow-9,
+        // Telemetry-IPFIX, Telemetry-SFlow).
         return new FlowEnrichmentFunction(
-                deserializer, nodeInfoLookup, localityCalculator, interfaceMarkingCache);
+                deserializer, nodeInfoLookup, localityCalculator, interfaceMarkingCache,
+                Map.of());
     }
 
     /**
@@ -83,11 +90,12 @@ public class FlowEnricherConfiguration {
      * application.yml; the suffixes {@code -in-0} / {@code -out-0} are
      * generated automatically by Spring Cloud Function.
      *
-     * <p>Returning {@code null} from the inner function discards the message
-     * (it does not become an output record).
+     * <p>The splitter signature {@code Function<byte[], List<byte[]>>} emits
+     * zero or more output records per input record; an empty list discards
+     * the message entirely.
      */
     @Bean
-    Function<byte[], byte[]> enrichFlows(FlowEnrichmentFunction enrichmentFunction) {
+    Function<byte[], List<byte[]>> enrichFlows(FlowEnrichmentFunction enrichmentFunction) {
         return enrichmentFunction::processMessage;
     }
 

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
@@ -16,53 +16,100 @@
  */
 package org.deltav.flows.enricher;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.deltav.flows.enricher.classification.ApplicationClassifier;
 import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
+import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator.Locality;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.enricher.mapping.FlowToDocumentMapper;
 import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos.TelemetryMessageLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
 
 /**
- * Phase 1.5 (Commit 3) flow enrichment pipeline. Dispatches incoming Sink
- * messages to protocol-specific processors by {@code moduleId}, then emits
- * a list of enriched FlowDocument byte arrays.
+ * Phase 1.5 (Commit 5) flow enrichment pipeline. Consumes a Spring Cloud
+ * Stream {@code Message<byte[]>} carrying the raw Kafka Sink payload plus the
+ * Kafka {@code kafka_receivedTopic} header, dispatches to a protocol-specific
+ * {@link ProtocolMessageProcessor} by module ID, enriches each parsed
+ * {@link Flow}, maps it to a {@link FlowDocumentProtos.FlowDocument}, and
+ * returns the list of serialized document byte arrays ready to publish on
+ * the outbound {@code deltav-flows} topic.
  *
- * <p><strong>Commit 3 scope:</strong> this commit establishes the new
- * {@code Function<byte[], List<byte[]>>} splitter signature with a placeholder
- * dispatch. The dispatch map is empty in Commit 3 because the
- * {@link ProtocolMessageProcessor} implementations are created in
- * Commit 4 (Task 8). Commit 5 (Task 12) wires the full per-flow enrichment
- * pipeline. Every code path therefore returns an empty list for now, which
- * Spring Cloud Stream interprets as "drop this input message without
- * producing any output records".
+ * <h2>Why {@code Function<Message<byte[]>, List<byte[]>>}?</h2>
  *
- * <p><strong>Known gap &mdash; moduleId dispatch:</strong> the Sink protobuf
- * envelope does not carry a {@code moduleId} field (see
- * {@link DeserializedSinkMessage}), so the single-argument
- * {@link SinkMessageDeserializer#deserialize(byte[])} path always reports
- * {@code moduleId == null}. A later commit will change the Spring Cloud
- * Stream function signature to accept {@code Message<byte[]>} so the topic
- * name can be read from headers and passed to
- * {@link SinkMessageDeserializer#deserialize(String, byte[])}. Until that
- * happens the dispatch lookup will always miss; this is fine for Commit 3
- * because the dispatch map is empty anyway.
+ * <p>The splitter-style return type ({@code List<byte[]>}) lets one input
+ * message produce zero, one, or many output records; Spring Cloud Stream
+ * interprets an empty list as "drop this input without producing any output."
+ * The {@link Message}-typed input lets us read the Kafka topic name from the
+ * {@link KafkaHeaders#RECEIVED_TOPIC} header. The Sink protobuf envelope does
+ * <em>not</em> carry a module ID field, so the topic name is the only place
+ * to recover it.
+ *
+ * <h2>Module ID extraction</h2>
+ *
+ * <p>The Kafka topic follows one of two naming schemes:
+ * <ul>
+ *   <li>{@code OpenNMS.Sink.<moduleId>} &mdash; when the Minion was configured
+ *       against an upstream horizon-style broker</li>
+ *   <li>{@code DeltaV.Sink.<moduleId>} &mdash; the delta-v-native prefix</li>
+ * </ul>
+ * The prefix is stripped to yield a module ID such as
+ * {@code Telemetry-Netflow-5}, which is used as the dispatch key into the
+ * processor map. Any other prefix (including a missing header) causes the
+ * function to drop the message.
+ *
+ * <h2>Per-flow enrichment</h2>
+ *
+ * <p>For each parsed flow, the pipeline:
+ * <ol>
+ *   <li>Looks up the exporter node info once from
+ *       {@code messageLog.getSourceAddress()} (reused across all flows in
+ *       this message log).</li>
+ *   <li>Looks up src and dst node info from {@code flow.getSrcAddr()} and
+ *       {@code flow.getDstAddr()}.</li>
+ *   <li>Computes src, dst, and aggregate flow locality via
+ *       {@link FlowLocalityCalculator}.</li>
+ *   <li>Marks the exporter's input and output SNMP interfaces (only when
+ *       the exporter node is known and the ifindex is set and positive).</li>
+ *   <li>Classifies the flow's application from its
+ *       dst-port/src-port/protocol via {@link ApplicationClassifier}.</li>
+ *   <li>Maps the enriched flow to a
+ *       {@link FlowDocumentProtos.FlowDocument} via
+ *       {@link FlowToDocumentMapper}.</li>
+ *   <li>Serializes the document to bytes and appends it to the result list.</li>
+ * </ol>
+ *
+ * <p>If enriching or mapping one flow throws an unchecked exception, that
+ * flow is skipped with a {@code WARN} log and the remaining flows in the
+ * message log continue to be processed. A single malformed flow must not
+ * poison the entire batch.
+ *
+ * <p>Phase 1.5 always passes {@code 0L} as the clock-correction argument to
+ * the mapper; Phase 1.6 will compute actual exporter clock skew.
  */
 public class FlowEnrichmentFunction {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlowEnrichmentFunction.class);
 
+    private static final String OPENNMS_SINK_PREFIX = "OpenNMS.Sink.";
+    private static final String DELTAV_SINK_PREFIX = "DeltaV.Sink.";
+
     private final SinkMessageDeserializer deserializer;
-    @SuppressWarnings("unused") // wired now; consumed in Commit 5 (full enrichment pipeline)
     private final JdbcNodeInfoLookup nodeInfoLookup;
-    @SuppressWarnings("unused") // wired now; consumed in Commit 5
     private final FlowLocalityCalculator localityCalculator;
-    @SuppressWarnings("unused") // wired now; consumed in Commit 5
     private final InterfaceMarkingCache interfaceMarkingCache;
+    private final ApplicationClassifier applicationClassifier;
+    private final FlowToDocumentMapper flowToDocumentMapper;
     private final Map<String, ProtocolMessageProcessor> processorsByModuleId;
 
     public FlowEnrichmentFunction(
@@ -70,54 +117,167 @@ public class FlowEnrichmentFunction {
             JdbcNodeInfoLookup nodeInfoLookup,
             FlowLocalityCalculator localityCalculator,
             InterfaceMarkingCache interfaceMarkingCache,
+            ApplicationClassifier applicationClassifier,
+            FlowToDocumentMapper flowToDocumentMapper,
             Map<String, ProtocolMessageProcessor> processorsByModuleId) {
         this.deserializer = deserializer;
         this.nodeInfoLookup = nodeInfoLookup;
         this.localityCalculator = localityCalculator;
         this.interfaceMarkingCache = interfaceMarkingCache;
+        this.applicationClassifier = applicationClassifier;
+        this.flowToDocumentMapper = flowToDocumentMapper;
         this.processorsByModuleId = Map.copyOf(processorsByModuleId);
     }
 
     /**
-     * Spring Cloud Stream function entry point. Returns a list of serialized
-     * enriched FlowDocument messages &mdash; one per parsed flow record, zero
-     * if the input is unparseable or contains no flows.
+     * Spring Cloud Stream function entry point. See the class Javadoc for a
+     * description of the enrichment pipeline and the {@code Message<byte[]>}
+     * signature rationale.
      *
-     * <p>Returning an empty list drops the input message without producing
-     * any output records.
+     * @param message the incoming Spring Cloud Stream message; must carry the
+     *                {@link KafkaHeaders#RECEIVED_TOPIC} header when it arrived
+     *                over the Kafka binder
+     * @return zero or more serialized {@link FlowDocumentProtos.FlowDocument}
+     *         byte arrays; never {@code null}
      */
-    public List<byte[]> processMessage(byte[] kafkaBytes) {
+    public List<byte[]> processMessage(Message<byte[]> message) {
+        if (message == null) {
+            return Collections.emptyList();
+        }
+        byte[] kafkaBytes = message.getPayload();
         if (kafkaBytes == null || kafkaBytes.length == 0) {
             return Collections.emptyList();
         }
 
-        DeserializedSinkMessage deserialized = deserializer.deserialize(kafkaBytes);
-        if (deserialized == null
-                || deserialized.messageLog() == null
-                || deserialized.messageLog().getMessageCount() == 0) {
+        String topicName = message.getHeaders().get(KafkaHeaders.RECEIVED_TOPIC, String.class);
+        String moduleId = extractModuleId(topicName);
+        if (moduleId == null) {
+            LOG.debug("Dropping message: unable to extract moduleId from topic '{}'", topicName);
             return Collections.emptyList();
         }
 
-        String moduleId = deserialized.moduleId();
-        if (moduleId == null) {
-            // Phase 1.5 pre-Commit-5 state: the Spring Cloud Stream binding
-            // does not yet supply the Kafka topic name, so the single-arg
-            // deserializer returns a null moduleId and the dispatch lookup
-            // has nothing to match against. Drop the message for now; a
-            // later commit will wire topic headers through the function
-            // signature.
-            LOG.debug("SinkMessage has no moduleId (topic header not wired yet); dropping");
-            return Collections.emptyList();
-        }
         ProtocolMessageProcessor processor = processorsByModuleId.get(moduleId);
         if (processor == null) {
             LOG.debug("No processor for moduleId '{}', dropping message", moduleId);
             return Collections.emptyList();
         }
 
-        // Commit 5 (Task 12) replaces this placeholder with the full per-flow
-        // enrichment pipeline: adapter.process() -> enrich each flow -> map to
-        // FlowDocument -> serialize -> add to result list.
-        return Collections.emptyList();
+        DeserializedSinkMessage deserialized = deserializer.deserialize(moduleId, kafkaBytes);
+        if (deserialized == null || deserialized.messageLog().getMessageCount() == 0) {
+            return Collections.emptyList();
+        }
+
+        TelemetryMessageLog messageLog = deserialized.messageLog();
+        List<Flow> flows = processor.process(messageLog);
+        if (flows.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Look up the exporter node info once per message log. The reported
+        // source address is the UDP sender on the Minion side, so it maps
+        // directly to an ipinterface row in the OpenNMS database.
+        String exporterAddress = messageLog.getSourceAddress();
+        String location = messageLog.getLocation();
+        JdbcNodeInfoLookup.NodeInfo exporterNodeInfo =
+                exporterAddress != null && !exporterAddress.isEmpty()
+                        ? nodeInfoLookup.lookupByIpAddress(exporterAddress)
+                        : null;
+
+        List<byte[]> results = new ArrayList<>(flows.size());
+        for (Flow flow : flows) {
+            try {
+                byte[] serialized = enrichAndSerialize(
+                        flow, exporterNodeInfo, exporterAddress, location);
+                results.add(serialized);
+            } catch (RuntimeException e) {
+                LOG.warn("Skipping flow due to enrichment failure ({} flows in batch, moduleId={}): {}",
+                        flows.size(), moduleId, e.getMessage(), e);
+            }
+        }
+        return results;
+    }
+
+    private byte[] enrichAndSerialize(
+            Flow flow,
+            JdbcNodeInfoLookup.NodeInfo exporterNodeInfo,
+            String exporterAddress,
+            String location) {
+
+        String srcAddr = flow.getSrcAddr();
+        String dstAddr = flow.getDstAddr();
+
+        JdbcNodeInfoLookup.NodeInfo srcNodeInfo =
+                (srcAddr != null && !srcAddr.isEmpty())
+                        ? nodeInfoLookup.lookupByIpAddress(srcAddr)
+                        : null;
+        JdbcNodeInfoLookup.NodeInfo dstNodeInfo =
+                (dstAddr != null && !dstAddr.isEmpty())
+                        ? nodeInfoLookup.lookupByIpAddress(dstAddr)
+                        : null;
+
+        Locality srcLocalityEnum = localityCalculator.classify(srcAddr);
+        Locality dstLocalityEnum = localityCalculator.classify(dstAddr);
+        Locality flowLocalityEnum = localityCalculator.flowLocality(srcAddr, dstAddr);
+
+        // Mark interfaces on the exporter as flow-enabled. Only run this when
+        // the exporter node is known (otherwise nodeId is meaningless) and
+        // when the ifindex is present and strictly positive (0 is "unknown"
+        // per the Netflow spec).
+        if (exporterNodeInfo != null) {
+            Integer inputIfIndex = flow.getInputSnmp();
+            if (inputIfIndex != null && inputIfIndex > 0) {
+                interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), inputIfIndex);
+            }
+            Integer outputIfIndex = flow.getOutputSnmp();
+            if (outputIfIndex != null && outputIfIndex > 0) {
+                interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), outputIfIndex);
+            }
+        }
+
+        int dstPort = flow.getDstPort() != null ? flow.getDstPort() : 0;
+        int srcPort = flow.getSrcPort() != null ? flow.getSrcPort() : 0;
+        int protocol = flow.getProtocol() != null ? flow.getProtocol() : 0;
+        String application = applicationClassifier.classify(dstPort, srcPort, protocol);
+
+        FlowDocumentProtos.FlowDocument doc = flowToDocumentMapper.map(
+                flow,
+                exporterNodeInfo,
+                srcNodeInfo,
+                dstNodeInfo,
+                application,
+                localityName(srcLocalityEnum),
+                localityName(dstLocalityEnum),
+                localityName(flowLocalityEnum),
+                exporterAddress,
+                location,
+                0L);
+        return doc.toByteArray();
+    }
+
+    /**
+     * Translates a {@link Locality} enum to the string form expected by
+     * {@link FlowToDocumentMapper}. The mapper compares to the literals
+     * {@code "PRIVATE"} and {@code "PUBLIC"}; anything else maps to
+     * {@code LOCALITY_UNKNOWN} in the proto, so we pass {@code null} for the
+     * unknown case.
+     */
+    private static String localityName(Locality locality) {
+        if (locality == null || locality == Locality.UNKNOWN) {
+            return null;
+        }
+        return locality.name();
+    }
+
+    private static String extractModuleId(String topicName) {
+        if (topicName == null) {
+            return null;
+        }
+        if (topicName.startsWith(OPENNMS_SINK_PREFIX)) {
+            return topicName.substring(OPENNMS_SINK_PREFIX.length());
+        }
+        if (topicName.startsWith(DELTAV_SINK_PREFIX)) {
+            return topicName.substring(DELTAV_SINK_PREFIX.length());
+        }
+        return null;
     }
 }

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
@@ -16,109 +16,108 @@
  */
 package org.deltav.flows.enricher;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
-import org.deltav.flows.proto.FlowDocumentProtos;
-import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Phase 1 (skeleton) flow enrichment pipeline. The processing path is:
+ * Phase 1.5 (Commit 3) flow enrichment pipeline. Dispatches incoming Sink
+ * messages to protocol-specific processors by {@code moduleId}, then emits
+ * a list of enriched FlowDocument byte arrays.
  *
- * <ol>
- *   <li>Deserialize the Kafka payload into a {@link TelemetryProtos.TelemetryMessageLog}
- *       via {@link SinkMessageDeserializer}.</li>
- *   <li>Look up the exporter NodeInfo by the message source address (the
- *       Minion-reported IP that received the original UDP packet).</li>
- *   <li>Build a {@link FlowDocumentProtos.FlowDocument} envelope with timestamp,
- *       host, location, and exporter_node populated.</li>
- *   <li>Serialize and emit to the {@code deltav-flows} output binding.</li>
- * </ol>
+ * <p><strong>Commit 3 scope:</strong> this commit establishes the new
+ * {@code Function<byte[], List<byte[]>>} splitter signature with a placeholder
+ * dispatch. The dispatch map is empty in Commit 3 because the
+ * {@link ProtocolMessageProcessor} implementations are created in
+ * Commit 4 (Task 8). Commit 5 (Task 12) wires the full per-flow enrichment
+ * pipeline. Every code path therefore returns an empty list for now, which
+ * Spring Cloud Stream interprets as "drop this input message without
+ * producing any output records".
  *
- * <p><strong>Phase 1 limitations (intentional):</strong>
- * <ul>
- *   <li>Per-flow protocol parsing (Netflow5/9, IPFIX, sFlow records inside
- *       the {@code TelemetryMessage} payload bytes) is NOT performed in this
- *       skeleton. The horizon protocol adapters will be wired in a follow-up
- *       PR once this Spring Cloud Stream pipeline is proven end-to-end.</li>
- *   <li>Application classification, src/dst node lookup, and locality
- *       calculation depend on per-flow parsed records and are similarly
- *       deferred. The {@link InterfaceMarkingCache},
- *       {@link FlowLocalityCalculator}, and {@link JdbcNodeInfoLookup#lookupByIpAddress}
- *       beans are wired through the constructor so the follow-up PR can use
- *       them without further bean changes.</li>
- *   <li>The unused fields are deliberately left in the constructor signature
- *       so this skeleton compiles to the same bean wiring the full pipeline
- *       will use; removing them now would just churn the configuration class
- *       in the next PR.</li>
- * </ul>
- *
- * <p>The output of this skeleton is a near-empty FlowDocument: callers
- * receive a real protobuf message they can deserialize, with the topic
- * contract proven, but the meaningful fields populated only by the follow-up
- * adapter integration.
+ * <p><strong>Known gap &mdash; moduleId dispatch:</strong> the Sink protobuf
+ * envelope does not carry a {@code moduleId} field (see
+ * {@link DeserializedSinkMessage}), so the single-argument
+ * {@link SinkMessageDeserializer#deserialize(byte[])} path always reports
+ * {@code moduleId == null}. A later commit will change the Spring Cloud
+ * Stream function signature to accept {@code Message<byte[]>} so the topic
+ * name can be read from headers and passed to
+ * {@link SinkMessageDeserializer#deserialize(String, byte[])}. Until that
+ * happens the dispatch lookup will always miss; this is fine for Commit 3
+ * because the dispatch map is empty anyway.
  */
 public class FlowEnrichmentFunction {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlowEnrichmentFunction.class);
 
     private final SinkMessageDeserializer deserializer;
+    @SuppressWarnings("unused") // wired now; consumed in Commit 5 (full enrichment pipeline)
     private final JdbcNodeInfoLookup nodeInfoLookup;
-    @SuppressWarnings("unused") // wired now; consumed in the follow-up adapter PR
+    @SuppressWarnings("unused") // wired now; consumed in Commit 5
     private final FlowLocalityCalculator localityCalculator;
-    @SuppressWarnings("unused") // wired now; consumed in the follow-up adapter PR
+    @SuppressWarnings("unused") // wired now; consumed in Commit 5
     private final InterfaceMarkingCache interfaceMarkingCache;
+    private final Map<String, ProtocolMessageProcessor> processorsByModuleId;
 
     public FlowEnrichmentFunction(
             SinkMessageDeserializer deserializer,
             JdbcNodeInfoLookup nodeInfoLookup,
             FlowLocalityCalculator localityCalculator,
-            InterfaceMarkingCache interfaceMarkingCache) {
+            InterfaceMarkingCache interfaceMarkingCache,
+            Map<String, ProtocolMessageProcessor> processorsByModuleId) {
         this.deserializer = deserializer;
         this.nodeInfoLookup = nodeInfoLookup;
         this.localityCalculator = localityCalculator;
         this.interfaceMarkingCache = interfaceMarkingCache;
+        this.processorsByModuleId = Map.copyOf(processorsByModuleId);
     }
 
     /**
-     * Spring Cloud Stream function entry point. Returns the protobuf bytes of
-     * an enriched FlowDocument, or {@code null} to drop the input message
-     * without producing an output record.
+     * Spring Cloud Stream function entry point. Returns a list of serialized
+     * enriched FlowDocument messages &mdash; one per parsed flow record, zero
+     * if the input is unparseable or contains no flows.
+     *
+     * <p>Returning an empty list drops the input message without producing
+     * any output records.
      */
-    public byte[] processMessage(byte[] kafkaBytes) {
-        TelemetryProtos.TelemetryMessageLog messageLog = deserializer.deserialize(kafkaBytes);
-        if (messageLog == null || messageLog.getMessageCount() == 0) {
-            return null;
+    public List<byte[]> processMessage(byte[] kafkaBytes) {
+        if (kafkaBytes == null || kafkaBytes.length == 0) {
+            return Collections.emptyList();
         }
 
-        try {
-            FlowDocumentProtos.FlowDocument.Builder builder =
-                    FlowDocumentProtos.FlowDocument.newBuilder()
-                            .setTimestamp(System.currentTimeMillis())
-                            .setHost(messageLog.getSourceAddress())
-                            .setLocation(messageLog.getLocation());
-
-            JdbcNodeInfoLookup.NodeInfo exporter =
-                    nodeInfoLookup.lookupByIpAddress(messageLog.getSourceAddress());
-            if (exporter != null) {
-                FlowDocumentProtos.NodeInfo.Builder exporterBuilder =
-                        FlowDocumentProtos.NodeInfo.newBuilder().setNodeId(exporter.nodeId());
-                if (exporter.foreignSource() != null) {
-                    exporterBuilder.setForeignSource(exporter.foreignSource());
-                }
-                if (exporter.foreignId() != null) {
-                    exporterBuilder.setForeignId(exporter.foreignId());
-                }
-                builder.setExporterNode(exporterBuilder.build());
-            }
-
-            return builder.build().toByteArray();
-        } catch (Exception e) {
-            LOG.warn("Failed to enrich flow message from {}: {}",
-                    messageLog.getSourceAddress(), e.getMessage());
-            return null;
+        DeserializedSinkMessage deserialized = deserializer.deserialize(kafkaBytes);
+        if (deserialized == null
+                || deserialized.messageLog() == null
+                || deserialized.messageLog().getMessageCount() == 0) {
+            return Collections.emptyList();
         }
+
+        String moduleId = deserialized.moduleId();
+        if (moduleId == null) {
+            // Phase 1.5 pre-Commit-5 state: the Spring Cloud Stream binding
+            // does not yet supply the Kafka topic name, so the single-arg
+            // deserializer returns a null moduleId and the dispatch lookup
+            // has nothing to match against. Drop the message for now; a
+            // later commit will wire topic headers through the function
+            // signature.
+            LOG.debug("SinkMessage has no moduleId (topic header not wired yet); dropping");
+            return Collections.emptyList();
+        }
+        ProtocolMessageProcessor processor = processorsByModuleId.get(moduleId);
+        if (processor == null) {
+            LOG.debug("No processor for moduleId '{}', dropping message", moduleId);
+            return Collections.emptyList();
+        }
+
+        // Commit 5 (Task 12) replaces this placeholder with the full per-flow
+        // enrichment pipeline: adapter.process() -> enrich each flow -> map to
+        // FlowDocument -> serialize -> add to result list.
+        return Collections.emptyList();
     }
 }

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
@@ -23,7 +23,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Unwraps the two-layer protobuf encoding used on Kafka Sink topics:
- * Kafka bytes → {@link SinkMessage} envelope → {@link TelemetryProtos.TelemetryMessageLog}.
+ * Kafka bytes &rarr; {@link SinkMessage} envelope &rarr;
+ * {@link TelemetryProtos.TelemetryMessageLog}.
  *
  * <p>The Sink IPC framework (OpenNMS Minion) supports message chunking for
  * payloads that exceed the Kafka message size limit. Flow telemetry messages
@@ -31,17 +32,36 @@ import org.slf4j.LoggerFactory;
  * the simpler path of dropping any chunked message it encounters and logging
  * a warning. Reassembly across chunks can be added later if it proves
  * necessary in production.
+ *
+ * <p><strong>moduleId source:</strong> the {@link SinkMessage} envelope does
+ * not carry a {@code moduleId} field; in the Sink IPC protocol the module
+ * identifier is derived from the Kafka topic name
+ * ({@code OpenNMS.Sink.{moduleId}}). Callers that know the topic should use
+ * the {@link #deserialize(String, byte[])} overload to supply the moduleId
+ * explicitly. The {@link #deserialize(byte[])} overload populates the
+ * {@link DeserializedSinkMessage#moduleId() moduleId} field as {@code null}.
  */
 public class SinkMessageDeserializer {
 
     private static final Logger LOG = LoggerFactory.getLogger(SinkMessageDeserializer.class);
 
     /**
-     * Deserializes a Kafka payload into a {@link TelemetryProtos.TelemetryMessageLog}.
-     * Returns {@code null} if the payload is null, malformed, or chunked. Callers
-     * should treat null as "drop and continue".
+     * Deserializes a Kafka payload into a {@link DeserializedSinkMessage}
+     * with an unknown (null) moduleId. Returns {@code null} if the payload is
+     * null, malformed, or chunked. Callers should treat null as
+     * "drop and continue".
      */
-    public TelemetryProtos.TelemetryMessageLog deserialize(byte[] kafkaBytes) {
+    public DeserializedSinkMessage deserialize(byte[] kafkaBytes) {
+        return deserialize(null, kafkaBytes);
+    }
+
+    /**
+     * Deserializes a Kafka payload into a {@link DeserializedSinkMessage},
+     * tagging the result with the given moduleId (typically derived from the
+     * Kafka topic name by the caller). Returns {@code null} if the payload is
+     * null, malformed, or chunked.
+     */
+    public DeserializedSinkMessage deserialize(String moduleId, byte[] kafkaBytes) {
         if (kafkaBytes == null) {
             return null;
         }
@@ -52,7 +72,9 @@ public class SinkMessageDeserializer {
                         sinkMessage.getMessageId(), sinkMessage.getTotalChunks());
                 return null;
             }
-            return TelemetryProtos.TelemetryMessageLog.parseFrom(sinkMessage.getContent());
+            TelemetryProtos.TelemetryMessageLog log =
+                    TelemetryProtos.TelemetryMessageLog.parseFrom(sinkMessage.getContent());
+            return new DeserializedSinkMessage(moduleId, log);
         } catch (Exception e) {
             LOG.warn("Failed to deserialize SinkMessage payload ({} bytes): {}",
                     kafkaBytes.length, e.getMessage());

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
@@ -50,7 +50,16 @@ public class SinkMessageDeserializer {
      * with an unknown (null) moduleId. Returns {@code null} if the payload is
      * null, malformed, or chunked. Callers should treat null as
      * "drop and continue".
+     *
+     * @deprecated Use {@link #deserialize(String, byte[])} instead. The
+     *     single-arg overload returns a {@link DeserializedSinkMessage} with
+     *     {@code moduleId == null}, which causes
+     *     {@link FlowEnrichmentFunction} to drop the message because protocol
+     *     dispatch requires a known module ID. This overload exists only for
+     *     backward compatibility with test code that doesn't care about
+     *     moduleId.
      */
+    @Deprecated
     public DeserializedSinkMessage deserialize(byte[] kafkaBytes) {
         return deserialize(null, kafkaBytes);
     }

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/ApplicationClassifier.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/ApplicationClassifier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.classification;
+
+/**
+ * Classifies a flow into a named application (for example {@code "HTTPS"} or
+ * {@code "DNS"}) from its transport ports and IP protocol. Returns the string
+ * {@code "unknown"} when no classification rule matches.
+ *
+ * <p>Implementations should be stateless and thread-safe.
+ */
+public interface ApplicationClassifier {
+
+    /**
+     * @param dstPort  the destination port as seen in the flow record
+     * @param srcPort  the source port as seen in the flow record
+     * @param protocol the IP protocol number (TCP=6, UDP=17, etc.)
+     * @return the application name, or {@code "unknown"} if no rule matched
+     */
+    String classify(int dstPort, int srcPort, int protocol);
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifier.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifier.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.classification;
+
+import java.util.Map;
+
+/**
+ * An {@link ApplicationClassifier} that maps well-known IANA port numbers to
+ * their canonical application name. The destination port is checked first;
+ * if it is not a well-known port, the source port is checked (to classify
+ * the return leg of a bidirectional conversation). If neither port matches,
+ * the result is {@code "unknown"}.
+ *
+ * <p>The mapping intentionally covers only the most common services — a
+ * more comprehensive classifier can be added in a later phase via a
+ * configurable rules engine. This implementation is stateless and
+ * thread-safe.
+ */
+public class PortBasedApplicationClassifier implements ApplicationClassifier {
+
+    private static final String UNKNOWN = "unknown";
+
+    private static final Map<Integer, String> WELL_KNOWN_PORTS = Map.ofEntries(
+            Map.entry(20, "FTP-data"),
+            Map.entry(21, "FTP"),
+            Map.entry(22, "SSH"),
+            Map.entry(23, "Telnet"),
+            Map.entry(25, "SMTP"),
+            Map.entry(53, "DNS"),
+            Map.entry(67, "DHCP"),
+            Map.entry(68, "DHCP"),
+            Map.entry(69, "TFTP"),
+            Map.entry(80, "HTTP"),
+            Map.entry(110, "POP3"),
+            Map.entry(123, "NTP"),
+            Map.entry(143, "IMAP"),
+            Map.entry(161, "SNMP"),
+            Map.entry(162, "SNMP-trap"),
+            Map.entry(389, "LDAP"),
+            Map.entry(443, "HTTPS"),
+            Map.entry(445, "SMB"),
+            Map.entry(465, "SMTPS"),
+            Map.entry(514, "Syslog"),
+            Map.entry(587, "SMTP"),
+            Map.entry(636, "LDAPS"),
+            Map.entry(993, "IMAPS"),
+            Map.entry(995, "POP3S"),
+            Map.entry(1433, "MSSQL"),
+            Map.entry(1521, "Oracle"),
+            Map.entry(3306, "MySQL"),
+            Map.entry(3389, "RDP"),
+            Map.entry(5432, "PostgreSQL"),
+            Map.entry(5672, "AMQP"),
+            Map.entry(6379, "Redis"),
+            Map.entry(8080, "HTTP-alt"),
+            Map.entry(8443, "HTTPS-alt"),
+            Map.entry(9092, "Kafka"),
+            Map.entry(9200, "Elasticsearch"),
+            Map.entry(27017, "MongoDB"));
+
+    @Override
+    public String classify(int dstPort, int srcPort, int protocol) {
+        final String byDst = WELL_KNOWN_PORTS.get(dstPort);
+        if (byDst != null) {
+            return byDst;
+        }
+        final String bySrc = WELL_KNOWN_PORTS.get(srcPort);
+        if (bySrc != null) {
+            return bySrc;
+        }
+        return UNKNOWN;
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.mapping;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.opennms.integration.api.v1.flows.Flow.Direction;
+import org.opennms.integration.api.v1.flows.Flow.NetflowVersion;
+import org.opennms.integration.api.v1.flows.Flow.SamplingAlgorithm;
+import org.opennms.netmgt.flows.api.Flow;
+
+/**
+ * Converts a horizon {@link Flow} plus enriched {@link JdbcNodeInfoLookup.NodeInfo}
+ * records, an application classification string, and locality enrichment
+ * strings into a {@link FlowDocumentProtos.FlowDocument} message ready for
+ * publication to the {@code deltav-flows} Kafka topic.
+ *
+ * <p><strong>Null-wrapper discipline.</strong> Horizon's {@link Flow}
+ * interface exposes most numeric fields as boxed wrapper types (for example,
+ * {@code Long getBytes()}) that may return {@code null} when the upstream
+ * exporter omitted the field from the flow record. The delta-v protobuf
+ * schema mirrors this with {@code google.protobuf.UInt64Value} and similar
+ * wrapper types, which are distinct messages whose presence can be queried
+ * with {@code hasXxx()}. This mapper carefully populates each wrapper-typed
+ * field <em>only</em> when the horizon getter returned a non-null value, so
+ * downstream consumers (ClickHouse column schemas, queries over the
+ * {@code deltav-flows} topic) can cleanly distinguish "the exporter did not
+ * report this value" from "the exporter reported zero."
+ *
+ * <p>Stateless and thread-safe.
+ */
+public class FlowToDocumentMapper {
+
+    public FlowDocumentProtos.FlowDocument map(
+            Flow flow,
+            JdbcNodeInfoLookup.NodeInfo exporterNodeInfo,
+            JdbcNodeInfoLookup.NodeInfo srcNodeInfo,
+            JdbcNodeInfoLookup.NodeInfo destNodeInfo,
+            String application,
+            String srcLocality,
+            String dstLocality,
+            String flowLocality) {
+
+        FlowDocumentProtos.FlowDocument.Builder builder = FlowDocumentProtos.FlowDocument.newBuilder();
+
+        // Top-level timestamp (proto uint64 timestamp, always set from Instant).
+        final Instant timestamp = flow.getTimestamp();
+        if (timestamp != null) {
+            builder.setTimestamp(timestamp.toEpochMilli());
+        }
+
+        // UInt64Value wrapper-typed fields: set only when the flow getter is non-null.
+        final Long bytes = flow.getBytes();
+        if (bytes != null) {
+            builder.setNumBytes(UInt64Value.of(bytes));
+        }
+        final Long packets = flow.getPackets();
+        if (packets != null) {
+            builder.setNumPackets(UInt64Value.of(packets));
+        }
+        final Long dstAs = flow.getDstAs();
+        if (dstAs != null) {
+            builder.setDstAs(UInt64Value.of(dstAs));
+        }
+        final Long srcAs = flow.getSrcAs();
+        if (srcAs != null) {
+            builder.setSrcAs(UInt64Value.of(srcAs));
+        }
+        final Instant firstSwitched = flow.getFirstSwitched();
+        if (firstSwitched != null) {
+            builder.setFirstSwitched(UInt64Value.of(firstSwitched.toEpochMilli()));
+        }
+        final Instant lastSwitched = flow.getLastSwitched();
+        if (lastSwitched != null) {
+            builder.setLastSwitched(UInt64Value.of(lastSwitched.toEpochMilli()));
+        }
+        final Instant deltaSwitched = flow.getDeltaSwitched();
+        if (deltaSwitched != null) {
+            builder.setDeltaSwitched(UInt64Value.of(deltaSwitched.toEpochMilli()));
+        }
+
+        // Flow sequence number is a primitive long in horizon — always set.
+        builder.setFlowSeqNum(UInt64Value.of(flow.getFlowSeqNum()));
+
+        // Flow record count is a primitive int in horizon — always set.
+        builder.setNumFlowRecords(UInt32Value.of(flow.getFlowRecords()));
+
+        // UInt32Value wrapper-typed fields: set only when non-null.
+        final Integer dstMaskLen = flow.getDstMaskLen();
+        if (dstMaskLen != null) {
+            builder.setDstMaskLen(UInt32Value.of(dstMaskLen));
+        }
+        final Integer dstPort = flow.getDstPort();
+        if (dstPort != null) {
+            builder.setDstPort(UInt32Value.of(dstPort));
+        }
+        final Integer srcMaskLen = flow.getSrcMaskLen();
+        if (srcMaskLen != null) {
+            builder.setSrcMaskLen(UInt32Value.of(srcMaskLen));
+        }
+        final Integer srcPort = flow.getSrcPort();
+        if (srcPort != null) {
+            builder.setSrcPort(UInt32Value.of(srcPort));
+        }
+        final Integer engineId = flow.getEngineId();
+        if (engineId != null) {
+            builder.setEngineId(UInt32Value.of(engineId));
+        }
+        final Integer engineType = flow.getEngineType();
+        if (engineType != null) {
+            builder.setEngineType(UInt32Value.of(engineType));
+        }
+        final Integer inputSnmp = flow.getInputSnmp();
+        if (inputSnmp != null) {
+            builder.setInputSnmpIfindex(UInt32Value.of(inputSnmp));
+        }
+        final Integer outputSnmp = flow.getOutputSnmp();
+        if (outputSnmp != null) {
+            builder.setOutputSnmpIfindex(UInt32Value.of(outputSnmp));
+        }
+        final Integer ipProtoVersion = flow.getIpProtocolVersion();
+        if (ipProtoVersion != null) {
+            builder.setIpProtocolVersion(UInt32Value.of(ipProtoVersion));
+        }
+        final Integer protocol = flow.getProtocol();
+        if (protocol != null) {
+            builder.setProtocol(UInt32Value.of(protocol));
+        }
+        final Integer tcpFlags = flow.getTcpFlags();
+        if (tcpFlags != null) {
+            builder.setTcpFlags(UInt32Value.of(tcpFlags));
+        }
+        final Integer tos = flow.getTos();
+        if (tos != null) {
+            builder.setTos(UInt32Value.of(tos));
+        }
+        final Integer dscp = flow.getDscp();
+        if (dscp != null) {
+            builder.setDscp(UInt32Value.of(dscp));
+        }
+        final Integer ecn = flow.getEcn();
+        if (ecn != null) {
+            builder.setEcn(UInt32Value.of(ecn));
+        }
+
+        // DoubleValue wrapper-typed fields: set only when non-null.
+        final Double samplingInterval = flow.getSamplingInterval();
+        if (samplingInterval != null) {
+            builder.setSamplingInterval(DoubleValue.of(samplingInterval));
+        }
+
+        // Plain string fields — proto3 scalar strings default to "" and cannot
+        // distinguish "unset" from "empty", but we still avoid setting null.
+        final String srcAddr = flow.getSrcAddr();
+        if (srcAddr != null) {
+            builder.setSrcAddress(srcAddr);
+        }
+        final String dstAddr = flow.getDstAddr();
+        if (dstAddr != null) {
+            builder.setDstAddress(dstAddr);
+        }
+        final String nextHop = flow.getNextHop();
+        if (nextHop != null) {
+            builder.setNextHopAddress(nextHop);
+        }
+
+        // Optional<String> hostname getters.
+        final Optional<String> srcHostname = flow.getSrcAddrHostname();
+        srcHostname.ifPresent(builder::setSrcHostname);
+        final Optional<String> dstHostname = flow.getDstAddrHostname();
+        dstHostname.ifPresent(builder::setDstHostname);
+        final Optional<String> nextHopHostname = flow.getNextHopHostname();
+        nextHopHostname.ifPresent(builder::setNextHopHostname);
+
+        // VLAN: horizon returns Integer, proto field is a string (historical schema).
+        final Integer vlan = flow.getVlan();
+        if (vlan != null) {
+            builder.setVlan(Integer.toString(vlan));
+        }
+
+        // Enums.
+        builder.setDirection(mapDirection(flow.getDirection()));
+        builder.setNetflowVersion(mapNetflowVersion(flow.getNetflowVersion()));
+        builder.setSamplingAlgorithm(mapSamplingAlgorithm(flow.getSamplingAlgorithm()));
+
+        // NodeInfo sub-messages: set only when enrichment provided a non-null lookup.
+        if (exporterNodeInfo != null) {
+            builder.setExporterNode(toProtoNodeInfo(exporterNodeInfo));
+        }
+        if (srcNodeInfo != null) {
+            builder.setSrcNode(toProtoNodeInfo(srcNodeInfo));
+        }
+        if (destNodeInfo != null) {
+            builder.setDestNode(toProtoNodeInfo(destNodeInfo));
+        }
+
+        // Application classification: default to "unknown" when null.
+        builder.setApplication(application != null ? application : "unknown");
+
+        // Locality enrichment.
+        builder.setSrcLocality(mapLocality(srcLocality));
+        builder.setDstLocality(mapLocality(dstLocality));
+        builder.setFlowLocality(mapLocality(flowLocality));
+
+        return builder.build();
+    }
+
+    private static FlowDocumentProtos.NodeInfo toProtoNodeInfo(JdbcNodeInfoLookup.NodeInfo info) {
+        FlowDocumentProtos.NodeInfo.Builder b = FlowDocumentProtos.NodeInfo.newBuilder();
+        b.setNodeId(info.nodeId());
+        if (info.foreignSource() != null) {
+            b.setForeignSource(info.foreignSource());
+        }
+        if (info.foreignId() != null) {
+            b.setForeignId(info.foreignId());
+        }
+        // The JdbcNodeInfoLookup.NodeInfo record does not carry OpenNMS
+        // category data; the proto NodeInfo.categories field is left empty
+        // until category enrichment is added in a later phase.
+        return b.build();
+    }
+
+    private static FlowDocumentProtos.Direction mapDirection(Direction direction) {
+        if (direction == null) {
+            return FlowDocumentProtos.Direction.DIRECTION_UNKNOWN;
+        }
+        return switch (direction) {
+            case INGRESS -> FlowDocumentProtos.Direction.INGRESS;
+            case EGRESS -> FlowDocumentProtos.Direction.EGRESS;
+            case UNKNOWN -> FlowDocumentProtos.Direction.DIRECTION_UNKNOWN;
+        };
+    }
+
+    private static FlowDocumentProtos.NetflowVersion mapNetflowVersion(NetflowVersion version) {
+        if (version == null) {
+            return FlowDocumentProtos.NetflowVersion.NETFLOW_VERSION_UNKNOWN;
+        }
+        return switch (version) {
+            case V5 -> FlowDocumentProtos.NetflowVersion.V5;
+            case V9 -> FlowDocumentProtos.NetflowVersion.V9;
+            case IPFIX -> FlowDocumentProtos.NetflowVersion.IPFIX;
+            case SFLOW -> FlowDocumentProtos.NetflowVersion.SFLOW;
+        };
+    }
+
+    private static FlowDocumentProtos.SamplingAlgorithm mapSamplingAlgorithm(SamplingAlgorithm algorithm) {
+        if (algorithm == null) {
+            return FlowDocumentProtos.SamplingAlgorithm.SAMPLING_ALGORITHM_UNKNOWN;
+        }
+        return switch (algorithm) {
+            case Unassigned -> FlowDocumentProtos.SamplingAlgorithm.SAMPLING_ALGORITHM_UNKNOWN;
+            case SystematicCountBasedSampling ->
+                    FlowDocumentProtos.SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
+            case SystematicTimeBasedSampling ->
+                    FlowDocumentProtos.SamplingAlgorithm.SYSTEMATIC_TIME_BASED_SAMPLING;
+            case RandomNOutOfNSampling ->
+                    FlowDocumentProtos.SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
+            case UniformProbabilisticSampling ->
+                    FlowDocumentProtos.SamplingAlgorithm.UNIFORM_PROBABILISTIC_SAMPLING;
+            case PropertyMatchFiltering ->
+                    FlowDocumentProtos.SamplingAlgorithm.PROPERTY_MATCH_FILTERING;
+            case HashBasedFiltering ->
+                    FlowDocumentProtos.SamplingAlgorithm.HASH_BASED_FILTERING;
+            case FlowStateDependentIntermediateFlowSelectionProcess ->
+                    FlowDocumentProtos.SamplingAlgorithm.FLOW_STATE_DEPENDENT_INTERMEDIATE_FLOW_SELECTION_PROCESS;
+        };
+    }
+
+    private static FlowDocumentProtos.Locality mapLocality(String locality) {
+        if (locality == null) {
+            return FlowDocumentProtos.Locality.LOCALITY_UNKNOWN;
+        }
+        return switch (locality) {
+            case "PRIVATE" -> FlowDocumentProtos.Locality.PRIVATE;
+            case "PUBLIC" -> FlowDocumentProtos.Locality.PUBLIC;
+            default -> FlowDocumentProtos.Locality.LOCALITY_UNKNOWN;
+        };
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java
@@ -52,6 +52,32 @@ import org.opennms.netmgt.flows.api.Flow;
  */
 public class FlowToDocumentMapper {
 
+    /**
+     * Build a {@link FlowDocumentProtos.FlowDocument} from a horizon {@link Flow}
+     * and its enrichment context.
+     *
+     * @param flow the parsed horizon flow record
+     * @param exporterNodeInfo resolved node info for the exporter, or {@code null}
+     *                         when no matching node was found
+     * @param srcNodeInfo      resolved node info for the source IP, or {@code null}
+     * @param destNodeInfo     resolved node info for the destination IP, or {@code null}
+     * @param application      application classification string (e.g. {@code "HTTPS"}),
+     *                         or {@code null} which maps to {@code "unknown"}
+     * @param srcLocality      source locality (one of {@code "PRIVATE"} / {@code "PUBLIC"},
+     *                         or {@code null} / other values for unknown)
+     * @param dstLocality      destination locality (same semantics as {@code srcLocality})
+     * @param flowLocality     aggregate flow locality (same semantics as {@code srcLocality})
+     * @param host             hostname or FQDN of the exporter (typically derived from
+     *                         {@code FlowSource.getSourceAddress()}). Empty or {@code null}
+     *                         leaves the proto field unset (empty string default).
+     * @param location         Minion location string (typically derived from
+     *                         {@code FlowSource.getLocation()}). Empty or {@code null}
+     *                         leaves the proto field unset.
+     * @param clockCorrection  clock-skew correction in milliseconds applied to timestamps.
+     *                         Phase 1.5 always passes {@code 0}; Phase 1.6 will compute
+     *                         actual skew. Always written to the proto (0 is a valid value).
+     * @return a fully populated {@code FlowDocument} proto message
+     */
     public FlowDocumentProtos.FlowDocument map(
             Flow flow,
             JdbcNodeInfoLookup.NodeInfo exporterNodeInfo,
@@ -60,7 +86,10 @@ public class FlowToDocumentMapper {
             String application,
             String srcLocality,
             String dstLocality,
-            String flowLocality) {
+            String flowLocality,
+            String host,
+            String location,
+            long clockCorrection) {
 
         FlowDocumentProtos.FlowDocument.Builder builder = FlowDocumentProtos.FlowDocument.newBuilder();
 
@@ -222,6 +251,21 @@ public class FlowToDocumentMapper {
         builder.setSrcLocality(mapLocality(srcLocality));
         builder.setDstLocality(mapLocality(dstLocality));
         builder.setFlowLocality(mapLocality(flowLocality));
+
+        // Exporter host/location enrichment (derived from FlowSource by the caller).
+        // Both are proto3 scalar strings that default to "" when unset, so we only
+        // write non-null, non-empty values to keep "unknown" distinguishable from
+        // "reported but empty".
+        if (host != null && !host.isEmpty()) {
+            builder.setHost(host);
+        }
+        if (location != null && !location.isEmpty()) {
+            builder.setLocation(location);
+        }
+
+        // Clock skew correction (milliseconds). Plain uint64; 0 is a valid value
+        // meaning "no correction applied", so we always set it.
+        builder.setClockCorrection(clockCorrection);
 
         return builder.build();
     }

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/pipeline/CapturingPipeline.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/pipeline/CapturingPipeline.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.pipeline;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.flows.api.FlowSource;
+import org.opennms.netmgt.flows.processing.Pipeline;
+import org.opennms.netmgt.flows.processing.ProcessingOptions;
+
+/**
+ * A {@link Pipeline} implementation that stashes the flows and source passed
+ * to its {@link #process} method instead of forwarding them to any downstream
+ * persister or sink.
+ *
+ * <p>This is the integration seam between horizon's protocol adapters
+ * ({@code Netflow5Adapter}, {@code Netflow9Adapter}, {@code IpfixAdapter},
+ * {@code SflowAdapter}) and delta-v's flow enrichment. Horizon adapters
+ * extend {@code AbstractFlowAdapter}, whose {@code handleMessageLog()} parses
+ * a {@code TelemetryMessageLog} into a list of {@link Flow} instances and
+ * then calls {@code pipeline.process(flows, source, options)} to persist
+ * them. By injecting a {@code CapturingPipeline} into the adapter instead of
+ * horizon's {@code PipelineImpl}, we intercept the parsed flows without
+ * triggering any of horizon's persistence, Elasticsearch indexing, or
+ * Kafka forwarding logic.
+ *
+ * <p><strong>This class is NOT thread-safe.</strong> Each adapter invocation
+ * must use a fresh instance — a single instance cannot be safely shared
+ * across concurrent message-log handling. The enricher's flow function
+ * constructs a new {@code CapturingPipeline} per message.
+ */
+public class CapturingPipeline implements Pipeline {
+
+    private List<Flow> capturedFlows = Collections.emptyList();
+    private FlowSource capturedSource;
+
+    @Override
+    public void process(List<Flow> flows, FlowSource source, ProcessingOptions options) {
+        this.capturedFlows = flows;
+        this.capturedSource = source;
+    }
+
+    public List<Flow> getCapturedFlows() {
+        return capturedFlows;
+    }
+
+    public FlowSource getCapturedSource() {
+        return capturedSource;
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for per-protocol processors that delegate flow parsing to a
+ * horizon {@link AbstractFlowAdapter} subclass. Subclasses override
+ * {@link #createAdapter(CapturingPipeline)} to construct the protocol-specific
+ * adapter (Netflow5, Netflow9, IPFIX, sFlow).
+ *
+ * <h2>Pipeline-per-invocation pattern</h2>
+ *
+ * <p>Horizon's {@code AbstractFlowAdapter} takes a
+ * {@code org.opennms.netmgt.flows.processing.Pipeline} reference in its
+ * constructor and stores it in a final field. The adapter's
+ * {@code handleMessageLog()} method parses each entry in the incoming
+ * {@code TelemetryMessageLog}, accumulates the resulting flows into a list,
+ * and then calls {@code pipeline.process(flows, source, options)} exactly
+ * once per message log to publish the flows downstream.
+ *
+ * <p>Because the pipeline reference is captured in the adapter's constructor
+ * and never reassigned, it is not possible to reuse a single adapter instance
+ * with different {@link CapturingPipeline} instances across calls. To keep
+ * each call independent and avoid cross-invocation contamination, this class
+ * constructs a <strong>fresh adapter</strong> and a <strong>fresh
+ * {@code CapturingPipeline}</strong> on every call to {@link #process}. The
+ * pipeline captures the parsed flows via its
+ * {@link CapturingPipeline#getCapturedFlows()} accessor, which this class
+ * returns to the caller.
+ *
+ * <h2>Exception handling</h2>
+ *
+ * <p>If {@code adapter.handleMessageLog()} throws any unchecked exception
+ * (e.g. a malformed {@code FlowMessage} protobuf in one of the entries, or
+ * a BSON document the sFlow adapter cannot decode), the exception is logged
+ * at {@code WARN} level and this method returns an empty list. The failure
+ * is not propagated to the caller because the Spring Cloud Stream binding
+ * must not abort the function on a single bad message &mdash; doing so would
+ * block the consumer on the offending record indefinitely. Horizon's own
+ * adapter code already catches the checked {@code FlowException} family
+ * internally, so in practice the only exceptions that can escape
+ * {@code handleMessageLog} are unchecked parser errors.
+ *
+ * <h2>Thread-safety</h2>
+ *
+ * <p>Because each {@link #process} call allocates its own adapter and
+ * pipeline, this class is <strong>effectively stateless and thread-safe
+ * for concurrent callers</strong>. Note, however, that the horizon adapters
+ * themselves are not designed to be shared across threads &mdash; our
+ * per-call construction is what keeps them safe here. A single
+ * {@link AbstractProtocolMessageProcessor} instance can be wired into the
+ * Spring Cloud Stream function dispatch map and shared across all messages.
+ */
+public abstract class AbstractProtocolMessageProcessor implements ProtocolMessageProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractProtocolMessageProcessor.class);
+
+    @Override
+    public List<Flow> process(TelemetryProtos.TelemetryMessageLog messageLog) {
+        if (messageLog == null || messageLog.getMessageCount() == 0) {
+            return Collections.emptyList();
+        }
+
+        final CapturingPipeline pipeline = new CapturingPipeline();
+        final AbstractFlowAdapter<?> adapter = createAdapter(pipeline);
+        try {
+            // TelemetryProtos.TelemetryMessageLog implements the
+            // org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog
+            // interface that handleMessageLog expects, so no wrapping is
+            // needed.
+            adapter.handleMessageLog(messageLog);
+        } catch (RuntimeException e) {
+            LOG.warn("Horizon adapter {} threw while processing telemetry message log with {} entries: {}",
+                    adapter.getClass().getSimpleName(),
+                    messageLog.getMessageCount(),
+                    e.getMessage(),
+                    e);
+            return Collections.emptyList();
+        } finally {
+            try {
+                adapter.destroy();
+            } catch (RuntimeException destroyEx) {
+                LOG.debug("Ignoring exception from adapter.destroy()", destroyEx);
+            }
+        }
+        return pipeline.getCapturedFlows();
+    }
+
+    /**
+     * Constructs the protocol-specific horizon adapter with the provided
+     * capturing pipeline. Called once per {@link #process} invocation.
+     *
+     * @param pipeline the capturing pipeline the adapter must publish to
+     * @return a freshly-constructed adapter bound to {@code pipeline}
+     */
+    protected abstract AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline);
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java
@@ -100,13 +100,11 @@ public abstract class AbstractProtocolMessageProcessor implements ProtocolMessag
                     e.getMessage(),
                     e);
             return Collections.emptyList();
-        } finally {
-            try {
-                adapter.destroy();
-            } catch (RuntimeException destroyEx) {
-                LOG.debug("Ignoring exception from adapter.destroy()", destroyEx);
-            }
         }
+        // Horizon's AbstractFlowAdapter.destroy() is a no-op in the versions
+        // we target; calling it here would add noise without any real cleanup
+        // and can be re-introduced if horizon ever gives destroy() real
+        // semantics.
         return pipeline.getCapturedFlows();
     }
 

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/IpfixMessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/IpfixMessageProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.Objects;
+
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Protocol processor for IPFIX (Netflow v10) messages. Wraps horizon's
+ * {@link IpfixAdapter}, which expects each
+ * {@code TelemetryMessageLogEntry} to carry a serialized
+ * {@code org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage}
+ * protobuf (the parser layer's normalized representation of an IPFIX
+ * data record after template resolution).
+ */
+public class IpfixMessageProcessor extends AbstractProtocolMessageProcessor {
+
+    private final AdapterDefinition adapterDefinition;
+    private final MetricRegistry metricRegistry;
+
+    public IpfixMessageProcessor(AdapterDefinition adapterDefinition, MetricRegistry metricRegistry) {
+        this.adapterDefinition = Objects.requireNonNull(adapterDefinition, "adapterDefinition");
+        this.metricRegistry = Objects.requireNonNull(metricRegistry, "metricRegistry");
+    }
+
+    @Override
+    protected AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline) {
+        return new IpfixAdapter(adapterDefinition, metricRegistry, pipeline);
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.Objects;
+
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Protocol processor for Netflow v5 messages. Wraps horizon's
+ * {@link Netflow5Adapter}, which expects each
+ * {@code TelemetryMessageLogEntry} to carry a serialized
+ * {@code org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage}
+ * protobuf (the parser layer's normalized representation).
+ */
+public class Netflow5MessageProcessor extends AbstractProtocolMessageProcessor {
+
+    private final AdapterDefinition adapterDefinition;
+    private final MetricRegistry metricRegistry;
+
+    public Netflow5MessageProcessor(AdapterDefinition adapterDefinition, MetricRegistry metricRegistry) {
+        this.adapterDefinition = Objects.requireNonNull(adapterDefinition, "adapterDefinition");
+        this.metricRegistry = Objects.requireNonNull(metricRegistry, "metricRegistry");
+    }
+
+    @Override
+    protected AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline) {
+        return new Netflow5Adapter(adapterDefinition, metricRegistry, pipeline);
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/Netflow9MessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/Netflow9MessageProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.Objects;
+
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Protocol processor for Netflow v9 messages. Wraps horizon's
+ * {@link Netflow9Adapter}, which expects each
+ * {@code TelemetryMessageLogEntry} to carry a serialized
+ * {@code org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage}
+ * protobuf (the parser layer's normalized representation of a Netflow v9
+ * data record after template resolution).
+ */
+public class Netflow9MessageProcessor extends AbstractProtocolMessageProcessor {
+
+    private final AdapterDefinition adapterDefinition;
+    private final MetricRegistry metricRegistry;
+
+    public Netflow9MessageProcessor(AdapterDefinition adapterDefinition, MetricRegistry metricRegistry) {
+        this.adapterDefinition = Objects.requireNonNull(adapterDefinition, "adapterDefinition");
+        this.metricRegistry = Objects.requireNonNull(metricRegistry, "metricRegistry");
+    }
+
+    @Override
+    protected AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline) {
+        return new Netflow9Adapter(adapterDefinition, metricRegistry, pipeline);
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java
@@ -16,15 +16,37 @@
  */
 package org.deltav.flows.enricher.protocol;
 
+import java.util.List;
+
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
 /**
- * Stub interface for Phase 1.5 Commit 3. Commit 4 (Task 8) will define the
- * real {@code process(TelemetryMessageLog)} method and four concrete
- * implementations wrapping horizon's {@code AbstractFlowAdapter} subclasses
- * (Netflow5, Netflow9, IPFIX, sFlow).
+ * Per-protocol processor that wraps one horizon {@code AbstractFlowAdapter}
+ * and exposes a uniform {@link #process(TelemetryProtos.TelemetryMessageLog)}
+ * method returning the parsed flows. One implementation exists per protocol:
+ * Netflow5, Netflow9, IPFIX, sFlow.
  *
- * <p>This stub exists so {@link org.deltav.flows.enricher.FlowEnrichmentFunction}
- * can be refactored to accept a dispatch map in Commit 3 without blocking on
- * Commit 4's per-protocol processor classes.
+ * <p>The telemetry protobuf type
+ * {@code org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos.TelemetryMessageLog}
+ * already implements horizon's
+ * {@code org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog}
+ * interface, so the protobuf can be passed directly into horizon adapters
+ * without an intermediate conversion step. Each entry in the message log is
+ * expected to carry a serialized {@code FlowMessage} protobuf (for the
+ * Netflow variants) or a serialized BSON document (for sFlow); these
+ * representations are the output of horizon's parser layer, which runs on
+ * the Minion before the raw wire bytes are shipped over Kafka Sink.
  */
 public interface ProtocolMessageProcessor {
+
+    /**
+     * Parses the telemetry message log into per-flow records via the
+     * underlying horizon adapter.
+     *
+     * @param messageLog the decoded Sink payload
+     * @return parsed flows (never {@code null}; may be empty if the message
+     *         log contained no records or parsing failed)
+     */
+    List<Flow> process(TelemetryProtos.TelemetryMessageLog messageLog);
 }

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+/**
+ * Stub interface for Phase 1.5 Commit 3. Commit 4 (Task 8) will define the
+ * real {@code process(TelemetryMessageLog)} method and four concrete
+ * implementations wrapping horizon's {@code AbstractFlowAdapter} subclasses
+ * (Netflow5, Netflow9, IPFIX, sFlow).
+ *
+ * <p>This stub exists so {@link org.deltav.flows.enricher.FlowEnrichmentFunction}
+ * can be refactored to accept a dispatch map in Commit 3 without blocking on
+ * Commit 4's per-protocol processor classes.
+ */
+public interface ProtocolMessageProcessor {
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/SFlowMessageProcessor.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/SFlowMessageProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.Objects;
+
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Protocol processor for sFlow messages. Wraps horizon's
+ * {@link SFlowAdapter}, which expects each
+ * {@code TelemetryMessageLogEntry} to carry a serialized BSON document
+ * (the sFlow parser layer's normalized representation). Each BSON document
+ * contains a top-level {@code data.samples} array that may produce zero or
+ * more {@link org.opennms.netmgt.flows.api.Flow} records.
+ */
+public class SFlowMessageProcessor extends AbstractProtocolMessageProcessor {
+
+    private final AdapterDefinition adapterDefinition;
+    private final MetricRegistry metricRegistry;
+
+    public SFlowMessageProcessor(AdapterDefinition adapterDefinition, MetricRegistry metricRegistry) {
+        this.adapterDefinition = Objects.requireNonNull(adapterDefinition, "adapterDefinition");
+        this.metricRegistry = Objects.requireNonNull(metricRegistry, "metricRegistry");
+    }
+
+    @Override
+    protected AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline) {
+        return new SFlowAdapter(adapterDefinition, metricRegistry, pipeline);
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/SimpleAdapterDefinition.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/SimpleAdapterDefinition.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.config.api.PackageDefinition;
+
+/**
+ * Minimal production implementation of horizon's {@link AdapterDefinition}
+ * interface for use by the four Phase 1.5 protocol processors. Returns the
+ * supplied name for both {@link #getName()} and {@link #getFullName()} (the
+ * adapter constructor uses {@code fullName} for metric-registry keys), and
+ * empty collections for everything else.
+ *
+ * <p>We don't extend horizon's existing {@code AdapterDefinition}
+ * implementations because they typically depend on XML-config loading we
+ * don't want in flow-enricher. The horizon flow adapters only consult
+ * {@code getFullName()} (metric key) and {@code getPackages()} (filter-rule
+ * dispatch, disabled here by returning an empty list) from their constructor,
+ * so this skeleton is sufficient.
+ *
+ * <p>The {@link AdapterDefinition} interface extends
+ * {@code TelemetryBeanDefinition}, which contributes
+ * {@link #getName()}, {@link #getClassName()}, and {@link #getParameterMap()}.
+ * All methods are implemented here.
+ */
+public class SimpleAdapterDefinition implements AdapterDefinition {
+
+    private final String name;
+
+    public SimpleAdapterDefinition(String name) {
+        this.name = Objects.requireNonNull(name, "name");
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getFullName() {
+        return name;
+    }
+
+    @Override
+    public String getClassName() {
+        return "";
+    }
+
+    @Override
+    public Map<String, String> getParameterMap() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<? extends PackageDefinition> getPackages() {
+        return Collections.emptyList();
+    }
+}

--- a/core/flow-enricher/src/main/resources/application.yml
+++ b/core/flow-enricher/src/main/resources/application.yml
@@ -23,6 +23,13 @@ spring:
           group: deltav-flow-enricher
         enrichFlows-out-0:
           destination: ${DELTAV_FLOWS_OUTPUT_TOPIC:deltav-flows}
+          # The function returns a List<byte[]> where each element is an
+          # already-serialized FlowDocument protobuf. useNativeEncoding=true
+          # tells Spring Cloud Function not to JSON-wrap the payload, which
+          # also lets the binder treat the List as a splitter (one Kafka
+          # record per list element) instead of a single JSON array.
+          producer:
+            use-native-encoding: true
       kafka:
         binder:
           brokers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.protobuf.ByteString;
+
+import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
+import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.model.SinkMessage;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
+class FlowEnrichmentFunctionTest {
+
+    private FlowEnrichmentFunction function;
+
+    @BeforeEach
+    void setUp() {
+        SinkMessageDeserializer deserializer = new SinkMessageDeserializer();
+        JdbcNodeInfoLookup nodeInfoLookup = mock(JdbcNodeInfoLookup.class);
+        FlowLocalityCalculator localityCalculator = mock(FlowLocalityCalculator.class);
+        InterfaceMarkingCache interfaceMarkingCache = mock(InterfaceMarkingCache.class);
+
+        function = new FlowEnrichmentFunction(
+                deserializer,
+                nodeInfoLookup,
+                localityCalculator,
+                interfaceMarkingCache,
+                Map.of()); // Commit 5 populates the dispatch map with real processors
+    }
+
+    @Test
+    void returnsEmptyListForNullMessage() {
+        List<byte[]> result = function.processMessage(null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyListForEmptyMessage() {
+        List<byte[]> result = function.processMessage(new byte[0]);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyListForGarbageBytes() {
+        List<byte[]> result = function.processMessage(new byte[]{0x01, 0x02, 0x03, 0x04});
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyListForEmptyTelemetryMessageLog() {
+        // Valid SinkMessage envelope wrapping an empty TelemetryMessageLog (no
+        // flow records): function must drop the message without producing output.
+        byte[] payload = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("Default")
+                .setSystemId("minion-01")
+                .setSourceAddress("192.168.1.1")
+                .setSourcePort(4729)
+                .build()
+                .toByteArray();
+        byte[] kafkaBytes = buildSinkMessageBytes("test-empty", payload);
+
+        List<byte[]> result = function.processMessage(kafkaBytes);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyListForUnknownModuleId() {
+        // Commit 3 scope: the dispatch map is empty, so every parseable message
+        // falls through to the "no processor for moduleId" path. A real flow
+        // record-bearing message still returns an empty list here. Commit 5
+        // (Task 12) replaces this placeholder with per-flow enrichment output.
+        byte[] payload = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("Default")
+                .setSystemId("minion-01")
+                .setSourceAddress("192.168.1.1")
+                .setSourcePort(4729)
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setTimestamp(System.currentTimeMillis())
+                        .setBytes(ByteString.copyFrom(new byte[]{0x00, 0x01, 0x02}))
+                        .build())
+                .build()
+                .toByteArray();
+        byte[] kafkaBytes = buildSinkMessageBytes("test-unknown-module", payload);
+
+        List<byte[]> result = function.processMessage(kafkaBytes);
+
+        assertThat(result).isEmpty();
+    }
+
+    private static byte[] buildSinkMessageBytes(String messageId, byte[] payload) {
+        return SinkMessage.newBuilder()
+                .setMessageId(messageId)
+                .setContent(ByteString.copyFrom(payload))
+                .setCurrentChunkNumber(0)
+                .setTotalChunks(1)
+                .build()
+                .toByteArray();
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
@@ -17,39 +17,86 @@
 package org.deltav.flows.enricher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 
+import org.deltav.flows.enricher.classification.ApplicationClassifier;
 import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
+import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator.Locality;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.enricher.mapping.FlowToDocumentMapper;
+import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
+import org.deltav.flows.proto.FlowDocumentProtos;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opennms.core.ipc.sink.model.SinkMessage;
+import org.opennms.integration.api.v1.flows.Flow.NetflowVersion;
+import org.opennms.netmgt.flows.api.Flow;
 import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 
 class FlowEnrichmentFunctionTest {
+
+    private static final String EXPORTER_ADDRESS = "192.0.2.10";
+    private static final String MINION_LOCATION = "Default";
+    private static final String NF5_TOPIC = "OpenNMS.Sink.Telemetry-Netflow-5";
+    private static final String NF5_MODULE_ID = "Telemetry-Netflow-5";
+
+    private SinkMessageDeserializer deserializer;
+    private JdbcNodeInfoLookup nodeInfoLookup;
+    private FlowLocalityCalculator localityCalculator;
+    private InterfaceMarkingCache interfaceMarkingCache;
+    private ApplicationClassifier applicationClassifier;
+    private FlowToDocumentMapper flowToDocumentMapper;
+    private ProtocolMessageProcessor nf5Processor;
 
     private FlowEnrichmentFunction function;
 
     @BeforeEach
     void setUp() {
-        SinkMessageDeserializer deserializer = new SinkMessageDeserializer();
-        JdbcNodeInfoLookup nodeInfoLookup = mock(JdbcNodeInfoLookup.class);
-        FlowLocalityCalculator localityCalculator = mock(FlowLocalityCalculator.class);
-        InterfaceMarkingCache interfaceMarkingCache = mock(InterfaceMarkingCache.class);
+        deserializer = new SinkMessageDeserializer();
+        nodeInfoLookup = mock(JdbcNodeInfoLookup.class);
+        localityCalculator = mock(FlowLocalityCalculator.class);
+        interfaceMarkingCache = mock(InterfaceMarkingCache.class);
+        applicationClassifier = mock(ApplicationClassifier.class);
+        flowToDocumentMapper = new FlowToDocumentMapper();
+        nf5Processor = mock(ProtocolMessageProcessor.class);
+
+        // Default mock behavior: unknown locality for unknown addresses,
+        // null node lookups, "unknown" application classification.
+        when(localityCalculator.classify(anyString())).thenReturn(Locality.UNKNOWN);
+        when(localityCalculator.flowLocality(anyString(), anyString())).thenReturn(Locality.UNKNOWN);
+        when(applicationClassifier.classify(anyInt(), anyInt(), anyInt())).thenReturn("unknown");
 
         function = new FlowEnrichmentFunction(
                 deserializer,
                 nodeInfoLookup,
                 localityCalculator,
                 interfaceMarkingCache,
-                Map.of()); // Commit 5 populates the dispatch map with real processors
+                applicationClassifier,
+                flowToDocumentMapper,
+                Map.of(NF5_MODULE_ID, nf5Processor));
     }
+
+    // ---- Commit 3 carry-forward tests (updated for Message<byte[]> signature) ----
 
     @Test
     void returnsEmptyListForNullMessage() {
@@ -58,14 +105,15 @@ class FlowEnrichmentFunctionTest {
     }
 
     @Test
-    void returnsEmptyListForEmptyMessage() {
-        List<byte[]> result = function.processMessage(new byte[0]);
+    void returnsEmptyListForEmptyPayload() {
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, new byte[0]));
         assertThat(result).isEmpty();
     }
 
     @Test
     void returnsEmptyListForGarbageBytes() {
-        List<byte[]> result = function.processMessage(new byte[]{0x01, 0x02, 0x03, 0x04});
+        Message<byte[]> message = messageWithTopic(NF5_TOPIC, new byte[]{0x01, 0x02, 0x03, 0x04});
+        List<byte[]> result = function.processMessage(message);
         assertThat(result).isEmpty();
     }
 
@@ -74,41 +122,271 @@ class FlowEnrichmentFunctionTest {
         // Valid SinkMessage envelope wrapping an empty TelemetryMessageLog (no
         // flow records): function must drop the message without producing output.
         byte[] payload = TelemetryProtos.TelemetryMessageLog.newBuilder()
-                .setLocation("Default")
+                .setLocation(MINION_LOCATION)
                 .setSystemId("minion-01")
-                .setSourceAddress("192.168.1.1")
+                .setSourceAddress(EXPORTER_ADDRESS)
                 .setSourcePort(4729)
                 .build()
                 .toByteArray();
         byte[] kafkaBytes = buildSinkMessageBytes("test-empty", payload);
 
-        List<byte[]> result = function.processMessage(kafkaBytes);
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void returnsEmptyListForUnknownModuleId() {
-        // Commit 3 scope: the dispatch map is empty, so every parseable message
-        // falls through to the "no processor for moduleId" path. A real flow
-        // record-bearing message still returns an empty list here. Commit 5
-        // (Task 12) replaces this placeholder with per-flow enrichment output.
+        // Topic with prefix we recognize but an unknown module ID suffix.
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(
+                messageWithTopic("OpenNMS.Sink.Telemetry-Made-Up", kafkaBytes));
+
+        assertThat(result).isEmpty();
+    }
+
+    // ---- New Commit 5 full-pipeline tests ----
+
+    @Test
+    void dispatchesByTopicPrefixAndExtractsModuleId() {
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 54321, 443, 6, 1, 2);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        assertThat(result).hasSize(1);
+        verify(nf5Processor).process(any());
+    }
+
+    @Test
+    void handlesDeltavSinkPrefixToo() {
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 54321, 443, 6, 1, 2);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(
+                messageWithTopic("DeltaV.Sink." + NF5_MODULE_ID, kafkaBytes));
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void returnsEmptyListForUnknownTopicPrefix() {
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(
+                messageWithTopic("Custom.Sink." + NF5_MODULE_ID, kafkaBytes));
+
+        assertThat(result).isEmpty();
+        verify(nf5Processor, never()).process(any());
+    }
+
+    @Test
+    void returnsEmptyListWhenTopicHeaderMissing() {
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+        Message<byte[]> noHeaderMessage = MessageBuilder.withPayload(kafkaBytes).build();
+
+        List<byte[]> result = function.processMessage(noHeaderMessage);
+
+        assertThat(result).isEmpty();
+        verify(nf5Processor, never()).process(any());
+    }
+
+    @Test
+    void looksUpExporterNodeOnceAndReusesAcrossFlows() {
+        Flow flow1 = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 1, 2);
+        Flow flow2 = buildFlow("10.0.0.3", "10.0.0.4", 333, 444, 17, 3, 4);
+        Flow flow3 = buildFlow("10.0.0.5", "10.0.0.6", 555, 666, 6, 5, 6);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow1, flow2, flow3));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        assertThat(result).hasSize(3);
+        // Exporter looked up exactly once regardless of how many flows we had.
+        verify(nodeInfoLookup, times(1)).lookupByIpAddress(EXPORTER_ADDRESS);
+    }
+
+    @Test
+    void enrichesEachFlowWithSrcAndDstNodeLookups() {
+        Flow flow1 = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 1, 2);
+        Flow flow2 = buildFlow("10.0.0.3", "10.0.0.4", 333, 444, 17, 3, 4);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow1, flow2));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        verify(nodeInfoLookup).lookupByIpAddress("10.0.0.1");
+        verify(nodeInfoLookup).lookupByIpAddress("10.0.0.2");
+        verify(nodeInfoLookup).lookupByIpAddress("10.0.0.3");
+        verify(nodeInfoLookup).lookupByIpAddress("10.0.0.4");
+    }
+
+    @Test
+    void callsInterfaceMarkingForInputAndOutputIfindex() {
+        // Exporter node resolves, flow has non-zero input/output ifindex.
+        JdbcNodeInfoLookup.NodeInfo exporterInfo =
+                new JdbcNodeInfoLookup.NodeInfo(42, "Minions", "exporter-1", MINION_LOCATION);
+        when(nodeInfoLookup.lookupByIpAddress(EXPORTER_ADDRESS)).thenReturn(exporterInfo);
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 7, 11);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        verify(interfaceMarkingCache).markIfNeeded(42L, 7);
+        verify(interfaceMarkingCache).markIfNeeded(42L, 11);
+    }
+
+    @Test
+    void skipsInterfaceMarkingWhenExporterUnknown() {
+        // Exporter lookup returns null — no node ID available.
+        when(nodeInfoLookup.lookupByIpAddress(EXPORTER_ADDRESS)).thenReturn(null);
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 7, 11);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        verify(interfaceMarkingCache, never()).markIfNeeded(anyLong(), anyInt());
+    }
+
+    @Test
+    void skipsInterfaceMarkingWhenIfindexIsZeroOrNull() {
+        JdbcNodeInfoLookup.NodeInfo exporterInfo =
+                new JdbcNodeInfoLookup.NodeInfo(99, "Minions", "exporter-9", MINION_LOCATION);
+        when(nodeInfoLookup.lookupByIpAddress(EXPORTER_ADDRESS)).thenReturn(exporterInfo);
+        // Ifindex 0 for both directions: "unknown" per Netflow spec.
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 0, 0);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        verify(interfaceMarkingCache, never()).markIfNeeded(anyLong(), anyInt());
+    }
+
+    @Test
+    void populatesApplicationFieldFromClassifier() throws InvalidProtocolBufferException {
+        when(applicationClassifier.classify(443, 54321, 6)).thenReturn("HTTPS");
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 54321, 443, 6, 1, 2);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        assertThat(result).hasSize(1);
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc.getApplication()).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void populatesLocalityFieldsFromCalculator() throws InvalidProtocolBufferException {
+        when(localityCalculator.classify("10.0.0.1")).thenReturn(Locality.PRIVATE);
+        when(localityCalculator.classify("198.51.100.5")).thenReturn(Locality.PUBLIC);
+        when(localityCalculator.flowLocality("10.0.0.1", "198.51.100.5")).thenReturn(Locality.PUBLIC);
+        Flow flow = buildFlow("10.0.0.1", "198.51.100.5", 54321, 443, 6, 1, 2);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        assertThat(result).hasSize(1);
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.PRIVATE);
+        assertThat(doc.getDstLocality()).isEqualTo(FlowDocumentProtos.Locality.PUBLIC);
+        assertThat(doc.getFlowLocality()).isEqualTo(FlowDocumentProtos.Locality.PUBLIC);
+    }
+
+    @Test
+    void continuesProcessingWhenOneFlowFailsEnrichment() {
+        // Construct one flow that throws when getSrcAddr() is called, and one
+        // that doesn't. The failing flow must be skipped but the good one must
+        // still produce an output record.
+        Flow goodFlow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 1, 2);
+        Flow badFlow = mock(Flow.class);
+        when(badFlow.getSrcAddr()).thenThrow(new RuntimeException("simulated enrichment failure"));
+        when(nf5Processor.process(any())).thenReturn(List.of(badFlow, goodFlow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        // Exactly one result from the surviving good flow.
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void populatesHostAndLocationFromTelemetryMessageLog() throws InvalidProtocolBufferException {
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 1, 2);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        assertThat(result).hasSize(1);
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc.getHost()).isEqualTo(EXPORTER_ADDRESS);
+        assertThat(doc.getLocation()).isEqualTo(MINION_LOCATION);
+    }
+
+    @Test
+    void passesZeroClockCorrectionInPhase15() throws InvalidProtocolBufferException {
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 1, 2);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        assertThat(result).hasSize(1);
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc.getClockCorrection()).isZero();
+    }
+
+    @Test
+    void populatesExporterNodeInfoFromLookup() throws InvalidProtocolBufferException {
+        JdbcNodeInfoLookup.NodeInfo exporterInfo =
+                new JdbcNodeInfoLookup.NodeInfo(77, "Minions", "exporter-77", MINION_LOCATION);
+        when(nodeInfoLookup.lookupByIpAddress(EXPORTER_ADDRESS)).thenReturn(exporterInfo);
+        Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 1, 2);
+        when(nf5Processor.process(any())).thenReturn(List.of(flow));
+        byte[] kafkaBytes = buildValidSinkMessageBytes();
+
+        List<byte[]> result = function.processMessage(messageWithTopic(NF5_TOPIC, kafkaBytes));
+
+        assertThat(result).hasSize(1);
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc.hasExporterNode()).isTrue();
+        assertThat(doc.getExporterNode().getNodeId()).isEqualTo(77);
+        assertThat(doc.getExporterNode().getForeignSource()).isEqualTo("Minions");
+        assertThat(doc.getExporterNode().getForeignId()).isEqualTo("exporter-77");
+    }
+
+    // ---- Helpers ----
+
+    private static Message<byte[]> messageWithTopic(String topicName, byte[] payload) {
+        return MessageBuilder.withPayload(payload)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, topicName)
+                .build();
+    }
+
+    private static byte[] buildValidSinkMessageBytes() {
+        // A valid, non-empty TelemetryMessageLog wrapped in a SinkMessage
+        // envelope. The actual contents of the TelemetryMessage entries don't
+        // matter because the processor is mocked.
         byte[] payload = TelemetryProtos.TelemetryMessageLog.newBuilder()
-                .setLocation("Default")
+                .setLocation(MINION_LOCATION)
                 .setSystemId("minion-01")
-                .setSourceAddress("192.168.1.1")
-                .setSourcePort(4729)
+                .setSourceAddress(EXPORTER_ADDRESS)
+                .setSourcePort(2055)
                 .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
                         .setTimestamp(System.currentTimeMillis())
-                        .setBytes(ByteString.copyFrom(new byte[]{0x00, 0x01, 0x02}))
+                        .setBytes(ByteString.copyFrom(new byte[]{0x00, 0x01, 0x02, 0x03}))
                         .build())
                 .build()
                 .toByteArray();
-        byte[] kafkaBytes = buildSinkMessageBytes("test-unknown-module", payload);
-
-        List<byte[]> result = function.processMessage(kafkaBytes);
-
-        assertThat(result).isEmpty();
+        return buildSinkMessageBytes("test-msg", payload);
     }
 
     private static byte[] buildSinkMessageBytes(String messageId, byte[] payload) {
@@ -119,5 +397,36 @@ class FlowEnrichmentFunctionTest {
                 .setTotalChunks(1)
                 .build()
                 .toByteArray();
+    }
+
+    /**
+     * Builds a minimal {@link Flow} mock that returns the supplied addressing
+     * fields and otherwise null-valued/default returns for everything else.
+     * The {@link FlowToDocumentMapper} tolerates all-null wrapper-typed
+     * getters per its null-wrapper discipline.
+     */
+    private static Flow buildFlow(
+            String srcAddr,
+            String dstAddr,
+            int srcPort,
+            int dstPort,
+            int protocol,
+            int inputSnmp,
+            int outputSnmp) {
+        Flow flow = mock(Flow.class);
+        when(flow.getSrcAddr()).thenReturn(srcAddr);
+        when(flow.getDstAddr()).thenReturn(dstAddr);
+        when(flow.getSrcPort()).thenReturn(srcPort);
+        when(flow.getDstPort()).thenReturn(dstPort);
+        when(flow.getProtocol()).thenReturn(protocol);
+        when(flow.getInputSnmp()).thenReturn(inputSnmp);
+        when(flow.getOutputSnmp()).thenReturn(outputSnmp);
+        when(flow.getTimestamp()).thenReturn(Instant.now());
+        when(flow.getNetflowVersion()).thenReturn(NetflowVersion.V5);
+        when(flow.getSrcAddrHostname()).thenReturn(Optional.empty());
+        when(flow.getDstAddrHostname()).thenReturn(Optional.empty());
+        when(flow.getNextHopHostname()).thenReturn(Optional.empty());
+        // Primitive long/int getters return 0 by default, which is fine.
+        return flow;
     }
 }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.opennms.core.ipc.sink.model.SinkMessage;
 import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
 
+@SuppressWarnings("deprecation") // intentionally exercises the deprecated single-arg overload
 class SinkMessageDeserializerTest {
 
     private final SinkMessageDeserializer deserializer = new SinkMessageDeserializer();

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java
@@ -30,46 +30,55 @@ class SinkMessageDeserializerTest {
 
     @Test
     void deserializesSingleChunkMessage() {
-        TelemetryProtos.TelemetryMessageLog messageLog = TelemetryProtos.TelemetryMessageLog.newBuilder()
-                .setLocation("Default")
-                .setSystemId("minion-01")
-                .setSourceAddress("192.168.1.1")
-                .setSourcePort(4729)
-                .build();
+        byte[] bytes = buildSinkMessageBytes("test-1", samplePayloadBytes(), 0, 1);
 
-        SinkMessage sinkMessage = SinkMessage.newBuilder()
-                .setMessageId("test-1")
-                .setContent(ByteString.copyFrom(messageLog.toByteArray()))
-                .setCurrentChunkNumber(0)
-                .setTotalChunks(1)
-                .build();
-
-        TelemetryProtos.TelemetryMessageLog result = deserializer.deserialize(sinkMessage.toByteArray());
+        DeserializedSinkMessage result = deserializer.deserialize(bytes);
 
         assertThat(result).isNotNull();
-        assertThat(result.getLocation()).isEqualTo("Default");
-        assertThat(result.getSystemId()).isEqualTo("minion-01");
-        assertThat(result.getSourceAddress()).isEqualTo("192.168.1.1");
-        assertThat(result.getSourcePort()).isEqualTo(4729);
+        assertThat(result.messageLog()).isNotNull();
+        assertThat(result.messageLog().getLocation()).isEqualTo("Default");
+        assertThat(result.messageLog().getSystemId()).isEqualTo("minion-01");
+        assertThat(result.messageLog().getSourceAddress()).isEqualTo("192.168.1.1");
+        assertThat(result.messageLog().getSourcePort()).isEqualTo(4729);
+    }
+
+    @Test
+    void deserializedMessageModuleIdIsNullForSingleArgOverload() {
+        // The Sink envelope does not carry a moduleId field (see DeserializedSinkMessage
+        // javadoc); the single-arg deserializer therefore always reports null. Wiring
+        // topic-derived moduleId through the function signature is a later commit.
+        byte[] bytes = buildSinkMessageBytes("test-moduleid", samplePayloadBytes(), 0, 1);
+
+        DeserializedSinkMessage result = deserializer.deserialize(bytes);
+
+        assertThat(result).isNotNull();
+        assertThat(result.moduleId()).isNull();
+    }
+
+    @Test
+    void deserializedMessageExposesModuleIdFromTwoArgOverload() {
+        byte[] bytes = buildSinkMessageBytes("test-moduleid-2arg", samplePayloadBytes(), 0, 1);
+
+        DeserializedSinkMessage result = deserializer.deserialize("Telemetry-Netflow-9", bytes);
+
+        assertThat(result).isNotNull();
+        assertThat(result.moduleId()).isEqualTo("Telemetry-Netflow-9");
+        assertThat(result.messageLog()).isNotNull();
+        assertThat(result.messageLog().getLocation()).isEqualTo("Default");
     }
 
     @Test
     void chunkedMessageIsDroppedAndReturnsNull() {
-        TelemetryProtos.TelemetryMessageLog messageLog = TelemetryProtos.TelemetryMessageLog.newBuilder()
-                .setLocation("Default")
-                .setSystemId("minion-01")
-                .setSourceAddress("192.168.1.1")
-                .setSourcePort(4729)
-                .build();
+        byte[] bytes = buildSinkMessageBytes("test-chunked", samplePayloadBytes(), 0, 3);
 
-        SinkMessage sinkMessage = SinkMessage.newBuilder()
-                .setMessageId("test-chunked")
-                .setContent(ByteString.copyFrom(messageLog.toByteArray()))
-                .setCurrentChunkNumber(0)
-                .setTotalChunks(3)
-                .build();
+        assertThat(deserializer.deserialize(bytes)).isNull();
+    }
 
-        assertThat(deserializer.deserialize(sinkMessage.toByteArray())).isNull();
+    @Test
+    void chunkedMessageIsDroppedAndReturnsNullForTwoArgOverload() {
+        byte[] bytes = buildSinkMessageBytes("test-chunked-2arg", samplePayloadBytes(), 0, 3);
+
+        assertThat(deserializer.deserialize("Telemetry-Netflow-5", bytes)).isNull();
     }
 
     @Test
@@ -80,5 +89,30 @@ class SinkMessageDeserializerTest {
     @Test
     void nullBytesReturnNull() {
         assertThat(deserializer.deserialize(null)).isNull();
+    }
+
+    @Test
+    void nullBytesReturnNullForTwoArgOverload() {
+        assertThat(deserializer.deserialize("Telemetry-Netflow-5", null)).isNull();
+    }
+
+    private static byte[] samplePayloadBytes() {
+        return TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("Default")
+                .setSystemId("minion-01")
+                .setSourceAddress("192.168.1.1")
+                .setSourcePort(4729)
+                .build()
+                .toByteArray();
+    }
+
+    private static byte[] buildSinkMessageBytes(String messageId, byte[] payload, int currentChunk, int totalChunks) {
+        return SinkMessage.newBuilder()
+                .setMessageId(messageId)
+                .setContent(ByteString.copyFrom(payload))
+                .setCurrentChunkNumber(currentChunk)
+                .setTotalChunks(totalChunks)
+                .build()
+                .toByteArray();
     }
 }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifierTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifierTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.classification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PortBasedApplicationClassifierTest {
+
+    private static final int TCP = 6;
+    private static final int UDP = 17;
+
+    private final PortBasedApplicationClassifier classifier = new PortBasedApplicationClassifier();
+
+    @Test
+    void classifiesHttpsByDstPort() {
+        assertThat(classifier.classify(443, 51234, TCP)).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void classifiesHttpsBySrcPortForReturnFlow() {
+        assertThat(classifier.classify(51234, 443, TCP)).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void dstPortTakesPriorityWhenBothPortsAreWellKnown() {
+        // dst=443 (HTTPS), src=80 (HTTP) — dst wins.
+        assertThat(classifier.classify(443, 80, TCP)).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void classifiesDnsOverUdp() {
+        assertThat(classifier.classify(53, 51234, UDP)).isEqualTo("DNS");
+    }
+
+    @Test
+    void classifiesSsh() {
+        assertThat(classifier.classify(22, 49152, TCP)).isEqualTo("SSH");
+    }
+
+    @Test
+    void classifiesHttp() {
+        assertThat(classifier.classify(80, 49152, TCP)).isEqualTo("HTTP");
+    }
+
+    @Test
+    void classifiesSmtpOn25And587() {
+        assertThat(classifier.classify(25, 49152, TCP)).isEqualTo("SMTP");
+        assertThat(classifier.classify(587, 49152, TCP)).isEqualTo("SMTP");
+    }
+
+    @Test
+    void classifiesDatabasePorts() {
+        assertThat(classifier.classify(5432, 49152, TCP)).isEqualTo("PostgreSQL");
+        assertThat(classifier.classify(3306, 49152, TCP)).isEqualTo("MySQL");
+        assertThat(classifier.classify(6379, 49152, TCP)).isEqualTo("Redis");
+    }
+
+    @Test
+    void classifiesKafka() {
+        assertThat(classifier.classify(9092, 49152, TCP)).isEqualTo("Kafka");
+    }
+
+    @Test
+    void classifiesElasticsearchAndMongo() {
+        assertThat(classifier.classify(9200, 49152, TCP)).isEqualTo("Elasticsearch");
+        assertThat(classifier.classify(27017, 49152, TCP)).isEqualTo("MongoDB");
+    }
+
+    @Test
+    void returnsUnknownWhenNeitherPortIsWellKnown() {
+        assertThat(classifier.classify(49152, 51234, TCP)).isEqualTo("unknown");
+    }
+
+    @Test
+    void classifiesSnmpAndSnmpTrap() {
+        assertThat(classifier.classify(161, 49152, UDP)).isEqualTo("SNMP");
+        assertThat(classifier.classify(162, 49152, UDP)).isEqualTo("SNMP-trap");
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.deltav.flows.enricher.FlowEnricherApplication;
+import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.model.SinkMessage;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.NetflowVersion;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * End-to-end integration test for the flow-enricher Spring Cloud Stream
+ * pipeline. Loads the full {@link FlowEnricherApplication} Spring Boot context
+ * with the in-memory {@link TestChannelBinderConfiguration test binder},
+ * synthesizes Sink messages for each of the four supported flow protocols
+ * (Netflow-5, Netflow-9, IPFIX, sFlow), and verifies that enriched
+ * {@link FlowDocumentProtos.FlowDocument} records are emitted on the
+ * {@code deltav-flows} output destination.
+ *
+ * <p>The {@link JdbcNodeInfoLookup} and {@link InterfaceMarkingCache} beans
+ * are replaced with Mockito mocks via {@link MockitoBean} (Spring Boot 4.0's
+ * successor to {@code @MockBean}). This sidesteps the
+ * {@link javax.sql.DataSource} dependency chain in
+ * {@code FlowEnricherConfiguration}: with those two beans mocked, Spring never
+ * needs to instantiate {@code flowEnricherJdbcTemplate}, so no
+ * {@code DataSource} bean is ever requested. We still explicitly exclude
+ * {@code DataSourceAutoConfiguration} for defense in depth.
+ *
+ * <p>Because {@link JdbcNodeInfoLookup#lookupByIpAddress(String)} always
+ * returns {@code null} in this test, the enricher's per-flow logic runs but
+ * cannot populate the {@code exporter_node}/{@code src_node}/{@code dest_node}
+ * fields. We therefore assert on the scalar fields the enricher populates
+ * regardless of node lookup success: {@code src_address}, {@code dst_address},
+ * {@code netflow_version}, {@code host}, {@code location}, and
+ * {@code application}.
+ */
+@SpringBootTest(
+        classes = { FlowEnricherApplication.class },
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+                "spring.cloud.function.definition=enrichFlows",
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+                // Force the in-memory TestChannelBinder ("integration") to be the
+                // default binder even though the Kafka binder jar is also on the
+                // classpath. Without this, SCS will try to instantiate the Kafka
+                // binder and fail because there's no broker.
+                "spring.cloud.stream.defaultBinder=integration",
+                // The function returns List<byte[]>. Without useNativeEncoding,
+                // Spring Cloud Function JSON-serializes the entire list into a
+                // single "[]"-shaped payload; with it, the binder honors the
+                // splitter semantics and emits one output message per list
+                // element. Matches the production setting in application.yml.
+                "spring.cloud.stream.bindings.enrichFlows-out-0.producer.use-native-encoding=true"
+        })
+@Import(TestChannelBinderConfiguration.class)
+class FlowEnrichmentStreamBinderIT {
+
+    private static final String OUTPUT_DESTINATION = "deltav-flows";
+    private static final String MINION_LOCATION = "test-location";
+    private static final String EXPORTER_ADDRESS = "192.0.2.254";
+
+    // Destination names matching the four comma-separated entries in
+    // application.yml's enrichFlows-in-0.destination. The test binder
+    // provisions one SubscribableChannel per entry, keyed by
+    // "<destination>.destination".
+    private static final String NF5_DESTINATION = "OpenNMS.Sink.Telemetry-Netflow-5";
+    private static final String NF9_DESTINATION = "OpenNMS.Sink.Telemetry-Netflow-9";
+    private static final String IPFIX_DESTINATION = "OpenNMS.Sink.Telemetry-IPFIX";
+    private static final String SFLOW_DESTINATION = "OpenNMS.Sink.Telemetry-SFlow";
+
+    @Autowired
+    private InputDestination input;
+
+    @Autowired
+    private OutputDestination output;
+
+    @MockitoBean
+    private JdbcNodeInfoLookup jdbcNodeInfoLookup;
+
+    @MockitoBean
+    private InterfaceMarkingCache interfaceMarkingCache;
+
+    @BeforeEach
+    void setUp() {
+        // All node lookups return null so the enricher runs without touching
+        // the database. The test asserts on scalar fields that survive a
+        // null NodeInfo, not on the exporter_node/src_node/dest_node fields.
+        when(jdbcNodeInfoLookup.lookupByIpAddress(anyString())).thenReturn(null);
+        // interfaceMarkingCache is a mock whose void markIfNeeded() method is
+        // a no-op by default; no stubbing needed. It's injected only to
+        // prevent the real bean from requiring a JdbcTemplate / DataSource.
+        //
+        // Drain any residual messages from previous tests on the shared
+        // output destination. The test binder reuses its PublishSubscribeChannel
+        // across @Test methods in the same @SpringBootTest class.
+        output.clear(OUTPUT_DESTINATION);
+    }
+
+    @Test
+    void netflow5MessageProducesEnrichedFlowDocument() throws Exception {
+        FlowMessage netflow5 = FlowMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setNetflowVersion(NetflowVersion.V5)
+                .setSrcAddress("192.0.2.1")
+                .setDstAddress("198.51.100.2")
+                .setNextHopAddress("203.0.113.1")
+                .setSrcPort(UInt32Value.of(54321))
+                .setDstPort(UInt32Value.of(443))
+                .setProtocol(UInt32Value.of(6))
+                .setTcpFlags(UInt32Value.of(0x18))
+                .setNumBytes(UInt64Value.of(1500L))
+                .setNumPackets(UInt64Value.of(10L))
+                .setFirstSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setLastSwitched(UInt64Value.of(1_700_000_001_000L))
+                .setDeltaSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setInputSnmpIfindex(UInt32Value.of(1))
+                .setOutputSnmpIfindex(UInt32Value.of(2))
+                .setIpProtocolVersion(UInt32Value.of(4))
+                .build();
+        byte[] sinkBytes = buildSinkMessageBytes(buildTelemetryMessageLog(netflow5.toByteArray()));
+
+        send(NF5_DESTINATION, sinkBytes);
+
+        Message<byte[]> received = output.receive(10_000, OUTPUT_DESTINATION);
+        assertThat(received).as("expected a FlowDocument on %s", OUTPUT_DESTINATION).isNotNull();
+
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(received.getPayload());
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V5);
+        assertThat(doc.getSrcAddress()).isEqualTo("192.0.2.1");
+        assertThat(doc.getDstAddress()).isEqualTo("198.51.100.2");
+        assertThat(doc.getDstPort().getValue()).isEqualTo(443);
+        assertThat(doc.getProtocol().getValue()).isEqualTo(6);
+        assertThat(doc.getHost()).isEqualTo(EXPORTER_ADDRESS);
+        assertThat(doc.getLocation()).isEqualTo(MINION_LOCATION);
+        assertThat(doc.getApplication()).isEqualTo("HTTPS");
+        // Node lookups all returned null, so exporter/src/dst node fields are
+        // unset (hasExporterNode / hasSrcNode / hasDestNode == false).
+        assertThat(doc.hasExporterNode()).isFalse();
+        assertThat(doc.hasSrcNode()).isFalse();
+        assertThat(doc.hasDestNode()).isFalse();
+    }
+
+    @Test
+    void netflow9MessageProducesEnrichedFlowDocument() throws Exception {
+        FlowMessage netflow9 = FlowMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setNetflowVersion(NetflowVersion.V9)
+                .setSrcAddress("10.0.0.1")
+                .setDstAddress("10.0.0.2")
+                .setNextHopAddress("10.0.0.254")
+                .setSrcPort(UInt32Value.of(12345))
+                .setDstPort(UInt32Value.of(53))
+                .setProtocol(UInt32Value.of(17)) // UDP
+                .setNumBytes(UInt64Value.of(2048L))
+                .setNumPackets(UInt64Value.of(16L))
+                .setFirstSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setLastSwitched(UInt64Value.of(1_700_000_001_000L))
+                .setDeltaSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setInputSnmpIfindex(UInt32Value.of(3))
+                .setOutputSnmpIfindex(UInt32Value.of(4))
+                .setIpProtocolVersion(UInt32Value.of(4))
+                .build();
+        byte[] sinkBytes = buildSinkMessageBytes(buildTelemetryMessageLog(netflow9.toByteArray()));
+
+        send(NF9_DESTINATION, sinkBytes);
+
+        Message<byte[]> received = output.receive(10_000, OUTPUT_DESTINATION);
+        assertThat(received).as("expected a FlowDocument on %s", OUTPUT_DESTINATION).isNotNull();
+
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(received.getPayload());
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V9);
+        assertThat(doc.getSrcAddress()).isEqualTo("10.0.0.1");
+        assertThat(doc.getDstAddress()).isEqualTo("10.0.0.2");
+        assertThat(doc.getDstPort().getValue()).isEqualTo(53);
+        assertThat(doc.getProtocol().getValue()).isEqualTo(17);
+        assertThat(doc.getHost()).isEqualTo(EXPORTER_ADDRESS);
+        assertThat(doc.getLocation()).isEqualTo(MINION_LOCATION);
+        assertThat(doc.getApplication()).isEqualTo("DNS");
+    }
+
+    @Test
+    void ipfixMessageProducesEnrichedFlowDocument() throws Exception {
+        FlowMessage ipfix = FlowMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setNetflowVersion(NetflowVersion.IPFIX)
+                .setSrcAddress("2001:db8::1")
+                .setDstAddress("2001:db8::2")
+                .setNextHopAddress("2001:db8::ffff")
+                .setSrcPort(UInt32Value.of(40000))
+                .setDstPort(UInt32Value.of(22))
+                .setProtocol(UInt32Value.of(6)) // TCP
+                .setTcpFlags(UInt32Value.of(0x02))
+                .setNumBytes(UInt64Value.of(4096L))
+                .setNumPackets(UInt64Value.of(32L))
+                .setFirstSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setLastSwitched(UInt64Value.of(1_700_000_002_000L))
+                .setDeltaSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setInputSnmpIfindex(UInt32Value.of(5))
+                .setOutputSnmpIfindex(UInt32Value.of(6))
+                .setIpProtocolVersion(UInt32Value.of(6))
+                .build();
+        byte[] sinkBytes = buildSinkMessageBytes(buildTelemetryMessageLog(ipfix.toByteArray()));
+
+        send(IPFIX_DESTINATION, sinkBytes);
+
+        Message<byte[]> received = output.receive(10_000, OUTPUT_DESTINATION);
+        assertThat(received).as("expected a FlowDocument on %s", OUTPUT_DESTINATION).isNotNull();
+
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(received.getPayload());
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.IPFIX);
+        assertThat(doc.getSrcAddress()).isEqualTo("2001:db8::1");
+        assertThat(doc.getDstAddress()).isEqualTo("2001:db8::2");
+        assertThat(doc.getDstPort().getValue()).isEqualTo(22);
+        assertThat(doc.getProtocol().getValue()).isEqualTo(6);
+        assertThat(doc.getIpProtocolVersion().getValue()).isEqualTo(6);
+        assertThat(doc.getHost()).isEqualTo(EXPORTER_ADDRESS);
+        assertThat(doc.getLocation()).isEqualTo(MINION_LOCATION);
+        assertThat(doc.getApplication()).isEqualTo("SSH");
+    }
+
+    @Test
+    void sflowMessageProducesEnrichedFlowDocuments() throws Exception {
+        byte[] bsonBytes = loadFixtureAsBsonBytes("/test-packets/sflow-sample.json");
+        TelemetryProtos.TelemetryMessageLog messageLog = buildTelemetryMessageLog(bsonBytes);
+        byte[] sinkBytes = buildSinkMessageBytes(messageLog);
+
+        send(SFLOW_DESTINATION, sinkBytes);
+
+        // The sFlow fixture contains five IPv4/IPv6 flows per
+        // SFlowMessageProcessorTest's expectation. Drain each one from the
+        // output destination and verify they're all parseable FlowDocuments
+        // tagged as SFLOW.
+        List<FlowDocumentProtos.FlowDocument> documents = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            long timeout = (i == 0) ? 10_000L : 2_000L;
+            Message<byte[]> received = output.receive(timeout, OUTPUT_DESTINATION);
+            assertThat(received)
+                    .as("expected sFlow document #%d on %s", i + 1, OUTPUT_DESTINATION)
+                    .isNotNull();
+            documents.add(FlowDocumentProtos.FlowDocument.parseFrom(received.getPayload()));
+        }
+
+        assertThat(documents).hasSize(5);
+        assertThat(documents).allSatisfy(doc -> {
+            assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.SFLOW);
+            assertThat(doc.getHost()).isEqualTo(EXPORTER_ADDRESS);
+            assertThat(doc.getLocation()).isEqualTo(MINION_LOCATION);
+        });
+
+        // No leftover records: the sixth receive should time out quickly.
+        Message<byte[]> surplus = output.receive(500, OUTPUT_DESTINATION);
+        assertThat(surplus).as("no surplus FlowDocuments beyond the expected 5").isNull();
+    }
+
+    @Test
+    void unknownTopicPrefixDropsMessage() throws Exception {
+        // Use a destination the enricher is NOT bound to: the input side is
+        // bound to the four OpenNMS.Sink.* channels, so to exercise the
+        // "unknown prefix" branch we must send through one of the bound
+        // destinations but with a header that carries a prefix the enricher
+        // doesn't recognize. We do that by overriding RECEIVED_TOPIC on the
+        // outbound message.
+        FlowMessage netflow5 = buildSimpleNetflow5();
+        byte[] sinkBytes = buildSinkMessageBytes(buildTelemetryMessageLog(netflow5.toByteArray()));
+
+        Message<byte[]> msg = MessageBuilder.withPayload(sinkBytes)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, "Custom.Sink.Telemetry-Netflow-5")
+                .build();
+        input.send(msg, NF5_DESTINATION);
+
+        // Enricher should drop the message because "Custom.Sink." isn't a
+        // recognized prefix. Short timeout since we're asserting the absence
+        // of output.
+        Message<byte[]> received = output.receive(1_000, OUTPUT_DESTINATION);
+        assertThat(received).as("expected no output for unknown topic prefix").isNull();
+    }
+
+    // ---- helpers ----
+
+    /**
+     * Wraps a payload in a Spring {@link Message} with the Kafka
+     * {@code RECEIVED_TOPIC} header set to the destination name (this
+     * simulates the header a real Kafka binder would attach on inbound
+     * records) and sends it through the {@link InputDestination} binding
+     * named after the destination.
+     */
+    private void send(String destinationName, byte[] sinkBytes) {
+        Message<byte[]> msg = MessageBuilder.withPayload(sinkBytes)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, destinationName)
+                .build();
+        input.send(msg, destinationName);
+    }
+
+    private static TelemetryProtos.TelemetryMessageLog buildTelemetryMessageLog(byte[] entryBytes) {
+        return TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation(MINION_LOCATION)
+                .setSystemId("test-system")
+                .setSourceAddress(EXPORTER_ADDRESS)
+                .setSourcePort(2055)
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(entryBytes))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+    }
+
+    private static byte[] buildSinkMessageBytes(TelemetryProtos.TelemetryMessageLog messageLog) {
+        return SinkMessage.newBuilder()
+                .setMessageId("it-" + System.nanoTime())
+                .setContent(ByteString.copyFrom(messageLog.toByteArray()))
+                .setCurrentChunkNumber(0)
+                .setTotalChunks(1)
+                .build()
+                .toByteArray();
+    }
+
+    private static FlowMessage buildSimpleNetflow5() {
+        return FlowMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setNetflowVersion(NetflowVersion.V5)
+                .setSrcAddress("192.0.2.1")
+                .setDstAddress("198.51.100.2")
+                .setSrcPort(UInt32Value.of(54321))
+                .setDstPort(UInt32Value.of(443))
+                .setProtocol(UInt32Value.of(6))
+                .setNumBytes(UInt64Value.of(1500L))
+                .setNumPackets(UInt64Value.of(10L))
+                .setFirstSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setLastSwitched(UInt64Value.of(1_700_000_001_000L))
+                .setDeltaSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setInputSnmpIfindex(UInt32Value.of(1))
+                .setOutputSnmpIfindex(UInt32Value.of(2))
+                .setIpProtocolVersion(UInt32Value.of(4))
+                .build();
+    }
+
+    private static byte[] loadFixtureAsBsonBytes(String resourcePath) throws Exception {
+        try (InputStream in = FlowEnrichmentStreamBinderIT.class.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                throw new IllegalStateException("Test fixture not found on classpath: " + resourcePath);
+            }
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                buf.write(chunk, 0, read);
+            }
+            String json = buf.toString(StandardCharsets.UTF_8);
+            BsonDocument doc = BsonDocument.parse(json);
+            return encodeBsonDocument(doc);
+        }
+    }
+
+    private static byte[] encodeBsonDocument(BsonDocument document) {
+        BasicOutputBuffer outputBuffer = new BasicOutputBuffer();
+        try (BsonBinaryWriter writer = new BsonBinaryWriter(outputBuffer)) {
+            new BsonDocumentCodec().encode(writer, document, EncoderContext.builder().build());
+        }
+        return outputBuffer.toByteArray();
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
@@ -59,7 +59,7 @@ class FlowToDocumentMapperTest {
         when(flow.getVlan()).thenReturn(42);
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.getTimestamp()).isEqualTo(1_700_000_000_000L);
         assertThat(doc.getSrcAddress()).isEqualTo("10.0.0.1");
@@ -82,7 +82,7 @@ class FlowToDocumentMapperTest {
         when(flow.getDeltaSwitched()).thenReturn(null);
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.hasNumBytes()).isFalse();
         assertThat(doc.hasNumPackets()).isFalse();
@@ -104,7 +104,7 @@ class FlowToDocumentMapperTest {
         when(flow.getDeltaSwitched()).thenReturn(Instant.EPOCH);
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.hasNumBytes()).isTrue();
         assertThat(doc.getNumBytes().getValue()).isEqualTo(0L);
@@ -124,7 +124,7 @@ class FlowToDocumentMapperTest {
                 42, "delta-v", "exporter-1", "Default");
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, exporter, null, null, null, null, null, null);
+                flow, exporter, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.hasExporterNode()).isTrue();
         assertThat(doc.getExporterNode().getNodeId()).isEqualTo(42);
@@ -135,7 +135,7 @@ class FlowToDocumentMapperTest {
     @Test
     void omitsNodeInfoMessagesWhenLookupReturnedNull() {
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.hasExporterNode()).isFalse();
         assertThat(doc.hasSrcNode()).isFalse();
@@ -145,7 +145,7 @@ class FlowToDocumentMapperTest {
     @Test
     void populatesApplicationAndLocalityFromEnrichmentParameters() {
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, "HTTPS", "PRIVATE", "PUBLIC", "PUBLIC");
+                flow, null, null, null, "HTTPS", "PRIVATE", "PUBLIC", "PUBLIC", null, null, 0L);
 
         assertThat(doc.getApplication()).isEqualTo("HTTPS");
         assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.PRIVATE);
@@ -162,7 +162,7 @@ class FlowToDocumentMapperTest {
         when(flow.getEcn()).thenReturn(null);
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.hasSrcPort()).isFalse();
         assertThat(doc.hasDstPort()).isFalse();
@@ -180,7 +180,7 @@ class FlowToDocumentMapperTest {
         when(flow.getEcn()).thenReturn(0);
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.hasSrcPort()).isTrue();
         assertThat(doc.getSrcPort().getValue()).isEqualTo(0);
@@ -194,15 +194,15 @@ class FlowToDocumentMapperTest {
     void mapsDirectionEnum() {
         when(flow.getDirection()).thenReturn(Direction.INGRESS);
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getDirection()).isEqualTo(FlowDocumentProtos.Direction.INGRESS);
 
         when(flow.getDirection()).thenReturn(Direction.EGRESS);
-        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        doc = mapper.map(flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getDirection()).isEqualTo(FlowDocumentProtos.Direction.EGRESS);
 
         when(flow.getDirection()).thenReturn(Direction.UNKNOWN);
-        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        doc = mapper.map(flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getDirection()).isEqualTo(FlowDocumentProtos.Direction.DIRECTION_UNKNOWN);
     }
 
@@ -210,19 +210,19 @@ class FlowToDocumentMapperTest {
     void mapsNetflowVersionEnum() {
         when(flow.getNetflowVersion()).thenReturn(NetflowVersion.V9);
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V9);
 
         when(flow.getNetflowVersion()).thenReturn(NetflowVersion.V5);
-        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        doc = mapper.map(flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V5);
 
         when(flow.getNetflowVersion()).thenReturn(NetflowVersion.IPFIX);
-        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        doc = mapper.map(flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.IPFIX);
 
         when(flow.getNetflowVersion()).thenReturn(NetflowVersion.SFLOW);
-        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        doc = mapper.map(flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.SFLOW);
     }
 
@@ -230,12 +230,12 @@ class FlowToDocumentMapperTest {
     void mapsSamplingAlgorithmEnum() {
         when(flow.getSamplingAlgorithm()).thenReturn(SamplingAlgorithm.SystematicCountBasedSampling);
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getSamplingAlgorithm())
                 .isEqualTo(FlowDocumentProtos.SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING);
 
         when(flow.getSamplingAlgorithm()).thenReturn(SamplingAlgorithm.Unassigned);
-        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        doc = mapper.map(flow, null, null, null, null, null, null, null, null, null, 0L);
         assertThat(doc.getSamplingAlgorithm())
                 .isEqualTo(FlowDocumentProtos.SamplingAlgorithm.SAMPLING_ALGORITHM_UNKNOWN);
     }
@@ -250,7 +250,7 @@ class FlowToDocumentMapperTest {
                 3, "fs", "dst", "Default");
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, exporter, src, dst, null, null, null, null);
+                flow, exporter, src, dst, null, null, null, null, null, null, 0L);
 
         assertThat(doc.hasExporterNode()).isTrue();
         assertThat(doc.getExporterNode().getNodeId()).isEqualTo(1);
@@ -263,11 +263,56 @@ class FlowToDocumentMapperTest {
     @Test
     void leavesApplicationAsUnknownWhenNullProvided() {
         FlowDocumentProtos.FlowDocument doc = mapper.map(
-                flow, null, null, null, null, null, null, null);
+                flow, null, null, null, null, null, null, null, null, null, 0L);
 
         assertThat(doc.getApplication()).isEqualTo("unknown");
         assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
         assertThat(doc.getDstLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
         assertThat(doc.getFlowLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
+    }
+
+    @Test
+    void populatesHostLocationAndClockCorrectionWhenProvided() {
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN",
+                "router-1.example.com", "MainOffice", 123L);
+
+        assertThat(doc.getHost()).isEqualTo("router-1.example.com");
+        assertThat(doc.getLocation()).isEqualTo("MainOffice");
+        assertThat(doc.getClockCorrection()).isEqualTo(123L);
+    }
+
+    @Test
+    void leavesHostAndLocationEmptyWhenNullProvided() {
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN",
+                null, null, 0L);
+
+        assertThat(doc.getHost()).isEmpty();
+        assertThat(doc.getLocation()).isEmpty();
+        assertThat(doc.getClockCorrection()).isEqualTo(0L);
+    }
+
+    @Test
+    void omitsSamplingIntervalWhenFlowGetterReturnsNull() {
+        when(flow.getSamplingInterval()).thenReturn(null);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null, null, null, 0L);
+
+        assertThat(doc.hasSamplingInterval()).isFalse();
+    }
+
+    @Test
+    void populatesSamplingIntervalWhenFlowGetterReturnsZero() {
+        when(flow.getSamplingInterval()).thenReturn(0.0);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null, null, null, 0L);
+
+        assertThat(doc.hasSamplingInterval()).isTrue();
+        assertThat(doc.getSamplingInterval().getValue()).isEqualTo(0.0);
     }
 }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.integration.api.v1.flows.Flow.Direction;
+import org.opennms.integration.api.v1.flows.Flow.NetflowVersion;
+import org.opennms.integration.api.v1.flows.Flow.SamplingAlgorithm;
+import org.opennms.netmgt.flows.api.Flow;
+
+class FlowToDocumentMapperTest {
+
+    private FlowToDocumentMapper mapper;
+    private Flow flow;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new FlowToDocumentMapper();
+        flow = mock(Flow.class);
+        // Sensible defaults so the mock returns null/0 everywhere unless overridden.
+        when(flow.getSrcAddrHostname()).thenReturn(Optional.empty());
+        when(flow.getDstAddrHostname()).thenReturn(Optional.empty());
+        when(flow.getNextHopHostname()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void mapsTimestampAndScalars() {
+        when(flow.getTimestamp()).thenReturn(Instant.ofEpochMilli(1_700_000_000_000L));
+        when(flow.getSrcAddr()).thenReturn("10.0.0.1");
+        when(flow.getDstAddr()).thenReturn("10.0.0.2");
+        when(flow.getNextHop()).thenReturn("10.0.0.254");
+        when(flow.getSrcAddrHostname()).thenReturn(Optional.of("src.local"));
+        when(flow.getDstAddrHostname()).thenReturn(Optional.of("dst.local"));
+        when(flow.getNextHopHostname()).thenReturn(Optional.of("gw.local"));
+        when(flow.getVlan()).thenReturn(42);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+
+        assertThat(doc.getTimestamp()).isEqualTo(1_700_000_000_000L);
+        assertThat(doc.getSrcAddress()).isEqualTo("10.0.0.1");
+        assertThat(doc.getDstAddress()).isEqualTo("10.0.0.2");
+        assertThat(doc.getNextHopAddress()).isEqualTo("10.0.0.254");
+        assertThat(doc.getSrcHostname()).isEqualTo("src.local");
+        assertThat(doc.getDstHostname()).isEqualTo("dst.local");
+        assertThat(doc.getNextHopHostname()).isEqualTo("gw.local");
+        assertThat(doc.getVlan()).isEqualTo("42");
+    }
+
+    @Test
+    void omitsUInt64ValueWrapperFieldsWhenFlowGetterReturnsNull() {
+        when(flow.getBytes()).thenReturn(null);
+        when(flow.getPackets()).thenReturn(null);
+        when(flow.getDstAs()).thenReturn(null);
+        when(flow.getSrcAs()).thenReturn(null);
+        when(flow.getFirstSwitched()).thenReturn(null);
+        when(flow.getLastSwitched()).thenReturn(null);
+        when(flow.getDeltaSwitched()).thenReturn(null);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+
+        assertThat(doc.hasNumBytes()).isFalse();
+        assertThat(doc.hasNumPackets()).isFalse();
+        assertThat(doc.hasDstAs()).isFalse();
+        assertThat(doc.hasSrcAs()).isFalse();
+        assertThat(doc.hasFirstSwitched()).isFalse();
+        assertThat(doc.hasLastSwitched()).isFalse();
+        assertThat(doc.hasDeltaSwitched()).isFalse();
+    }
+
+    @Test
+    void populatesUInt64ValueWrapperFieldsWhenFlowGetterReturnsZero() {
+        when(flow.getBytes()).thenReturn(0L);
+        when(flow.getPackets()).thenReturn(0L);
+        when(flow.getDstAs()).thenReturn(0L);
+        when(flow.getSrcAs()).thenReturn(0L);
+        when(flow.getFirstSwitched()).thenReturn(Instant.EPOCH);
+        when(flow.getLastSwitched()).thenReturn(Instant.EPOCH);
+        when(flow.getDeltaSwitched()).thenReturn(Instant.EPOCH);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+
+        assertThat(doc.hasNumBytes()).isTrue();
+        assertThat(doc.getNumBytes().getValue()).isEqualTo(0L);
+        assertThat(doc.hasNumPackets()).isTrue();
+        assertThat(doc.getNumPackets().getValue()).isEqualTo(0L);
+        assertThat(doc.hasDstAs()).isTrue();
+        assertThat(doc.hasSrcAs()).isTrue();
+        assertThat(doc.hasFirstSwitched()).isTrue();
+        assertThat(doc.getFirstSwitched().getValue()).isEqualTo(0L);
+        assertThat(doc.hasLastSwitched()).isTrue();
+        assertThat(doc.hasDeltaSwitched()).isTrue();
+    }
+
+    @Test
+    void populatesExporterNodeWhenEnrichmentProvidesIt() {
+        JdbcNodeInfoLookup.NodeInfo exporter = new JdbcNodeInfoLookup.NodeInfo(
+                42, "delta-v", "exporter-1", "Default");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, exporter, null, null, null, null, null, null);
+
+        assertThat(doc.hasExporterNode()).isTrue();
+        assertThat(doc.getExporterNode().getNodeId()).isEqualTo(42);
+        assertThat(doc.getExporterNode().getForeignSource()).isEqualTo("delta-v");
+        assertThat(doc.getExporterNode().getForeignId()).isEqualTo("exporter-1");
+    }
+
+    @Test
+    void omitsNodeInfoMessagesWhenLookupReturnedNull() {
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+
+        assertThat(doc.hasExporterNode()).isFalse();
+        assertThat(doc.hasSrcNode()).isFalse();
+        assertThat(doc.hasDestNode()).isFalse();
+    }
+
+    @Test
+    void populatesApplicationAndLocalityFromEnrichmentParameters() {
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, "HTTPS", "PRIVATE", "PUBLIC", "PUBLIC");
+
+        assertThat(doc.getApplication()).isEqualTo("HTTPS");
+        assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.PRIVATE);
+        assertThat(doc.getDstLocality()).isEqualTo(FlowDocumentProtos.Locality.PUBLIC);
+        assertThat(doc.getFlowLocality()).isEqualTo(FlowDocumentProtos.Locality.PUBLIC);
+    }
+
+    @Test
+    void mapsUInt32ValueWrappersNullSemantics() {
+        when(flow.getSrcPort()).thenReturn(null);
+        when(flow.getDstPort()).thenReturn(null);
+        when(flow.getProtocol()).thenReturn(null);
+        when(flow.getDscp()).thenReturn(null);
+        when(flow.getEcn()).thenReturn(null);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+
+        assertThat(doc.hasSrcPort()).isFalse();
+        assertThat(doc.hasDstPort()).isFalse();
+        assertThat(doc.hasProtocol()).isFalse();
+        assertThat(doc.hasDscp()).isFalse();
+        assertThat(doc.hasEcn()).isFalse();
+    }
+
+    @Test
+    void mapsUInt32ValueWrappersZeroIsPopulated() {
+        when(flow.getSrcPort()).thenReturn(0);
+        when(flow.getDstPort()).thenReturn(0);
+        when(flow.getProtocol()).thenReturn(0);
+        when(flow.getDscp()).thenReturn(0);
+        when(flow.getEcn()).thenReturn(0);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+
+        assertThat(doc.hasSrcPort()).isTrue();
+        assertThat(doc.getSrcPort().getValue()).isEqualTo(0);
+        assertThat(doc.hasDstPort()).isTrue();
+        assertThat(doc.hasProtocol()).isTrue();
+        assertThat(doc.hasDscp()).isTrue();
+        assertThat(doc.hasEcn()).isTrue();
+    }
+
+    @Test
+    void mapsDirectionEnum() {
+        when(flow.getDirection()).thenReturn(Direction.INGRESS);
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+        assertThat(doc.getDirection()).isEqualTo(FlowDocumentProtos.Direction.INGRESS);
+
+        when(flow.getDirection()).thenReturn(Direction.EGRESS);
+        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        assertThat(doc.getDirection()).isEqualTo(FlowDocumentProtos.Direction.EGRESS);
+
+        when(flow.getDirection()).thenReturn(Direction.UNKNOWN);
+        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        assertThat(doc.getDirection()).isEqualTo(FlowDocumentProtos.Direction.DIRECTION_UNKNOWN);
+    }
+
+    @Test
+    void mapsNetflowVersionEnum() {
+        when(flow.getNetflowVersion()).thenReturn(NetflowVersion.V9);
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V9);
+
+        when(flow.getNetflowVersion()).thenReturn(NetflowVersion.V5);
+        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V5);
+
+        when(flow.getNetflowVersion()).thenReturn(NetflowVersion.IPFIX);
+        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.IPFIX);
+
+        when(flow.getNetflowVersion()).thenReturn(NetflowVersion.SFLOW);
+        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.SFLOW);
+    }
+
+    @Test
+    void mapsSamplingAlgorithmEnum() {
+        when(flow.getSamplingAlgorithm()).thenReturn(SamplingAlgorithm.SystematicCountBasedSampling);
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+        assertThat(doc.getSamplingAlgorithm())
+                .isEqualTo(FlowDocumentProtos.SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING);
+
+        when(flow.getSamplingAlgorithm()).thenReturn(SamplingAlgorithm.Unassigned);
+        doc = mapper.map(flow, null, null, null, null, null, null, null);
+        assertThat(doc.getSamplingAlgorithm())
+                .isEqualTo(FlowDocumentProtos.SamplingAlgorithm.SAMPLING_ALGORITHM_UNKNOWN);
+    }
+
+    @Test
+    void mapsSrcAndDstNodeInfoWhenAllProvided() {
+        JdbcNodeInfoLookup.NodeInfo exporter = new JdbcNodeInfoLookup.NodeInfo(
+                1, "fs", "exporter", "Default");
+        JdbcNodeInfoLookup.NodeInfo src = new JdbcNodeInfoLookup.NodeInfo(
+                2, "fs", "src", "Default");
+        JdbcNodeInfoLookup.NodeInfo dst = new JdbcNodeInfoLookup.NodeInfo(
+                3, "fs", "dst", "Default");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, exporter, src, dst, null, null, null, null);
+
+        assertThat(doc.hasExporterNode()).isTrue();
+        assertThat(doc.getExporterNode().getNodeId()).isEqualTo(1);
+        assertThat(doc.hasSrcNode()).isTrue();
+        assertThat(doc.getSrcNode().getNodeId()).isEqualTo(2);
+        assertThat(doc.hasDestNode()).isTrue();
+        assertThat(doc.getDestNode().getNodeId()).isEqualTo(3);
+    }
+
+    @Test
+    void leavesApplicationAsUnknownWhenNullProvided() {
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null, null, null, null, null);
+
+        assertThat(doc.getApplication()).isEqualTo("unknown");
+        assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
+        assertThat(doc.getDstLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
+        assertThat(doc.getFlowLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/pipeline/CapturingPipelineTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/pipeline/CapturingPipelineTest.java
@@ -29,7 +29,7 @@ import org.opennms.netmgt.flows.processing.ProcessingOptions;
 class CapturingPipelineTest {
 
     @Test
-    void capturesFlowsAndSourcePassedToProcess() throws Exception {
+    void capturesFlowsAndSourcePassedToProcess() {
         CapturingPipeline pipeline = new CapturingPipeline();
         Flow flow1 = mock(Flow.class);
         Flow flow2 = mock(Flow.class);
@@ -50,7 +50,7 @@ class CapturingPipelineTest {
     }
 
     @Test
-    void secondProcessCallReplacesFirstCaptures() throws Exception {
+    void secondProcessCallReplacesFirstCaptures() {
         CapturingPipeline pipeline = new CapturingPipeline();
         Flow flow1 = mock(Flow.class);
         Flow flow2 = mock(Flow.class);

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/pipeline/CapturingPipelineTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/pipeline/CapturingPipelineTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.flows.api.FlowSource;
+import org.opennms.netmgt.flows.processing.ProcessingOptions;
+
+class CapturingPipelineTest {
+
+    @Test
+    void capturesFlowsAndSourcePassedToProcess() throws Exception {
+        CapturingPipeline pipeline = new CapturingPipeline();
+        Flow flow1 = mock(Flow.class);
+        Flow flow2 = mock(Flow.class);
+        FlowSource source = new FlowSource("Default", "192.0.2.10", null);
+
+        pipeline.process(List.of(flow1, flow2), source, ProcessingOptions.builder().build());
+
+        assertThat(pipeline.getCapturedFlows()).containsExactly(flow1, flow2);
+        assertThat(pipeline.getCapturedSource()).isSameAs(source);
+    }
+
+    @Test
+    void capturedFlowsIsEmptyListBeforeProcessIsCalled() {
+        CapturingPipeline pipeline = new CapturingPipeline();
+
+        assertThat(pipeline.getCapturedFlows()).isEmpty();
+        assertThat(pipeline.getCapturedSource()).isNull();
+    }
+
+    @Test
+    void secondProcessCallReplacesFirstCaptures() throws Exception {
+        CapturingPipeline pipeline = new CapturingPipeline();
+        Flow flow1 = mock(Flow.class);
+        Flow flow2 = mock(Flow.class);
+        FlowSource source1 = new FlowSource("LocA", "192.0.2.10", null);
+        FlowSource source2 = new FlowSource("LocB", "192.0.2.20", null);
+
+        pipeline.process(List.of(flow1), source1, ProcessingOptions.builder().build());
+        pipeline.process(List.of(flow2), source2, ProcessingOptions.builder().build());
+
+        assertThat(pipeline.getCapturedFlows()).containsExactly(flow2);
+        assertThat(pipeline.getCapturedSource()).isSameAs(source2);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/IpfixMessageProcessorTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/IpfixMessageProcessorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.integration.api.v1.flows.Flow.NetflowVersion;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+
+/**
+ * Tests {@link IpfixMessageProcessor}. IPFIX (Netflow v10) data records
+ * share horizon's normalized {@link FlowMessage} protobuf with Netflow v5
+ * and Netflow v9; the only difference at this layer is the
+ * {@code netflow_version} field. Template/data distinction happens in the
+ * parser layer (on the Minion) before the {@code FlowMessage} reaches the
+ * adapter.
+ */
+class IpfixMessageProcessorTest {
+
+    private IpfixMessageProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        AdapterDefinition adapterDefinition = TestAdapterDefinitions.testAdapterDefinition("ipfix-test");
+        MetricRegistry metricRegistry = new MetricRegistry();
+        processor = new IpfixMessageProcessor(adapterDefinition, metricRegistry);
+    }
+
+    @Test
+    void processReturnsEmptyListForNullMessageLog() {
+        assertThat(processor.process(null)).isEmpty();
+    }
+
+    @Test
+    void processParsesIpfixFlowMessage() {
+        FlowMessage flowMessage = FlowMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setNetflowVersion(org.opennms.netmgt.telemetry.protocols.netflow.transport.NetflowVersion.IPFIX)
+                .setSrcAddress("2001:db8::1")
+                .setDstAddress("2001:db8::2")
+                .setNextHopAddress("2001:db8::ffff")
+                .setSrcPort(UInt32Value.of(40000))
+                .setDstPort(UInt32Value.of(22))
+                .setProtocol(UInt32Value.of(6)) // TCP
+                .setTcpFlags(UInt32Value.of(0x02)) // SYN
+                .setNumBytes(UInt64Value.of(4096L))
+                .setNumPackets(UInt64Value.of(32L))
+                .setFirstSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setLastSwitched(UInt64Value.of(1_700_000_002_000L))
+                .setDeltaSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setInputSnmpIfindex(UInt32Value.of(5))
+                .setOutputSnmpIfindex(UInt32Value.of(6))
+                .setIpProtocolVersion(UInt32Value.of(6))
+                .build();
+
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSystemId("test-system")
+                .setSourceAddress("10.0.0.100")
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(flowMessage.toByteArray()))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+
+        List<Flow> flows = processor.process(log);
+
+        assertThat(flows).hasSize(1);
+        Flow flow = flows.get(0);
+        assertThat(flow.getSrcAddr()).isEqualTo("2001:db8::1");
+        assertThat(flow.getDstAddr()).isEqualTo("2001:db8::2");
+        assertThat(flow.getProtocol()).isEqualTo(6);
+        assertThat(flow.getDstPort()).isEqualTo(22);
+        assertThat(flow.getIpProtocolVersion()).isEqualTo(6);
+        assertThat(flow.getNetflowVersion()).isEqualTo(NetflowVersion.IPFIX);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessorTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessorTest.java
@@ -152,8 +152,7 @@ class Netflow5MessageProcessorTest {
 
     private static FlowMessage buildNetflow5FlowMessage() {
         // Represents a Netflow v5 record already parsed from wire format into
-        // horizon's normalized FlowMessage protobuf. Field choices mirror the
-        // hand-crafted Netflow5 record in the plan document:
+        // horizon's normalized FlowMessage protobuf.
         //   src=192.0.2.1:54321, dst=198.51.100.2:443, proto=6 (TCP),
         //   packets=10, bytes=1500, tcpFlags=0x18 (PSH+ACK).
         return FlowMessage.newBuilder()

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessorTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessorTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.integration.api.v1.flows.Flow.NetflowVersion;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+
+/**
+ * Tests {@link Netflow5MessageProcessor} by constructing a
+ * {@link FlowMessage} protobuf directly (the parser layer's normalized
+ * representation), wrapping its serialized bytes in a
+ * {@link TelemetryProtos.TelemetryMessageLog}, and asserting that the
+ * processor returns the expected parsed flow.
+ *
+ * <p>The horizon adapter's job at this layer is to take a
+ * {@code FlowMessage} protobuf (already parsed from Netflow v5 wire format
+ * on the Minion) and wrap it in a {@code NetflowMessage} implementation of
+ * the {@link Flow} interface. Constructing the {@code FlowMessage} directly
+ * avoids pulling in horizon's Netflow parser module as a test dependency.
+ */
+class Netflow5MessageProcessorTest {
+
+    private Netflow5MessageProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        AdapterDefinition adapterDefinition = TestAdapterDefinitions.testAdapterDefinition("netflow5-test");
+        MetricRegistry metricRegistry = new MetricRegistry();
+        processor = new Netflow5MessageProcessor(adapterDefinition, metricRegistry);
+    }
+
+    @Test
+    void processReturnsEmptyListForNullMessageLog() {
+        assertThat(processor.process(null)).isEmpty();
+    }
+
+    @Test
+    void processReturnsEmptyListForEmptyMessageLog() {
+        TelemetryProtos.TelemetryMessageLog emptyLog = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSystemId("test-system")
+                .setSourceAddress("192.0.2.254")
+                .build();
+        assertThat(processor.process(emptyLog)).isEmpty();
+    }
+
+    @Test
+    void processParsesSingleFlowMessageProtobuf() {
+        FlowMessage flowMessage = buildNetflow5FlowMessage();
+        TelemetryProtos.TelemetryMessageLog log = wrapInMessageLog(flowMessage);
+
+        List<Flow> flows = processor.process(log);
+
+        assertThat(flows).hasSize(1);
+        Flow flow = flows.get(0);
+        assertThat(flow.getSrcAddr()).isEqualTo("192.0.2.1");
+        assertThat(flow.getDstAddr()).isEqualTo("198.51.100.2");
+        assertThat(flow.getDstPort()).isEqualTo(443);
+        assertThat(flow.getSrcPort()).isEqualTo(54321);
+        assertThat(flow.getProtocol()).isEqualTo(6);
+        assertThat(flow.getBytes()).isEqualTo(1500L);
+        assertThat(flow.getPackets()).isEqualTo(10L);
+        assertThat(flow.getTcpFlags()).isEqualTo(0x18);
+        assertThat(flow.getNetflowVersion()).isEqualTo(NetflowVersion.V5);
+    }
+
+    @Test
+    void processParsesMultipleEntriesInMessageLog() {
+        FlowMessage flowMessage = buildNetflow5FlowMessage();
+        byte[] serialized = flowMessage.toByteArray();
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSystemId("test-system")
+                .setSourceAddress("192.0.2.254")
+                .setSourcePort(2055)
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(serialized))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(serialized))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+
+        List<Flow> flows = processor.process(log);
+
+        // NetflowAdapter emits one Flow per FlowMessage protobuf entry
+        assertThat(flows).hasSize(2);
+    }
+
+    @Test
+    void processReturnsEmptyListWhenEntryBytesAreInvalid() {
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSystemId("test-system")
+                .setSourceAddress("192.0.2.254")
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFromUtf8("not a valid FlowMessage protobuf"))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+
+        // NetflowAdapter.parse() catches InvalidProtocolBufferException and
+        // returns null, so the adapter publishes an empty flow list to the
+        // pipeline. The processor returns that empty list without throwing.
+        List<Flow> flows = processor.process(log);
+
+        assertThat(flows).isEmpty();
+    }
+
+    private static TelemetryProtos.TelemetryMessageLog wrapInMessageLog(FlowMessage flowMessage) {
+        return TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSystemId("test-system")
+                .setSourceAddress("192.0.2.254")
+                .setSourcePort(2055)
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(flowMessage.toByteArray()))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+    }
+
+    private static FlowMessage buildNetflow5FlowMessage() {
+        // Represents a Netflow v5 record already parsed from wire format into
+        // horizon's normalized FlowMessage protobuf. Field choices mirror the
+        // hand-crafted Netflow5 record in the plan document:
+        //   src=192.0.2.1:54321, dst=198.51.100.2:443, proto=6 (TCP),
+        //   packets=10, bytes=1500, tcpFlags=0x18 (PSH+ACK).
+        return FlowMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setNetflowVersion(org.opennms.netmgt.telemetry.protocols.netflow.transport.NetflowVersion.V5)
+                .setSrcAddress("192.0.2.1")
+                .setDstAddress("198.51.100.2")
+                .setNextHopAddress("203.0.113.1")
+                .setSrcPort(UInt32Value.of(54321))
+                .setDstPort(UInt32Value.of(443))
+                .setProtocol(UInt32Value.of(6))
+                .setTcpFlags(UInt32Value.of(0x18))
+                .setNumBytes(UInt64Value.of(1500L))
+                .setNumPackets(UInt64Value.of(10L))
+                .setFirstSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setLastSwitched(UInt64Value.of(1_700_000_001_000L))
+                .setDeltaSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setInputSnmpIfindex(UInt32Value.of(1))
+                .setOutputSnmpIfindex(UInt32Value.of(2))
+                .setIpProtocolVersion(UInt32Value.of(4))
+                .build();
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow9MessageProcessorTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow9MessageProcessorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.integration.api.v1.flows.Flow.NetflowVersion;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+
+/**
+ * Tests {@link Netflow9MessageProcessor}. Netflow v9 data records share
+ * horizon's normalized {@link FlowMessage} protobuf with Netflow v5 and
+ * IPFIX; the only difference at this layer is the
+ * {@code netflow_version} field. Template/data distinction happens in the
+ * parser layer (on the Minion) before the {@code FlowMessage} reaches the
+ * adapter.
+ */
+class Netflow9MessageProcessorTest {
+
+    private Netflow9MessageProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        AdapterDefinition adapterDefinition = TestAdapterDefinitions.testAdapterDefinition("netflow9-test");
+        MetricRegistry metricRegistry = new MetricRegistry();
+        processor = new Netflow9MessageProcessor(adapterDefinition, metricRegistry);
+    }
+
+    @Test
+    void processReturnsEmptyListForNullMessageLog() {
+        assertThat(processor.process(null)).isEmpty();
+    }
+
+    @Test
+    void processParsesNetflow9FlowMessage() {
+        FlowMessage flowMessage = FlowMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setNetflowVersion(org.opennms.netmgt.telemetry.protocols.netflow.transport.NetflowVersion.V9)
+                .setSrcAddress("10.0.0.1")
+                .setDstAddress("10.0.0.2")
+                .setNextHopAddress("10.0.0.254")
+                .setSrcPort(UInt32Value.of(12345))
+                .setDstPort(UInt32Value.of(80))
+                .setProtocol(UInt32Value.of(17)) // UDP
+                .setNumBytes(UInt64Value.of(2048L))
+                .setNumPackets(UInt64Value.of(16L))
+                .setFirstSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setLastSwitched(UInt64Value.of(1_700_000_001_000L))
+                .setDeltaSwitched(UInt64Value.of(1_700_000_000_000L))
+                .setInputSnmpIfindex(UInt32Value.of(3))
+                .setOutputSnmpIfindex(UInt32Value.of(4))
+                .setIpProtocolVersion(UInt32Value.of(4))
+                .build();
+
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSystemId("test-system")
+                .setSourceAddress("10.0.0.100")
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(flowMessage.toByteArray()))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+
+        List<Flow> flows = processor.process(log);
+
+        assertThat(flows).hasSize(1);
+        Flow flow = flows.get(0);
+        assertThat(flow.getSrcAddr()).isEqualTo("10.0.0.1");
+        assertThat(flow.getDstAddr()).isEqualTo("10.0.0.2");
+        assertThat(flow.getProtocol()).isEqualTo(17);
+        assertThat(flow.getDstPort()).isEqualTo(80);
+        assertThat(flow.getNetflowVersion()).isEqualTo(NetflowVersion.V9);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/SFlowMessageProcessorTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/SFlowMessageProcessorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.protobuf.ByteString;
+
+/**
+ * Tests {@link SFlowMessageProcessor}. sFlow uses a BSON document (not a
+ * protobuf) as the parser layer's normalized representation. The test
+ * fixture {@code test-packets/sflow-sample.json} is a JSON text
+ * representation of a BSON document lifted verbatim from horizon's own
+ * sFlow adapter test suite; at test time we parse it into a
+ * {@link BsonDocument} and re-serialize it to canonical BSON bytes before
+ * feeding it to the processor. The horizon adapter expects exactly those
+ * BSON bytes as the {@code TelemetryMessageLogEntry} payload.
+ *
+ * <p>The fixture contains seven sample records, five of which are valid
+ * IPv4/IPv6 flows per horizon's {@code SFlowConverterTest}.
+ */
+class SFlowMessageProcessorTest {
+
+    private SFlowMessageProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        AdapterDefinition adapterDefinition = TestAdapterDefinitions.testAdapterDefinition("sflow-test");
+        MetricRegistry metricRegistry = new MetricRegistry();
+        processor = new SFlowMessageProcessor(adapterDefinition, metricRegistry);
+    }
+
+    @Test
+    void processReturnsEmptyListForNullMessageLog() {
+        assertThat(processor.process(null)).isEmpty();
+    }
+
+    @Test
+    void processParsesSflowBsonDocument() throws Exception {
+        byte[] bsonBytes = loadFixtureAsBsonBytes("/test-packets/sflow-sample.json");
+
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSystemId("test-system")
+                .setSourceAddress("127.0.0.1")
+                .setSourcePort(6343)
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(bsonBytes))
+                        .setTimestamp(1521618510235L)
+                        .build())
+                .build();
+
+        List<Flow> flows = processor.process(log);
+
+        // Matches horizon's own SFlowConverterTest expectation: the fixture
+        // contains seven samples, five of which carry IPv4/IPv6 information
+        // and are therefore emitted as flows.
+        assertThat(flows).hasSize(5);
+        assertThat(flows).allSatisfy(flow -> assertThat(flow).isNotNull());
+    }
+
+    private static byte[] loadFixtureAsBsonBytes(String resourcePath) throws Exception {
+        try (InputStream in = SFlowMessageProcessorTest.class.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                throw new IllegalStateException("Test fixture not found on classpath: " + resourcePath);
+            }
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                buf.write(chunk, 0, read);
+            }
+            String json = buf.toString(StandardCharsets.UTF_8);
+            BsonDocument doc = BsonDocument.parse(json);
+            return encodeBsonDocument(doc);
+        }
+    }
+
+    private static byte[] encodeBsonDocument(BsonDocument document) {
+        BasicOutputBuffer outputBuffer = new BasicOutputBuffer();
+        try (BsonBinaryWriter writer = new BsonBinaryWriter(outputBuffer)) {
+            new BsonDocumentCodec().encode(writer, document, EncoderContext.builder().build());
+        }
+        return outputBuffer.toByteArray();
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/TestAdapterDefinitions.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/TestAdapterDefinitions.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+
+/**
+ * Test helper that builds minimal {@link AdapterDefinition} mocks for the
+ * per-protocol processor tests. Horizon's
+ * {@code AbstractFlowAdapter} constructor reads {@code getFullName()} (for
+ * metric registry key construction) and {@code getPackages()} (for
+ * {@code ProcessingOptions} wiring); both are stubbed with sensible defaults
+ * here. The other {@code AdapterDefinition} methods
+ * ({@code getName()}, {@code getClassName()}, {@code getParameterMap()}) are
+ * also stubbed so that any future call site picks up a non-null value.
+ */
+public final class TestAdapterDefinitions {
+
+    private TestAdapterDefinitions() {
+    }
+
+    /**
+     * Builds a minimal {@link AdapterDefinition} mock suitable for
+     * instantiating any of horizon's flow adapters in a unit test. The
+     * returned mock has no packages (empty list) so
+     * {@code ProcessingOptions} filtering is disabled.
+     *
+     * @param name short adapter name used for both {@code getName()} and
+     *             {@code getFullName()}; also used as the metric registry
+     *             prefix by {@code AbstractFlowAdapter}
+     * @return a Mockito mock of {@code AdapterDefinition}
+     */
+    public static AdapterDefinition testAdapterDefinition(String name) {
+        AdapterDefinition def = mock(AdapterDefinition.class);
+        when(def.getName()).thenReturn(name);
+        when(def.getFullName()).thenReturn(name);
+        when(def.getClassName()).thenReturn("org.deltav.flows.enricher.protocol.TestAdapter");
+        when(def.getParameterMap()).thenReturn(Map.of());
+        when(def.getPackages()).thenReturn(Collections.emptyList());
+        return def;
+    }
+}

--- a/core/flow-enricher/src/test/resources/test-packets/sflow-sample.json
+++ b/core/flow-enricher/src/test/resources/test-packets/sflow-sample.json
@@ -1,0 +1,409 @@
+{
+  "time": { "$numberLong" : "1521618510235" },
+  "data": {
+    "agent_address": {
+      "ipv4": "127.0.0.1"
+    },
+    "sub_agent_id": {
+      "$numberLong": "0"
+    },
+    "sequence_number": {
+      "$numberLong": "35"
+    },
+    "uptime": {
+      "$numberLong": "89000"
+    },
+    "samples": [
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "$numberLong": "24"
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1536"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "4"
+          },
+          "output": {
+            "$numberLong": "17"
+          },
+          "flows": {
+            "0:1001": {
+              "src_vlan": {
+                "$numberLong": "0"
+              },
+              "src_priority": {
+                "$numberLong": "0"
+              },
+              "dst_vlan": {
+                "$numberLong": "0"
+              },
+              "dst_priority": {
+                "$numberLong": "0"
+              }
+            },
+            "0:1": {
+              "protocol": 1,
+              "frame_length": {
+                "$numberLong": "1298"
+              },
+              "stripped": {
+                "$numberLong": "4"
+              },
+              "ethernet": {},
+              "ipv6": {
+                "tos": 0,
+                "length": 1280,
+                "protocol": 6,
+                "src_ip": "2a00:1450:4001:81a:0:0:0:2009",
+                "dst_ip": "2001:638:301:11a0:80bd:5840:2551:5687",
+                "src_port": 443,
+                "dst_port": 41536,
+                "tcp_flags": 16
+              }
+            }
+          }
+        }
+      },
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "$numberLong": "25"
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1600"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "5"
+          },
+          "output": {
+            "$numberLong": "1073741823"
+          },
+          "flows": {
+            "0:1001": {
+              "src_vlan": {
+                "$numberLong": "0"
+              },
+              "src_priority": {
+                "$numberLong": "0"
+              },
+              "dst_vlan": {
+                "$numberLong": "0"
+              },
+              "dst_priority": {
+                "$numberLong": "0"
+              }
+            },
+            "0:1": {
+              "protocol": 1,
+              "frame_length": {
+                "$numberLong": "1298"
+              },
+              "stripped": {
+                "$numberLong": "4"
+              },
+              "ethernet": {},
+              "ipv6": {
+                "tos": 0,
+                "length": 1280,
+                "protocol": 6,
+                "src_ip": "2a00:1450:4001:81a:0:0:0:2009",
+                "dst_ip": "2001:638:301:11a0:80bd:5840:2551:5687",
+                "src_port": 443,
+                "dst_port": 41536,
+                "tcp_flags": 16
+              }
+            }
+          }
+        }
+      },
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "$numberLong": "26"
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1664"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "17"
+          },
+          "output": {
+            "$numberLong": "4"
+          },
+          "flows": {
+            "0:1001": {
+              "src_vlan": {
+                "$numberLong": "0"
+              },
+              "src_priority": {
+                "$numberLong": "0"
+              },
+              "dst_vlan": {
+                "$numberLong": "0"
+              },
+              "dst_priority": {
+                "$numberLong": "0"
+              }
+            },
+            "0:1": {
+              "protocol": 1,
+              "frame_length": {
+                "$numberLong": "90"
+              },
+              "stripped": {
+                "$numberLong": "4"
+              },
+              "ethernet": {},
+              "ipv6": {
+                "tos": 0,
+                "length": 72,
+                "protocol": 6,
+                "src_ip": "2001:638:301:11a0:80bd:5840:2551:5687",
+                "dst_ip": "2a00:1450:4001:81a:0:0:0:2009",
+                "src_port": 41450,
+                "dst_port": 443,
+                "tcp_flags": 16
+              }
+            }
+          }
+        }
+      },
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "$numberLong": "27"
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1728"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "1073741823"
+          },
+          "output": {
+            "$numberLong": "18"
+          },
+          "flows": {
+            "0:1001": {
+              "src_vlan": {
+                "$numberLong": "0"
+              },
+              "src_priority": {
+                "$numberLong": "0"
+              },
+              "dst_vlan": {
+                "$numberLong": "0"
+              },
+              "dst_priority": {
+                "$numberLong": "0"
+              }
+            },
+            "0:1": {
+              "protocol": 1,
+              "frame_length": {
+                "$numberLong": "1298"
+              },
+              "stripped": {
+                "$numberLong": "4"
+              },
+              "ethernet": {},
+              "ipv6": {
+                "tos": 0,
+                "length": 1280,
+                "protocol": 6,
+                "src_ip": "2a00:1450:4001:81a:0:0:0:2009",
+                "dst_ip": "2001:638:301:11a0:80bd:5840:2551:5687",
+                "src_port": 443,
+                "dst_port": 41450,
+                "tcp_flags": 16
+              }
+            }
+          }
+        }
+      },
+      {
+        "format": "0:3",
+        "data": {
+          "sequence_number": {
+            "source_id_type": { "$numberLong": "0" },
+            "source_id_index": { "$numberLong": "28" }
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1792"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "format": { "$numberLong": "0" },
+            "value": { "$numberLong": "4" }
+          },
+          "output": {
+            "format": { "$numberLong": "0" },
+            "value": { "$numberLong": "42" }
+          },
+          "flows": {
+            "0:1001": {
+              "src_vlan": {
+                "$numberLong": "0"
+              },
+              "src_priority": {
+                "$numberLong": "0"
+              },
+              "dst_vlan": {
+                "$numberLong": "0"
+              },
+              "dst_priority": {
+                "$numberLong": "0"
+              }
+            },
+            "0:1": {
+              "protocol": 1,
+              "frame_length": {
+                "$numberLong": "203"
+              },
+              "stripped": {
+                "$numberLong": "4"
+              },
+              "ethernet": {},
+              "ipv6": {
+                "tos": 0,
+                "length": 185,
+                "protocol": 6,
+                "src_ip": "2a00:1450:4001:81a:0:0:0:2009",
+                "dst_ip": "2001:638:301:11a0:80bd:5840:2551:5687",
+                "src_port": 443,
+                "dst_port": 41450,
+                "tcp_flags": 24
+              }
+            }
+          }
+        }
+      },
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "$numberLong": "28"
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1792"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "4"
+          },
+          "output": {
+            "$numberLong": "17"
+          },
+          "flows": {
+            "0:2": {
+              "length": {
+                "$numberLong": "1234"
+              },
+              "src_mac": "00:00:00:00:00:00",
+              "dst_mac": "00:00:00:00:00:00",
+              "type": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        }
+      },
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "source_id_type": { "$numberLong": "0" },
+            "source_id_index": { "$numberLong": "28" }
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1792"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "4"
+          },
+          "output": {
+            "$numberLong": "17"
+          },
+          "flows": {
+            "0:1": {
+              "protocol": 1,
+              "frame_length": {
+                "$numberLong": "203"
+              },
+              "stripped": {
+                "$numberLong": "4"
+              },
+              "ethernet": {}
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/docs/superpowers/plans/2026-04-10-flow-enricher-phase15.md
+++ b/docs/superpowers/plans/2026-04-10-flow-enricher-phase15.md
@@ -1,0 +1,2703 @@
+# Flow Enricher (Phase 1.5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire horizon protocol adapters (Netflow-5, Netflow-9, IPFIX, sFlow) into the existing `flow-enricher` Spring Boot service so each incoming `TelemetryMessageLog` is parsed into one or more `Flow` objects, enriched with src/dst node lookups, locality, interface marking, and a port-based application classification, and then emitted as a `List<byte[]>` of `FlowDocumentProtos.FlowDocument` messages to the `deltav-flows` Kafka topic.
+
+**Architecture:** Extends the Phase 1 skeleton in-place. Changes the Spring Cloud Stream function signature from `Function<byte[], byte[]>` to `Function<byte[], List<byte[]>>` (the canonical "splitter" pattern). Dispatches per-message based on the SinkMessage `moduleId` field, invoking a `ProtocolMessageProcessor` per protocol that drives the corresponding horizon `AbstractFlowAdapter` against a `CapturingPipeline` that stashes the parsed `List<Flow>`. Each captured flow runs through src/dst node lookup, locality calculation, interface marking, and port-based classification, then maps to `FlowDocumentProtos.FlowDocument` via an own-rolled `FlowToDocumentMapper` (no horizon `FlowDocumentBuilder` dependency). Horizon's classification engine, clock-skew correction, and `nodeDeleted` cache eviction are deferred to Phase 1.6.
+
+**Tech Stack:** Spring Boot 4.0.3, Spring Cloud Stream 2025.1.1 (Kafka binder), Protocol Buffers 3.25.5, PostgreSQL JDBC, Horizon 1.0.7 flow protocol adapter JARs (`netflow-adapter-netflow5`, `netflow-adapter-netflow9`, `netflow-adapter-ipfix`, `sflow-adapter`), `org.opennms.features.flows.flows-api` for the `Flow` interface, `org.opennms.features.flows.classification-api` for the `Pipeline` interface, Dropwizard `MetricRegistry` (required by adapter constructors).
+
+**Spec:** `docs/superpowers/specs/2026-04-09-flow-processor-design.md` (Phase 1.5 section)
+
+**Brainstorm rationale:** The design decisions referenced throughout this plan (List-based fan-out, SinkMessage moduleId dispatch, own mapper, port-based classifier stub, all-four-protocols-in-one-PR scope) were settled in the 2026-04-10 brainstorm session. This plan describes HOW, not WHY — refer to the spec or the brainstorm transcript for rationale.
+
+---
+
+## Prerequisites
+
+Before starting this plan:
+
+1. **Phase 1 skeleton merged** (PR #139, done 2026-04-09) — `core/flow-enricher/` module exists with Spring Cloud Stream + Kafka binder wiring
+2. **Phase 2 ClickHouse spec merged** (PR #141, in review as of 2026-04-10) — not a blocker for Phase 1.5 code, but the ClickHouse schema relies on the fully-populated FlowDocument that this plan produces
+3. **Horizon 1.0.7 published** (done) — provides the flow adapter JARs via GitHub Packages
+4. **`develop` is up to date** — run `git pull origin develop` before creating the feature branch (per the project's `feedback_pull_before_branching` memory)
+
+**Note on the existing skeleton state:** The Phase 1 skeleton already wires `SinkMessageDeserializer`, `JdbcNodeInfoLookup`, `FlowLocalityCalculator`, and `InterfaceMarkingCache` into the `FlowEnrichmentFunction` constructor. Two of those four beans carry `@SuppressWarnings("unused")` because Phase 1 doesn't consume them. Phase 1.5 removes those suppressions and actually uses all four beans during per-flow enrichment. The skeleton's current `processMessage(byte[]) → byte[]` method and its corresponding `@Bean Function<byte[], byte[]>` declaration are replaced by `processMessage(byte[]) → List<byte[]>` and `@Bean Function<byte[], List<byte[]>>` respectively — the rest of the constructor wiring is preserved.
+
+---
+
+## File Structure
+
+This plan creates new files under three new sub-packages inside `core/flow-enricher/src/main/java/org/deltav/flows/enricher/` and adds matching test files. Existing skeleton files are modified rather than replaced.
+
+```
+core/flow-enricher/
+├── pom.xml                                          — MODIFIED (add 4 adapter deps + flows-api + processing-api)
+└── src/
+    ├── main/
+    │   ├── java/org/deltav/flows/enricher/
+    │   │   ├── FlowEnricherApplication.java         — unchanged
+    │   │   ├── FlowEnricherConfiguration.java       — MODIFIED (bean wiring changes, dispatch map)
+    │   │   ├── SinkMessageDeserializer.java         — MODIFIED (expose moduleId)
+    │   │   ├── DeserializedSinkMessage.java         — NEW (record carrying moduleId + TelemetryMessageLog)
+    │   │   ├── FlowEnrichmentFunction.java          — MODIFIED (List<byte[]> signature, full pipeline)
+    │   │   ├── classification/
+    │   │   │   ├── ApplicationClassifier.java       — NEW (interface)
+    │   │   │   └── PortBasedApplicationClassifier.java — NEW (static port map)
+    │   │   ├── mapping/
+    │   │   │   └── FlowToDocumentMapper.java        — NEW (Flow → FlowDocument with null-wrapper semantics)
+    │   │   ├── pipeline/
+    │   │   │   └── CapturingPipeline.java           — NEW (stashes List<Flow> and FlowSource)
+    │   │   ├── protocol/
+    │   │   │   ├── ProtocolMessageProcessor.java    — NEW (interface)
+    │   │   │   ├── AbstractProtocolMessageProcessor.java — NEW (shared driver: handleMessageLog + capture)
+    │   │   │   ├── Netflow5MessageProcessor.java    — NEW
+    │   │   │   ├── Netflow9MessageProcessor.java    — NEW
+    │   │   │   ├── IpfixMessageProcessor.java       — NEW
+    │   │   │   └── SFlowMessageProcessor.java       — NEW
+    │   │   └── enrichment/
+    │   │       ├── FlowLocalityCalculator.java      — unchanged (skeleton bean, called per-flow in Phase 1.5)
+    │   │       ├── InterfaceMarkingCache.java       — unchanged (skeleton bean, called per-flow in Phase 1.5)
+    │   │       └── JdbcNodeInfoLookup.java          — unchanged (skeleton bean, called 3x per-flow in Phase 1.5)
+    │   └── resources/
+    │       └── application.yml                      — unchanged (existing bindings already support the new signature)
+    └── test/
+        ├── java/org/deltav/flows/enricher/
+        │   ├── FlowEnrichmentFunctionTest.java      — MODIFIED (new signature, dispatch assertions)
+        │   ├── classification/
+        │   │   └── PortBasedApplicationClassifierTest.java — NEW
+        │   ├── mapping/
+        │   │   └── FlowToDocumentMapperTest.java    — NEW (~300 lines, null-wrapper edge cases)
+        │   ├── pipeline/
+        │   │   └── CapturingPipelineTest.java       — NEW
+        │   ├── protocol/
+        │   │   ├── TestAdapterDefinitions.java      — NEW (test helper: testAdapterDefinition(String))
+        │   │   ├── Netflow5MessageProcessorTest.java — NEW (hand-crafted hex bytes)
+        │   │   ├── Netflow9MessageProcessorTest.java — NEW (horizon .dat fixture)
+        │   │   ├── IpfixMessageProcessorTest.java    — NEW (horizon .dat fixture)
+        │   │   └── SFlowMessageProcessorTest.java    — NEW (horizon .dat fixture)
+        │   └── integration/
+        │       └── FlowEnrichmentStreamBinderIT.java — NEW (all four protocols, test binder)
+        └── resources/
+            └── test-packets/
+                ├── netflow9-sample.dat              — NEW (copied from horizon)
+                ├── ipfix-sample.dat                 — NEW (copied from horizon)
+                └── sflow-sample.dat                 — NEW (copied from horizon)
+```
+
+---
+
+## Commit structure
+
+Per the brainstorm, the PR lands in six logical commits that let reviewers follow the layering:
+
+1. **pom.xml** — four adapter JARs plus flows-api and processing-api, all with the standard exclusion block
+2. **Shared infrastructure** — `CapturingPipeline`, `FlowToDocumentMapper`, `ApplicationClassifier` interface + `PortBasedApplicationClassifier`, and all their unit tests
+3. **Splitter refactor** — `SinkMessageDeserializer` change to expose `moduleId`, `DeserializedSinkMessage` record, `FlowEnrichmentFunction` signature change to `List<byte[]>` with placeholder dispatch, updated `FlowEnrichmentFunctionTest`
+4. **Protocol processors** — `ProtocolMessageProcessor` interface, `AbstractProtocolMessageProcessor` base class, four concrete implementations, their unit tests, and the test fixture files
+5. **Final wiring** — `FlowEnricherConfiguration` bean changes (new processor beans, dispatch map, orchestration bean), full per-flow enrichment path (locality + src/dst node lookup + interface marking + classification + mapping)
+6. **Integration test** — `FlowEnrichmentStreamBinderIT` exercising all four protocols through the in-memory test binder
+
+Tasks below are grouped to match this commit structure — each "commit" checkbox at the end of a task group represents one of the six commits.
+
+---
+
+## Task 1: Add horizon adapter dependencies to pom.xml
+
+**Files:**
+- Modify: `core/flow-enricher/pom.xml`
+
+The flow-enricher pom already has exclusion blocks for `org.opennms.core.ipc.sink.common` and `org.opennms.features.telemetry.common`. This task adds six more horizon dependencies, each with an identical exclusion block. Copy the existing exclusion block verbatim for each new dependency.
+
+- [ ] **Step 1: Verify the adapter artifact IDs are published in horizon 1.0.7**
+
+Run:
+```bash
+curl -s "https://maven.pkg.github.com/pbrane/delta-v-horizon/org/opennms/features/telemetry/protocols/netflow/org.opennms.features.telemetry.protocols.netflow.adapter.netflow5/1.0.7/" 2>&1 | head -5
+```
+Expected: 401 response (auth required, but the artifact path is resolved by the server, confirming the artifact exists)
+
+Alternative verification via local Maven:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher dependency:list 2>&1 | grep -i "netflow5\|netflow9\|ipfix\|sflow\|flows-api\|processing-api" | head -20
+```
+
+- [ ] **Step 2: Add netflow5 adapter dependency**
+
+Open `core/flow-enricher/pom.xml`. After the existing `org.opennms.features.telemetry.common` dependency block (ends around line 119), add:
+
+```xml
+<!-- Horizon: Netflow-5 protocol adapter -->
+<dependency>
+    <groupId>org.opennms.features.telemetry.protocols.netflow</groupId>
+    <artifactId>org.opennms.features.telemetry.protocols.netflow.adapter.netflow5</artifactId>
+    <exclusions>
+        <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+        <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+        <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-security-dependencies</artifactId></exclusion>
+        <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+        <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
+        <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+        <exclusion><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId></exclusion>
+        <exclusion><groupId>org.slf4j</groupId><artifactId>log4j-over-slf4j</artifactId></exclusion>
+        <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-log4j2</artifactId></exclusion>
+        <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+        <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+        <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
+        <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+    </exclusions>
+</dependency>
+```
+
+- [ ] **Step 3: Add netflow9 adapter dependency**
+
+Immediately after the netflow5 block, add the same structure with these changes:
+- `<artifactId>org.opennms.features.telemetry.protocols.netflow.adapter.netflow9</artifactId>`
+- Comment: `<!-- Horizon: Netflow-9 protocol adapter -->`
+- All exclusions identical
+
+- [ ] **Step 4: Add IPFIX adapter dependency**
+
+Immediately after the netflow9 block, add the same structure with:
+- `<artifactId>org.opennms.features.telemetry.protocols.netflow.adapter.ipfix</artifactId>`
+- Comment: `<!-- Horizon: IPFIX protocol adapter -->`
+
+- [ ] **Step 5: Add sFlow adapter dependency**
+
+Immediately after the IPFIX block, add the same structure with:
+- `<groupId>org.opennms.features.telemetry.protocols.sflow</groupId>`
+- `<artifactId>org.opennms.features.telemetry.protocols.sflow.adapter</artifactId>`
+- Comment: `<!-- Horizon: sFlow protocol adapter -->`
+
+- [ ] **Step 6: Add flows-api dependency (for Flow interface)**
+
+After the sflow adapter block, add:
+
+```xml
+<!-- Horizon: Flow interface (return type of adapter pipeline) -->
+<dependency>
+    <groupId>org.opennms.features.flows</groupId>
+    <artifactId>org.opennms.features.flows.flows-api</artifactId>
+    <exclusions>
+        <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+        <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+    </exclusions>
+</dependency>
+```
+
+This is a lightweight JAR (just the API interfaces) so the exclusion block is minimal.
+
+- [ ] **Step 7: Add flow processing API dependency (for Pipeline interface)**
+
+After the flows-api block, add:
+
+```xml
+<!-- Horizon: Pipeline interface (integration seam for CapturingPipeline) -->
+<dependency>
+    <groupId>org.opennms.features.flows</groupId>
+    <artifactId>org.opennms.netmgt.flows.processing.api</artifactId>
+    <exclusions>
+        <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+        <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+        <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+        <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+    </exclusions>
+</dependency>
+```
+
+- [ ] **Step 8: Add Dropwizard MetricRegistry dependency**
+
+The horizon adapters require a `com.codahale.metrics.MetricRegistry` constructor argument. If this is not already transitively provided, add it explicitly. After the processing-api block:
+
+```xml
+<!-- Dropwizard Metrics (required by horizon adapter constructors) -->
+<dependency>
+    <groupId>io.dropwizard.metrics</groupId>
+    <artifactId>metrics-core</artifactId>
+</dependency>
+```
+
+(Version is managed by the horizon BOM or Spring Boot BOM — do not specify a version here.)
+
+- [ ] **Step 9: Verify the module still compiles**
+
+Run:
+```bash
+cd /Users/david/development/src/opennms/delta-v
+./compile.pl -pl :org.deltav.flows.flow-enricher -DskipTests compile 2>&1 | tail -30
+```
+Expected: `BUILD SUCCESS`. If there are resolution errors, check the GitHub Packages credentials and verify the artifact IDs match what's actually published.
+
+- [ ] **Step 10: Verify adapter classes are on the classpath**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher dependency:tree 2>&1 | grep -E "netflow5|netflow9|ipfix|sflow.adapter|flows-api|processing.api"
+```
+Expected: six lines showing the adapter and API JARs resolved from horizon 1.0.7.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add core/flow-enricher/pom.xml
+git commit -m "feat(flow-enricher): add horizon adapter dependencies for Phase 1.5"
+```
+
+---
+
+## Task 2: Create CapturingPipeline
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/pipeline/CapturingPipeline.java`
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/pipeline/CapturingPipelineTest.java`
+
+The `CapturingPipeline` implements horizon's `org.opennms.netmgt.flows.processing.Pipeline` interface. When horizon's `AbstractFlowAdapter.handleMessageLog()` is called, it internally invokes `pipeline.process(List<Flow>, FlowSource, ProcessingOptions)`. Our implementation does not persist or forward the flows — it just stashes them into instance fields so the caller can pull them out afterwards.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/flow-enricher/src/test/java/org/deltav/flows/enricher/pipeline/CapturingPipelineTest.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.flows.processing.ProcessingOptions;
+import org.opennms.netmgt.flows.processing.enrichment.EnrichedFlow;
+import org.opennms.netmgt.flows.processing.pipeline.Pipeline;
+import org.opennms.netmgt.flows.processing.source.FlowSource;
+import org.opennms.netmgt.flows.api.Flow;
+
+class CapturingPipelineTest {
+
+    @Test
+    void capturesFlowsAndSourcePassedToProcess() throws Exception {
+        CapturingPipeline pipeline = new CapturingPipeline();
+        Flow flow1 = mock(Flow.class);
+        Flow flow2 = mock(Flow.class);
+        FlowSource source = new FlowSource("test-location", "192.0.2.1", null);
+
+        pipeline.process(List.of(flow1, flow2), source, ProcessingOptions.defaults());
+
+        assertThat(pipeline.getCapturedFlows()).containsExactly(flow1, flow2);
+        assertThat(pipeline.getCapturedSource()).isEqualTo(source);
+    }
+
+    @Test
+    void capturedFlowsIsEmptyListBeforeProcessIsCalled() {
+        CapturingPipeline pipeline = new CapturingPipeline();
+        assertThat(pipeline.getCapturedFlows()).isEmpty();
+        assertThat(pipeline.getCapturedSource()).isNull();
+    }
+
+    @Test
+    void secondProcessCallReplacesFirstCaptures() throws Exception {
+        CapturingPipeline pipeline = new CapturingPipeline();
+        Flow firstFlow = mock(Flow.class);
+        Flow secondFlow = mock(Flow.class);
+        FlowSource source1 = new FlowSource("loc1", "192.0.2.1", null);
+        FlowSource source2 = new FlowSource("loc2", "192.0.2.2", null);
+
+        pipeline.process(List.of(firstFlow), source1, ProcessingOptions.defaults());
+        pipeline.process(List.of(secondFlow), source2, ProcessingOptions.defaults());
+
+        assertThat(pipeline.getCapturedFlows()).containsExactly(secondFlow);
+        assertThat(pipeline.getCapturedSource()).isEqualTo(source2);
+    }
+}
+```
+
+**Note:** The exact package paths for `Pipeline`, `FlowSource`, `ProcessingOptions`, and `Flow` depend on which horizon JAR exposes them. If the test won't compile because of import errors, run `./compile.pl -pl :org.deltav.flows.flow-enricher dependency:tree | grep -i "flow\|processing"` and search the resolved JARs for the actual class locations. Update the imports to match. The `Pipeline` interface is the key one — it's in `org.opennms.netmgt.flows.processing.pipeline.Pipeline` in horizon 1.0.7 per the brainstorm findings.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd /Users/david/development/src/opennms/delta-v
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=CapturingPipelineTest test 2>&1 | tail -20
+```
+Expected: Compilation failure — `CapturingPipeline` class does not exist.
+
+- [ ] **Step 3: Create the CapturingPipeline class**
+
+Create `core/flow-enricher/src/main/java/org/deltav/flows/enricher/pipeline/CapturingPipeline.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.pipeline;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.flows.processing.ProcessingOptions;
+import org.opennms.netmgt.flows.processing.pipeline.Pipeline;
+import org.opennms.netmgt.flows.processing.source.FlowSource;
+
+/**
+ * Pipeline implementation that stashes the flows passed to
+ * {@link #process(List, FlowSource, ProcessingOptions)} so the caller can
+ * retrieve them via {@link #getCapturedFlows()} and {@link #getCapturedSource()}.
+ *
+ * <p>This is the integration seam between horizon's {@code AbstractFlowAdapter}
+ * and our Phase 1.5 enrichment. The adapter calls {@code pipeline.process(...)}
+ * at the end of its parse-and-convert cycle; we use this "pipeline" as a
+ * no-op sink so we can pull the {@link Flow} list out without triggering any
+ * of horizon's persistence or forwarding logic.
+ *
+ * <p><strong>Not thread-safe and not reusable across concurrent invocations.</strong>
+ * Each protocol processor creates a fresh {@code CapturingPipeline} per call
+ * to avoid cross-contamination.
+ */
+public class CapturingPipeline implements Pipeline {
+
+    private List<Flow> capturedFlows = Collections.emptyList();
+    private FlowSource capturedSource;
+
+    @Override
+    public void process(List<Flow> flows, FlowSource source, ProcessingOptions options) {
+        this.capturedFlows = flows;
+        this.capturedSource = source;
+    }
+
+    public List<Flow> getCapturedFlows() {
+        return capturedFlows;
+    }
+
+    public FlowSource getCapturedSource() {
+        return capturedSource;
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=CapturingPipelineTest test 2>&1 | tail -20
+```
+Expected: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`.
+
+If compilation fails with "cannot find symbol: class Pipeline" or similar, the package location in the horizon JAR is different. Check the dependency tree and update imports in both the test and the production file.
+
+- [ ] **Step 5: Do NOT commit yet**
+
+This task is part of Commit 2 (Shared Infrastructure). It commits together with Tasks 3, 4, and 5.
+
+---
+
+## Task 3: Create FlowToDocumentMapper
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java`
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java`
+
+The mapper converts a horizon `Flow` (plus our enriched NodeInfo records for src, dst, exporter) into a `FlowDocumentProtos.FlowDocument`. The critical discipline is explicit null handling for `google.protobuf.*Value` wrapper fields: call `setXxx(UInt64Value.of(v))` only when the getter returns non-null, so downstream consumers (ClickHouse) can distinguish "unset" from "zero."
+
+- [ ] **Step 1: Write the failing test — core scalar mapping**
+
+Create `core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.flows.api.Flow;
+
+class FlowToDocumentMapperTest {
+
+    private final FlowToDocumentMapper mapper = new FlowToDocumentMapper();
+
+    @Test
+    void mapsTimestampAndScalars() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1712700000000L);
+        when(flow.getSrcAddr()).thenReturn("192.0.2.1");
+        when(flow.getDstAddr()).thenReturn("198.51.100.2");
+        when(flow.getNextHop()).thenReturn("203.0.113.1");
+        when(flow.getSrcHostname()).thenReturn("client.example.com");
+        when(flow.getDstHostname()).thenReturn("server.example.com");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.getTimestamp()).isEqualTo(1712700000000L);
+        assertThat(doc.getSrcAddress()).isEqualTo("192.0.2.1");
+        assertThat(doc.getDstAddress()).isEqualTo("198.51.100.2");
+        assertThat(doc.getNextHopAddress()).isEqualTo("203.0.113.1");
+        assertThat(doc.getSrcHostname()).isEqualTo("client.example.com");
+        assertThat(doc.getDstHostname()).isEqualTo("server.example.com");
+    }
+
+    @Test
+    void omitsUInt64ValueWrapperFieldsWhenFlowGetterReturnsNull() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1712700000000L);
+        when(flow.getSrcAddr()).thenReturn("192.0.2.1");
+        when(flow.getDstAddr()).thenReturn("198.51.100.2");
+        when(flow.getBytes()).thenReturn(null);
+        when(flow.getPackets()).thenReturn(null);
+        when(flow.getSrcAs()).thenReturn(null);
+        when(flow.getDstAs()).thenReturn(null);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.hasNumBytes()).isFalse();
+        assertThat(doc.hasNumPackets()).isFalse();
+        assertThat(doc.hasSrcAs()).isFalse();
+        assertThat(doc.hasDstAs()).isFalse();
+    }
+
+    @Test
+    void populatesUInt64ValueWrapperFieldsWhenFlowGetterReturnsZero() {
+        // CRITICAL: 0 is a valid value, distinct from null. The mapper must
+        // set the wrapper to UInt64Value.of(0), not leave it unset.
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1712700000000L);
+        when(flow.getSrcAddr()).thenReturn("192.0.2.1");
+        when(flow.getDstAddr()).thenReturn("198.51.100.2");
+        when(flow.getBytes()).thenReturn(0L);
+        when(flow.getPackets()).thenReturn(0L);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.hasNumBytes()).isTrue();
+        assertThat(doc.getNumBytes().getValue()).isEqualTo(0L);
+        assertThat(doc.hasNumPackets()).isTrue();
+        assertThat(doc.getNumPackets().getValue()).isEqualTo(0L);
+    }
+
+    @Test
+    void populatesExporterNodeWhenEnrichmentProvidesIt() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1712700000000L);
+        when(flow.getSrcAddr()).thenReturn("192.0.2.1");
+        when(flow.getDstAddr()).thenReturn("198.51.100.2");
+
+        JdbcNodeInfoLookup.NodeInfo exporterInfo = new JdbcNodeInfoLookup.NodeInfo(
+                42, "selfmonitor", "router-1", List.of("edge", "router"));
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, exporterInfo, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.hasExporterNode()).isTrue();
+        assertThat(doc.getExporterNode().getNodeId()).isEqualTo(42);
+        assertThat(doc.getExporterNode().getForeignSource()).isEqualTo("selfmonitor");
+        assertThat(doc.getExporterNode().getForeignId()).isEqualTo("router-1");
+        assertThat(doc.getExporterNode().getCategoriesList()).containsExactly("edge", "router");
+    }
+
+    @Test
+    void omitsNodeInfoMessagesWhenLookupReturnedNull() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1712700000000L);
+        when(flow.getSrcAddr()).thenReturn("192.0.2.1");
+        when(flow.getDstAddr()).thenReturn("198.51.100.2");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.hasExporterNode()).isFalse();
+        assertThat(doc.hasSrcNode()).isFalse();
+        assertThat(doc.hasDestNode()).isFalse();
+    }
+
+    @Test
+    void populatesApplicationAndLocalityFromEnrichmentParameters() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1712700000000L);
+        when(flow.getSrcAddr()).thenReturn("192.0.2.1");
+        when(flow.getDstAddr()).thenReturn("198.51.100.2");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "HTTPS", "PRIVATE", "PUBLIC", "PUBLIC");
+
+        assertThat(doc.getApplication()).isEqualTo("HTTPS");
+        assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.PRIVATE);
+        assertThat(doc.getDstLocality()).isEqualTo(FlowDocumentProtos.Locality.PUBLIC);
+        assertThat(doc.getFlowLocality()).isEqualTo(FlowDocumentProtos.Locality.PUBLIC);
+    }
+}
+```
+
+This is a starter test file — the full test covers every field. Additional test methods for each remaining field group (UInt32Value wrappers for ports/AS/mask_len/etc., direction enum, sampling_algorithm enum, netflow_version enum, ifindex fields, tcp_flags, tos/dscp/ecn, vlan, host/location) are written after the mapper class itself is in place. The six tests above establish the null-wrapper discipline pattern that the remaining tests follow.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=FlowToDocumentMapperTest test 2>&1 | tail -20
+```
+Expected: Compilation failure — `FlowToDocumentMapper` class does not exist, OR `map(...)` method signature mismatch.
+
+- [ ] **Step 3: Create the FlowToDocumentMapper class**
+
+Create `core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.mapping;
+
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.opennms.netmgt.flows.api.Flow;
+
+/**
+ * Mechanical field-by-field mapper from horizon's {@link Flow} interface to
+ * our {@link FlowDocumentProtos.FlowDocument} protobuf class. Handles the
+ * {@code google.protobuf.*Value} wrapper semantics explicitly — a null Flow
+ * getter result leaves the corresponding FlowDocument field unset, while a
+ * zero result calls {@code setXxx(UInt64Value.of(0))} so downstream consumers
+ * (ClickHouse) can distinguish "unset" from "zero."
+ */
+public class FlowToDocumentMapper {
+
+    /**
+     * Maps a flow to a FlowDocument. The enriched fields (node info for
+     * exporter/src/dst, application classification, locality strings) are
+     * passed as separate parameters because they are computed by the
+     * orchestrator, not by the Flow itself.
+     *
+     * @param flow the parsed flow from the horizon adapter
+     * @param exporterNodeInfo exporter node lookup result, may be null if not in inventory
+     * @param srcNodeInfo source node lookup result, may be null
+     * @param destNodeInfo destination node lookup result, may be null
+     * @param application classified application name ("HTTPS", "DNS", ..., or "unknown")
+     * @param srcLocality "PRIVATE", "PUBLIC", or "UNKNOWN"
+     * @param dstLocality "PRIVATE", "PUBLIC", or "UNKNOWN"
+     * @param flowLocality "PRIVATE", "PUBLIC", or "UNKNOWN"
+     */
+    public FlowDocumentProtos.FlowDocument map(
+            Flow flow,
+            JdbcNodeInfoLookup.NodeInfo exporterNodeInfo,
+            JdbcNodeInfoLookup.NodeInfo srcNodeInfo,
+            JdbcNodeInfoLookup.NodeInfo destNodeInfo,
+            String application,
+            String srcLocality,
+            String dstLocality,
+            String flowLocality) {
+
+        FlowDocumentProtos.FlowDocument.Builder b = FlowDocumentProtos.FlowDocument.newBuilder();
+
+        // Scalars (always populated)
+        b.setTimestamp(flow.getTimestamp());
+        b.setClockCorrection(flow.getClockCorrection() != null ? flow.getClockCorrection() : 0L);
+
+        if (flow.getSrcAddr() != null) {
+            b.setSrcAddress(flow.getSrcAddr());
+        }
+        if (flow.getDstAddr() != null) {
+            b.setDstAddress(flow.getDstAddr());
+        }
+        if (flow.getNextHop() != null) {
+            b.setNextHopAddress(flow.getNextHop());
+        }
+        if (flow.getSrcHostname() != null) {
+            b.setSrcHostname(flow.getSrcHostname());
+        }
+        if (flow.getDstHostname() != null) {
+            b.setDstHostname(flow.getDstHostname());
+        }
+        if (flow.getNextHopHostname() != null) {
+            b.setNextHopHostname(flow.getNextHopHostname());
+        }
+
+        // Volume (UInt64Value wrappers — null means unset, 0 means zero)
+        if (flow.getBytes() != null) {
+            b.setNumBytes(UInt64Value.of(flow.getBytes()));
+        }
+        if (flow.getPackets() != null) {
+            b.setNumPackets(UInt64Value.of(flow.getPackets()));
+        }
+
+        // Flow lifetime
+        if (flow.getFirstSwitched() != null) {
+            b.setFirstSwitched(UInt64Value.of(flow.getFirstSwitched()));
+        }
+        if (flow.getLastSwitched() != null) {
+            b.setLastSwitched(UInt64Value.of(flow.getLastSwitched()));
+        }
+        if (flow.getDeltaSwitched() != null) {
+            b.setDeltaSwitched(UInt64Value.of(flow.getDeltaSwitched()));
+        }
+        if (flow.getFlowSeqNum() != null) {
+            b.setFlowSeqNum(UInt64Value.of(flow.getFlowSeqNum()));
+        }
+        if (flow.getNumFlowRecords() != null) {
+            b.setNumFlowRecords(UInt32Value.of(flow.getNumFlowRecords()));
+        }
+
+        // Ports and AS numbers
+        if (flow.getSrcPort() != null) {
+            b.setSrcPort(UInt32Value.of(flow.getSrcPort()));
+        }
+        if (flow.getDstPort() != null) {
+            b.setDstPort(UInt32Value.of(flow.getDstPort()));
+        }
+        if (flow.getSrcAs() != null) {
+            b.setSrcAs(UInt64Value.of(flow.getSrcAs()));
+        }
+        if (flow.getDstAs() != null) {
+            b.setDstAs(UInt64Value.of(flow.getDstAs()));
+        }
+        if (flow.getSrcMaskLen() != null) {
+            b.setSrcMaskLen(UInt32Value.of(flow.getSrcMaskLen()));
+        }
+        if (flow.getDstMaskLen() != null) {
+            b.setDstMaskLen(UInt32Value.of(flow.getDstMaskLen()));
+        }
+
+        // Protocol / QoS / TCP
+        if (flow.getProtocol() != null) {
+            b.setProtocol(UInt32Value.of(flow.getProtocol()));
+        }
+        if (flow.getIpProtocolVersion() != null) {
+            b.setIpProtocolVersion(UInt32Value.of(flow.getIpProtocolVersion()));
+        }
+        if (flow.getTcpFlags() != null) {
+            b.setTcpFlags(UInt32Value.of(flow.getTcpFlags()));
+        }
+        if (flow.getTos() != null) {
+            b.setTos(UInt32Value.of(flow.getTos()));
+        }
+        if (flow.getDscp() != null) {
+            b.setDscp(UInt32Value.of(flow.getDscp()));
+        }
+        if (flow.getEcn() != null) {
+            b.setEcn(UInt32Value.of(flow.getEcn()));
+        }
+        if (flow.getVlan() != null) {
+            b.setVlan(flow.getVlan());
+        }
+
+        // Interface indexes
+        if (flow.getInputSnmp() != null) {
+            b.setInputSnmpIfindex(UInt32Value.of(flow.getInputSnmp()));
+        }
+        if (flow.getOutputSnmp() != null) {
+            b.setOutputSnmpIfindex(UInt32Value.of(flow.getOutputSnmp()));
+        }
+
+        // Engine
+        if (flow.getEngineId() != null) {
+            b.setEngineId(UInt32Value.of(flow.getEngineId()));
+        }
+        if (flow.getEngineType() != null) {
+            b.setEngineType(UInt32Value.of(flow.getEngineType()));
+        }
+
+        // Direction enum
+        if (flow.getDirection() != null) {
+            switch (flow.getDirection()) {
+                case INGRESS -> b.setDirection(FlowDocumentProtos.Direction.INGRESS);
+                case EGRESS  -> b.setDirection(FlowDocumentProtos.Direction.EGRESS);
+                default      -> b.setDirection(FlowDocumentProtos.Direction.DIRECTION_UNKNOWN);
+            }
+        }
+
+        // Netflow version enum
+        if (flow.getNetflowVersion() != null) {
+            switch (flow.getNetflowVersion()) {
+                case V5    -> b.setNetflowVersion(FlowDocumentProtos.NetflowVersion.V5);
+                case V9    -> b.setNetflowVersion(FlowDocumentProtos.NetflowVersion.V9);
+                case IPFIX -> b.setNetflowVersion(FlowDocumentProtos.NetflowVersion.IPFIX);
+                case SFLOW -> b.setNetflowVersion(FlowDocumentProtos.NetflowVersion.SFLOW);
+                default    -> b.setNetflowVersion(FlowDocumentProtos.NetflowVersion.NETFLOW_VERSION_UNKNOWN);
+            }
+        }
+
+        // Sampling
+        if (flow.getSamplingAlgorithm() != null) {
+            b.setSamplingAlgorithm(mapSamplingAlgorithm(flow.getSamplingAlgorithm()));
+        }
+        if (flow.getSamplingInterval() != null) {
+            b.setSamplingInterval(DoubleValue.of(flow.getSamplingInterval()));
+        }
+
+        // Enriched fields (from orchestrator, not from Flow)
+        b.setApplication(application != null ? application : "unknown");
+        b.setSrcLocality(parseLocality(srcLocality));
+        b.setDstLocality(parseLocality(dstLocality));
+        b.setFlowLocality(parseLocality(flowLocality));
+
+        // NodeInfo messages
+        if (exporterNodeInfo != null) {
+            b.setExporterNode(toNodeInfo(exporterNodeInfo));
+        }
+        if (srcNodeInfo != null) {
+            b.setSrcNode(toNodeInfo(srcNodeInfo));
+        }
+        if (destNodeInfo != null) {
+            b.setDestNode(toNodeInfo(destNodeInfo));
+        }
+
+        return b.build();
+    }
+
+    private static FlowDocumentProtos.NodeInfo toNodeInfo(JdbcNodeInfoLookup.NodeInfo info) {
+        FlowDocumentProtos.NodeInfo.Builder nb = FlowDocumentProtos.NodeInfo.newBuilder()
+                .setNodeId(info.nodeId());
+        if (info.foreignSource() != null) {
+            nb.setForeignSource(info.foreignSource());
+        }
+        if (info.foreignId() != null) {
+            nb.setForeignId(info.foreignId());
+        }
+        if (info.categories() != null) {
+            nb.addAllCategories(info.categories());
+        }
+        return nb.build();
+    }
+
+    private static FlowDocumentProtos.Locality parseLocality(String locality) {
+        if (locality == null) {
+            return FlowDocumentProtos.Locality.LOCALITY_UNKNOWN;
+        }
+        switch (locality) {
+            case "PRIVATE": return FlowDocumentProtos.Locality.PRIVATE;
+            case "PUBLIC":  return FlowDocumentProtos.Locality.PUBLIC;
+            default:        return FlowDocumentProtos.Locality.LOCALITY_UNKNOWN;
+        }
+    }
+
+    private static FlowDocumentProtos.SamplingAlgorithm mapSamplingAlgorithm(
+            org.opennms.netmgt.flows.api.Flow.SamplingAlgorithm src) {
+        switch (src) {
+            case SystematicCountBasedSampling:
+                return FlowDocumentProtos.SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
+            case SystematicTimeBasedSampling:
+                return FlowDocumentProtos.SamplingAlgorithm.SYSTEMATIC_TIME_BASED_SAMPLING;
+            case RandomNOutOfNSampling:
+                return FlowDocumentProtos.SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
+            case UniformProbabilisticSampling:
+                return FlowDocumentProtos.SamplingAlgorithm.UNIFORM_PROBABILISTIC_SAMPLING;
+            case PropertyMatchFiltering:
+                return FlowDocumentProtos.SamplingAlgorithm.PROPERTY_MATCH_FILTERING;
+            case HashBasedFiltering:
+                return FlowDocumentProtos.SamplingAlgorithm.HASH_BASED_FILTERING;
+            case FlowStateDependentIntermediateFlowSelectionProcess:
+                return FlowDocumentProtos.SamplingAlgorithm.FLOW_STATE_DEPENDENT_INTERMEDIATE_FLOW_SELECTION_PROCESS;
+            default:
+                return FlowDocumentProtos.SamplingAlgorithm.SAMPLING_ALGORITHM_UNKNOWN;
+        }
+    }
+}
+```
+
+**Note on method names:** The exact getter names on horizon's `Flow` interface may differ slightly from what's written above (`getSrcAddr()` vs `getSrcAddress()`, `getBytes()` vs `getNumBytes()`, etc.). After creating the file, the compile step will surface any mismatches. Run `./compile.pl -pl :org.deltav.flows.flow-enricher -DskipTests compile` and fix any symbol-not-found errors by checking the actual method names via IntelliJ autocomplete or `javap -p` against the resolved `flows-api` JAR.
+
+- [ ] **Step 4: Run the test to verify the first six tests pass**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=FlowToDocumentMapperTest test 2>&1 | tail -30
+```
+Expected: `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0` after any method-name fixes from Step 3.
+
+- [ ] **Step 5: Extend the test file with the remaining field-group tests**
+
+Add the following test methods to `FlowToDocumentMapperTest.java` (after the existing six). These follow the same null-wrapper discipline for each remaining field group. Write each test, run it, confirm it fails (or passes if the mapping is already correct), add any missing production code, and re-run.
+
+```java
+    @Test
+    void mapsUInt32ValueWrappersNullSemantics() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1L);
+        when(flow.getSrcAddr()).thenReturn("1.1.1.1");
+        when(flow.getDstAddr()).thenReturn("2.2.2.2");
+        when(flow.getSrcPort()).thenReturn(null);
+        when(flow.getDstPort()).thenReturn(null);
+        when(flow.getProtocol()).thenReturn(null);
+        when(flow.getDscp()).thenReturn(null);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.hasSrcPort()).isFalse();
+        assertThat(doc.hasDstPort()).isFalse();
+        assertThat(doc.hasProtocol()).isFalse();
+        assertThat(doc.hasDscp()).isFalse();
+    }
+
+    @Test
+    void mapsUInt32ValueWrappersZeroIsPopulated() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1L);
+        when(flow.getSrcAddr()).thenReturn("1.1.1.1");
+        when(flow.getDstAddr()).thenReturn("2.2.2.2");
+        when(flow.getSrcPort()).thenReturn(0);
+        when(flow.getDstPort()).thenReturn(0);
+        when(flow.getProtocol()).thenReturn(0);
+        when(flow.getDscp()).thenReturn(0);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.hasSrcPort()).isTrue();
+        assertThat(doc.getSrcPort().getValue()).isEqualTo(0);
+        assertThat(doc.hasDstPort()).isTrue();
+        assertThat(doc.getDstPort().getValue()).isEqualTo(0);
+        assertThat(doc.hasProtocol()).isTrue();
+        assertThat(doc.getProtocol().getValue()).isEqualTo(0);
+        assertThat(doc.hasDscp()).isTrue();
+        assertThat(doc.getDscp().getValue()).isEqualTo(0);
+    }
+
+    @Test
+    void mapsDirectionEnum() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1L);
+        when(flow.getSrcAddr()).thenReturn("1.1.1.1");
+        when(flow.getDstAddr()).thenReturn("2.2.2.2");
+        when(flow.getDirection()).thenReturn(Flow.Direction.INGRESS);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.getDirection()).isEqualTo(FlowDocumentProtos.Direction.INGRESS);
+    }
+
+    @Test
+    void mapsNetflowVersionEnum() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1L);
+        when(flow.getSrcAddr()).thenReturn("1.1.1.1");
+        when(flow.getDstAddr()).thenReturn("2.2.2.2");
+        when(flow.getNetflowVersion()).thenReturn(Flow.NetflowVersion.V9);
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                "unknown", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+
+        assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V9);
+    }
+
+    @Test
+    void mapsSrcAndDstNodeInfoWhenAllProvided() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1L);
+        when(flow.getSrcAddr()).thenReturn("192.168.1.1");
+        when(flow.getDstAddr()).thenReturn("10.0.0.1");
+
+        JdbcNodeInfoLookup.NodeInfo exporter = new JdbcNodeInfoLookup.NodeInfo(1, "fs", "fid1", List.of("a"));
+        JdbcNodeInfoLookup.NodeInfo src = new JdbcNodeInfoLookup.NodeInfo(2, "fs", "fid2", List.of("b"));
+        JdbcNodeInfoLookup.NodeInfo dest = new JdbcNodeInfoLookup.NodeInfo(3, "fs", "fid3", List.of("c"));
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, exporter, src, dest,
+                "unknown", "PRIVATE", "PRIVATE", "PRIVATE");
+
+        assertThat(doc.getExporterNode().getNodeId()).isEqualTo(1);
+        assertThat(doc.getSrcNode().getNodeId()).isEqualTo(2);
+        assertThat(doc.getDestNode().getNodeId()).isEqualTo(3);
+    }
+
+    @Test
+    void leavesApplicationAsUnknownWhenNullProvided() {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1L);
+        when(flow.getSrcAddr()).thenReturn("1.1.1.1");
+        when(flow.getDstAddr()).thenReturn("2.2.2.2");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(flow, null, null, null,
+                null, null, null, null);
+
+        assertThat(doc.getApplication()).isEqualTo("unknown");
+        assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
+        assertThat(doc.getDstLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
+        assertThat(doc.getFlowLocality()).isEqualTo(FlowDocumentProtos.Locality.LOCALITY_UNKNOWN);
+    }
+```
+
+- [ ] **Step 6: Run the full FlowToDocumentMapperTest**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=FlowToDocumentMapperTest test 2>&1 | tail -30
+```
+Expected: `Tests run: 12, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 7: Do NOT commit yet**
+
+This task is part of Commit 2 (Shared Infrastructure). It commits together with Tasks 2, 4, and 5.
+
+---
+
+## Task 4: Create ApplicationClassifier interface and PortBasedApplicationClassifier
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/ApplicationClassifier.java`
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifier.java`
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifierTest.java`
+
+The classifier provides the `application` field on every FlowDocument. Phase 1.5 ships a port-based stub that covers ~30 well-known ports; Phase 1.6 replaces the implementation with horizon's `DefaultClassificationEngine`. The interface is the seam that makes the replacement a bean swap.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/flow-enricher/src/test/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifierTest.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.classification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PortBasedApplicationClassifierTest {
+
+    private static final int TCP = 6;
+    private static final int UDP = 17;
+
+    private final PortBasedApplicationClassifier classifier = new PortBasedApplicationClassifier();
+
+    @Test
+    void classifiesHttpsByDestPort() {
+        assertThat(classifier.classify(443, 54321, TCP)).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void classifiesHttpsBySourcePortWhenDestPortUnknown() {
+        // Return flow: server sends from 443 to client ephemeral port
+        assertThat(classifier.classify(54321, 443, TCP)).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void prefersDestPortOverSourcePortWhenBothAreKnown() {
+        // Unusual: HTTP client also happens to bind to port 53 ephemerally
+        // dst=80 should win over src=53
+        assertThat(classifier.classify(80, 53, TCP)).isEqualTo("HTTP");
+    }
+
+    @Test
+    void classifiesDnsUdp() {
+        assertThat(classifier.classify(53, 12345, UDP)).isEqualTo("DNS");
+    }
+
+    @Test
+    void classifiesSshTcp() {
+        assertThat(classifier.classify(22, 54321, TCP)).isEqualTo("SSH");
+    }
+
+    @Test
+    void classifiesHttp() {
+        assertThat(classifier.classify(80, 54321, TCP)).isEqualTo("HTTP");
+    }
+
+    @Test
+    void classifiesSmtpByCommonPorts() {
+        assertThat(classifier.classify(25, 54321, TCP)).isEqualTo("SMTP");
+        assertThat(classifier.classify(587, 54321, TCP)).isEqualTo("SMTP");
+    }
+
+    @Test
+    void classifiesDatabasePorts() {
+        assertThat(classifier.classify(5432, 54321, TCP)).isEqualTo("PostgreSQL");
+        assertThat(classifier.classify(3306, 54321, TCP)).isEqualTo("MySQL");
+        assertThat(classifier.classify(6379, 54321, TCP)).isEqualTo("Redis");
+    }
+
+    @Test
+    void classifiesKafka() {
+        assertThat(classifier.classify(9092, 54321, TCP)).isEqualTo("Kafka");
+    }
+
+    @Test
+    void returnsUnknownForNonStandardPorts() {
+        assertThat(classifier.classify(54321, 54322, TCP)).isEqualTo("unknown");
+        assertThat(classifier.classify(8888, 8889, TCP)).isEqualTo("unknown");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=PortBasedApplicationClassifierTest test 2>&1 | tail -20
+```
+Expected: Compilation failure — class does not exist.
+
+- [ ] **Step 3: Create the ApplicationClassifier interface**
+
+Create `core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/ApplicationClassifier.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.classification;
+
+/**
+ * Classifies a flow into an application name for dashboard aggregation.
+ *
+ * <p>Phase 1.5 ships {@link PortBasedApplicationClassifier} as the default
+ * implementation. Phase 1.6 will replace it with a real rule-based classifier
+ * backed by horizon's classification engine. Callers depend on this interface,
+ * not the concrete implementation.
+ */
+public interface ApplicationClassifier {
+
+    /**
+     * Returns the application name for a flow, or {@code "unknown"} if
+     * no classification applies.
+     *
+     * @param dstPort destination port (16-bit unsigned, passed as int)
+     * @param srcPort source port (16-bit unsigned, passed as int)
+     * @param protocol IP protocol number (6 = TCP, 17 = UDP)
+     */
+    String classify(int dstPort, int srcPort, int protocol);
+}
+```
+
+- [ ] **Step 4: Create the PortBasedApplicationClassifier implementation**
+
+Create `core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifier.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.classification;
+
+import java.util.Map;
+
+/**
+ * Static-map-based classifier that covers roughly 30 well-known ports.
+ * Checks dst_port first (client-to-server traffic), then src_port (return
+ * traffic from a server), then returns "unknown". Protocol number is
+ * accepted for future enum matching but is not currently used for
+ * discrimination because the well-known ports are unambiguous.
+ *
+ * <p>Replace with horizon's {@code DefaultClassificationEngine} in Phase 1.6.
+ */
+public class PortBasedApplicationClassifier implements ApplicationClassifier {
+
+    private static final Map<Integer, String> WELL_KNOWN = Map.ofEntries(
+            Map.entry(20, "FTP-data"),
+            Map.entry(21, "FTP"),
+            Map.entry(22, "SSH"),
+            Map.entry(23, "Telnet"),
+            Map.entry(25, "SMTP"),
+            Map.entry(53, "DNS"),
+            Map.entry(67, "DHCP"),
+            Map.entry(68, "DHCP"),
+            Map.entry(69, "TFTP"),
+            Map.entry(80, "HTTP"),
+            Map.entry(110, "POP3"),
+            Map.entry(123, "NTP"),
+            Map.entry(143, "IMAP"),
+            Map.entry(161, "SNMP"),
+            Map.entry(162, "SNMP-trap"),
+            Map.entry(389, "LDAP"),
+            Map.entry(443, "HTTPS"),
+            Map.entry(445, "SMB"),
+            Map.entry(465, "SMTPS"),
+            Map.entry(514, "Syslog"),
+            Map.entry(587, "SMTP"),
+            Map.entry(636, "LDAPS"),
+            Map.entry(993, "IMAPS"),
+            Map.entry(995, "POP3S"),
+            Map.entry(1433, "MSSQL"),
+            Map.entry(1521, "Oracle"),
+            Map.entry(3306, "MySQL"),
+            Map.entry(3389, "RDP"),
+            Map.entry(5432, "PostgreSQL"),
+            Map.entry(5672, "AMQP"),
+            Map.entry(6379, "Redis"),
+            Map.entry(8080, "HTTP-alt"),
+            Map.entry(8443, "HTTPS-alt"),
+            Map.entry(9092, "Kafka"),
+            Map.entry(9200, "Elasticsearch"),
+            Map.entry(27017, "MongoDB")
+    );
+
+    @Override
+    public String classify(int dstPort, int srcPort, int protocol) {
+        String byDst = WELL_KNOWN.get(dstPort);
+        if (byDst != null) {
+            return byDst;
+        }
+        String bySrc = WELL_KNOWN.get(srcPort);
+        if (bySrc != null) {
+            return bySrc;
+        }
+        return "unknown";
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=PortBasedApplicationClassifierTest test 2>&1 | tail -20
+```
+Expected: `Tests run: 10, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 6: Do NOT commit yet**
+
+This task is part of Commit 2. Commits with Tasks 2, 3, and 5.
+
+---
+
+## Task 5: Commit the shared infrastructure
+
+**Files:** All files from Tasks 2, 3, 4.
+
+- [ ] **Step 1: Verify all shared-infrastructure tests pass together**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher test 2>&1 | tail -20
+```
+Expected: All existing skeleton tests (24) plus the new Phase 1.5 tests (10 from classifier + 12 from mapper + 3 from pipeline = 25) all pass. Total: 49 tests, 0 failures.
+
+- [ ] **Step 2: Stage the files**
+
+Run:
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/pipeline/CapturingPipeline.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/ApplicationClassifier.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifier.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/pipeline/CapturingPipelineTest.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/classification/PortBasedApplicationClassifierTest.java
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(flow-enricher): add CapturingPipeline, mapper, classifier shared infra"
+```
+
+---
+
+## Task 6: Refactor SinkMessageDeserializer to expose moduleId
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java`
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java`
+- Modify: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java`
+
+The deserializer currently returns only `TelemetryMessageLog`. We need it to return both the `moduleId` (from the SinkMessage envelope) and the `TelemetryMessageLog` (the payload) so the orchestrator can dispatch on module ID.
+
+- [ ] **Step 1: Read the current SinkMessageDeserializer**
+
+```bash
+cat core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
+```
+Note the current return type and the parsing logic. This tells you exactly what lines to change.
+
+- [ ] **Step 2: Create the DeserializedSinkMessage record**
+
+Create `core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher;
+
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
+/**
+ * Result of parsing a Kafka Sink topic record. Carries both the SinkMessage's
+ * moduleId (used for protocol dispatch) and the decoded TelemetryMessageLog
+ * payload (passed to the corresponding protocol adapter).
+ *
+ * @param moduleId the Sink module identifier, e.g., "Telemetry-Netflow-5"
+ * @param messageLog the decoded telemetry payload
+ */
+public record DeserializedSinkMessage(String moduleId, TelemetryProtos.TelemetryMessageLog messageLog) {
+}
+```
+
+- [ ] **Step 3: Update the existing SinkMessageDeserializerTest**
+
+The existing test calls `deserialize(bytes)` and expects a `TelemetryMessageLog` return. Update it to expect `DeserializedSinkMessage`:
+
+Open `core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java`. Wherever it declares `TelemetryProtos.TelemetryMessageLog result = deserializer.deserialize(bytes)`, change to `DeserializedSinkMessage result = deserializer.deserialize(bytes)` and assert against `result.messageLog()` instead of `result` directly. Add a new test case:
+
+```java
+    @Test
+    void deserializedMessageExposesModuleId() {
+        // Construct a SinkMessage with moduleId "Telemetry-Netflow-9"
+        byte[] bytes = buildSinkMessageBytes("Telemetry-Netflow-9", sampleTelemetryLogBytes());
+
+        DeserializedSinkMessage result = deserializer.deserialize(bytes);
+
+        assertThat(result).isNotNull();
+        assertThat(result.moduleId()).isEqualTo("Telemetry-Netflow-9");
+        assertThat(result.messageLog()).isNotNull();
+    }
+```
+
+The `buildSinkMessageBytes(String, byte[])` helper wraps the payload in a SinkMessage protobuf with the given moduleId. If the existing test file doesn't have this helper, add it or adapt existing fixture code. The SinkMessage protobuf class is `org.opennms.core.ipc.sink.model.SinkMessageProtos.SinkMessage`.
+
+- [ ] **Step 4: Run the updated test to verify it fails**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=SinkMessageDeserializerTest test 2>&1 | tail -30
+```
+Expected: Compilation failure — `deserialize(...)` returns `TelemetryMessageLog`, not `DeserializedSinkMessage`.
+
+- [ ] **Step 5: Update SinkMessageDeserializer to return DeserializedSinkMessage**
+
+Open `core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java`. Change the return type of `deserialize(byte[])` from `TelemetryProtos.TelemetryMessageLog` to `DeserializedSinkMessage`. Inside the method, after parsing the SinkMessage, extract the `moduleId` field and construct the record:
+
+```java
+public DeserializedSinkMessage deserialize(byte[] kafkaBytes) {
+    try {
+        SinkMessageProtos.SinkMessage sinkMsg = SinkMessageProtos.SinkMessage.parseFrom(kafkaBytes);
+        String moduleId = sinkMsg.getModuleId();
+        TelemetryProtos.TelemetryMessageLog log =
+                TelemetryProtos.TelemetryMessageLog.parseFrom(sinkMsg.getContent());
+        return new DeserializedSinkMessage(moduleId, log);
+    } catch (InvalidProtocolBufferException e) {
+        LOG.warn("Failed to deserialize Sink message: {}", e.getMessage());
+        return null;
+    }
+}
+```
+
+If the current method does not use `SinkMessageProtos.SinkMessage` as the outer envelope (e.g., if it deserializes directly to `TelemetryMessageLog`), check the skeleton's existing implementation — the outer envelope is required to get the moduleId. You may need to add the SinkMessage parse step.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=SinkMessageDeserializerTest test 2>&1 | tail -20
+```
+Expected: All SinkMessageDeserializerTest tests pass, including the new moduleId assertion.
+
+- [ ] **Step 7: Do NOT commit yet**
+
+This task is part of Commit 3 (Splitter Refactor). It commits together with Task 7.
+
+---
+
+## Task 7: Refactor FlowEnrichmentFunction to Function<byte[], List<byte[]>> with placeholder dispatch
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java`
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`
+- Modify: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java`
+
+This task changes the function signature from `byte[] → byte[]` to `byte[] → List<byte[]>`. It adds a placeholder dispatch that returns an empty list for unknown moduleIds, matching the Phase 1 skeleton's "drop unknown messages" behavior. The actual per-protocol processing is wired in Task 12.
+
+- [ ] **Step 1: Read the current FlowEnrichmentFunction**
+
+```bash
+cat core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
+```
+
+- [ ] **Step 2: Update FlowEnrichmentFunctionTest to expect List<byte[]>**
+
+Open `core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java`. Change the test that exercises the existing skeleton path:
+
+```java
+    @Test
+    void returnsEmptyListForNullOrEmptyMessage() {
+        List<byte[]> result = function.processMessage(null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyListForUnknownModuleId() {
+        // Build a SinkMessage with moduleId "Telemetry-UnknownThing"
+        byte[] kafkaBytes = buildSinkMessageBytes("Telemetry-UnknownThing", sampleTelemetryLogBytes());
+
+        List<byte[]> result = function.processMessage(kafkaBytes);
+
+        assertThat(result).isEmpty();
+    }
+```
+
+Remove any old test assertions that depended on the `byte[]` return type (such as `assertThat(result).isNotNull()` where `result` was a single byte array).
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=FlowEnrichmentFunctionTest test 2>&1 | tail -20
+```
+Expected: Compilation failure — `processMessage` returns `byte[]`, test expects `List<byte[]>`.
+
+- [ ] **Step 4: Change FlowEnrichmentFunction signature and implement placeholder dispatch**
+
+Open `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java`. Replace the entire file with:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
+import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
+import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Phase 1.5 flow enrichment pipeline. Dispatches on the SinkMessage moduleId
+ * to one of four protocol processors (netflow5/netflow9/ipfix/sflow), parses
+ * the raw bytes into flows via horizon adapters, enriches each flow with
+ * node/locality/classification/interface-marking data, and emits a
+ * {@code List<byte[]>} of FlowDocumentProtos.FlowDocument messages.
+ *
+ * <p>Returning an empty list drops the input message without producing any
+ * output records. This happens when the moduleId is unknown, the payload
+ * cannot be parsed, or the adapter produces zero flows.
+ */
+public class FlowEnrichmentFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlowEnrichmentFunction.class);
+
+    private final SinkMessageDeserializer deserializer;
+    private final JdbcNodeInfoLookup nodeInfoLookup;
+    private final FlowLocalityCalculator localityCalculator;
+    private final InterfaceMarkingCache interfaceMarkingCache;
+    private final Map<String, ProtocolMessageProcessor> processorsByModuleId;
+
+    public FlowEnrichmentFunction(
+            SinkMessageDeserializer deserializer,
+            JdbcNodeInfoLookup nodeInfoLookup,
+            FlowLocalityCalculator localityCalculator,
+            InterfaceMarkingCache interfaceMarkingCache,
+            Map<String, ProtocolMessageProcessor> processorsByModuleId) {
+        this.deserializer = deserializer;
+        this.nodeInfoLookup = nodeInfoLookup;
+        this.localityCalculator = localityCalculator;
+        this.interfaceMarkingCache = interfaceMarkingCache;
+        this.processorsByModuleId = Map.copyOf(processorsByModuleId);
+    }
+
+    public List<byte[]> processMessage(byte[] kafkaBytes) {
+        if (kafkaBytes == null || kafkaBytes.length == 0) {
+            return Collections.emptyList();
+        }
+
+        DeserializedSinkMessage deserialized = deserializer.deserialize(kafkaBytes);
+        if (deserialized == null || deserialized.messageLog() == null
+                || deserialized.messageLog().getMessageCount() == 0) {
+            return Collections.emptyList();
+        }
+
+        ProtocolMessageProcessor processor = processorsByModuleId.get(deserialized.moduleId());
+        if (processor == null) {
+            LOG.debug("No processor for moduleId '{}', dropping message", deserialized.moduleId());
+            return Collections.emptyList();
+        }
+
+        // Task 12 wires the full enrichment pipeline here. The placeholder
+        // for Commit 3 returns an empty list so the function compiles and
+        // the binding contract is proven with the new signature.
+        return Collections.emptyList();
+    }
+}
+```
+
+- [ ] **Step 5: Update FlowEnricherConfiguration for the new function signature**
+
+Open `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`. Change the `enrichFlows` bean declaration from `Function<byte[], byte[]>` to `Function<byte[], List<byte[]>>`:
+
+```java
+    @Bean
+    Function<byte[], List<byte[]>> enrichFlows(FlowEnrichmentFunction enrichmentFunction) {
+        return enrichmentFunction::processMessage;
+    }
+```
+
+Add the import `java.util.List` and `java.util.Map`. Also update the `FlowEnrichmentFunction` bean declaration — it now takes a `Map<String, ProtocolMessageProcessor>` as its fifth constructor parameter. For this commit, wire an empty map:
+
+```java
+    @Bean
+    FlowEnrichmentFunction flowEnrichmentFunction(
+            SinkMessageDeserializer deserializer,
+            JdbcNodeInfoLookup nodeInfoLookup,
+            FlowLocalityCalculator localityCalculator,
+            InterfaceMarkingCache interfaceMarkingCache) {
+        return new FlowEnrichmentFunction(
+                deserializer, nodeInfoLookup, localityCalculator, interfaceMarkingCache,
+                Map.of());  // populated with real processors in Task 12
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher test 2>&1 | tail -30
+```
+Expected: All existing tests plus the updated FlowEnrichmentFunctionTest pass. No compilation errors.
+
+**Note on the `ProtocolMessageProcessor` import:** The interface doesn't exist yet — it's created in Task 8. Create a temporary stub interface in `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java` with just the package declaration and `public interface ProtocolMessageProcessor {}` so this task compiles. Task 8 fills in the real interface contents.
+
+- [ ] **Step 7: Commit (Splitter Refactor)**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/SinkMessageDeserializerTest.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
+git commit -m "feat(flow-enricher): refactor function to List<byte[]> splitter signature"
+```
+
+---
+
+## Task 8: Create ProtocolMessageProcessor interface and AbstractProtocolMessageProcessor
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java` (replace the stub)
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java`
+
+The interface declares the common contract. The abstract base class holds the shared driver logic (create a fresh `CapturingPipeline`, call `adapter.handleMessageLog`, return captured flows).
+
+- [ ] **Step 1: Replace the stub ProtocolMessageProcessor interface**
+
+Open `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ProtocolMessageProcessor.java` and replace the stub with:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.List;
+
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
+/**
+ * Per-protocol processor that wraps one horizon AbstractFlowAdapter and
+ * exposes a uniform {@code process()} method returning the parsed flows.
+ * One implementation exists per protocol (Netflow5, Netflow9, IPFIX, sFlow).
+ */
+public interface ProtocolMessageProcessor {
+
+    /**
+     * Parses the telemetry message log into per-flow records via the
+     * underlying horizon adapter.
+     *
+     * @param messageLog the decoded Sink payload
+     * @return parsed flows (never null; may be empty)
+     */
+    List<Flow> process(TelemetryProtos.TelemetryMessageLog messageLog);
+}
+```
+
+- [ ] **Step 2: Create AbstractProtocolMessageProcessor**
+
+Create `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared driver logic for all four protocol processors. Each concrete
+ * subclass supplies an {@link AbstractFlowAdapter} instance via the
+ * constructor. The {@link #process(TelemetryProtos.TelemetryMessageLog)}
+ * method instantiates a fresh {@link CapturingPipeline}, drives the adapter,
+ * and returns the captured flows.
+ */
+public abstract class AbstractProtocolMessageProcessor implements ProtocolMessageProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractProtocolMessageProcessor.class);
+
+    protected final AbstractFlowAdapter<?> adapter;
+
+    protected AbstractProtocolMessageProcessor(AbstractFlowAdapter<?> adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public List<Flow> process(TelemetryProtos.TelemetryMessageLog messageLog) {
+        CapturingPipeline pipeline = new CapturingPipeline();
+        // NOTE: we construct the adapter with our CapturingPipeline already
+        // injected via the subclass constructor; the pipeline is fresh per
+        // invocation so captures don't leak across messages in concurrent
+        // invocations. The adapter's handleMessageLog() method drives the
+        // parse-and-convert cycle that ultimately calls pipeline.process().
+        //
+        // CAVEAT: The horizon adapter holds a reference to the pipeline
+        // passed at construction time, so a per-invocation pipeline requires
+        // a per-invocation adapter OR a thread-local pipeline holder. See
+        // the subclass constructor comment for the approach used.
+        try {
+            adapter.handleMessageLog(messageLog);
+        } catch (Exception e) {
+            LOG.warn("Adapter {} failed to process message log: {}",
+                    adapter.getClass().getSimpleName(), e.getMessage());
+            return Collections.emptyList();
+        }
+        return pipeline.getCapturedFlows();
+    }
+}
+```
+
+**Important note on the pipeline-per-invocation pattern:** The naive implementation above creates a fresh `CapturingPipeline` in `process()` but uses the adapter held as an instance field — which was constructed with a DIFFERENT pipeline. This will NOT work because the adapter's field reference won't update.
+
+The correct pattern is one of:
+
+(a) **Per-invocation adapter construction** — build a new adapter with a new pipeline on every call. Cheap for simple adapters but potentially expensive for ones that cache templates (Netflow-9/IPFIX).
+
+(b) **Thread-local pipeline holder** — use a `ThreadLocal<CapturingPipeline>` and a proxy pipeline that delegates to whichever pipeline is currently set. The adapter holds the proxy; the processor swaps the thread-local per invocation.
+
+(c) **Synchronized processor with mutable adapter pipeline** — if `AbstractFlowAdapter` exposes a setter for the pipeline (check with `javap`), synchronize on the processor and set the pipeline before calling `handleMessageLog`.
+
+**Recommended: option (a)** for Phase 1.5 because templates are cached at a different layer inside the adapter (not tied to the Pipeline instance) and per-invocation construction is a few microseconds. Subclasses will therefore create their adapter inside `process()` rather than in the constructor. Update the base class:
+
+```java
+public abstract class AbstractProtocolMessageProcessor implements ProtocolMessageProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractProtocolMessageProcessor.class);
+
+    @Override
+    public List<Flow> process(TelemetryProtos.TelemetryMessageLog messageLog) {
+        CapturingPipeline pipeline = new CapturingPipeline();
+        AbstractFlowAdapter<?> adapter = createAdapter(pipeline);
+        try {
+            adapter.handleMessageLog(messageLog);
+        } catch (Exception e) {
+            LOG.warn("Adapter {} failed to process message log: {}",
+                    adapter.getClass().getSimpleName(), e.getMessage());
+            return Collections.emptyList();
+        }
+        return pipeline.getCapturedFlows();
+    }
+
+    /**
+     * Subclass supplies a fresh adapter instance wired to the given pipeline.
+     * Called on every {@link #process(TelemetryProtos.TelemetryMessageLog)}
+     * invocation to keep the pipeline-per-invocation invariant.
+     */
+    protected abstract AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline);
+}
+```
+
+- [ ] **Step 3: Do NOT commit yet**
+
+This task is part of Commit 4 (Protocol Processors). It commits together with Tasks 9, 10, and 11.
+
+---
+
+## Task 9: Create TestAdapterDefinitions helper
+
+**Files:**
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/TestAdapterDefinitions.java`
+
+Horizon adapters require an `AdapterDefinition` constructor argument. This helper provides minimal mocks so every per-protocol test doesn't reinvent the stubbing.
+
+- [ ] **Step 1: Create the helper**
+
+Create `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/TestAdapterDefinitions.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+
+/**
+ * Test fixtures for constructing minimal {@link AdapterDefinition} mocks.
+ * The horizon adapter constructors require a non-null AdapterDefinition with
+ * at least a {@code name} set; this helper provides sensible defaults.
+ */
+public final class TestAdapterDefinitions {
+
+    private TestAdapterDefinitions() {
+    }
+
+    public static AdapterDefinition testAdapterDefinition(String name) {
+        AdapterDefinition def = mock(AdapterDefinition.class);
+        when(def.getName()).thenReturn(name);
+        when(def.isEnabled()).thenReturn(true);
+        return def;
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -DskipTests test-compile 2>&1 | tail -10
+```
+Expected: `BUILD SUCCESS`. If `AdapterDefinition` import fails, check the actual package path — it may be `org.opennms.netmgt.telemetry.api.adapter.AdapterDefinition` or similar. Update the import.
+
+---
+
+## Task 10: Create Netflow5MessageProcessor with hand-crafted packet test
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessor.java`
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessorTest.java`
+
+Netflow-5 is the simplest protocol (fixed-format, no templates). We hand-craft a minimal valid packet as a byte array and verify our processor produces the expected flow count.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessorTest.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.deltav.flows.enricher.protocol.TestAdapterDefinitions.testAdapterDefinition;
+
+import java.util.List;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.protobuf.ByteString;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
+class Netflow5MessageProcessorTest {
+
+    /**
+     * Minimal Netflow v5 packet: header + one flow record.
+     *
+     * Netflow v5 header (24 bytes):
+     *   version(2) count(2) sysUptime(4) unixSecs(4) unixNsecs(4)
+     *   flowSequence(4) engineType(1) engineId(1) samplingInterval(2)
+     *
+     * Netflow v5 record (48 bytes):
+     *   srcAddr(4) dstAddr(4) nextHop(4) input(2) output(2)
+     *   dPkts(4) dOctets(4) first(4) last(4) srcPort(2) dstPort(2)
+     *   pad1(1) tcpFlags(1) prot(1) tos(1) srcAs(2) dstAs(2)
+     *   srcMask(1) dstMask(1) pad2(2)
+     */
+    private static byte[] buildNetflow5Packet() {
+        byte[] packet = new byte[24 + 48];
+
+        // Header
+        packet[0] = 0x00; packet[1] = 0x05;    // version = 5
+        packet[2] = 0x00; packet[3] = 0x01;    // count = 1
+        // sysUptime = 0 (4 bytes)
+        // unixSecs = 0 (4 bytes) — adapter may reject 0; set to 1
+        packet[15] = 0x01;
+        // unixNsecs = 0
+        // flowSequence = 0
+        // engineType = 0
+        // engineId = 0
+        // samplingInterval = 0
+
+        // Record starts at offset 24
+        int off = 24;
+        // srcAddr = 192.0.2.1 (4 bytes)
+        packet[off] = (byte)192; packet[off+1] = 0; packet[off+2] = 2; packet[off+3] = 1;
+        // dstAddr = 198.51.100.2
+        packet[off+4] = (byte)198; packet[off+5] = 51; packet[off+6] = 100; packet[off+7] = 2;
+        // nextHop = 203.0.113.1
+        packet[off+8] = (byte)203; packet[off+9] = 0; packet[off+10] = 113; packet[off+11] = 1;
+        // input = 1, output = 2
+        packet[off+13] = 1;
+        packet[off+15] = 2;
+        // dPkts = 10
+        packet[off+19] = 10;
+        // dOctets = 1500
+        packet[off+22] = 0x05; packet[off+23] = (byte)0xDC;
+        // first = 100
+        packet[off+27] = 100;
+        // last = 200
+        packet[off+31] = (byte)200;
+        // srcPort = 54321
+        packet[off+32] = (byte)0xD4; packet[off+33] = 0x31;
+        // dstPort = 443
+        packet[off+34] = 0x01; packet[off+35] = (byte)0xBB;
+        // tcpFlags = 0x18 (PSH+ACK)
+        packet[off+37] = 0x18;
+        // prot = 6 (TCP)
+        packet[off+38] = 6;
+        // tos, srcAs, dstAs, srcMask, dstMask, pad all zero
+
+        return packet;
+    }
+
+    @Test
+    void parsesOneNetflow5PacketIntoOneFlow() {
+        Netflow5MessageProcessor processor = new Netflow5MessageProcessor(
+                testAdapterDefinition("Netflow-5"),
+                new MetricRegistry());
+
+        byte[] packetBytes = buildNetflow5Packet();
+
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSourceAddress("192.0.2.254")
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(packetBytes))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+
+        List<Flow> flows = processor.process(log);
+
+        assertThat(flows).hasSize(1);
+        Flow flow = flows.get(0);
+        assertThat(flow.getSrcAddr()).isEqualTo("192.0.2.1");
+        assertThat(flow.getDstAddr()).isEqualTo("198.51.100.2");
+        assertThat(flow.getDstPort()).isEqualTo(443);
+        assertThat(flow.getProtocol()).isEqualTo(6);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=Netflow5MessageProcessorTest test 2>&1 | tail -20
+```
+Expected: Compilation failure — `Netflow5MessageProcessor` does not exist.
+
+- [ ] **Step 3: Create Netflow5MessageProcessor**
+
+Create `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/Netflow5MessageProcessor.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter;
+
+public class Netflow5MessageProcessor extends AbstractProtocolMessageProcessor {
+
+    private final AdapterDefinition adapterDefinition;
+    private final MetricRegistry metricRegistry;
+
+    public Netflow5MessageProcessor(AdapterDefinition adapterDefinition, MetricRegistry metricRegistry) {
+        this.adapterDefinition = adapterDefinition;
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    protected AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline) {
+        return new Netflow5Adapter(adapterDefinition, metricRegistry, pipeline);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=Netflow5MessageProcessorTest test 2>&1 | tail -30
+```
+Expected: `Tests run: 1, Failures: 0, Errors: 0`.
+
+**Likely issues and fixes:**
+- **"class Netflow5Adapter not found"** — check actual package with `javap` against the netflow5 adapter JAR. It may be under a slightly different package name.
+- **"constructor mismatch"** — the adapter constructor may take additional arguments (e.g., a `DnsResolver`). Check with `javap -public Netflow5Adapter` and pass reasonable defaults (pass null for optional args, or construct minimal mocks).
+- **"adapter returned 0 flows"** — the hand-crafted packet may have an issue. Enable adapter debug logging (`logging.level.org.opennms.netmgt.telemetry=DEBUG` in a test `application.properties`) and check where parsing failed. Common issues: header field endianness, unix_secs=0 being rejected as invalid.
+
+- [ ] **Step 5: Do NOT commit yet**
+
+This task is part of Commit 4. Commits with Tasks 8, 9, 11.
+
+---
+
+## Task 11: Create Netflow9, IPFIX, sFlow processors with horizon fixture tests
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/Netflow9MessageProcessor.java`
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/IpfixMessageProcessor.java`
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/SFlowMessageProcessor.java`
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow9MessageProcessorTest.java`
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/IpfixMessageProcessorTest.java`
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/SFlowMessageProcessorTest.java`
+- Create: `core/flow-enricher/src/test/resources/test-packets/netflow9-sample.dat`
+- Create: `core/flow-enricher/src/test/resources/test-packets/ipfix-sample.dat`
+- Create: `core/flow-enricher/src/test/resources/test-packets/sflow-sample.dat`
+
+These three protocols are template-based (Netflow9/IPFIX) or sampling-based (sFlow) and too complex to hand-write in bytes. We copy binary test fixtures from horizon's own adapter tests.
+
+- [ ] **Step 1: Locate horizon's adapter test fixtures**
+
+Horizon's telemetry adapter tests live in:
+- `features/telemetry/protocols/netflow/adapter/netflow9/src/test/resources/netflow9/*.dat`
+- `features/telemetry/protocols/netflow/adapter/ipfix/src/test/resources/ipfix/*.dat`
+- `features/telemetry/protocols/sflow/src/test/resources/sflow/*.dat`
+
+These files are AGPL-licensed the same as the rest of horizon, so copying them into our test resources is fine. Pick the smallest fixture that contains a template + at least one data flowset (for netflow9/ipfix) or one sample record (for sflow).
+
+Run:
+```bash
+find ~/.m2/repository/org/opennms/features/telemetry -name "*.dat" 2>/dev/null | head -20
+```
+
+If the horizon test resources are not in `~/.m2/repository` (Maven typically strips test resources), clone the delta-v-horizon repo into a scratch directory and copy from there:
+
+```bash
+cd /tmp
+git clone --depth 1 https://github.com/pbrane/delta-v-horizon.git horizon-fixtures
+find horizon-fixtures -path '*/test/resources/*.dat' | grep -E "netflow9|ipfix|sflow" | head -10
+```
+
+- [ ] **Step 2: Copy the smallest suitable fixtures into our test resources**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+mkdir -p core/flow-enricher/src/test/resources/test-packets
+cp /tmp/horizon-fixtures/features/telemetry/protocols/netflow/adapter/netflow9/src/test/resources/<chosen>.dat \
+   core/flow-enricher/src/test/resources/test-packets/netflow9-sample.dat
+# Repeat for ipfix and sflow
+```
+
+Verify the files copied:
+```bash
+ls -la core/flow-enricher/src/test/resources/test-packets/
+```
+Expected: three `.dat` files, each 100-2000 bytes.
+
+- [ ] **Step 3: Write Netflow9MessageProcessorTest**
+
+Create `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/Netflow9MessageProcessorTest.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.deltav.flows.enricher.protocol.TestAdapterDefinitions.testAdapterDefinition;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.protobuf.ByteString;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+
+class Netflow9MessageProcessorTest {
+
+    @Test
+    void parsesHorizonFixtureIntoAtLeastOneFlow() throws IOException {
+        byte[] packetBytes = loadFixture("/test-packets/netflow9-sample.dat");
+
+        Netflow9MessageProcessor processor = new Netflow9MessageProcessor(
+                testAdapterDefinition("Netflow-9"),
+                new MetricRegistry());
+
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSourceAddress("192.0.2.254")
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(packetBytes))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+
+        List<Flow> flows = processor.process(log);
+
+        // The fixture may be a template-only packet (no data records) or a
+        // data packet after a template. We assert >= 0 here and verify
+        // specific field values via the StreamBinderIT which uses the same
+        // fixture end-to-end.
+        assertThat(flows).isNotNull();
+    }
+
+    private static byte[] loadFixture(String classpathPath) throws IOException {
+        try (InputStream in = Netflow9MessageProcessorTest.class.getResourceAsStream(classpathPath)) {
+            if (in == null) {
+                throw new IOException("Fixture not found on classpath: " + classpathPath);
+            }
+            return in.readAllBytes();
+        }
+    }
+}
+```
+
+**Note:** Netflow-9 requires a template flowset to arrive BEFORE any data flowset it decodes. If the chosen fixture is a data-only packet, the adapter will cache the template lookup failure and return zero flows. Either pick a fixture that contains both a template flowset and a data flowset in one UDP packet, or send two messages in sequence (template first, then data). For the initial test, the "isNotNull" assertion is a smoke test that just verifies the adapter doesn't throw; the full field-level assertion happens in `FlowEnrichmentStreamBinderIT`.
+
+- [ ] **Step 4: Create Netflow9MessageProcessor**
+
+Same shape as Netflow5MessageProcessor but with the Netflow9 adapter:
+
+```java
+package org.deltav.flows.enricher.protocol;
+
+import com.codahale.metrics.MetricRegistry;
+import org.deltav.flows.enricher.pipeline.CapturingPipeline;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.flows.AbstractFlowAdapter;
+import org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter;
+
+public class Netflow9MessageProcessor extends AbstractProtocolMessageProcessor {
+
+    private final AdapterDefinition adapterDefinition;
+    private final MetricRegistry metricRegistry;
+
+    public Netflow9MessageProcessor(AdapterDefinition adapterDefinition, MetricRegistry metricRegistry) {
+        this.adapterDefinition = adapterDefinition;
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    protected AbstractFlowAdapter<?> createAdapter(CapturingPipeline pipeline) {
+        return new Netflow9Adapter(adapterDefinition, metricRegistry, pipeline);
+    }
+}
+```
+
+- [ ] **Step 5: Run the Netflow9 test**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=Netflow9MessageProcessorTest test 2>&1 | tail -20
+```
+Expected: `Tests run: 1, Failures: 0`.
+
+- [ ] **Step 6: Repeat Steps 3-5 for IpfixMessageProcessor**
+
+Create `IpfixMessageProcessorTest.java` (identical structure to Netflow9 test, pointing at `ipfix-sample.dat`), then create `IpfixMessageProcessor.java` with `IpfixAdapter` from `org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter`. Run the test.
+
+- [ ] **Step 7: Repeat Steps 3-5 for SFlowMessageProcessor**
+
+Create `SFlowMessageProcessorTest.java` (same structure, `sflow-sample.dat`), then `SFlowMessageProcessor.java` with `SFlowAdapter` from `org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter`. Run the test.
+
+- [ ] **Step 8: Run all protocol tests together**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest='*MessageProcessorTest' test 2>&1 | tail -30
+```
+Expected: 4 tests, 0 failures (one per protocol processor).
+
+- [ ] **Step 9: Commit (Protocol Processors)**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/ \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/ \
+        core/flow-enricher/src/test/resources/test-packets/
+git commit -m "feat(flow-enricher): add protocol processors for all four flow protocols"
+```
+
+---
+
+## Task 12: Wire full enrichment pipeline in FlowEnrichmentFunction
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java`
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`
+- Modify: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java`
+
+This task replaces the placeholder empty-list return from Task 7 with the real per-flow enrichment. Each flow gets exporter/src/dst node lookups, locality calculation, interface marking, classification, and mapping to `FlowDocument`.
+
+- [ ] **Step 1: Extend FlowEnrichmentFunctionTest with full-pipeline cases**
+
+Add to `FlowEnrichmentFunctionTest.java`:
+
+```java
+    @Test
+    void dispatchesNetflow5MessagesToNetflow5Processor() {
+        // Given a Sink message with moduleId "Telemetry-Netflow-5" and
+        // a mock processor that returns two synthetic flows
+        Flow flow1 = mockFlowWithAddresses("10.0.0.1", "8.8.8.8", 443, 6);
+        Flow flow2 = mockFlowWithAddresses("10.0.0.2", "1.1.1.1", 80, 6);
+
+        when(netflow5Processor.process(any())).thenReturn(List.of(flow1, flow2));
+
+        byte[] kafkaBytes = buildSinkMessageBytes("Telemetry-Netflow-5", sampleTelemetryLogBytes());
+
+        List<byte[]> result = function.processMessage(kafkaBytes);
+
+        assertThat(result).hasSize(2);
+        // Verify each emitted byte[] is a valid FlowDocument
+        FlowDocumentProtos.FlowDocument doc1 = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc1.getSrcAddress()).isEqualTo("10.0.0.1");
+        assertThat(doc1.getApplication()).isEqualTo("HTTPS");
+    }
+
+    @Test
+    void looksUpSrcDstAndExporterNodesForEachFlow() {
+        Flow flow = mockFlowWithAddresses("10.0.0.1", "8.8.8.8", 443, 6);
+        when(netflow9Processor.process(any())).thenReturn(List.of(flow));
+        when(nodeInfoLookup.lookupByIpAddress("10.0.0.1"))
+                .thenReturn(new JdbcNodeInfoLookup.NodeInfo(100, "fs", "src", List.of()));
+        when(nodeInfoLookup.lookupByIpAddress("8.8.8.8"))
+                .thenReturn(null);
+        when(nodeInfoLookup.lookupByIpAddress("192.0.2.254"))
+                .thenReturn(new JdbcNodeInfoLookup.NodeInfo(42, "fs", "exporter", List.of("edge")));
+
+        byte[] kafkaBytes = buildSinkMessageBytes("Telemetry-Netflow-9",
+                sampleTelemetryLogBytesWithSourceAddress("192.0.2.254"));
+
+        List<byte[]> result = function.processMessage(kafkaBytes);
+
+        assertThat(result).hasSize(1);
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc.hasSrcNode()).isTrue();
+        assertThat(doc.getSrcNode().getNodeId()).isEqualTo(100);
+        assertThat(doc.hasDestNode()).isFalse();
+        assertThat(doc.hasExporterNode()).isTrue();
+        assertThat(doc.getExporterNode().getNodeId()).isEqualTo(42);
+    }
+
+    @Test
+    void marksInterfaceWhenExporterAndIfIndexKnown() {
+        Flow flow = mockFlowWithAddresses("10.0.0.1", "8.8.8.8", 443, 6);
+        when(flow.getInputSnmp()).thenReturn(12);
+        when(flow.getOutputSnmp()).thenReturn(13);
+        when(netflow9Processor.process(any())).thenReturn(List.of(flow));
+        when(nodeInfoLookup.lookupByIpAddress("192.0.2.254"))
+                .thenReturn(new JdbcNodeInfoLookup.NodeInfo(42, "fs", "exporter", List.of()));
+
+        byte[] kafkaBytes = buildSinkMessageBytes("Telemetry-Netflow-9",
+                sampleTelemetryLogBytesWithSourceAddress("192.0.2.254"));
+
+        function.processMessage(kafkaBytes);
+
+        verify(interfaceMarkingCache).markIfNeeded(42, 12);
+        verify(interfaceMarkingCache).markIfNeeded(42, 13);
+    }
+
+    @Test
+    void calculatesLocalityForSrcAndDst() {
+        Flow flow = mockFlowWithAddresses("10.0.0.1", "8.8.8.8", 443, 6);
+        when(netflow9Processor.process(any())).thenReturn(List.of(flow));
+        when(localityCalculator.calculate("10.0.0.1")).thenReturn("PRIVATE");
+        when(localityCalculator.calculate("8.8.8.8")).thenReturn("PUBLIC");
+
+        byte[] kafkaBytes = buildSinkMessageBytes("Telemetry-Netflow-9", sampleTelemetryLogBytes());
+
+        List<byte[]> result = function.processMessage(kafkaBytes);
+
+        assertThat(result).hasSize(1);
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(result.get(0));
+        assertThat(doc.getSrcLocality()).isEqualTo(FlowDocumentProtos.Locality.PRIVATE);
+        assertThat(doc.getDstLocality()).isEqualTo(FlowDocumentProtos.Locality.PUBLIC);
+    }
+
+    private Flow mockFlowWithAddresses(String src, String dst, int dstPort, int protocol) {
+        Flow flow = mock(Flow.class);
+        when(flow.getTimestamp()).thenReturn(1712700000000L);
+        when(flow.getSrcAddr()).thenReturn(src);
+        when(flow.getDstAddr()).thenReturn(dst);
+        when(flow.getDstPort()).thenReturn(dstPort);
+        when(flow.getSrcPort()).thenReturn(54321);
+        when(flow.getProtocol()).thenReturn(protocol);
+        return flow;
+    }
+```
+
+The `@BeforeEach` setup needs to create mock instances of `Netflow5MessageProcessor`, `Netflow9MessageProcessor`, etc., and pass them as the `Map<String, ProtocolMessageProcessor>` constructor argument with the correct module ID keys.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=FlowEnrichmentFunctionTest test 2>&1 | tail -30
+```
+Expected: Compilation failure or assertion failures — the current placeholder returns empty list.
+
+- [ ] **Step 3: Implement the full enrichment pipeline in FlowEnrichmentFunction**
+
+Replace the placeholder `return Collections.emptyList()` in `processMessage` with the full pipeline:
+
+```java
+    public List<byte[]> processMessage(byte[] kafkaBytes) {
+        if (kafkaBytes == null || kafkaBytes.length == 0) {
+            return Collections.emptyList();
+        }
+
+        DeserializedSinkMessage deserialized = deserializer.deserialize(kafkaBytes);
+        if (deserialized == null || deserialized.messageLog() == null
+                || deserialized.messageLog().getMessageCount() == 0) {
+            return Collections.emptyList();
+        }
+
+        ProtocolMessageProcessor processor = processorsByModuleId.get(deserialized.moduleId());
+        if (processor == null) {
+            LOG.debug("No processor for moduleId '{}', dropping message", deserialized.moduleId());
+            return Collections.emptyList();
+        }
+
+        TelemetryProtos.TelemetryMessageLog messageLog = deserialized.messageLog();
+        List<Flow> flows = processor.process(messageLog);
+        if (flows.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Exporter lookup (once per message, cached)
+        String exporterAddress = messageLog.getSourceAddress();
+        JdbcNodeInfoLookup.NodeInfo exporter = nodeInfoLookup.lookupByIpAddress(exporterAddress);
+
+        List<byte[]> results = new ArrayList<>(flows.size());
+        for (Flow flow : flows) {
+            try {
+                // Per-flow src/dst lookups
+                JdbcNodeInfoLookup.NodeInfo srcNode = (flow.getSrcAddr() != null)
+                        ? nodeInfoLookup.lookupByIpAddress(flow.getSrcAddr()) : null;
+                JdbcNodeInfoLookup.NodeInfo dstNode = (flow.getDstAddr() != null)
+                        ? nodeInfoLookup.lookupByIpAddress(flow.getDstAddr()) : null;
+
+                // Locality
+                String srcLocality = (flow.getSrcAddr() != null)
+                        ? localityCalculator.calculate(flow.getSrcAddr()) : "UNKNOWN";
+                String dstLocality = (flow.getDstAddr() != null)
+                        ? localityCalculator.calculate(flow.getDstAddr()) : "UNKNOWN";
+                String flowLocality = computeFlowLocality(srcLocality, dstLocality);
+
+                // Interface marking (only when exporter known and ifindex provided)
+                if (exporter != null) {
+                    if (flow.getInputSnmp() != null && flow.getInputSnmp() > 0) {
+                        interfaceMarkingCache.markIfNeeded(exporter.nodeId(), flow.getInputSnmp());
+                    }
+                    if (flow.getOutputSnmp() != null && flow.getOutputSnmp() > 0) {
+                        interfaceMarkingCache.markIfNeeded(exporter.nodeId(), flow.getOutputSnmp());
+                    }
+                }
+
+                // Classification (port-based stub)
+                int dstPort = flow.getDstPort() != null ? flow.getDstPort() : 0;
+                int srcPort = flow.getSrcPort() != null ? flow.getSrcPort() : 0;
+                int protocol = flow.getProtocol() != null ? flow.getProtocol() : 0;
+                String application = applicationClassifier.classify(dstPort, srcPort, protocol);
+
+                // Mapping
+                FlowDocumentProtos.FlowDocument doc = flowToDocumentMapper.map(
+                        flow, exporter, srcNode, dstNode,
+                        application, srcLocality, dstLocality, flowLocality);
+
+                results.add(doc.toByteArray());
+            } catch (Exception e) {
+                LOG.warn("Failed to enrich flow (src={}, dst={}): {}",
+                        flow.getSrcAddr(), flow.getDstAddr(), e.getMessage());
+            }
+        }
+
+        return results;
+    }
+
+    private static String computeFlowLocality(String src, String dst) {
+        if ("PUBLIC".equals(src) || "PUBLIC".equals(dst)) {
+            return "PUBLIC";
+        }
+        if ("PRIVATE".equals(src) && "PRIVATE".equals(dst)) {
+            return "PRIVATE";
+        }
+        return "UNKNOWN";
+    }
+```
+
+Add the required fields to the constructor: `ApplicationClassifier applicationClassifier` and `FlowToDocumentMapper flowToDocumentMapper`.
+
+- [ ] **Step 4: Update FlowEnricherConfiguration with new processors and dispatch map**
+
+In `FlowEnricherConfiguration.java`, add four new processor beans and an `ApplicationClassifier` bean:
+
+```java
+    @Bean
+    ApplicationClassifier applicationClassifier() {
+        return new PortBasedApplicationClassifier();
+    }
+
+    @Bean
+    FlowToDocumentMapper flowToDocumentMapper() {
+        return new FlowToDocumentMapper();
+    }
+
+    @Bean
+    MetricRegistry flowEnricherMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    Netflow5MessageProcessor netflow5Processor(MetricRegistry flowEnricherMetricRegistry) {
+        return new Netflow5MessageProcessor(
+                buildAdapterDefinition("Netflow-5"), flowEnricherMetricRegistry);
+    }
+
+    @Bean
+    Netflow9MessageProcessor netflow9Processor(MetricRegistry flowEnricherMetricRegistry) {
+        return new Netflow9MessageProcessor(
+                buildAdapterDefinition("Netflow-9"), flowEnricherMetricRegistry);
+    }
+
+    @Bean
+    IpfixMessageProcessor ipfixProcessor(MetricRegistry flowEnricherMetricRegistry) {
+        return new IpfixMessageProcessor(
+                buildAdapterDefinition("IPFIX"), flowEnricherMetricRegistry);
+    }
+
+    @Bean
+    SFlowMessageProcessor sflowProcessor(MetricRegistry flowEnricherMetricRegistry) {
+        return new SFlowMessageProcessor(
+                buildAdapterDefinition("SFlow"), flowEnricherMetricRegistry);
+    }
+
+    private static AdapterDefinition buildAdapterDefinition(String name) {
+        // Minimal AdapterDefinition with only name and enabled=true.
+        // If AdapterDefinition is not mockable at runtime, use a simple anonymous
+        // inner class implementation instead.
+        return new AdapterDefinition() {
+            @Override public String getName() { return name; }
+            @Override public boolean isEnabled() { return true; }
+            // Implement other methods to return null/defaults as required by the interface
+        };
+    }
+```
+
+Update the `flowEnrichmentFunction` bean to inject the dispatch map:
+
+```java
+    @Bean
+    FlowEnrichmentFunction flowEnrichmentFunction(
+            SinkMessageDeserializer deserializer,
+            JdbcNodeInfoLookup nodeInfoLookup,
+            FlowLocalityCalculator localityCalculator,
+            InterfaceMarkingCache interfaceMarkingCache,
+            ApplicationClassifier applicationClassifier,
+            FlowToDocumentMapper flowToDocumentMapper,
+            Netflow5MessageProcessor netflow5Processor,
+            Netflow9MessageProcessor netflow9Processor,
+            IpfixMessageProcessor ipfixProcessor,
+            SFlowMessageProcessor sflowProcessor) {
+
+        Map<String, ProtocolMessageProcessor> dispatchMap = Map.of(
+                "Telemetry-Netflow-5", netflow5Processor,
+                "Telemetry-Netflow-9", netflow9Processor,
+                "Telemetry-IPFIX",     ipfixProcessor,
+                "Telemetry-SFlow",     sflowProcessor);
+
+        return new FlowEnrichmentFunction(
+                deserializer, nodeInfoLookup, localityCalculator, interfaceMarkingCache,
+                applicationClassifier, flowToDocumentMapper, dispatchMap);
+    }
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher test 2>&1 | tail -30
+```
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit (Final Wiring)**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
+git commit -m "feat(flow-enricher): wire full per-flow enrichment pipeline"
+```
+
+---
+
+## Task 13: Integration test with spring-cloud-stream-test-binder
+
+**Files:**
+- Create: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java`
+
+End-to-end integration test that exercises the full Spring Boot context with the in-memory test binder, sends synthetic Sink messages for each protocol, and verifies enriched FlowDocument records appear on the output channel.
+
+- [ ] **Step 1: Create the integration test**
+
+Create `core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.flows.enricher.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import com.google.protobuf.ByteString;
+
+import org.deltav.flows.proto.FlowDocumentProtos;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.model.SinkMessageProtos;
+import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+@SpringBootTest(classes = { org.deltav.flows.enricher.FlowEnricherApplication.class },
+        properties = {
+                "spring.cloud.function.definition=enrichFlows",
+                "spring.autoconfigure.exclude=" + "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+                "deltav.flows.node-lookup.cache-ttl=1m",
+                "deltav.flows.interface-marking.cache-ttl=1m"
+        })
+@Import(TestChannelBinderConfiguration.class)
+class FlowEnrichmentStreamBinderIT {
+
+    @Autowired
+    private InputDestination input;
+
+    @Autowired
+    private OutputDestination output;
+
+    @Test
+    void netflow5SinkMessageProducesEnrichedFlowDocuments() throws Exception {
+        byte[] sinkMessageBytes = buildSinkMessage("Telemetry-Netflow-5",
+                loadFixtureOrBuildNetflow5Packet());
+
+        input.send(MessageBuilder.withPayload(sinkMessageBytes).build());
+
+        Message<byte[]> outMsg = output.receive(5_000);
+        assertThat(outMsg).isNotNull();
+        FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(outMsg.getPayload());
+        assertThat(doc.getTimestamp()).isGreaterThan(0);
+    }
+
+    @Test
+    void netflow9SinkMessageProducesEnrichedFlowDocuments() throws Exception {
+        byte[] sinkMessageBytes = buildSinkMessage("Telemetry-Netflow-9",
+                loadFixture("/test-packets/netflow9-sample.dat"));
+
+        input.send(MessageBuilder.withPayload(sinkMessageBytes).build());
+
+        Message<byte[]> outMsg = output.receive(5_000);
+        // May be null if the fixture is template-only (zero data flows)
+        // Assert a soft condition: either null (template) or a valid FlowDocument
+        if (outMsg != null) {
+            FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(outMsg.getPayload());
+            assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.V9);
+        }
+    }
+
+    @Test
+    void ipfixSinkMessageProducesEnrichedFlowDocuments() throws Exception {
+        byte[] sinkMessageBytes = buildSinkMessage("Telemetry-IPFIX",
+                loadFixture("/test-packets/ipfix-sample.dat"));
+
+        input.send(MessageBuilder.withPayload(sinkMessageBytes).build());
+
+        Message<byte[]> outMsg = output.receive(5_000);
+        if (outMsg != null) {
+            FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(outMsg.getPayload());
+            assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.IPFIX);
+        }
+    }
+
+    @Test
+    void sflowSinkMessageProducesEnrichedFlowDocuments() throws Exception {
+        byte[] sinkMessageBytes = buildSinkMessage("Telemetry-SFlow",
+                loadFixture("/test-packets/sflow-sample.dat"));
+
+        input.send(MessageBuilder.withPayload(sinkMessageBytes).build());
+
+        Message<byte[]> outMsg = output.receive(5_000);
+        if (outMsg != null) {
+            FlowDocumentProtos.FlowDocument doc = FlowDocumentProtos.FlowDocument.parseFrom(outMsg.getPayload());
+            assertThat(doc.getNetflowVersion()).isEqualTo(FlowDocumentProtos.NetflowVersion.SFLOW);
+        }
+    }
+
+    private static byte[] buildSinkMessage(String moduleId, byte[] payload) {
+        TelemetryProtos.TelemetryMessageLog log = TelemetryProtos.TelemetryMessageLog.newBuilder()
+                .setLocation("test-location")
+                .setSourceAddress("192.0.2.254")
+                .addMessage(TelemetryProtos.TelemetryMessage.newBuilder()
+                        .setBytes(ByteString.copyFrom(payload))
+                        .setTimestamp(System.currentTimeMillis())
+                        .build())
+                .build();
+        SinkMessageProtos.SinkMessage sinkMsg = SinkMessageProtos.SinkMessage.newBuilder()
+                .setModuleId(moduleId)
+                .setContent(log.toByteString())
+                .build();
+        return sinkMsg.toByteArray();
+    }
+
+    private static byte[] loadFixture(String classpathPath) throws IOException {
+        try (InputStream in = FlowEnrichmentStreamBinderIT.class.getResourceAsStream(classpathPath)) {
+            if (in == null) {
+                throw new IOException("Fixture not found: " + classpathPath);
+            }
+            return in.readAllBytes();
+        }
+    }
+
+    private static byte[] loadFixtureOrBuildNetflow5Packet() {
+        // For Netflow-5 we use the hand-crafted packet from the unit test.
+        // Copy the buildNetflow5Packet() method here or extract it to a shared test helper.
+        return Netflow5MessageProcessorTest.buildNetflow5Packet();
+    }
+}
+```
+
+**Important notes:**
+
+1. **DataSource exclusion** — The integration test disables the JDBC datasource autoconfiguration because the tests don't hit PostgreSQL. The `JdbcNodeInfoLookup` bean still gets constructed with a `null` or stub `JdbcTemplate`; node lookups will return null for all addresses, which is fine — the test doesn't assert on node info enrichment.
+
+2. **Extract `buildNetflow5Packet()` to a shared helper** — The method in Task 10's test file should be made package-visible or moved to a common `test-packets/NetflowPackets.java` utility that both the unit test and the IT import. Make this move as part of this task.
+
+3. **Application context classes** — If Spring Boot fails to start because the `DataSource` is required, you may need to provide a stub `JdbcTemplate` bean via a `@TestConfiguration` inside the test class that overrides the production `flowEnricherJdbcTemplate` bean.
+
+- [ ] **Step 2: Run the integration test**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher -Dtest=FlowEnrichmentStreamBinderIT test 2>&1 | tail -40
+```
+Expected: All four tests pass (or the Netflow-9/IPFIX/sFlow ones pass conditionally as documented by the `if (outMsg != null)` guard).
+
+Common failures and fixes:
+- **"Failed to start ApplicationContext"** — the `DataSource` exclusion may need to be different for your Spring Boot version. Try also excluding `DataSourceTransactionManagerAutoConfiguration`.
+- **"No qualifying bean of type FlowEnrichmentFunction"** — the `FlowEnricherConfiguration` may require `DataSource` indirectly. Add a `@MockBean DataSource dataSource` or provide a stub.
+- **Output timeout (`outMsg is null` when expected non-null)** — turn on debug logging for `org.springframework.cloud.stream` and check whether the function bean was registered and invoked.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+```bash
+./compile.pl -pl :org.deltav.flows.flow-enricher test 2>&1 | tail -30
+```
+Expected: All tests pass. Total count should be 24 (skeleton) + 3 (CapturingPipeline) + 12 (Mapper) + 10 (Classifier) + 1 (Netflow5 processor) + 1 (Netflow9 processor) + 1 (IPFIX processor) + 1 (sFlow processor) + ~5 updated (FlowEnrichmentFunction) + 4 (IT) = **~61 tests total**.
+
+- [ ] **Step 4: Commit (Integration Test)**
+
+```bash
+git add core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/
+git commit -m "test(flow-enricher): add stream-binder integration test for all four protocols"
+```
+
+---
+
+## Task 14: Final build verification and optional local run
+
+**Files:** No new files.
+
+- [ ] **Step 1: Run the full flow-enricher module build**
+
+Run:
+```bash
+cd /Users/david/development/src/opennms/delta-v
+./compile.pl -pl :org.deltav.flows.flow-enricher -am install 2>&1 | tail -30
+```
+Expected: `BUILD SUCCESS`, all tests pass, JAR installed to local Maven repo.
+
+- [ ] **Step 2 (optional): Build the flow-enricher Docker image**
+
+```bash
+cd opennms-container/delta-v
+./build.sh flow-enricher 2>&1 | tail -20
+```
+Expected: Docker image `opennms/flow-enricher:${VERSION}` built successfully.
+
+- [ ] **Step 3 (optional): Start the delta-v stack and observe real flows**
+
+```bash
+cd opennms-container/delta-v
+docker compose --profile full up -d flow-enricher
+docker compose logs -f flow-enricher | head -50
+```
+
+From the labbox or another traffic source, generate some NetFlow traffic directed at the Minion. Then:
+
+```bash
+docker compose exec kafka kafka-console-consumer.sh \
+    --bootstrap-server localhost:9092 \
+    --topic deltav-flows \
+    --max-messages 5 \
+    --timeout-ms 30000 | head -20
+```
+
+Expected: Up to 5 protobuf binary messages visible on the `deltav-flows` topic. Decoding them via `protoc --decode` with the `.proto` file should show populated flow records.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feature/flow-enricher-phase15
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --repo pbrane/delta-v --base develop \
+    --title "feat(flow-enricher): Phase 1.5 horizon adapter integration" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Wires horizon protocol adapters (Netflow-5, Netflow-9, IPFIX, sFlow) into the flow-enricher service so each incoming TelemetryMessageLog is parsed into flows, enriched with src/dst/exporter node lookups, locality, interface marking, and port-based classification, and emitted as a List<FlowDocument> to the deltav-flows Kafka topic.
+
+- Function signature changed from `Function<byte[], byte[]>` to `Function<byte[], List<byte[]>>` (Spring Cloud Stream splitter pattern)
+- Runtime dispatch by `SinkMessage.moduleId` to one of four protocol processors
+- New `CapturingPipeline` implements horizon's `Pipeline` interface as a capturing sink
+- New `FlowToDocumentMapper` does field-by-field `Flow → FlowDocumentProtos.FlowDocument` with explicit null-wrapper semantics
+- New `PortBasedApplicationClassifier` stub covering ~30 well-known ports (replaced with real classification engine in Phase 1.6)
+- All four horizon adapter JARs added with standard exclusion blocks
+- Deferred to Phase 1.6: horizon classification engine, clock-skew correction, nodeDeleted cache eviction
+
+## Review plan
+
+- [ ] pom.xml exclusion blocks match the existing pattern for sink.common and telemetry.common
+- [ ] CapturingPipeline is per-invocation (not reused) — see AbstractProtocolMessageProcessor.createAdapter()
+- [ ] FlowToDocumentMapperTest asserts null-wrapper discipline (unset vs zero)
+- [ ] Four protocol processors follow identical shape with only the adapter class varying
+- [ ] FlowEnrichmentFunction dispatches on SinkMessage.moduleId with a Map lookup
+- [ ] FlowEnrichmentStreamBinderIT exercises all four protocols through the in-memory test binder
+- [ ] No ClickHouse or Phase 2 concerns leak into this PR
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** Every Phase 1.5 deliverable from `docs/superpowers/specs/2026-04-09-flow-processor-design.md` is covered by a task:
+- `CapturingPipeline` implementation → Task 2
+- `FlowToDocumentMapper` → Task 3
+- Per-protocol processors → Tasks 8-11
+- Function refactor to splitter signature → Task 7
+- Runtime dispatch by moduleId → Tasks 6, 7, 12
+- Classification, clock-skew, interface-marking integration → Task 12 (classification via stub), clock-skew deferred to Phase 1.6
+- Live integration test against the running delta-v stack → Task 14 Step 3 (optional manual validation)
+
+**Placeholder scan:** No "TBD", "TODO", "implement later", or "add error handling" placeholders. Every step has concrete code or a specific command. A few implementation-discovery notes ("check the actual package path," "method names may differ") are present, which is intentional because horizon JAR introspection requires the build to actually resolve before the exact names are known.
+
+**Type consistency:**
+- `FlowEnrichmentFunction` constructor signature evolves from 4 args in Task 7 to 7 args (adds `ApplicationClassifier`, `FlowToDocumentMapper`, dispatch map) in Task 12. Both are documented explicitly.
+- `DeserializedSinkMessage` record fields are `moduleId` and `messageLog` throughout.
+- `FlowToDocumentMapper.map(...)` takes 8 arguments: flow + three NodeInfo + application + three locality strings. Consistent across Task 3 and Task 12.
+- `JdbcNodeInfoLookup.NodeInfo` constructor uses `(nodeId, foreignSource, foreignId, categories)` in Task 3 test and Task 12 test — same order.
+
+---
+
+## Plan complete

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,8 @@
       <dependency><groupId>org.opennms.features.enlinkd</groupId><artifactId>org.opennms.features.enlinkd.daemon</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.enlinkd</groupId><artifactId>org.opennms.features.enlinkd.service.impl</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.events</groupId><artifactId>org.opennms.features.events.kafka-consumer</artifactId><version>${deltav.horizon.version}</version></dependency>
+      <dependency><groupId>org.opennms.features.flows</groupId><artifactId>org.opennms.features.flows.api</artifactId><version>${deltav.horizon.version}</version></dependency>
+      <dependency><groupId>org.opennms.features.flows</groupId><artifactId>org.opennms.features.flows.processing</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.minion</groupId><artifactId>core-impl</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.minion.heartbeat</groupId><artifactId>org.opennms.features.minion.heartbeat.common</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.minion.heartbeat</groupId><artifactId>org.opennms.features.minion.heartbeat.producer</artifactId><version>${deltav.horizon.version}</version></dependency>
@@ -234,6 +236,8 @@
       <dependency><groupId>org.opennms.features.telemetry</groupId><artifactId>org.opennms.features.telemetry.daemon</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.telemetry</groupId><artifactId>org.opennms.features.telemetry.registry</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.telemetry.config</groupId><artifactId>org.opennms.features.telemetry.config.jaxb</artifactId><version>${deltav.horizon.version}</version></dependency>
+      <dependency><groupId>org.opennms.features.telemetry.protocols.netflow</groupId><artifactId>org.opennms.features.telemetry.protocols.netflow.adapter</artifactId><version>${deltav.horizon.version}</version></dependency>
+      <dependency><groupId>org.opennms.features.telemetry.protocols.sflow</groupId><artifactId>org.opennms.features.telemetry.protocols.sflow.adapter</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.features.topologies</groupId><artifactId>org.opennms.features.topologies.service.impl</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.protocols</groupId><artifactId>org.opennms.protocols.radius</artifactId><version>${deltav.horizon.version}</version></dependency>
 


### PR DESCRIPTION
## Summary

Wires horizon protocol adapters (Netflow-5, Netflow-9, IPFIX, sFlow) into the flow-enricher service so each incoming `TelemetryMessageLog` from Kafka Sink topics is parsed into flows, enriched with src/dst/exporter node lookups, locality calculation, interface marking, and port-based application classification, and emitted as a splitter-pattern `List<FlowDocument>` to the `deltav-flows` Kafka topic — one enriched protobuf record per flow.

This is the Phase 1.5 implementation of the Nephron replacement spec, following the Phase 1 skeleton that shipped in PR #139 and the Phase 2 ClickHouse spec pivot in PR #141. The `deltav-flows` Kafka topic is the public contract that Phase 2 (ClickHouse) consumes from.

## What changed

- **9 commits** on top of the plan document (included as the first commit on this branch). 96 tests total, 0 failures, ~15-second test suite.
- **`FlowEnrichmentFunction`** refactored from `Function<byte[], byte[]>` (placeholder) to `Function<Message<byte[]>, List<byte[]>>` (splitter). Reads `kafka_receivedTopic` header, strips `OpenNMS.Sink.` or `DeltaV.Sink.` prefix to derive moduleId, dispatches to one of four protocol processors.
- **New shared infrastructure:** `CapturingPipeline` (horizon `Pipeline` interface implemented as a no-op sink that stashes captured flows), `FlowToDocumentMapper` (field-by-field mapper with explicit null-wrapper semantics for `google.protobuf.*Value` fields), `ApplicationClassifier` interface + `PortBasedApplicationClassifier` stub (~36 well-known ports, replaced by horizon's classification engine in Phase 1.6).
- **Four protocol processors** each wrapping one horizon `AbstractFlowAdapter` subclass. Fresh `CapturingPipeline` + fresh adapter per invocation because the adapter holds its `Pipeline` as a constructor-injected final field.
- **Per-flow enrichment pipeline:** exporter node lookup once per message (amortized via Caffeine cache), per-flow src/dst node lookups, locality calculation, interface marking (guarded by exporter-known + ifindex > 0), classification, mapping to `FlowDocumentProtos.FlowDocument`.
- **End-to-end integration test** using `spring-cloud-stream-test-binder` that drives all four protocols through the full Spring Boot context.
- **Critical production fix discovered by the integration test:** added `producer.use-native-encoding=true` to the `enrichFlows-out-0` binding in `application.yml`. Without it, Spring Cloud Stream 5.0.1 JSON-serializes the entire `List<byte[]>` as one array payload instead of emitting each element as a separate record — the splitter pattern would have been silently broken in production.

## Commits (in order)

1. `93299e4e877` — pom.xml: add 5 horizon adapter deps with standard exclusion blocks
2. `ef123508e5a` — pom.xml: tighten `flows.api` exclusions to prevent Spring 4 classpath leak (caught by Commit 1's code review)
3. `eadbdb64335` — shared infrastructure: `CapturingPipeline`, `FlowToDocumentMapper`, `PortBasedApplicationClassifier`
4. `e1b39e8caea` — mapper followup: add `host`, `location`, `clockCorrection` parameters so Commit 5 has a complete mapper signature
5. `3fc02129ac5` — splitter refactor: `Function<byte[], List<byte[]>>` signature, two-arg deserializer exposing `moduleId`, stub `ProtocolMessageProcessor` interface
6. `f834c72f55c` — protocol processors: `AbstractProtocolMessageProcessor` + 4 concrete processors + TDD tests using `FlowMessage` protobuf builder (not wire packets — see architectural discoveries below)
7. `80829fa79f6` — wire full per-flow enrichment pipeline, add `SimpleAdapterDefinition`, update function signature to `Function<Message<byte[]>, List<byte[]>>` to read Kafka topic header, remove all `@SuppressWarnings("unused")` from the now-used dependency fields
8. `6c92015ccc7` — integration test using Spring Cloud Stream test binder for all four protocols; includes the `use-native-encoding` production fix

## Architectural discoveries during implementation

Several assumptions in the plan file turned out to be wrong and were corrected in-flight. These are worth calling out so future plan writers don't repeat the mistakes:

1. **Horizon's flow adapter module topology is not what the plan assumed.** The plan called for 6 per-protocol netflow adapter JARs; reality is one monolithic `org.opennms.features.telemetry.protocols.netflow.adapter` JAR that contains Netflow5, Netflow9, and IPFIX adapters in subpackages. The plan's guessed artifact IDs for `flows-api` (actual: `flows.api`) and `processing.api` (actual: `flows.processing` with no api/impl split) were also wrong. The parent POM needed new `<dependencyManagement>` entries because the horizon BOM does not declare these modules.

2. **`SinkMessage` envelope has no `moduleId` field.** The plan assumed `SinkMessage.getModuleId()` existed as a protobuf field. It doesn't. The Sink IPC framework derives moduleId from the Kafka topic name pattern (`OpenNMS.Sink.{moduleId}`). Commit 3 added a two-arg `SinkMessageDeserializer.deserialize(String moduleId, byte[])` overload as a clean seam; Commit 5 wired `Function<Message<byte[]>, List<byte[]>>` to read the topic header and pass the derived moduleId.

3. **Horizon's flow adapters do NOT consume raw wire bytes.** They consume pre-decoded `FlowMessage` protobufs (for Netflow variants) or BSON documents (for sFlow). The wire parsing happens in Minion's parser layer before the Kafka Sink publish step. The plan's "hand-crafted Netflow v5 binary wire packet" test approach was based on a wrong mental model. Tests use `FlowMessage.newBuilder()` for netflow variants and horizon's own BSON fixture for sFlow, which is simpler AND matches what Minion actually sends.

4. **`Function<byte[], List<byte[]>>` does NOT behave as a splitter by default in Spring Cloud Stream 5.0.1.** The integration test caught this: without `producer.use-native-encoding=true` on the output binding, the framework JSON-serializes the entire list as one array payload. The fix is applied in `application.yml` lines 28-32 with an explanatory comment.

5. **Build wrapper is `./mvnw`, not `./compile.pl`.** The plan file referenced `./compile.pl` throughout; that file doesn't exist in delta-v. The plan file still has these stale references — worth fixing in a followup docs cleanup.

## Review plan

- [ ] **FlowEnrichmentFunction** (`core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java`) — main orchestrator. Check the `Message<byte[]>` signature, `extractModuleId()` prefix handling, exporter lookup amortization, per-flow try/catch isolation, null safety throughout the loop.
- [ ] **AbstractProtocolMessageProcessor** (`core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java`) — pipeline-per-invocation pattern. The Javadoc explains why fresh pipeline + fresh adapter per call is necessary.
- [ ] **FlowToDocumentMapper** (`core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java`) — null-wrapper discipline for `google.protobuf.*Value` fields. The paired tests `omits...WhenReturnsNull` and `populates...WhenReturnsZero` for UInt64Value and UInt32Value enforce the invariant.
- [ ] **FlowEnricherConfiguration** (`core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`) — bean wiring for the four protocol processors, dispatch map, `SimpleAdapterDefinition` construction.
- [ ] **application.yml** (`core/flow-enricher/src/main/resources/application.yml`) — the `producer.use-native-encoding: true` fix on `enrichFlows-out-0`. Without this, the splitter pipeline is silently broken.
- [ ] **FlowEnrichmentStreamBinderIT** (`core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java`) — end-to-end integration test across all four protocols plus unknown-prefix drop.
- [ ] Run the full test suite: `./mvnw -pl :org.deltav.flows.flow-enricher test` — expect 96 tests, 0 failures.
- [ ] (Optional) Start the delta-v stack with `docker compose --profile full up -d flow-enricher` and observe real flow traffic on `deltav-flows` via `kafka-console-consumer`.

## Known followups (tracked for future sessions)

### Important — track before more daemons import `flows.processing`

**Transitive classpath regression from `flows.processing`.** The `org.opennms.features.flows.processing` dependency brings in `opennms-config` and its full JAXB/Atomikos/EclipseLink/xalan/dom4j/Rhino tail via `collection.thresholding.api`. This directly contradicts the Karaf-removal decisions in PRs #91-100 and the `feedback_karaf_is_dead` memory-index item. Runtime is unaffected because flow-enricher never exercises the polluted code paths, but Docker image size bloats and Spring Boot class-path scanning walks dead JARs on startup. Recommended fixes (in order of preference): (a) copy `Pipeline`, `ProcessingOptions`, `FlowSource` as local stubs in delta-v — matches the `OnmsCriteria` stub pattern already established — and drop the `flows.processing` dependency entirely; (b) open a horizon-side PR to extract the three interfaces into a tiny `flows-processing-api` JAR; (c) interim: add a blanket `org.opennms:opennms-config` exclusion to the `flows.processing` dependency block.

### Minor polish items (non-blocking)

- Update stale "later commit of the Phase 1.5 effort" Javadoc in `DeserializedSinkMessage.java` lines 37-45 (should be past tense now that Commit 3 is on this branch)
- Remove the `@Deprecated` one-arg `SinkMessageDeserializer.deserialize(byte[])` overload — there are no production callers, only test code
- Consider changing `FlowToDocumentMapper` to accept `Locality` enum directly instead of round-tripping through strings
- Extract the BSON fixture loader helper from `SFlowMessageProcessorTest` and `FlowEnrichmentStreamBinderIT` into a shared test utility
- Update `TestAdapterDefinitions` test helper to use `SimpleAdapterDefinition` directly instead of Mockito stubs
- Type consistency: `InterfaceMarkingCache.markIfNeeded(long, int)` uses `long` for nodeId but `JdbcNodeInfoLookup.NodeInfo.nodeId()` returns `int`
- Test coverage: `InterfaceMarkingCacheCleaner` scheduled bean has no direct test
- Plan file documentation bug: `docs/superpowers/plans/2026-04-10-flow-enricher-phase15.md` references `./compile.pl` throughout (should be `./mvnw`)

## Phase 1.5 scope boundaries

**In scope (delivered):**
- Horizon adapter integration for all four flow protocols
- Exporter/src/dst node lookup via JDBC
- Locality calculation
- Interface marking with TTL cache
- Port-based application classifier stub
- Full per-flow enrichment pipeline with null-wrapper discipline
- Splitter-pattern `List<byte[]>` output
- End-to-end integration test with Spring Cloud Stream test binder

**Deferred to Phase 1.6:**
- Horizon's rule-based `DefaultClassificationEngine` (replaces the port-based stub)
- Clock-skew correction (the `clock_correction` field is currently always 0)
- `nodeDeleted` Kafka event listener for cache eviction (TTL-based expiry is used as a bounded-staleness workaround)

**Deferred to future phases:**
- `flows.processing` classpath cleanup (see Important followup above)
- Documentation updates to the plan file