### PR TITLE
feat(e2e): add sFlow test exporter + known-failing E2E assertion

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -577,6 +577,24 @@ services:
       NETFLOW_VERSION: "9"
       TRAFFIC_INTERVAL: "5"
 
+  flow-sflow-testnode-1:
+    profiles: [full]
+    build: ./sflow-exporter
+    container_name: flow-sflow-testnode-1
+    hostname: flow-sflow-testnode-1
+    cap_add:
+      - NET_RAW
+    depends_on:
+      minion:
+        condition: service_healthy
+    environment:
+      SFLOW_COLLECTOR: minion:4729
+      # sampling=1 means sample every packet — necessary for a low-traffic
+      # test bed. polling=10 emits counter samples every 10s.
+      SAMPLING_RATE: "1"
+      POLLING_INTERVAL: "10"
+      TRAFFIC_INTERVAL: "2"
+
 volumes:
   pgdata:
   kafkadata:

--- a/opennms-container/delta-v/sflow-exporter/Dockerfile
+++ b/opennms-container/delta-v/sflow-exporter/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:12-slim
+
+# host-sflow is not packaged for Debian/Ubuntu main repositories and InMon
+# only ships amd64 .deb files. We build from source — the build is a plain
+# Makefile with minimal dependencies and finishes in ~30 seconds.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        git \
+        ca-certificates \
+        libpcap-dev \
+        iproute2 \
+        iputils-ping \
+        curl \
+        bash \
+    && git clone --depth=1 https://github.com/sflow/host-sflow.git /tmp/host-sflow \
+    && make -C /tmp/host-sflow FEATURES="PCAP" \
+    && make -C /tmp/host-sflow install \
+    && rm -rf /tmp/host-sflow \
+    && DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove \
+        build-essential clang git libpcap-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/opennms-container/delta-v/sflow-exporter/entrypoint.sh
+++ b/opennms-container/delta-v/sflow-exporter/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SFLOW_COLLECTOR="${SFLOW_COLLECTOR:-minion:4729}"
+CAPTURE_INTERFACE="${CAPTURE_INTERFACE:-eth0}"
+SAMPLING_RATE="${SAMPLING_RATE:-100}"
+POLLING_INTERVAL="${POLLING_INTERVAL:-20}"
+TRAFFIC_TARGETS="${TRAFFIC_TARGETS:-kafka postgres minion-default-01}"
+TRAFFIC_INTERVAL="${TRAFFIC_INTERVAL:-5}"
+
+SFLOW_COLLECTOR_HOST="${SFLOW_COLLECTOR%%:*}"
+SFLOW_COLLECTOR_PORT="${SFLOW_COLLECTOR##*:}"
+if [[ "$SFLOW_COLLECTOR_HOST" == "$SFLOW_COLLECTOR_PORT" ]]; then
+    SFLOW_COLLECTOR_PORT="6343"
+fi
+
+echo "[sflow-exporter] Writing /etc/hsflowd.conf..."
+cat > /etc/hsflowd.conf <<EOF
+sflow {
+  DNSSD = off
+  polling = ${POLLING_INTERVAL}
+  sampling = ${SAMPLING_RATE}
+  agent = ${CAPTURE_INTERFACE}
+  collector {
+    ip = ${SFLOW_COLLECTOR_HOST}
+    udpport = ${SFLOW_COLLECTOR_PORT}
+  }
+  pcap { dev = ${CAPTURE_INTERFACE} }
+}
+EOF
+cat /etc/hsflowd.conf
+
+echo "[sflow-exporter] Waiting for interface ${CAPTURE_INTERFACE}..."
+while ! ip link show "$CAPTURE_INTERFACE" >/dev/null 2>&1; do
+    sleep 1
+done
+
+echo "[sflow-exporter] Starting hsflowd (sFlow -> ${SFLOW_COLLECTOR_HOST}:${SFLOW_COLLECTOR_PORT})..."
+hsflowd -d -f /etc/hsflowd.conf &
+HSFLOWD_PID=$!
+
+echo "[sflow-exporter] Starting traffic generator (targets: ${TRAFFIC_TARGETS})..."
+while true; do
+    for target in $TRAFFIC_TARGETS; do
+        ping -c 1 -W 1 "$target" >/dev/null 2>&1 || true
+        curl -sf --max-time 2 "http://${target}:8080/" >/dev/null 2>&1 || true
+    done
+    if ! kill -0 "$HSFLOWD_PID" 2>/dev/null; then
+        echo "[sflow-exporter] hsflowd exited; restarting..."
+        hsflowd -d -f /etc/hsflowd.conf &
+        HSFLOWD_PID=$!
+    fi
+    sleep "$TRAFFIC_INTERVAL"
+done

--- a/opennms-container/delta-v/test-flows-e2e.sh
+++ b/opennms-container/delta-v/test-flows-e2e.sh
@@ -180,6 +180,22 @@ else
   exit 1
 fi
 
