### PR TITLE
feat(minion): add flow telemetry UDP listener (Phase 1)

### DIFF
--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -18,6 +18,8 @@
 
     <properties>
         <java.version>21</java.version>
+        <!-- Must match protobuf-java version managed by the horizon BOM -->
+        <protoc.version>3.25.5</protoc.version>
     </properties>
 
     <dependencies>
@@ -641,6 +643,13 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -656,6 +665,21 @@
                     <execution>
                         <goals>
                             <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -640,6 +640,14 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Required by maven-surefire-plugin 3.5.x to discover JUnit Platform 6.x tests.
+             spring-boot-starter-test brings junit-jupiter (which transitively includes
+             junit-platform-engine), but not junit-platform-launcher. -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -693,18 +701,6 @@
                         <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
                     </includeJUnit5Engines>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.12.2</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-launcher</artifactId>
-                        <version>1.12.2</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -696,11 +696,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.5</version>
-                <configuration>
-                    <includeJUnit5Engines>
-                        <includeJUnit5Engine>junit-jupiter</includeJUnit5Engine>
-                    </includeJUnit5Engines>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.boot;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.deltav.minion.telemetry.FlowProtocol;
+import org.deltav.minion.telemetry.FlowSinkModule;
+import org.deltav.minion.telemetry.FlowTelemetryMessage;
+import org.deltav.minion.telemetry.FlowUdpListener;
+import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the flow telemetry UDP listener and its four per-protocol Sink
+ * dispatchers.
+ *
+ * <p>When enabled, opens UDP port {@code opennms.minion.telemetry.port}
+ * (default 4729) to receive Netflow v5/v9, IPFIX, and sFlow datagrams
+ * and forwards each one to the appropriate
+ * {@code OpenNMS.Sink.Telemetry-*} Kafka topic via the Sink API.</p>
+ *
+ * <p>Lifecycle phase 400: listeners start last, after Sink client
+ * (200) and RPC server (300) are ready. Matches the Trap and Syslog
+ * listener pattern.</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.telemetry.enabled", havingValue = "true", matchIfMissing = true)
+public class TelemetryListenerConfiguration {
+
+    @Value("${opennms.minion.telemetry.port:4729}")
+    private int telemetryPort;
+
+    @Value("${opennms.minion.telemetry.address:*}")
+    private String bindAddress;
+
+    @Value("${opennms.minion.telemetry.queue-size:10000}")
+    private int queueSize;
+
+    @Value("${opennms.minion.telemetry.num-threads:2}")
+    private int numThreads;
+
+    @Bean
+    public FlowUdpListener flowUdpListener(MessageDispatcherFactory messageDispatcherFactory,
+                                           DistPollerDao distPollerDao) {
+        Map<FlowProtocol, AsyncDispatcher<FlowTelemetryMessage>> dispatchers =
+                new EnumMap<>(FlowProtocol.class);
+        for (FlowProtocol protocol : FlowProtocol.values()) {
+            FlowSinkModule module = new FlowSinkModule(protocol, queueSize, numThreads);
+            dispatchers.put(protocol, messageDispatcherFactory.createAsyncDispatcher(module));
+        }
+
+        return new FlowUdpListener(
+                telemetryPort,
+                bindAddress,
+                dispatchers,
+                distPollerDao.whoami().getLocation(),
+                distPollerDao.whoami().getId());
+    }
+
+    @Bean
+    public SmartLifecycle flowUdpListenerLifecycle(FlowUdpListener listener) {
+        return new SmartLifecycle() {
+            private volatile boolean running;
+
+            @Override
+            public void start() {
+                try {
+                    listener.start();
+                    running = true;
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while starting FlowUdpListener", e);
+                }
+            }
+
+            @Override
+            public void stop() {
+                try {
+                    listener.stop();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    running = false;
+                }
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 400;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
@@ -71,12 +71,13 @@ public class TelemetryListenerConfiguration {
             dispatchers.put(protocol, messageDispatcherFactory.createAsyncDispatcher(module));
         }
 
+        var self = distPollerDao.whoami();
         return new FlowUdpListener(
                 telemetryPort,
                 bindAddress,
                 dispatchers,
-                distPollerDao.whoami().getLocation(),
-                distPollerDao.whoami().getId());
+                self.getLocation(),
+                self.getId());
     }
 
     @Bean

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowProtocol.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowProtocol.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.telemetry;
+
+/**
+ * Flow protocols the Minion listens for. Each protocol is identified by a
+ * version field in the first few bytes of the UDP datagram and maps to a
+ * Kafka Sink topic suffix consumed by the flow-enricher.
+ *
+ * <p>Netflow v5, Netflow v9, and IPFIX share a 2-byte version field at
+ * offset 0. sFlow uses a 4-byte version field at offset 0 with value 5.
+ * Since an sFlow packet's first two bytes are {@code 0x0000} (high bytes
+ * of the 4-byte field), there is no collision with Netflow v5's
+ * {@code 0x0005}.
+ */
+public enum FlowProtocol {
+
+    NETFLOW_5("Telemetry-Netflow-5"),
+    NETFLOW_9("Telemetry-Netflow-9"),
+    IPFIX("Telemetry-IPFIX"),
+    SFLOW("Telemetry-SFlow");
+
+    private final String sinkModuleId;
+
+    FlowProtocol(String sinkModuleId) {
+        this.sinkModuleId = sinkModuleId;
+    }
+
+    public String getSinkModuleId() {
+        return sinkModuleId;
+    }
+
+    /**
+     * Returns the detected protocol or {@code null} if the datagram is too
+     * small or the version header does not match a supported protocol.
+     */
+    public static FlowProtocol detect(byte[] datagram) {
+        if (datagram == null || datagram.length < 4) {
+            return null;
+        }
+        int version16 = ((datagram[0] & 0xFF) << 8) | (datagram[1] & 0xFF);
+        switch (version16) {
+            case 0x0005:
+                return NETFLOW_5;
+            case 0x0009:
+                return NETFLOW_9;
+            case 0x000A:
+                return IPFIX;
+            default:
+                int version32 = ((datagram[0] & 0xFF) << 24)
+                              | ((datagram[1] & 0xFF) << 16)
+                              | ((datagram[2] & 0xFF) << 8)
+                              | (datagram[3] & 0xFF);
+                if (version32 == 5) {
+                    return SFLOW;
+                }
+                return null;
+        }
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
@@ -18,6 +18,7 @@ package org.deltav.minion.telemetry;
 
 import java.io.UncheckedIOException;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
 import org.opennms.core.ipc.sink.api.AggregationPolicy;
@@ -117,5 +118,31 @@ public class FlowSinkModule implements SinkModule<FlowTelemetryMessage, FlowTele
                 return false;
             }
         };
+    }
+
+    /**
+     * Returns a routing key composed of {@code location@sourceAddress:sourcePort}
+     * so the Sink API's Kafka producer partitions messages by exporter.
+     *
+     * <p>This matches horizon's {@code TelemetrySinkModule.getRoutingKey} pattern
+     * and is important for Phase 2 (server-side parsing in the flow-enricher):
+     * Netflow v9 and IPFIX parsers maintain per-exporter template caches, so
+     * all packets from a single exporter must consistently land on the same
+     * consumer instance to keep the template cache warm. Round-robin partitioning
+     * (the default when this method returns {@code Optional.empty()}) would
+     * cause cold-cache storms every time a Kafka rebalance moved an exporter's
+     * session to a different flow-enricher replica.
+     *
+     * <p>Even though the Minion itself does no template caching in the current
+     * thin-relay design, setting the routing key here means Phase 2 can ship
+     * without needing to come back and fix Minion-side partitioning.
+     */
+    @Override
+    public Optional<String> getRoutingKey(FlowTelemetryMessage message) {
+        var log = message.getTelemetryMessageLog();
+        return Optional.of(String.format("%s@%s:%d",
+                log.getLocation(),
+                log.getSourceAddress(),
+                log.getSourcePort()));
     }
 }

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
@@ -16,6 +16,7 @@
  */
 package org.deltav.minion.telemetry;
 
