### PR TITLE
feat(flow-enricher): re-enable sFlow in production

### DIFF
--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -45,6 +45,7 @@ import org.deltav.flows.enricher.protocol.IpfixMessageProcessor;
 import org.deltav.flows.enricher.protocol.Netflow5MessageProcessor;
 import org.deltav.flows.enricher.protocol.Netflow9MessageProcessor;
 import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
+import org.deltav.flows.enricher.protocol.SFlowMessageProcessor;
 import org.deltav.flows.enricher.protocol.SimpleAdapterDefinition;
 import org.opennms.netmgt.dnsresolver.api.DnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
@@ -53,6 +54,7 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow5UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.InformationElementDatabase;
+import org.opennms.netmgt.telemetry.protocols.sflow.parser.SFlowUdpParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -150,20 +152,21 @@ public class FlowEnricherConfiguration {
     }
 
     /**
-     * Lifecycle bean that starts and stops the Netflow5, Netflow9, and IPFIX
-     * UDP parsers as part of the Spring application context lifecycle. sFlow
-     * is deliberately excluded because its parser is not wired as a bean
-     * (see the comment on the missing sflowUdpParser bean for the reason).
+     * Lifecycle bean that starts and stops the Netflow5, Netflow9, IPFIX, and
+     * sFlow UDP parsers as part of the Spring application context lifecycle.
+     * Each parser's {@code start()} runs in {@code @PostConstruct} with the
+     * shared scheduler, and its {@code stop()} runs on context close.
      */
     @Bean
     ParserLifecycle flowParserLifecycle(
             ScheduledExecutorService flowParserSessionCleanup,
             Netflow5UdpParser netflow5UdpParser,
             Netflow9UdpParser netflow9UdpParser,
-            IpfixUdpParser ipfixUdpParser) {
+            IpfixUdpParser ipfixUdpParser,
+            SFlowUdpParser sflowUdpParser) {
         return new ParserLifecycle(
                 flowParserSessionCleanup,
-                List.of(netflow5UdpParser, netflow9UdpParser, ipfixUdpParser));
+                List.of(netflow5UdpParser, netflow9UdpParser, ipfixUdpParser, sflowUdpParser));
     }
 
     /**
@@ -311,16 +314,30 @@ public class FlowEnricherConfiguration {
                 informationElementDatabase);
     }
 
-    // NOTE: SFlowUdpParser is deliberately NOT wired as a Spring bean.
-    // Horizon's SFlowUdpParser constructor references
-    // org.opennms.core.concurrent.LogPreservingThreadFactory, which lives in
-    // org.opennms:opennms-util — a legacy module that delta-v excludes from
-    // every dependency block (per feedback_fix_horizon_not_exclusions).
-    // Instantiating the bean would fail with NoClassDefFoundError at
-    // Spring startup. sFlow traffic arriving on OpenNMS.Sink.Telemetry-SFlow
-    // is silently dropped by FlowEnrichmentFunction because its moduleId
-    // will not be present in the dispatch map. See
-    // project_flow_enricher_sflow_classpath_gap.md for the unblock path.
+    /**
+     * sFlow UDP parser. Unlike the Netflow5/9/IPFIX parsers, {@link SFlowUdpParser}
+     * does not extend horizon's {@code ParserBase} — it implements
+     * {@link UdpParser} directly and manages its own internal
+     * {@link java.util.concurrent.ThreadPoolExecutor} created from a
+     * {@link org.opennms.core.concurrent.LogPreservingThreadFactory}.
+     *
+     * <p>The delta-v-local shim of {@code LogPreservingThreadFactory} (at
+     * {@code core/flow-enricher/src/main/java/org/opennms/core/concurrent/LogPreservingThreadFactory.java})
+     * shadows horizon's class by fully-qualified name, so both bean
+     * construction and {@link SFlowUdpParser#start(ScheduledExecutorService)}
+     * succeed without pulling in the banned {@code opennms-util} module.
+     * This is the same shim that unblocks the Netflow parsers (see the
+     * {@code feature/flow-enricher-phase2-parser-bridge} merge).
+     */
+    @Bean
+    SFlowUdpParser sflowUdpParser(
+            ThreadLocalDispatcher threadLocalDispatcher,
+            DnsResolver flowParserDnsResolver) {
+        return new SFlowUdpParser(
+                "SFlow",
+                threadLocalDispatcher,
+                flowParserDnsResolver);
+    }
 
     @Bean
     Netflow5MessageProcessor netflow5Processor(
@@ -358,11 +375,17 @@ public class FlowEnricherConfiguration {
                 threadLocalDispatcher);
     }
 
