### PR TITLE
fix(flow-enricher): make CapturingDispatcher thread-safe — eliminate Netflow9 NPE/AIOOBE

### DIFF
--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/CapturingDispatcher.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/CapturingDispatcher.java
@@ -17,8 +17,8 @@
 package org.deltav.flows.enricher.parser;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
@@ -30,12 +30,32 @@ import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
  * capture sink for horizon {@link org.opennms.netmgt.telemetry.listeners.UdpParser}
  * instances during the flow-enricher's Stage 1 parse step.
  *
- * <p><strong>This class is NOT thread-safe.</strong> A fresh instance must be
- * created per {@code process()} call and installed into the singleton
- * {@link ThreadLocalDispatcher}. Sharing one instance across concurrent
- * threads or across sequential calls on the same thread will mix flows from
- * different exporters, which is a correctness bug the Stage 1 error-handling
- * contract explicitly forbids.
+ * <p><strong>Thread-safety:</strong> {@link #send} is safe to call concurrently
+ * from multiple threads. Horizon's {@code Netflow9UdpParser} (and the rest of
+ * its {@code ParserBase} family) dispatches flow records on an internal
+ * {@code ThreadPoolExecutor}, so a single batch parse can spread its
+ * {@code dispatcher.send(...)} calls across many worker threads. The earlier
+ * implementation used a plain {@link ArrayList} without synchronisation, which
+ * is fine in single-threaded sFlow tests but raced under concurrent Netflow9
+ * dispatches: {@code ArrayList.add} occasionally threw
+ * {@code ArrayIndexOutOfBoundsException} on capacity expansion and even more
+ * often produced a {@code null} entry that bombed downstream iteration in
+ * {@code AbstractProtocolMessageProcessor.synthesizeParsedLog} with an NPE on
+ * {@code msg.getBuffer()}. This implementation guards both {@link #send} and
+ * {@link #getCaptured} with synchronisation on the captured list.
+ *
+ * <p>Each call to {@link #getCaptured} returns an immutable defensive copy
+ * snapshot rather than a wrapper, so callers can iterate without any
+ * additional locking even if a parser thread is still dispatching after the
+ * snapshot is taken (which should not happen in production because the
+ * processor calls {@code parser.parse(...).join()} before reading captures,
+ * but defensive snapshots keep the contract simple).
+ *
+ * <p>One {@link CapturingDispatcher} instance is still created per
+ * {@code process()} call and installed into the singleton
+ * {@link ThreadLocalDispatcher}. Sharing one instance across sequential calls
+ * would mix flows from different exporters, which is a correctness bug the
+ * Stage 1 error-handling contract explicitly forbids.
  */
 public class CapturingDispatcher implements AsyncDispatcher<TelemetryMessage> {
 
@@ -43,13 +63,18 @@ public class CapturingDispatcher implements AsyncDispatcher<TelemetryMessage> {
 
     @Override
     public CompletableFuture<DispatchStatus> send(TelemetryMessage message) {
-        captured.add(message);
+        Objects.requireNonNull(message, "message");
+        synchronized (captured) {
+            captured.add(message);
+        }
         return CompletableFuture.completedFuture(DispatchStatus.DISPATCHED);
     }
 
     @Override
     public int getQueueSize() {
-        return captured.size();
+        synchronized (captured) {
+            return captured.size();
+        }
     }
 
     @Override
@@ -58,10 +83,14 @@ public class CapturingDispatcher implements AsyncDispatcher<TelemetryMessage> {
     }
 
     /**
-     * Returns an unmodifiable view of the messages dispatched to this
-     * instance since it was created. Order matches dispatch order.
+     * Returns an immutable snapshot of the messages dispatched to this
+     * instance since it was created. The returned list is a defensive copy:
+     * subsequent {@link #send} calls do not mutate it, and callers can
+     * iterate it without external locking.
      */
     public List<TelemetryMessage> getCaptured() {
-        return Collections.unmodifiableList(captured);
+        synchronized (captured) {
+            return List.copyOf(captured);
+        }
     }
 }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/CapturingDispatcherTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/CapturingDispatcherTest.java
@@ -21,9 +21,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.opennms.core.ipc.sink.api.AsyncDispatcher.DispatchStatus;
 import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
 
@@ -83,5 +89,92 @@ class CapturingDispatcherTest {
         dispatcher.close();
         // After close, the captured list is still accessible
         assertThat(dispatcher.getCaptured()).hasSize(1);
+    }
+
+    @Test
+    void sendRejectsNullMessage() {
+        CapturingDispatcher dispatcher = new CapturingDispatcher();
+        assertThatThrownBy(() -> dispatcher.send(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("message");
+    }
+
+    /**
+     * Stress test for the thread-safety contract documented on
+     * {@link CapturingDispatcher}. Reproduces the production race observed on
+     * the Netflow9 path: horizon's {@code Netflow9UdpParser} dispatches flow
+     * records on an internal thread pool, so a single batch parse fans
+     * {@code dispatcher.send(...)} calls across many worker threads. The
+     * earlier {@link java.util.ArrayList}-backed implementation either threw
+     * {@code ArrayIndexOutOfBoundsException} on capacity expansion or left
+     * {@code null} slots that downstream iteration tripped over with NPE in
+     * {@code AbstractProtocolMessageProcessor.synthesizeParsedLog}. With the
+     * synchronised implementation, all messages must be captured and every
+     * captured slot must be non-null. A {@link CountDownLatch} fires every
+     * worker simultaneously to maximise contention.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void concurrentSendsAreThreadSafe() throws Exception {
+        final int threadCount = 16;
+        final int sendsPerThread = 2_000;
+        final int totalSends = threadCount * sendsPerThread;
+
+        CapturingDispatcher dispatcher = new CapturingDispatcher();
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            final int threadIndex = t;
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < sendsPerThread; i++) {
+                        TelemetryMessage msg = new TelemetryMessage(
+                                new InetSocketAddress("10.0." + threadIndex + "." + (i & 0xff), 1234),
+                                ByteBuffer.wrap(new byte[]{(byte) threadIndex, (byte) i}));
+                        dispatcher.send(msg);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        boolean finished = done.await(20, TimeUnit.SECONDS);
+        pool.shutdown();
+        assertThat(finished).as("all worker threads completed within 20s").isTrue();
+
+        List<TelemetryMessage> captured = dispatcher.getCaptured();
+        assertThat(captured)
+                .as("every send() call must produce exactly one captured entry")
+                .hasSize(totalSends);
+        assertThat(captured)
+                .as("no captured slot should be null — that was the production bug signature")
+                .doesNotContainNull();
+        assertThat(dispatcher.getQueueSize())
+                .as("getQueueSize() must agree with getCaptured().size() under concurrency")
+                .isEqualTo(totalSends);
+    }
+
+    @Test
+    void getCapturedReturnsImmutableSnapshot() {
+        CapturingDispatcher dispatcher = new CapturingDispatcher();
+        dispatcher.send(new TelemetryMessage(
+                new InetSocketAddress("10.0.0.1", 1234),
+                ByteBuffer.wrap(new byte[]{1})));
+
+        List<TelemetryMessage> snapshot = dispatcher.getCaptured();
+        // Subsequent sends must NOT mutate the snapshot the caller already holds.
+        dispatcher.send(new TelemetryMessage(
+                new InetSocketAddress("10.0.0.2", 5678),
+                ByteBuffer.wrap(new byte[]{2})));
+
+        assertThat(snapshot).hasSize(1);
+        assertThat(dispatcher.getCaptured()).hasSize(2);
     }
 }


### PR DESCRIPTION
## Summary

Two intermittent flow-enricher exceptions on the **Netflow9** path — a `java.util.ArrayList.add` `ArrayIndexOutOfBoundsException` and a downstream `NullPointerException` at `AbstractProtocolMessageProcessor.synthesizeParsedLog:204` — share one root cause: `CapturingDispatcher.captured` was a plain `ArrayList`, but horizon's `Netflow9UdpParser` dispatches flow records on its internal `ParserBase` `ThreadPoolExecutor` so a single batch parse fans `dispatcher.send(...)` calls across many worker threads.

This PR makes `CapturingDispatcher` thread-safe and adds stress test coverage.

## The two failure modes

Both observed in the live `delta-v-flow-enricher` container.

### Mode 1 — AIOOBE on capacity expansion
```
java.util.concurrent.CompletionException:
  java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
    at java.base/java.util.ArrayList.add(...)
    at org.deltav.flows.enricher.parser.CapturingDispatcher.send(CapturingDispatcher.java:46)
    at org.deltav.flows.enricher.parser.ThreadLocalDispatcher.send(...)
    at org.opennms.netmgt.telemetry.protocols.netflow.parser.ParserBase.lambda\$transmit\$6(ParserBase.java:345)
```
Two threads race the `ArrayList` capacity expansion. The size pointer increments past capacity before the array is replaced, and the next thread tries to write at an index the backing array does not have.

### Mode 2 — NPE on iteration
```
java.lang.NullPointerException: Cannot invoke "...TelemetryMessage.getBuffer()" because "msg" is null
  at org.deltav.flows.enricher.protocol.AbstractProtocolMessageProcessor.synthesizeParsedLog(AbstractProtocolMessageProcessor.java:204)
```
A partially completed concurrent `add` leaves a `null` slot in the array. Subsequent iteration via `for (TelemetryMessage msg : captured)` returns `null`, and `msg.getBuffer()` NPEs. This is the secondary work item from PR #155's session prompt.

## Fix

- `CapturingDispatcher.send` and `getQueueSize` and `getCaptured` are now synchronised on the `captured` list.
- `send` rejects `null` messages with `Objects.requireNonNull` so a future caller bug surfaces loudly instead of silently corrupting downstream iteration.
- `getCaptured` returns an immutable defensive snapshot via `List.copyOf` so callers can iterate without external locking. (In production, `processor` calls `parser.parse(...).join()` before reading captures, but the defensive snapshot keeps the contract simple regardless.)
- Updated class javadoc to document the new thread-safety contract and the production race that motivated the change.

## Regression coverage

`CapturingDispatcherTest.concurrentSendsAreThreadSafe`:
- Spawns **16 worker threads**, each calling `send()` **2 000 times** (**32 000 total** dispatches) gated by a `CountDownLatch` to maximise contention.
- Asserts: `getCaptured().size() == 32 000`, `doesNotContainNull()`, and `getQueueSize() == 32 000`.
- `@Timeout(30s)` so an infinite hang fails fast.

Reliably reproduces both Mode 1 and Mode 2 against the unsynchronised `ArrayList` (verified locally by toggling the `synchronized` blocks off). Passes against the synchronised implementation.

Two additional new tests cover the null-rejection contract (`sendRejectsNullMessage`) and the immutable-snapshot contract (`getCapturedReturnsImmutableSnapshot`).

## Test plan

- [x] `./mvnw -pl core/flow-enricher test` — 123 tests, 0 failures (was 121 before; +2 because three new CD tests minus one less SFlow test on this branch base)
- [x] `CapturingDispatcherTest.concurrentSendsAreThreadSafe` reproduces and fixes both failure modes
- [x] Existing four `CapturingDispatcherTest` tests still pass
- [ ] Live verification: rebuild flow-enricher, restart container, monitor logs for the AIOOBE/NPE — should be silent