### PR TITLE
fix(build): self-heal stale daemon-boot JARs before staging images

### DIFF
--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -29,6 +29,64 @@ VERSION="$(cd "$REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version 
 log() { echo "==> $*"; }
 err() { echo "ERROR: $*" >&2; exit 1; }
 
+# Detect daemon-boot modules whose source is newer than their target JAR and
+# rebuild them in-place. Guards against the "stale JAR" failure mode where
+# `do_deltav_images` stages a weeks-old JAR into a freshly-built Docker image,
+# producing an image with a recent mtime but stale class files inside.
+# A single mtime comparison per module is much cheaper than a blind rebuild.
+check_daemon_boot_freshness() {
+    log "Checking daemon-boot JAR freshness..."
+    local stale_modules=()
+    local module_dir module_name jar candidate src_dir pom
+
+    for module_dir in "$REPO_ROOT"/core/daemon-boot-*/; do
+        module_name=$(basename "${module_dir%/}")
+        src_dir="${module_dir%/}/src/main"
+        pom="${module_dir%/}/pom.xml"
+
+        # Look for the Spring Boot fat jar, excluding the -sources / -javadoc /
+        # .original siblings that live alongside it after `mvn package`.
+        jar=""
+        for candidate in "${module_dir%/}"/target/org.opennms.core."${module_name}"-*.jar; do
+            case "$candidate" in
+                *-sources.jar|*-javadoc.jar|*.original) continue ;;
+            esac
+            if [ -f "$candidate" ]; then
+                jar="$candidate"
+                break
+            fi
+        done
+
+        if [ -z "$jar" ]; then
+            log "  stale: core/$module_name (no target JAR)"
+            stale_modules+=("core/$module_name")
+            continue
+        fi
+
+        # If any .java under src/main/ or the pom.xml is newer than the JAR,
+        # the module needs a rebuild. find -newer is portable across macOS
+        # BSD find and GNU find.
+        if [ -n "$(find "$src_dir" "$pom" -newer "$jar" -print 2>/dev/null)" ]; then
+            log "  stale: core/$module_name (source newer than $(basename "$jar"))"
+            stale_modules+=("core/$module_name")
+        fi
+    done
+
+    if [ ${#stale_modules[@]} -eq 0 ]; then
+        log "All daemon-boot JARs are up-to-date"
+        return
+    fi
+
+    log "Rebuilding ${#stale_modules[@]} stale daemon-boot module(s)..."
+    local pl_args
+    pl_args=$(IFS=,; echo "${stale_modules[*]}")
+    local test_flag=""
+    [ "$SKIP_TESTS" = "true" ] && test_flag="-DskipTests"
+    ( cd "$REPO_ROOT" && ./mvnw -B $test_flag -pl "$pl_args" -am install ) \
+        || err "Failed to rebuild stale daemon-boot modules"
+    log "Stale modules rebuilt"
+}
+
 check_prereqs() {
     command -v docker >/dev/null 2>&1 || err "docker not found"
     command -v ./mvnw >/dev/null 2>&1 || true  # Maven wrapper
@@ -110,6 +168,13 @@ do_deltav_images() {
     if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
         err "opennms/jre-deltav:21 not found — run './build.sh jre' first"
     fi
+
+    # Phase 0: Self-heal stale daemon-boot JARs before staging. If any
+    # module's source files are newer than its target JAR, `do_deltav_images`
+    # would otherwise stage the stale JAR into the new image, producing a
+    # container with fresh mtime but outdated class files. Rebuild the stale
+    # modules in-place so the images carry current code.
+    check_daemon_boot_freshness
 
     # Phase 1: Extract and deduplicate
     "$SCRIPT_DIR/compute-shared-libs.sh" "$REPO_ROOT" "$VERSION"


### PR DESCRIPTION
## Summary

- Adds `check_daemon_boot_freshness()` as Phase 0 of `do_deltav_images` in `opennms-container/delta-v/build.sh`.
- Walks every `core/daemon-boot-*/` module, finds its Spring Boot fat JAR under `target/`, and compares mtime against every `.java` under `src/main/` plus `pom.xml`.
- Any module with source newer than its packaged JAR (or with no JAR at all) gets rebuilt in-place via `./mvnw -pl ... -am install` before the rest of `do_deltav_images` runs.
- When everything is fresh, the check prints one line and moves on — the happy path cost is a handful of `find` invocations (tens of milliseconds on my machine).

## Why

Discovered in PR #153 while working on the sFlow test exporter. The running Minion container had a `daemon-boot-minion.jar` with an mtime of `2026-04-13 13:17` (today's `build.sh` run) but `.class` files inside dated `2026-04-09`. The class set was four days stale: `TelemetryListenerConfiguration`, `FlowUdpListener`, `FlowSinkModule`, and `FlowProtocol` (merged in PR #148 on 2026-04-12) were entirely absent. As a result, sFlow datagrams sent to `minion:4729` hit a Minion with no UDP listener and were dropped silently.

The root cause: `build.sh deltav` stages `core/daemon-boot-*/target/*.jar` into the Docker images verbatim. When the local `target/` has been sitting untouched since the last compile, `build.sh` happily ships those stale JARs inside an otherwise-current image. The image's `docker images` timestamp says "built today" but the class files inside say otherwise — a misleading pairing that's hard to diagnose without unpacking the JAR.

The `feedback_rebuild_all_daemons.md` auto-memory note calls this out ("Always rebuild ALL 12 daemon boot JARs before `build.sh deltav`"), but it's a rule you have to remember rather than something the tooling enforces. This PR moves the enforcement into `build.sh` itself so the failure mode can't repeat.

## How

`check_daemon_boot_freshness()` is purely a Bash function — no new dependencies.

1. Glob `core/daemon-boot-*/`, capturing every module including `daemon-boot-minion-common`.
2. For each module, find the Spring Boot fat JAR under `target/` (filtering out `-sources.jar`, `-javadoc.jar`, and `.original` siblings).
3. If no JAR exists → stale.
4. Otherwise: `find "$src_dir" "$pom" -newer "$jar" -print` and check for any output. `-newer` is POSIX-compliant and works identically on BSD find (macOS) and GNU find (Linux).
5. Collect all stale modules, join them into a comma-separated `-pl` list, and call `./mvnw -B -DskipTests -pl <list> -am install`. `-am` pulls in upstream dependencies automatically (e.g., `daemon-boot-minion-common` when `daemon-boot-minion` is stale).
6. Fail loudly via `err` if the rebuild itself fails — better to halt than to ship half-stale images.

## Tradeoffs

- **False negatives when mvn was run partially:** If someone ran `mvn compile` without `mvn package`, the `target/classes/*.class` files would be newer than the `target/*.jar` but the check still sees fresh `.jar` vs older `.java` and skips. This is a niche workflow — `./mvnw install` always packages. Not worth the complexity of comparing against `target/classes/` too.
- **pom.xml bumps trigger a full rebuild:** Editing any daemon-boot pom.xml will mark the module stale. That's correct — pom changes can materially affect the fat JAR.
- **Doesn't cover `flow-enricher` or `db-init`:** Both already call `./mvnw -f core/flow-enricher/pom.xml package` inside their respective `do_*_image` helpers, so they're immune to the stale-target problem. The check intentionally scopes to `daemon-boot-*` only.

## Test plan

- [x] `bash -n build.sh` — syntax clean
- [x] Baseline: run `check_daemon_boot_freshness` against the current working tree → prints `All daemon-boot JARs are up-to-date` and returns
- [x] Touch `core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowUdpListener.java` → detector reports `stale: core/daemon-boot-minion (source newer than org.opennms.core.daemon-boot-minion-0.0.1-SNAPSHOT.jar)` and kicks off `./mvnw -pl core/daemon-boot-minion -am install` (4 s)
- [x] Re-run after the rebuild → back to `All daemon-boot JARs are up-to-date`
- [ ] Human review: is there any daemon-boot module I should *not* auto-rebuild (e.g., something with a custom build step)?