-    // Deliberately no SFlowMessageProcessor @Bean — see the comment on the
-    // missing sflowUdpParser @Bean method above for why. The
-    // SFlowMessageProcessor class itself remains in the codebase (and its
-    // unit test uses FakeUdpParser so it still runs) but it is not wired
-    // into Spring.
+    @Bean
+    SFlowMessageProcessor sflowProcessor(
+            SFlowUdpParser sflowUdpParser,
+            MetricRegistry flowEnricherMetricRegistry,
+            ThreadLocalDispatcher threadLocalDispatcher) {
+        return new SFlowMessageProcessor(
+                sflowUdpParser,
+                new SimpleAdapterDefinition("SFlow"),
+                flowEnricherMetricRegistry,
+                threadLocalDispatcher);
+    }
 
     @Bean
     FlowEnrichmentFunction flowEnrichmentFunction(
@@ -374,12 +397,14 @@ public class FlowEnricherConfiguration {
             FlowToDocumentMapper flowToDocumentMapper,
             Netflow5MessageProcessor netflow5Processor,
             Netflow9MessageProcessor netflow9Processor,
-            IpfixMessageProcessor ipfixProcessor) {
+            IpfixMessageProcessor ipfixProcessor,
+            SFlowMessageProcessor sflowProcessor) {
 
         Map<String, ProtocolMessageProcessor> dispatchMap = Map.of(
                 "Telemetry-Netflow-5", netflow5Processor,
                 "Telemetry-Netflow-9", netflow9Processor,
-                "Telemetry-IPFIX",     ipfixProcessor);
+                "Telemetry-IPFIX",     ipfixProcessor,
+                "Telemetry-SFlow",     sflowProcessor);
 
         return new FlowEnrichmentFunction(
                 deserializer,

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java
@@ -45,6 +45,7 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow5UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.NetflowVersion;
+import org.opennms.netmgt.telemetry.protocols.sflow.parser.SFlowUdpParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.InputDestination;
@@ -76,16 +77,23 @@ import io.netty.buffer.ByteBuf;
  * {@code DataSource} bean is ever requested. We still explicitly exclude
  * {@code DataSourceAutoConfiguration} for defense in depth.
  *
- * <p>The four {@link org.opennms.netmgt.telemetry.listeners.UdpParser} beans
- * ({@link Netflow5UdpParser}, {@link Netflow9UdpParser}, {@link IpfixUdpParser},
- * {@link SFlowUdpParser}) are also replaced with Mockito mocks. This avoids
- * classpath issues with {@code LogPreservingThreadFactory} in
- * {@link SFlowUdpParser} and allows the test to inject pre-parsed
- * {@code FlowMessage} / BSON bytes directly as Stage 1 output, bypassing
- * actual wire-format parsing. The mock parsers act as passthrough stubs:
- * they dispatch the received {@link ByteBuf} bytes unchanged via the shared
- * {@link ThreadLocalDispatcher} so Stage 2 sees the same bytes the test
- * put into the Sink message envelope.
+ * <p>The Netflow5/Netflow9/IPFIX {@link org.opennms.netmgt.telemetry.listeners.UdpParser}
+ * beans are replaced with Mockito mocks that dispatch the received
+ * {@link ByteBuf} bytes unchanged via the shared {@link ThreadLocalDispatcher}.
+ * Stage 2 of {@code AbstractProtocolMessageProcessor} therefore sees the
+ * pre-encoded {@code FlowMessage} protobuf bytes the test put into the Sink
+ * message envelope, bypassing wire-format parsing.
+ *
+ * <p>{@link SFlowUdpParser} is deliberately NOT mocked — it is wired as a
+ * real Spring bean. This means the test exercises the delta-v-local
+ * {@link org.opennms.core.concurrent.LogPreservingThreadFactory} shim
+ * transitively via bean construction and {@code flowParserLifecycle} start,
+ * giving unit-test-speed coverage of a class that previously required a
+ * full container rebuild to validate. The sFlow parser sits idle during
+ * this IT because none of the tests feed raw sFlow wire bytes; its Stage 1
+ * ↔ Stage 2 BSON handoff is covered by {@code SFlowMessageProcessorTest}
+ * using a {@code FakeUdpParser}. Live sFlow verification via a real
+ * wire-format exporter is a separate followup.
  *
  * <p>Because {@link JdbcNodeInfoLookup#lookupByIpAddress(String)} always
  * returns {@code null} in this test, the enricher's per-flow logic runs but
@@ -127,13 +135,11 @@ class FlowEnrichmentStreamBinderIT {
     private static final String NF5_DESTINATION = "OpenNMS.Sink.Telemetry-Netflow-5";
     private static final String NF9_DESTINATION = "OpenNMS.Sink.Telemetry-Netflow-9";
     private static final String IPFIX_DESTINATION = "OpenNMS.Sink.Telemetry-IPFIX";
-    // SFLOW_DESTINATION intentionally absent: the real SFlowUdpParser cannot
-    // be instantiated in delta-v's classpath (see
-    // project_flow_enricher_sflow_classpath_gap.md), so sFlow is not wired
-    // into Spring and any messages on OpenNMS.Sink.Telemetry-SFlow are dropped
-    // silently by the enricher's dispatchMap lookup. Phase 2 ships without
-    // sFlow support by design; the SFlowMessageProcessor unit test uses a
-    // FakeUdpParser and remains passing in isolation.
+    // SFLOW_DESTINATION omitted because this IT does not drive raw sFlow
+    // wire bytes through the enricher. The real SFlowUdpParser bean is
+    // constructed in this context (via the LogPreservingThreadFactory shim)
+    // but sits idle; its Stage 1 ↔ Stage 2 BSON handoff is covered by
+    // SFlowMessageProcessorTest with a FakeUdpParser.
 
     @Autowired
     private InputDestination input;
@@ -151,11 +157,11 @@ class FlowEnrichmentStreamBinderIT {
     private InterfaceMarkingCache interfaceMarkingCache;
 
     /**
-     * Mock parsers replace the real horizon UdpParser beans.
+     * Mock parsers replace the real Netflow5/9/IPFIX UdpParser beans.
      * Their {@code parse()} stubs dispatch received buffer bytes unchanged
      * via {@link ThreadLocalDispatcher} so Stage 2 sees the same
-     * pre-parsed bytes the test injected (FlowMessage protobuf).
-     * sFlow is deliberately NOT mocked — it is not wired into Spring at all.
+     * pre-parsed bytes the test injected (FlowMessage protobuf). sFlow uses
+     * its real bean (see class-level javadoc for rationale).
      */
     @MockitoBean
     private Netflow5UdpParser netflow5UdpParser;


### PR DESCRIPTION
## Summary

- Re-adds `SFlowUdpParser` and `SFlowMessageProcessor` @Bean methods to `FlowEnricherConfiguration`, and maps `Telemetry-SFlow` → `sflowProcessor` in `FlowEnrichmentFunction`'s dispatch map. sFlow was unwired from production in Phase 2 Task 5/6 because `SFlowUdpParser`'s constructor references `org.opennms.core.concurrent.LogPreservingThreadFactory`, which lives in the project-banned `opennms-util` module.
- The Phase 2 Task 12 shim (commit `12f015b259f`) already satisfies that FQN via classpath shadowing — this PR confirms the hypothesis that the shim covers sFlow's direct usage (line 85 of `SFlowUdpParser.java`) as well as the Netflow parsers' `ParserBase.start()` path. No new shims needed.
- `FlowEnrichmentStreamBinderIT` now uses the **real** `SFlowUdpParser` bean (not a Mockito mock like the three Netflow parsers). This gives unit-test-speed coverage of the shim in an integration test context — a shim regression will fail `mvn test` in ~3 seconds instead of requiring a container rebuild to surface.

## What this PR does NOT do

- Does **not** add `opennms-util` as a production dependency — the shim is the point. The test-scope `opennms-util` added in Phase 2 Task 9 is unchanged.
- Does **not** add an sFlow wire-format E2E test. Live sFlow verification is a separate followup that requires an sflowtool (or equivalent) test exporter in docker-compose. Tracked in memory `project_flow_enricher_sflow_live_verification.md`.
- Does **not** touch `LogPreservingThreadFactory.java` itself.

## Test plan

- [x] `./mvnw test` in `core/flow-enricher` — **120 tests pass** (same count as Phase 2; the adjustment is wiring-only, no new test methods)
- [x] `FlowEnrichmentStreamBinderIT` (4 tests) passes with the real `SFlowUdpParser` bean, proving context startup with the shim
- [x] `SKIP_TESTS=true ./build.sh deltav` rebuild succeeds
- [x] `docker compose up -d --force-recreate --no-deps flow-enricher` — container reaches `Up (healthy)` in 28s, `FlowEnricherApplication` started in 2.98s
- [x] Log contains `Started horizon parser SFlow` alongside Netflow-5/Netflow-9/IPFIX — **no `NoClassDefFoundError`**
- [x] Kafka consumer group assigns partitions `OpenNMS.Sink.Telemetry-SFlow-0..3` to a new consumer client
- [x] `./test-flows-e2e.sh` — **15 passed / 1 failed** (same as Phase 2 baseline; the 1 failure is the pre-existing `exporter_node_id > 0` node-provisioning issue, unrelated to this PR)
- [x] 695 Netflow v9 flows ingested into `flows_raw` over 10 minutes; all 4 dimension MVs populated (`flows_by_application_1m`, `flows_by_source_ip_1m`, `flows_by_conversation_1m`, `flows_by_dscp_1m`)

## Followup

- [ ] Add sflowtool test exporter to `docker-compose.yml` and extend `test-flows-e2e.sh` to assert sFlow rows in `flows_raw` (gives us wire-format E2E coverage)
- [ ] Dropwizard → Micrometer metrics bridge for parser throughput (`project_flow_enricher_actuator_metrics_bridge.md`)