+# Per-protocol assertions. Proves each exporter's datagrams travel the full
+# Minion → Kafka → flow-enricher → ClickHouse path. The netflow_version
+# column is a String whose value comes from the FlowDocument protobuf enum
+# name (NetflowVersion.V9 → "V9", NetflowVersion.SFLOW → "SFLOW").
+for proto in V9 SFLOW; do
+  PROTO_QUERY="SELECT count() FROM deltav.flows_raw WHERE netflow_version = '${proto}' AND timestamp > now() - INTERVAL 10 MINUTE"
+  if wait_for_ch "$PROTO_QUERY" 120 "flows_raw ${proto} rows (last 10 min)" 10; then
+    PROTO_COUNT=$(ch_query "$PROTO_QUERY" 2>/dev/null || echo "0")
+    ok "flows_raw has ${PROTO_COUNT} ${proto} records in the last 10 minutes"
+  else
+    PROTO_TOTAL=$(ch_query "SELECT count() FROM deltav.flows_raw WHERE netflow_version = '${proto}'" 2>/dev/null || echo "0")
+    SEEN_VERSIONS=$(ch_query "SELECT DISTINCT netflow_version FROM deltav.flows_raw WHERE timestamp > now() - INTERVAL 10 MINUTE" 2>/dev/null | tr '\n' ',' || echo "")
+    fail "No recent ${proto} rows in flows_raw within 120s (total ${proto} rows: ${PROTO_TOTAL}, versions seen recently: ${SEEN_VERSIONS:-none})"
+  fi
+done
+
 # ══════════════════════════════════════════════════════════════════
 # Phase 3: Dimension materialized views have data
 # ══════════════════════════════════════════════════════════════════
@@ -242,7 +258,8 @@ echo "========================================"
 echo ""
 echo "Validated:"
 echo "  Phase 1: ClickHouse healthy + all DDL tables exist"
-echo "  Phase 2: flows_raw receiving data (Telemetryd → flow-enricher → ClickHouse)"
+echo "  Phase 2: flows_raw receiving data (Minion → flow-enricher → ClickHouse)"
+echo "  Phase 2: Per-protocol rows (Netflow v9 from softflowd, sFlow from hsflowd)"
 echo "  Phase 3: All 4 dimension MVs populated (application, source_ip, conversation, dscp)"
 echo "  Phase 4: Enrichment integrity (exporter_node_id, src_address)"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- New `opennms-container/delta-v/sflow-exporter/` service that builds hsflowd from source on `debian:12-slim`, writes `/etc/hsflowd.conf` from env vars, and generates ping/curl traffic so hsflowd has packets to sample.
