### PR TITLE
fix(flow-enricher): exclude Karaf-era transitive deps from horizon dependency blocks

### DIFF
--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -94,6 +94,8 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-util</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>jaxb-dependencies</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -115,6 +117,8 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-util</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>jaxb-dependencies</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -136,6 +140,8 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-util</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>jaxb-dependencies</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -157,6 +163,8 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-util</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>jaxb-dependencies</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -179,6 +187,7 @@
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
                 <exclusion><groupId>org.opennms.features.jest</groupId><artifactId>jest-complete-osgi</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>jaxb-dependencies</artifactId></exclusion>
             </exclusions>
         </dependency>
 
@@ -200,6 +209,13 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
                 <exclusion><groupId>com.fasterxml.jackson.module</groupId><artifactId>jackson-module-scala_2.13</artifactId></exclusion>
                 <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-config</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.features.collection.thresholding</groupId><artifactId>org.opennms.features.collection.thresholding.api</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>atomikos-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>jaxb-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>jasypt-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.features.config</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-util</artifactId></exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Summary

- Adds `jaxb-dependencies` and `opennms-util` exclusions to all six horizon dependency blocks in `core/flow-enricher/pom.xml`
- Adds `opennms-config`, `thresholding.api`, `atomikos-dependencies`, `jasypt-dependencies`, and `features.config.*` exclusions to the `flows.processing` block specifically
- Eliminates EclipseLink 2.5.1, Atomikos JTA, JAXB XJC code generator, and the full legacy config stack from the flow-enricher classpath

**Before:** `flows.processing → collection.thresholding.api → opennms-config` pulled in the full Atomikos/JAXB/EclipseLink chain. Additionally, `jaxb-dependencies` entered through four other horizon dependency paths via `opennms-util` and `core.xml`.

**After:** servicemix=0, opennms-config=0, atomikos=0, eclipselink=0, jaxb-xjc=0. All 96 tests pass.

Refs: PR #142 final code review (Important finding), `project_flows_processing_classpath_regression.md`

## Test plan

- [x] `./mvnw -pl :org.deltav.flows.flow-enricher -DskipTests compile` — BUILD SUCCESS
- [x] `dependency:tree | grep -c opennms-config` → 0
- [x] `dependency:tree | grep -c atomikos` → 0
- [x] `dependency:tree | grep -c eclipselink` → 0
- [x] `dependency:tree | grep -c jaxb-xjc` → 0
- [x] `dependency:tree | grep -c servicemix.bundles` → 0
- [x] `./mvnw -pl :org.deltav.flows.flow-enricher test` — 96 tests, 0 failures