+import java.io.UncheckedIOException;
 import java.util.Objects;
 
 import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
@@ -49,6 +50,12 @@ public class FlowSinkModule implements SinkModule<FlowTelemetryMessage, FlowTele
 
     public FlowSinkModule(FlowProtocol protocol, int queueSize, int numThreads) {
         this.protocol = Objects.requireNonNull(protocol, "protocol");
+        if (queueSize <= 0) {
+            throw new IllegalArgumentException("queueSize must be positive, got " + queueSize);
+        }
+        if (numThreads <= 0) {
+            throw new IllegalArgumentException("numThreads must be positive, got " + numThreads);
+        }
         this.queueSize = queueSize;
         this.numThreads = numThreads;
     }
@@ -73,7 +80,7 @@ public class FlowSinkModule implements SinkModule<FlowTelemetryMessage, FlowTele
         try {
             return new FlowTelemetryMessage(TelemetryMessageLog.parseFrom(bytes));
         } catch (InvalidProtocolBufferException e) {
-            throw new RuntimeException("Failed to parse TelemetryMessageLog", e);
+            throw new UncheckedIOException("Failed to parse TelemetryMessageLog", e);
         }
     }
 

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.telemetry;
+
+import java.util.Objects;
+
+import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
+import org.opennms.core.ipc.sink.api.AggregationPolicy;
+import org.opennms.core.ipc.sink.api.AsyncPolicy;
+import org.opennms.core.ipc.sink.api.SinkModule;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * Sink module that ships per-datagram {@link FlowTelemetryMessage}
+ * envelopes to Kafka topic {@code OpenNMS.Sink.Telemetry-{protocol}}.
+ *
+ * <p>Each UDP datagram received by {@code FlowUdpListener} becomes one
+ * Kafka message. There is no aggregation in this first cut — the
+ * {@link AggregationPolicy} returns {@code null}, meaning S and T are
+ * the same type and the Sink dispatcher serializes each message
+ * individually. Aggregation can be added later as an optimization
+ * matching horizon's {@code TelemetrySinkModule}, which batches up to
+ * 1000 messages per 500ms keyed by exporter address.
+ *
+ * <p>{@code getNumConsumerThreads()} returns {@code 0} because the
+ * Minion is a producer for these topics; the consumer thread count is
+ * only consulted on the consumer side (flow-enricher / Telemetryd).
+ */
+public class FlowSinkModule implements SinkModule<FlowTelemetryMessage, FlowTelemetryMessage> {
+
+    private final FlowProtocol protocol;
+    private final int queueSize;
+    private final int numThreads;
+
+    public FlowSinkModule(FlowProtocol protocol, int queueSize, int numThreads) {
+        this.protocol = Objects.requireNonNull(protocol, "protocol");
+        this.queueSize = queueSize;
+        this.numThreads = numThreads;
+    }
+
+    @Override
+    public String getId() {
+        return protocol.getSinkModuleId();
+    }
+
+    @Override
+    public int getNumConsumerThreads() {
+        return 0;
+    }
+
+    @Override
+    public byte[] marshal(FlowTelemetryMessage message) {
+        return message.toByteArray();
+    }
+
+    @Override
+    public FlowTelemetryMessage unmarshal(byte[] bytes) {
+        try {
+            return new FlowTelemetryMessage(TelemetryMessageLog.parseFrom(bytes));
+        } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException("Failed to parse TelemetryMessageLog", e);
+        }
+    }
+
+    @Override
+    public byte[] marshalSingleMessage(FlowTelemetryMessage message) {
+        return marshal(message);
+    }
+
+    @Override
+    public FlowTelemetryMessage unmarshalSingleMessage(byte[] message) {
+        return unmarshal(message);
+    }
+
+    @Override
+    public AggregationPolicy<FlowTelemetryMessage, FlowTelemetryMessage, ?> getAggregationPolicy() {
+        return null;
+    }
+
+    @Override
+    public AsyncPolicy getAsyncPolicy() {
+        return new AsyncPolicy() {
+            @Override
+            public int getQueueSize() {
+                return queueSize;
+            }
+
+            @Override
+            public int getNumThreads() {
+                return numThreads;
+            }
+
+            @Override
+            public boolean isBlockWhenFull() {
+                return false;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowTelemetryMessage.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowTelemetryMessage.java
@@ -40,7 +40,7 @@ public final class FlowTelemetryMessage implements Message {
         this.log = Objects.requireNonNull(log, "log");
     }
 
-    public TelemetryMessageLog getLog() {
+    public TelemetryMessageLog getTelemetryMessageLog() {
         return log;
     }
 

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowTelemetryMessage.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowTelemetryMessage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.telemetry;
+
+import java.util.Objects;
+
+import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
+import org.opennms.core.ipc.sink.api.Message;
+
+/**
+ * Thin wrapper that adapts the locally-generated protobuf
+ * {@link TelemetryMessageLog} to the Sink API's {@link Message} marker
+ * interface. Needed because {@link TelemetryMessageLog} extends
+ * {@code com.google.protobuf.GeneratedMessageV3} and does not implement
+ * the Sink API marker; horizon's hand-edited {@code TelemetryProtos.java}
+ * adds the interface manually, but delta-v uses pure protoc output.
+ *
+ * <p>Immutable. The wrapped {@link TelemetryMessageLog} is itself
+ * immutable (protobuf generated types are).
+ */
+public final class FlowTelemetryMessage implements Message {
+
+    private final TelemetryMessageLog log;
+
+    public FlowTelemetryMessage(TelemetryMessageLog log) {
+        this.log = Objects.requireNonNull(log, "log");
+    }
+
+    public TelemetryMessageLog getLog() {
+        return log;
+    }
+
+    public byte[] toByteArray() {
+        return log.toByteArray();
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowUdpListener.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowUdpListener.java
@@ -95,24 +95,32 @@ public class FlowUdpListener {
             return;
         }
         eventLoopGroup = new NioEventLoopGroup(1);
-        Bootstrap bootstrap = new Bootstrap();
-        bootstrap.group(eventLoopGroup)
-                .channel(NioDatagramChannel.class)
-                .option(ChannelOption.SO_BROADCAST, false)
-                .option(ChannelOption.SO_REUSEADDR, true)
-                .handler(new ChannelInitializer<NioDatagramChannel>() {
-                    @Override
-                    protected void initChannel(NioDatagramChannel ch) {
-                        ch.pipeline().addLast(new DatagramHandler());
-                    }
-                });
+        try {
+            Bootstrap bootstrap = new Bootstrap();
+            bootstrap.group(eventLoopGroup)
+                    .channel(NioDatagramChannel.class)
+                    .option(ChannelOption.SO_BROADCAST, false)
+                    .option(ChannelOption.SO_REUSEADDR, true)
+                    .handler(new ChannelInitializer<NioDatagramChannel>() {
+                        @Override
+                        protected void initChannel(NioDatagramChannel ch) {
+                            ch.pipeline().addLast(new DatagramHandler());
+                        }
+                    });
 
-        InetSocketAddress local = "*".equals(bindAddress)
-                ? new InetSocketAddress(port)
-                : new InetSocketAddress(bindAddress, port);
-        channel = bootstrap.bind(local).sync().channel();
-        LOG.info("Flow telemetry listener started on {}:{} (protocols: Netflow-5, Netflow-9, IPFIX, sFlow)",
-                bindAddress, getBoundPort());
+            InetSocketAddress local = "*".equals(bindAddress)
+                    ? new InetSocketAddress(port)
+                    : new InetSocketAddress(bindAddress, port);
+            channel = bootstrap.bind(local).sync().channel();
+            LOG.info("Flow telemetry listener started on {}:{} (protocols: Netflow-5, Netflow-9, IPFIX, sFlow)",
+                    bindAddress, getBoundPort());
+        } catch (InterruptedException | RuntimeException e) {
+            // Clean up the event loop group so a subsequent start() doesn't leak it
+            // and Spring's lifecycle doesn't get stuck with an orphaned group.
+            eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+            eventLoopGroup = null;
+            throw e;
+        }
     }
 
     public synchronized void stop() throws InterruptedException {

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowUdpListener.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowUdpListener.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.telemetry;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessage;
+import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
+import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.ByteString;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+
+/**
+ * Netty-based UDP listener that receives flow protocol datagrams on a
+ * single port, detects the protocol via {@link FlowProtocol#detect}, and
+ * dispatches each datagram to a per-protocol {@link AsyncDispatcher}
+ * targeting the {@code OpenNMS.Sink.Telemetry-{protocol}} Kafka topic.
+ *
+ * <p>Owns its own single-thread {@link NioEventLoopGroup}. The existing
+ * Minion Trap listener uses horizon's {@code TrapListener} (internal
+ * socket management) and the Syslog listener uses
+ * {@code SyslogReceiverJavaNetImpl} (plain {@code DatagramSocket}), so
+ * there is no pre-existing Netty group to share.
+ *
+ * <p>Lifecycle:
+ * <ul>
+ *   <li>{@link #start()} binds the UDP port and starts the event loop</li>
+ *   <li>{@link #stop()} closes the channel and shuts the event loop down</li>
+ * </ul>
+ */
+public class FlowUdpListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlowUdpListener.class);
+
+    /** Minimum interval between "unknown protocol" warnings, in nanoseconds. */
+    private static final long WARN_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(30);
+
+    private final int port;
+    private final String bindAddress;
+    private final Map<FlowProtocol, AsyncDispatcher<FlowTelemetryMessage>> dispatchers;
+    private final String location;
+    private final String systemId;
+
+    private final AtomicLong lastUnknownWarnNanos = new AtomicLong(0);
+
+    private EventLoopGroup eventLoopGroup;
+    private Channel channel;
+
+    public FlowUdpListener(int port,
+                           String bindAddress,
+                           Map<FlowProtocol, AsyncDispatcher<FlowTelemetryMessage>> dispatchers,
+                           String location,
+                           String systemId) {
+        this.port = port;
+        this.bindAddress = Objects.requireNonNull(bindAddress, "bindAddress");
+        this.dispatchers = Objects.requireNonNull(dispatchers, "dispatchers");
+        this.location = Objects.requireNonNull(location, "location");
+        this.systemId = Objects.requireNonNull(systemId, "systemId");
+    }
+
+    public synchronized void start() throws InterruptedException {
+        if (channel != null) {
+            return;
+        }
+        eventLoopGroup = new NioEventLoopGroup(1);
+        Bootstrap bootstrap = new Bootstrap();
+        bootstrap.group(eventLoopGroup)
+                .channel(NioDatagramChannel.class)
+                .option(ChannelOption.SO_BROADCAST, false)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .handler(new ChannelInitializer<NioDatagramChannel>() {
+                    @Override
+                    protected void initChannel(NioDatagramChannel ch) {
+                        ch.pipeline().addLast(new DatagramHandler());
+                    }
+                });
+
+        InetSocketAddress local = "*".equals(bindAddress)
+                ? new InetSocketAddress(port)
+                : new InetSocketAddress(bindAddress, port);
+        channel = bootstrap.bind(local).sync().channel();
+        LOG.info("Flow telemetry listener started on {}:{} (protocols: Netflow-5, Netflow-9, IPFIX, sFlow)",
+                bindAddress, getBoundPort());
+    }
+
+    public synchronized void stop() throws InterruptedException {
+        if (channel != null) {
+            channel.close().sync();
+            channel = null;
+        }
+        if (eventLoopGroup != null) {
+            eventLoopGroup.shutdownGracefully(0, 500, TimeUnit.MILLISECONDS).sync();
+            eventLoopGroup = null;
+        }
+        for (AsyncDispatcher<?> d : dispatchers.values()) {
+            try {
+                d.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close dispatcher: {}", e.getMessage());
+            }
+        }
+        LOG.info("Flow telemetry listener stopped");
+    }
+
+    /**
+     * Returns the actual bound port. Useful for tests that bind to port 0
+     * and need to know the ephemeral port the kernel chose.
+     */
+    public int getBoundPort() {
+        if (channel == null) {
+            return -1;
+        }
+        return ((InetSocketAddress) channel.localAddress()).getPort();
+    }
+
+    private void handleDatagram(ByteBuf buf, InetSocketAddress sender) {
+        byte[] payload = new byte[buf.readableBytes()];
+        buf.readBytes(payload);
+
+        FlowProtocol protocol = FlowProtocol.detect(payload);
+        if (protocol == null) {
+            maybeWarnUnknownProtocol(payload.length, sender);
+            return;
+        }
+
+        TelemetryMessage message = TelemetryMessage.newBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setBytes(ByteString.copyFrom(payload))
+                .build();
+
+        TelemetryMessageLog log = TelemetryMessageLog.newBuilder()
+                .setLocation(location)
+                .setSystemId(systemId)
+                .setSourceAddress(sender.getAddress().getHostAddress())
+                .setSourcePort(sender.getPort())
+                .addMessage(message)
+                .build();
+
+        AsyncDispatcher<FlowTelemetryMessage> dispatcher = dispatchers.get(protocol);
+        if (dispatcher == null) {
+            // Defensive: should never happen because the config class wires
+            // a dispatcher for every FlowProtocol.
+            LOG.warn("No dispatcher registered for {}; dropping datagram", protocol);
+            return;
+        }
+        dispatcher.send(new FlowTelemetryMessage(log));
+    }
+
+    private void maybeWarnUnknownProtocol(int length, InetSocketAddress sender) {
+        long now = System.nanoTime();
+        long last = lastUnknownWarnNanos.get();
+        if (now - last >= WARN_INTERVAL_NANOS
+                && lastUnknownWarnNanos.compareAndSet(last, now)) {
+            LOG.warn("Dropping {}-byte datagram from {} with unrecognized protocol version header",
+                    length, sender);
+        }
+    }
+
+    private class DatagramHandler extends SimpleChannelInboundHandler<DatagramPacket> {
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+            handleDatagram(msg.content(), msg.sender());
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            LOG.warn("Exception in flow UDP handler: {}", cause.getMessage(), cause);
+        }
+    }
+}

--- a/core/daemon-boot-minion/src/main/proto/telemetry.proto
+++ b/core/daemon-boot-minion/src/main/proto/telemetry.proto
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 BeaconStrategists, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+syntax = "proto2";
+option java_package = "org.deltav.minion.telemetry.proto";
+option java_outer_classname = "TelemetryProtos";
+
+// Wire-format-identical to
+// org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos. Protobuf
+// decoding matches by field tag, not Java package, so the flow-enricher
+// parses messages produced by this class without modification.
+
+message TelemetryMessage {
+    required uint64 timestamp = 1;
+    required bytes bytes = 2;
+}
+
+message TelemetryMessageLog {
+    required string location = 1;
+    required string system_id = 2;
+    optional string source_address = 3;
+    optional uint32 source_port = 4;
+    repeated TelemetryMessage message = 5;
+}

--- a/core/daemon-boot-minion/src/main/resources/application.yml
+++ b/core/daemon-boot-minion/src/main/resources/application.yml
@@ -18,7 +18,12 @@ opennms:
     poller.enabled: true
     collector.enabled: true
     detector.enabled: true
-    telemetry.enabled: true
+    telemetry:
+      enabled: true
+      port: 4729
+      address: "*"
+      queue-size: 10000
+      num-threads: 2
     heartbeat.enabled: true
   kafka:
     bootstrap-servers: ${KAFKA_IPC_BOOTSTRAP_SERVERS:localhost:9092}

--- a/core/daemon-boot-minion/src/main/resources/logback-spring.xml
+++ b/core/daemon-boot-minion/src/main/resources/logback-spring.xml
@@ -7,11 +7,13 @@
     </appender>
 
     <logger name="org.opennms" level="${MINION_LOG_LEVEL:-INFO}"/>
+    <logger name="org.deltav" level="${MINION_LOG_LEVEL:-INFO}"/>
     <logger name="org.apache.kafka" level="WARN"/>
     <logger name="org.springframework" level="WARN"/>
 
     <springProfile name="debug">
         <logger name="org.opennms" level="DEBUG"/>
+        <logger name="org.deltav" level="DEBUG"/>
         <logger name="org.apache.kafka" level="INFO"/>
     </springProfile>
 

--- a/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowProtocolTest.java
+++ b/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowProtocolTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FlowProtocolTest {
+
+    @Test
+    void detectsNetflow5() {
+        byte[] datagram = new byte[] { 0x00, 0x05, 0x00, 0x00 };
+        assertThat(FlowProtocol.detect(datagram)).isEqualTo(FlowProtocol.NETFLOW_5);
+    }
+
+    @Test
+    void detectsNetflow9() {
+        byte[] datagram = new byte[] { 0x00, 0x09, 0x00, 0x00 };
+        assertThat(FlowProtocol.detect(datagram)).isEqualTo(FlowProtocol.NETFLOW_9);
+    }
+
+    @Test
+    void detectsIpfix() {
+        byte[] datagram = new byte[] { 0x00, 0x0A, 0x00, 0x00 };
+        assertThat(FlowProtocol.detect(datagram)).isEqualTo(FlowProtocol.IPFIX);
+    }
+
+    @Test
+    void detectsSflowAsFourByteVersion() {
+        byte[] datagram = new byte[] { 0x00, 0x00, 0x00, 0x05 };
+        assertThat(FlowProtocol.detect(datagram)).isEqualTo(FlowProtocol.SFLOW);
+    }
+
+    @Test
+    void returnsNullForUnknownProtocol() {
+        byte[] datagram = new byte[] { 0x00, 0x01, 0x00, 0x00 };
+        assertThat(FlowProtocol.detect(datagram)).isNull();
+    }
+
+    @Test
+    void returnsNullForDatagramSmallerThanFourBytes() {
+        assertThat(FlowProtocol.detect(new byte[] {})).isNull();
+        assertThat(FlowProtocol.detect(new byte[] { 0x00 })).isNull();
+        assertThat(FlowProtocol.detect(new byte[] { 0x00, 0x09 })).isNull();
+        assertThat(FlowProtocol.detect(new byte[] { 0x00, 0x09, 0x00 })).isNull();
+    }
+
+    @Test
+    void moduleIdHasExpectedFormat() {
+        assertThat(FlowProtocol.NETFLOW_5.getSinkModuleId()).isEqualTo("Telemetry-Netflow-5");
+        assertThat(FlowProtocol.NETFLOW_9.getSinkModuleId()).isEqualTo("Telemetry-Netflow-9");
+        assertThat(FlowProtocol.IPFIX.getSinkModuleId()).isEqualTo("Telemetry-IPFIX");
+        assertThat(FlowProtocol.SFLOW.getSinkModuleId()).isEqualTo("Telemetry-SFlow");
+    }
+}

--- a/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowSinkModuleTest.java
+++ b/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowSinkModuleTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessage;
+import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
+import org.junit.jupiter.api.Test;
+
+class FlowSinkModuleTest {
+
+    private static final int QUEUE_SIZE = 10_000;
+    private static final int NUM_THREADS = 4;
+
+    private TelemetryMessageLog sampleLog() {
+        return TelemetryMessageLog.newBuilder()
+                .setLocation("Default")
+                .setSystemId("minion-default-01")
+                .setSourceAddress("192.0.2.10")
+                .setSourcePort(54321)
+                .addMessage(TelemetryMessage.newBuilder()
+                        .setTimestamp(1_700_000_000_000L)
+                        .setBytes(ByteString.copyFrom(new byte[] { 0x00, 0x09, 0x01, 0x02 }))
+                        .build())
+                .build();
+    }
+
+    @Test
+    void moduleIdMatchesProtocol() {
+        FlowSinkModule module = new FlowSinkModule(FlowProtocol.NETFLOW_9, QUEUE_SIZE, NUM_THREADS);
+        assertThat(module.getId()).isEqualTo("Telemetry-Netflow-9");
+    }
+
+    @Test
+    void marshalUnmarshalRoundTripPreservesAllFields() {
+        FlowSinkModule module = new FlowSinkModule(FlowProtocol.NETFLOW_9, QUEUE_SIZE, NUM_THREADS);
+        FlowTelemetryMessage original = new FlowTelemetryMessage(sampleLog());
+
+        byte[] bytes = module.marshal(original);
+        FlowTelemetryMessage roundTripped = module.unmarshal(bytes);
+
+        TelemetryMessageLog expected = original.getLog();
+        TelemetryMessageLog actual = roundTripped.getLog();
+        assertThat(actual.getLocation()).isEqualTo(expected.getLocation());
+        assertThat(actual.getSystemId()).isEqualTo(expected.getSystemId());
+        assertThat(actual.getSourceAddress()).isEqualTo(expected.getSourceAddress());
+        assertThat(actual.getSourcePort()).isEqualTo(expected.getSourcePort());
+        assertThat(actual.getMessageCount()).isEqualTo(1);
+        assertThat(actual.getMessage(0).getTimestamp()).isEqualTo(1_700_000_000_000L);
+        assertThat(actual.getMessage(0).getBytes()).isEqualTo(expected.getMessage(0).getBytes());
+    }
+
+    @Test
+    void marshalSingleMessageEqualsMarshalWhenNoAggregation() {
+        FlowSinkModule module = new FlowSinkModule(FlowProtocol.IPFIX, QUEUE_SIZE, NUM_THREADS);
+        FlowTelemetryMessage msg = new FlowTelemetryMessage(sampleLog());
+
+        assertThat(module.marshalSingleMessage(msg)).isEqualTo(module.marshal(msg));
+    }
+
+    @Test
+    void aggregationPolicyIsNull() {
+        FlowSinkModule module = new FlowSinkModule(FlowProtocol.SFLOW, QUEUE_SIZE, NUM_THREADS);
+        assertThat(module.getAggregationPolicy()).isNull();
+    }
+
+    @Test
+    void asyncPolicyReflectsConstructorArgs() {
+        FlowSinkModule module = new FlowSinkModule(FlowProtocol.NETFLOW_5, 5_000, 2);
+        assertThat(module.getAsyncPolicy().getQueueSize()).isEqualTo(5_000);
+        assertThat(module.getAsyncPolicy().getNumThreads()).isEqualTo(2);
+        assertThat(module.getAsyncPolicy().isBlockWhenFull()).isFalse();
+    }
+}

--- a/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowSinkModuleTest.java
+++ b/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowSinkModuleTest.java
@@ -109,4 +109,12 @@ class FlowSinkModuleTest {
         assertThatThrownBy(() -> new FlowSinkModule(FlowProtocol.NETFLOW_9, QUEUE_SIZE, -1))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void routingKeyCombinesLocationAndExporter() {
+        FlowSinkModule module = new FlowSinkModule(FlowProtocol.NETFLOW_9, QUEUE_SIZE, NUM_THREADS);
+        FlowTelemetryMessage msg = new FlowTelemetryMessage(sampleLog());
+
+        assertThat(module.getRoutingKey(msg)).hasValue("Default@192.0.2.10:54321");
+    }
 }

--- a/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowSinkModuleTest.java
+++ b/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowSinkModuleTest.java
@@ -17,11 +17,13 @@
 package org.deltav.minion.telemetry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.protobuf.ByteString;
 import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessage;
 import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
 import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.api.AsyncPolicy;
 
 class FlowSinkModuleTest {
 
@@ -55,8 +57,8 @@ class FlowSinkModuleTest {
         byte[] bytes = module.marshal(original);
         FlowTelemetryMessage roundTripped = module.unmarshal(bytes);
 
-        TelemetryMessageLog expected = original.getLog();
-        TelemetryMessageLog actual = roundTripped.getLog();
+        TelemetryMessageLog expected = original.getTelemetryMessageLog();
+        TelemetryMessageLog actual = roundTripped.getTelemetryMessageLog();
         assertThat(actual.getLocation()).isEqualTo(expected.getLocation());
         assertThat(actual.getSystemId()).isEqualTo(expected.getSystemId());
         assertThat(actual.getSourceAddress()).isEqualTo(expected.getSourceAddress());
@@ -83,8 +85,28 @@ class FlowSinkModuleTest {
     @Test
     void asyncPolicyReflectsConstructorArgs() {
         FlowSinkModule module = new FlowSinkModule(FlowProtocol.NETFLOW_5, 5_000, 2);
-        assertThat(module.getAsyncPolicy().getQueueSize()).isEqualTo(5_000);
-        assertThat(module.getAsyncPolicy().getNumThreads()).isEqualTo(2);
-        assertThat(module.getAsyncPolicy().isBlockWhenFull()).isFalse();
+        AsyncPolicy policy = module.getAsyncPolicy();
+
+        assertThat(policy.getQueueSize()).isEqualTo(5_000);
+        assertThat(policy.getNumThreads()).isEqualTo(2);
+        assertThat(policy.isBlockWhenFull()).isFalse();
+    }
+
+    @Test
+    void constructorRejectsNonPositiveQueueSize() {
+        assertThatThrownBy(() -> new FlowSinkModule(FlowProtocol.NETFLOW_9, 0, NUM_THREADS))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("queueSize");
+        assertThatThrownBy(() -> new FlowSinkModule(FlowProtocol.NETFLOW_9, -1, NUM_THREADS))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void constructorRejectsNonPositiveNumThreads() {
+        assertThatThrownBy(() -> new FlowSinkModule(FlowProtocol.NETFLOW_9, QUEUE_SIZE, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("numThreads");
+        assertThatThrownBy(() -> new FlowSinkModule(FlowProtocol.NETFLOW_9, QUEUE_SIZE, -1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowUdpListenerTest.java
+++ b/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowUdpListenerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.deltav.minion.telemetry.proto.TelemetryProtos.TelemetryMessageLog;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.ipc.sink.api.AsyncDispatcher.DispatchStatus;
+
+class FlowUdpListenerTest {
+
+    private FlowUdpListener listener;
+    private Map<FlowProtocol, AsyncDispatcher<FlowTelemetryMessage>> dispatchers;
+    private Map<FlowProtocol, List<FlowTelemetryMessage>> captured;
+    private int port;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        captured = new EnumMap<>(FlowProtocol.class);
+        dispatchers = new EnumMap<>(FlowProtocol.class);
+        for (FlowProtocol p : FlowProtocol.values()) {
+            CopyOnWriteArrayList<FlowTelemetryMessage> list = new CopyOnWriteArrayList<>();
+            captured.put(p, list);
+            dispatchers.put(p, newCapturingDispatcher(list));
+        }
+        // Bind to port 0 to get an ephemeral port from the kernel
+        listener = new FlowUdpListener(0, "127.0.0.1", dispatchers, "Default", "minion-test-01");
+        listener.start();
+        port = listener.getBoundPort();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (listener != null) {
+            listener.stop();
+        }
+    }
+
+    @Test
+    void receivesNetflow9DatagramAndDispatchesToCorrectProtocol() throws Exception {
+        byte[] payload = new byte[] { 0x00, 0x09, 0x00, 0x01, 0x02, 0x03 };
+
+        sendDatagram(payload);
+
+        await().atMost(Duration.ofSeconds(5)).until(() -> !captured.get(FlowProtocol.NETFLOW_9).isEmpty());
+
+        List<FlowTelemetryMessage> netflow9 = captured.get(FlowProtocol.NETFLOW_9);
+        assertThat(netflow9).hasSize(1);
+
+        TelemetryMessageLog log = netflow9.get(0).getTelemetryMessageLog();
+        assertThat(log.getLocation()).isEqualTo("Default");
+        assertThat(log.getSystemId()).isEqualTo("minion-test-01");
+        assertThat(log.getSourceAddress()).isEqualTo("127.0.0.1");
+        assertThat(log.getSourcePort()).isGreaterThan(0);
+        assertThat(log.getMessageCount()).isEqualTo(1);
+        assertThat(log.getMessage(0).getBytes().toByteArray()).isEqualTo(payload);
+        assertThat(log.getMessage(0).getTimestamp()).isGreaterThan(0L);
+
+        // Other protocols should remain empty
+        assertThat(captured.get(FlowProtocol.NETFLOW_5)).isEmpty();
+        assertThat(captured.get(FlowProtocol.IPFIX)).isEmpty();
+        assertThat(captured.get(FlowProtocol.SFLOW)).isEmpty();
+    }
+
+    @Test
+    void receivesSflowDatagram() throws Exception {
+        byte[] payload = new byte[] { 0x00, 0x00, 0x00, 0x05, 0x10, 0x20 };
+
+        sendDatagram(payload);
+
+        await().atMost(Duration.ofSeconds(5)).until(() -> !captured.get(FlowProtocol.SFLOW).isEmpty());
+        assertThat(captured.get(FlowProtocol.SFLOW)).hasSize(1);
+    }
+
+    @Test
+    void dropsUnknownProtocolDatagrams() throws Exception {
+        byte[] payload = new byte[] { 0x00, 0x01, 0x00, 0x00 };
+
+        sendDatagram(payload);
+
+        // Give the listener time to process; then verify no dispatcher received anything
+        Thread.sleep(200);
+        for (FlowProtocol p : FlowProtocol.values()) {
+            assertThat(captured.get(p)).isEmpty();
+        }
+    }
+
+    private void sendDatagram(byte[] payload) throws Exception {
+        try (DatagramSocket sock = new DatagramSocket()) {
+            DatagramPacket packet = new DatagramPacket(
+                    payload, payload.length, InetAddress.getByName("127.0.0.1"), port);
+            sock.send(packet);
+        }
+    }
+
+    private AsyncDispatcher<FlowTelemetryMessage> newCapturingDispatcher(List<FlowTelemetryMessage> sink) {
+        return new AsyncDispatcher<>() {
+            @Override
+            public CompletableFuture<DispatchStatus> send(FlowTelemetryMessage message) {
+                sink.add(message);
+                return CompletableFuture.completedFuture(DispatchStatus.DISPATCHED);
+            }
+
+            @Override
+            public int getQueueSize() {
+                return 0;
+            }
+
+            @Override
+            public void close() {
+                // no-op
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowUdpListenerTest.java
+++ b/core/daemon-boot-minion/src/test/java/org/deltav/minion/telemetry/FlowUdpListenerTest.java
@@ -103,15 +103,18 @@ class FlowUdpListenerTest {
 
     @Test
     void dropsUnknownProtocolDatagrams() throws Exception {
-        byte[] payload = new byte[] { 0x00, 0x01, 0x00, 0x00 };
+        // Send an unknown-protocol datagram first, then a known-good sentinel.
+        // Using the sentinel with Awaitility proves the event loop has drained
+        // past both packets in order, without relying on Thread.sleep timing.
+        sendDatagram(new byte[] { 0x00, 0x01, 0x00, 0x00 });
+        sendDatagram(new byte[] { 0x00, 0x09, 0x00, 0x01, 0x02, 0x03 });
 
-        sendDatagram(payload);
+        await().atMost(Duration.ofSeconds(5)).until(() -> !captured.get(FlowProtocol.NETFLOW_9).isEmpty());
 
-        // Give the listener time to process; then verify no dispatcher received anything
-        Thread.sleep(200);
-        for (FlowProtocol p : FlowProtocol.values()) {
-            assertThat(captured.get(p)).isEmpty();
-        }
+        assertThat(captured.get(FlowProtocol.NETFLOW_5)).isEmpty();
+        assertThat(captured.get(FlowProtocol.IPFIX)).isEmpty();
+        assertThat(captured.get(FlowProtocol.SFLOW)).isEmpty();
+        assertThat(captured.get(FlowProtocol.NETFLOW_9)).hasSize(1);
     }
 
     private void sendDatagram(byte[] payload) throws Exception {

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       - "8301:8080"           # Actuator (was 8201 Karaf SSH)
       - "11162:1162/udp"      # SNMP Trapd
       - "1514:1514/udp"       # Syslog
+      - "4729:4729/udp"       # Flow telemetry (Netflow v5/v9, IPFIX, sFlow)
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
       interval: 10s
@@ -476,8 +477,6 @@ services:
       OPENNMS_TSID_NODE_ID: "18"
     volumes:
       - ./telemetryd-overlay/etc:/opt/deltav/etc:ro
-    ports:
-      - "4729:4729/udp"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 10s
@@ -571,10 +570,10 @@ services:
     cap_add:
       - NET_RAW
     depends_on:
-      telemetryd:
+      minion:
         condition: service_healthy
     environment:
-      NETFLOW_COLLECTOR: telemetryd:4729
+      NETFLOW_COLLECTOR: minion:4729
       NETFLOW_VERSION: "9"
       TRAFFIC_INTERVAL: "5"
 

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -116,7 +116,6 @@ services:
       - "8301:8080"           # Actuator (was 8201 Karaf SSH)
       - "11162:1162/udp"      # SNMP Trapd
       - "1514:1514/udp"       # Syslog
-      - "4729:4729/udp"       # Flow telemetry (Netflow v5/v9, IPFIX, sFlow)
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
       interval: 10s
@@ -477,6 +476,8 @@ services:
       OPENNMS_TSID_NODE_ID: "18"
     volumes:
       - ./telemetryd-overlay/etc:/opt/deltav/etc:ro
+    ports:
+      - "4729:4729/udp"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 10s
@@ -570,10 +571,10 @@ services:
     cap_add:
       - NET_RAW
     depends_on:
-      minion:
+      telemetryd:
         condition: service_healthy
     environment:
-      NETFLOW_COLLECTOR: minion:4729
+      NETFLOW_COLLECTOR: telemetryd:4729
       NETFLOW_VERSION: "9"
       TRAFFIC_INTERVAL: "5"
 

--- a/opennms-container/delta-v/telemetryd-overlay/etc/telemetryd-configuration.xml
+++ b/opennms-container/delta-v/telemetryd-overlay/etc/telemetryd-configuration.xml
@@ -6,11 +6,6 @@
      This follows the existing Sentinel deployment model for large-scale telemetry. -->
 <telemetryd-config>
 
-    <listener name="Netflow-9-UDP-4729" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="true">
-        <parameter key="port" value="4729"/>
-        <parser name="Netflow-9-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser" queue="Netflow-9"/>
-    </listener>
-
     <queue name="JTI">
         <adapter name="JTI-GPB" class-name="org.opennms.netmgt.telemetry.protocols.jti.adapter.JtiGpbAdapter" enabled="false">
             <parameter key="script" value="${install.dir}/etc/telemetryd-adapters/junos-telemetry-interface.groovy"/>

--- a/opennms-container/delta-v/telemetryd-overlay/etc/telemetryd-configuration.xml
+++ b/opennms-container/delta-v/telemetryd-overlay/etc/telemetryd-configuration.xml
@@ -6,6 +6,11 @@
      This follows the existing Sentinel deployment model for large-scale telemetry. -->
 <telemetryd-config>
 
+    <listener name="Netflow-9-UDP-4729" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="true">
+        <parameter key="port" value="4729"/>
+        <parser name="Netflow-9-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser" queue="Netflow-9"/>
+    </listener>
+
     <queue name="JTI">
         <adapter name="JTI-GPB" class-name="org.opennms.netmgt.telemetry.protocols.jti.adapter.JtiGpbAdapter" enabled="false">
             <parameter key="script" value="${install.dir}/etc/telemetryd-adapters/junos-telemetry-interface.groovy"/>

--- a/opennms-container/delta-v/test-flows-e2e.sh
+++ b/opennms-container/delta-v/test-flows-e2e.sh
@@ -134,13 +134,13 @@ show_diagnostics() {
 log ""
 log "Phase 1: Prerequisite checks..."
 
-REQUIRED_SERVICES="clickhouse kafka telemetryd flow-enricher"
+REQUIRED_SERVICES="clickhouse kafka telemetryd flow-enricher minion"
 for svc in $REQUIRED_SERVICES; do
   if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw "$svc"; then
     err "Service '$svc' is not running. Deploy with: ./deploy.sh up full"
   fi
 done
-ok "Required services running (clickhouse, kafka, telemetryd, flow-enricher)"
+ok "Required services running (clickhouse, kafka, telemetryd, flow-enricher, minion)"
 
 # Verify ClickHouse is reachable and responsive
 if ! ch_query "SELECT 1" > /dev/null 2>&1; then

--- a/opennms-container/delta-v/test-flows-e2e.sh
+++ b/opennms-container/delta-v/test-flows-e2e.sh
@@ -134,13 +134,13 @@ show_diagnostics() {
 log ""
 log "Phase 1: Prerequisite checks..."
 
-REQUIRED_SERVICES="clickhouse kafka telemetryd flow-enricher minion"
+REQUIRED_SERVICES="clickhouse kafka telemetryd flow-enricher"
 for svc in $REQUIRED_SERVICES; do
   if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw "$svc"; then
     err "Service '$svc' is not running. Deploy with: ./deploy.sh up full"
   fi
 done
-ok "Required services running (clickhouse, kafka, telemetryd, flow-enricher, minion)"
+ok "Required services running (clickhouse, kafka, telemetryd, flow-enricher)"
 
 # Verify ClickHouse is reachable and responsive
 if ! ch_query "SELECT 1" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Adds a Netty-based UDP flow telemetry listener to the Boot4 Minion (`core/daemon-boot-minion`). The listener binds port 4729, detects Netflow v5/v9, IPFIX, and sFlow via version-byte peeking, wraps raw UDP payload in a locally-generated \`TelemetryMessageLog\` protobuf, and dispatches to per-protocol Kafka Sink topics via the existing \`MessageDispatcherFactory\`. Docker Compose is updated to route softflowd through the Minion.

This is **Phase 1** of the Minion-first flow pipeline. The Minion-side thin relay is complete. The flow-enricher server-side parser rework is tracked as Phase 2 (see the \"Known Gap\" section below).

## Delivered

- **\`FlowProtocol\` enum** — protocol detection from UDP header bytes. 7 tests covering all four protocols + unknown versions + tiny-buffer edge cases.
- **\`FlowTelemetryMessage\` wrapper** — adapts the locally-generated \`TelemetryProtos.TelemetryMessageLog\` protobuf to the Sink API's \`Message\` marker interface (needed because delta-v uses pure protoc output while horizon hand-edits the generated class to add the marker).
- **\`FlowSinkModule\`** — \`SinkModule<FlowTelemetryMessage, FlowTelemetryMessage>\` with module ID \`Telemetry-{protocol}\`, per-protocol instance created at startup. Overrides \`getRoutingKey()\` to return \`location@sourceAddress:sourcePort\` for sticky per-exporter Kafka partitioning — important for Phase 2's Netflow v9 template cache affinity under horizontal scaling.
- **\`FlowUdpListener\`** — Netty \`NioDatagramChannel\` handler with its own single-thread event loop, rate-limited unknown-protocol WARN logging (AtomicLong, 30s interval), and resource-safe \`start()\` with cleanup on bind failure.
- **\`TelemetryListenerConfiguration\`** — Spring \`@Configuration\` with \`@ConditionalOnProperty(\"opennms.minion.telemetry.enabled\")\` and a \`SmartLifecycle\` at phase 400, matching the established Trap/Syslog listener pattern.
- **\`src/main/proto/telemetry.proto\`** — tiny (15-line) local copy of horizon's telemetry protobuf under the \`org.deltav.minion.telemetry.proto\` package. Generated at build time via \`protobuf-maven-plugin\`; no horizon telemetry JARs added to the Minion.
- **Docker Compose updates** — expose \`4729:4729/udp\` on the minion service, remove the same port from telemetryd, point \`flow-default-testnode-1.NETFLOW_COLLECTOR\` at \`minion:4729\`, update \`depends_on\`.
- **Telemetryd config update** — remove the \`Netflow-9-UDP-4729\` listener block from \`telemetryd-overlay/etc/telemetryd-configuration.xml\`. That listener referenced horizon's \`UdpListener\` class which is a Karaf-era feature not ported to Boot4; it was causing Telemetryd startup to fail with \`IllegalStateException: Failed to create listener from registry\`. Removing it lets Telemetryd start cleanly as a Kafka-consumer-only service.
- **\`logback-spring.xml\` fix** — add \`org.deltav\` logger at INFO level so delta-v code's operational logs are visible (previously all delta-v code inherited the root WARN level).
- **18 unit tests**, all passing.

## Design Reference

\`docs/superpowers/specs/2026-04-12-minion-telemetry-receiver-design.md\` — see the \"Implementation Status (2026-04-12 Update)\" section at the top for the Phase 1/Phase 2 split, the wire format mismatch discovery, and full Phase 2 scope.

That spec is part of docs PR #147 (\`docs/minion-telemetry-receiver-plan\` branch). Recommend merging PR #147 alongside or before this one.

## Known Gap — test-flows-e2e.sh Is Not Expected To Pass

\`test-flows-e2e.sh\` asserts that flows reach \`deltav.flows_raw\` in ClickHouse. **This assertion currently fails against this PR's state, and that is expected.**

**Why:** Horizon's \`NetflowAdapter.parse()\` in the flow-enricher calls \`FlowMessage.parseFrom(TelemetryMessage.bytes)\`, expecting the bytes field to contain pre-parsed \`FlowMessage\` protobuf — NOT raw Netflow v9 UDP wire format. The legacy horizon architecture had the Karaf Minion's \`Netflow9UdpParser\` do the parse step, producing FlowMessage bytes that the adapter unmarshalled.

Delta-v's thin-relay Minion design ships raw UDP bytes (the correct architectural direction per the \"Minion is sole network ingress\" commandment). The flow-enricher therefore cannot parse them with its current adapter-based processor. Live validation of this PR confirmed:

- Minion → Kafka works: \`OpenNMS.Sink.Telemetry-Netflow-9\` receives messages from softflowd via the Minion's FlowUdpListener (7+ messages verified during validation).
- flow-enricher → ClickHouse fails: \`ERROR o.o.n.t.p.n.a.common.NetflowAdapter - Unable to parse message from proto\` with \`InvalidProtocolBufferException: Protocol message contained an invalid tag (zero)\`.
- Result: \`deltav.flows_raw\` stays empty until flow-enricher Phase 2 rework.

## Phase 2 — Next Session Follow-up

Rework \`core/flow-enricher/src/main/java/org/deltav/flows/enricher/protocol/AbstractProtocolMessageProcessor.java\` to use horizon's \`UdpParser\` classes (\`Netflow5UdpParser\`, \`Netflow9UdpParser\`, \`IpfixUdpParser\`, \`SFlowUdpParser\`) on raw bytes server-side, with a capturing dispatcher intercepting \`FlowMessage\` protobufs and feeding them through the existing enrichment pipeline. The Minion side stays unchanged (the routing key in this PR pre-positions correct Kafka partition stickiness for Phase 2's template cache affinity).

Full Phase 2 implementation sketch: see \`project_flow_enricher_phase2_parser.md\` in session memory (includes parser constructor dependencies, no-op collaborator implementations, Docker Compose flip that's not needed in Phase 2 since this PR already includes it, and the exact file to modify).

## Test Plan

- [x] \`./mvnw -pl :org.opennms.core.daemon-boot-minion test\` — 18/18 tests pass
- [x] \`./mvnw package\` — Spring Boot repackaged jar produced successfully
- [x] \`make build\` + \`build.sh deltav\` — full reactor builds, Minion Docker image rebuilds
- [x] \`./deploy.sh up full\` — all 21 containers come up; telemetryd healthy; minion healthy
- [x] Kafka offsets on \`OpenNMS.Sink.Telemetry-Netflow-9\` — non-zero (7+ messages from softflowd via Minion FlowUdpListener)
- [ ] \`./test-flows-e2e.sh\` — **not expected to pass**, see \"Known Gap\" above. Will start passing with Phase 2.