- New `flow-sflow-testnode-1` compose service mirroring `flow-default-testnode-1`, but pointed at `minion:4729` as an sFlow collector (same port shared with Netflow v5/v9/IPFIX — delta-v Minion's `FlowUdpListener` discriminates by datagram content via `FlowProtocol.detect()`).
- `test-flows-e2e.sh` Phase 2 now runs a per-protocol assertion loop over `V9` and `SFLOW`, filtering `deltav.flows_raw` by `netflow_version`. The literal `'SFLOW'` matches the `FlowDocument.NetflowVersion.SFLOW` protobuf enum name that ClickHouse's `ProtobufSingle` deserializer writes through to the `LowCardinality(String)` column.

## The hsflowd build

Neither Alpine 3.21 nor Debian/Ubuntu main ship `host-sflow`. InMon publishes `.deb` files but only for `amd64`, so on aarch64 we have to build from source. The Dockerfile installs `build-essential clang git ca-certificates libpcap-dev`, clones `github.com/sflow/host-sflow` default branch, runs `make FEATURES=PCAP install`, and purges the build tools afterward. Build takes ~20 s. Final image ~160 MB.

The Makefile hardcodes `clang` (not `$(CC)`) for the mod_json compile step, which is why `clang` is in the build deps alongside `build-essential`.

## Why `sampling=1`

Default hsflowd sampling rate is 100 (1-in-100 packets). The test bed's traffic generator is ~1 pps (one ping + one curl per target every 2 s across 3 targets). At sampling=100 that's roughly one packet sample every 500 s — way outside our 120 s assertion timeout. `sampling=1` samples every packet, which produces meaningful datagram volume in the first 10-20 s. Counter polling is at 10 s for the same reason.

## Known-failing sFlow assertion (expected)

The sFlow assertion in `test-flows-e2e.sh` is **expected to FAIL** in this PR. The assertion is committed strict (not marked non-fatal) so it is a loud signal until the bug below is fixed.

**End-to-end observations on the current stack:**

| Stage | Netflow v9 | sFlow |
|---|---|---|
| Minion UDP 4729 bind | ✅ | ✅ |
| Minion → `OpenNMS.Sink.Telemetry-*` Kafka | ✅ (~1800 msgs) | ✅ (~300 msgs over a few min) |
| flow-enricher consumes (lag = 0) | ✅ | ✅ |
| `deltav.flows_raw` rows (last 10 min) | ~700 rows | **0 rows** |

The sFlow Kafka messages are consumed (consumer offsets advance, lag = 0), but **zero rows appear in `deltav.flows_raw` with `netflow_version = 'SFLOW'`**, and there are no corresponding `WARN`/`ERROR` lines in the flow-enricher logs for the sFlow path. It is a silent drop — not a parse failure that logs, just messages going in and nothing coming out.

**What the flow-enricher logs _do_ show** — and what this PR surfaces as a secondary finding — is an intermittent Netflow9 parser bug unrelated to sFlow:

\`\`\`
WARN  d.f.e.p.AbstractProtocolMessageProcessor : Parser Netflow9UdpParser failed on message log (1 entries, sourceAddr=172.18.0.21):
  Cannot invoke \"org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage.getBuffer()\" because \"msg\" is null
java.lang.NullPointerException: Cannot invoke \"...TelemetryMessage.getBuffer()\" because \"msg\" is null
    at org.deltav.flows.enricher.protocol.AbstractProtocolMessageProcessor.synthesizeParsedLog(AbstractProtocolMessageProcessor.java:204)
    at org.deltav.flows.enricher.protocol.AbstractProtocolMessageProcessor.runParser(AbstractProtocolMessageProcessor.java:176)
    at org.deltav.flows.enricher.protocol.AbstractProtocolMessageProcessor.process(AbstractProtocolMessageProcessor.java:114)
    at org.deltav.flows.enricher.FlowEnrichmentFunction.processMessage(FlowEnrichmentFunction.java:171)
\`\`\`

`172.18.0.21` is `flow-default-testnode-1` (softflowd Netflow v9), so this is a **Netflow v9 bug**, not a sFlow bug. It fires intermittently but Netflow v9 is still producing hundreds of rows per minute, so not all batches hit the NPE path. Worth investigating in a separate PR.

Also seen earlier:
\`\`\`
java.util.concurrent.CompletionException: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
  Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
\`\`\`
— also from Netflow9 parser threads (thread names like `[flow-9-Thread-*]`).

Neither exception is on the sFlow path. The sFlow path is **entirely silent**, which is the real puzzle for followup work:
- Does `SFlowUdpParser.parse()` accept hsflowd's datagrams and return zero samples?
- Does `SFlowAdapter` see samples but emit zero `FlowDocument`s (counter-only samples instead of flow samples)?
- Does the horizon sFlow parser even look at BSON-vs-XDR wire format the same way hsflowd emits it?

`FlowEnrichmentStreamBinderIT` uses the real `SFlowUdpParser` but feeds it pre-canned bytes — it doesn't exercise the full hsflowd-generated wire format. This PR is the first time the live path has been hit, and it's the first time the gap has become visible.

## Session-side finding: stale daemon JARs in rebuilt Docker images

During this session I discovered that the running Minion container contained a `daemon-boot-minion.jar` with `.class` mtimes from **April 9**, even though the image itself was rebuilt **April 13** at 13:17. `build.sh deltav` blindly copies whatever is in `core/daemon-boot-*/target/` into the Docker image, and the local `target/` had never been rebuilt after PR #148 merged the `TelemetryListenerConfiguration` / `FlowUdpListener` code. This is the recurring stale-JAR pattern captured in the `feedback_rebuild_all_daemons.md` memory. The fix this session was:

1. `rm -rf ~/.m2/repository/org/deltav/core/org.opennms.core.daemon-boot-*`
2. `./mvnw -DskipTests -pl core/daemon-boot-{all 13} -am install` (15 s)
3. `./build.sh deltav` (restages fresh JARs)
4. `docker compose --profile full up -d` (recreates containers)

**Suggested followup (not in this PR):** make `build.sh deltav` self-healing by adding a pre-step that runs `./mvnw -pl core/daemon-boot-* -am install` whenever any `target/*.jar` is older than any `.java` under the corresponding module's `src/main/`. That would close this failure mode permanently without requiring every developer to remember a new command.

## Test plan

- [x] `docker compose --profile full build flow-sflow-testnode-1` builds the hsflowd image cleanly
- [x] `docker compose up -d flow-sflow-testnode-1` — hsflowd runs (PID 10 inside the container), emits both counter and packet samples to `minion:4729`
- [x] Minion logs `Flow telemetry listener started on *:4729 (protocols: Netflow-5, Netflow-9, IPFIX, sFlow)` at phase 400
- [x] `/proc/net/udp6` in the Minion container shows `:1279` bound
- [x] `OpenNMS.Sink.Telemetry-SFlow` partitions accumulate messages and the `deltav-flow-enricher` consumer group reaches lag = 0 on them
- [x] Netflow v9 continues to flow through to `deltav.flows_raw` at ~70 rows/min
- [ ] **sFlow rows appear in `deltav.flows_raw` with `netflow_version = 'SFLOW'`** ← blocked on the flow-enricher silent-drop bug
- [ ] `./test-flows-e2e.sh` passes end-to-end ← will pass on the V9 half, fail on the sFlow half until the bug above is fixed