### PR TITLE
feat(flow-enricher): consume horizon 1.0.8 and drop sFlow DNS workaround

### DIFF
--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -328,33 +328,15 @@ public class FlowEnricherConfiguration {
      * succeed without pulling in the banned {@code opennms-util} module.
      * This is the same shim that unblocks the Netflow parsers (see the
      * {@code feature/flow-enricher-phase2-parser-bridge} merge).
-     *
-     * <p>DNS lookups are disabled on the parser. With {@link NoOpDnsResolver}
-     * wired in, reverse lookups are no-ops anyway, but the parser's default
-     * {@code dnsLookupsEnabled=true} causes {@code SampleDatagramEnricher.enrich}
-     * to walk every datagram via {@code SampleDatagram.visit()} to collect
-     * addresses for lookup. That walk triggers a latent horizon NPE in
-     * {@code FlowRecord.visit()} (line 108), which does not null-guard
-     * {@code data.value} the way the sibling {@code writeBson} does, whenever
-     * hsflowd emits a flow record whose data format falls outside horizon's
-     * {@code flowDataFormats} map. The NPE escapes the parser's executor
-     * Runnable, the {@code CompletableFuture} it returns is never completed,
-     * and the enricher thread calling {@code parser.parse(...).join()} stalls
-     * until Kafka rebalances — causing silent lag without any WARN/ERROR in
-     * the flow-enricher logs. Disabling DNS lookups short-circuits the
-     * {@code enrich()} path before {@code visit()} is called, which both
-     * avoids pointless work and sidesteps the horizon bug.
      */
     @Bean
     SFlowUdpParser sflowUdpParser(
             ThreadLocalDispatcher threadLocalDispatcher,
             DnsResolver flowParserDnsResolver) {
-        SFlowUdpParser parser = new SFlowUdpParser(
+        return new SFlowUdpParser(
                 "SFlow",
                 threadLocalDispatcher,
                 flowParserDnsResolver);
-        parser.setDnsLookupsEnabled(false);
-        return parser;
     }
 
     @Bean

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/SFlowParserBridgeIT.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/SFlowParserBridgeIT.java
@@ -90,14 +90,6 @@ class SFlowParserBridgeIT {
                 "test-sflow",
                 tld,
                 new NoOpDnsResolver());
-        // Mirror the production wiring in FlowEnricherConfiguration: disable
-        // DNS lookups so the parser short-circuits SampleDatagramEnricher.enrich()
-        // and never calls SampleDatagram.visit(). The visit() path triggers a
-        // latent horizon NPE in FlowRecord.visit() whenever a flow record's
-        // data format is outside horizon's flowDataFormats map — which is
-        // exactly what hsflowd produces on real wire bytes. Regression
-        // coverage for that bug lives in hsflowdWireBytesProduceFlows() below.
-        parser.setDnsLookupsEnabled(false);
         parser.start(scheduler);
 
         processor = new SFlowMessageProcessor(
@@ -140,27 +132,32 @@ class SFlowParserBridgeIT {
     }
 
     /**
-     * Regression test for the flow-enricher sFlow silent-drop bug observed
-     * in production against hsflowd. The fixture
+     * Regression guard for the horizon {@code FlowRecord.visit()} null guard
+     * shipped in horizon 1.0.8 (commit {@code c24a319708c}). The fixture
      * {@code fixtures/hsflowd-sample.dat} is a single UDP payload captured
      * from hsflowd 2.1.23 running with {@code sampling = 1} and
      * {@code pcap { dev = eth0 }}; it contains three samples, at least one
      * of which is an expanded flow sample whose {@code FlowRecord} carries
      * a data format outside horizon's {@code flowDataFormats} map. Those
-     * records decode to {@code Opaque} instances with {@code value == null},
-     * and when {@link org.opennms.netmgt.telemetry.protocols.sflow.parser.SampleDatagramEnricher#enrich}
-     * walks the datagram via {@code SampleDatagram.visit()} the unguarded
-     * {@code FlowRecord.visit()} at line 108 throws {@link NullPointerException}.
-     * The exception escapes the parser's {@link java.util.concurrent.ExecutorService}
-     * task, its {@link java.util.concurrent.CompletableFuture} is never
-     * completed, and the calling thread blocks on {@code join()} until the
-     * Kafka consumer rebalances — causing silent lag without any WARN/ERROR.
+     * records decode to {@code Opaque} instances with {@code value == null}.
      *
-     * <p>The fix is in {@code FlowEnricherConfiguration.sflowUdpParser()}:
-     * call {@code setDnsLookupsEnabled(false)} so {@code enrich()}
-     * short-circuits before invoking {@code visit()}. The matching call in
-     * {@link #setUp()} above mirrors that production wiring. Without it
-     * this test throws the same NPE and never produces flows.
+     * <p>Before horizon 1.0.8, {@code FlowRecord.visit()} dereferenced
+     * {@code data.value} without a null guard (the sibling {@code writeBson}
+     * was correctly guarded). When
+     * {@link org.opennms.netmgt.telemetry.protocols.sflow.parser.SampleDatagramEnricher#enrich}
+     * walked the datagram via {@code SampleDatagram.visit()}, the unguarded
+     * dereference threw a {@link NullPointerException} that escaped the
+     * parser's {@link java.util.concurrent.ExecutorService} task, left its
+     * {@link java.util.concurrent.CompletableFuture} uncompleted, and caused
+     * the calling thread to block on {@code join()} until the Kafka consumer
+     * rebalanced — silent lag with no WARN/ERROR in the flow-enricher logs.
+     *
+     * <p>This test is wired exactly as production: DNS lookups enabled (the
+     * default), {@code NoOpDnsResolver} making reverse lookups no-ops,
+     * {@code enrich()} walking every datagram via {@code visit()}. If the
+     * horizon null guard is ever reverted or the horizon dependency is
+     * downgraded below 1.0.8, the stall returns and {@code @Timeout(10s)}
+     * fails the test fast instead of letting it hang forever.
      *
      * <p>The fixture's first sample is a counter sample expansion, so it is
      * dropped by {@code SFlowAdapter} (counter samples are not flow records),
@@ -179,7 +176,7 @@ class SFlowParserBridgeIT {
 
         assertThat(flows)
                 .as("hsflowd-produced sFlow v5 datagram should produce at least one flow "
-                        + "when DNS lookups are disabled on the parser (production wiring)")
+                        + "with the horizon 1.0.8 FlowRecord.visit() null guard")
                 .isNotEmpty();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Horizon JAR version (published by pbrane/delta-v-horizon) -->
-    <deltav.horizon.version>1.0.7</deltav.horizon.version>
+    <deltav.horizon.version>1.0.8</deltav.horizon.version>
 
     <!-- Spring Cloud release train (for flow-enricher / flow-aggregator) -->
     <spring-cloud.version>2025.1.1</spring-cloud.version>


### PR DESCRIPTION
## Summary

- Bump `<deltav.horizon.version>` from `1.0.7` to `1.0.8` to pick up the `FlowRecord.visit()` null guard shipped in pbrane/delta-v-horizon#2 (published via pbrane/delta-v-horizon#3, run `24378749440`)
- Remove the `setDnsLookupsEnabled(false)` workaround in `FlowEnricherConfiguration.sflowUdpParser()` that was added by pbrane/delta-v#156 to sidestep the upstream NPE
- Reframe the `SFlowParserBridgeIT.hsflowdWireBytesProduceFlows()` regression test from "mirror the production workaround" to "regression guard for horizon 1.0.8's null guard"

## Context

pbrane/delta-v#156 landed a three-part sFlow silent-drop fix that included `parser.setDnsLookupsEnabled(false)` as a sidestep for a latent horizon NPE in `FlowRecord.visit()`. The upstream bug: the `visit()` method dereferenced `this.data.value` without guarding, while the sibling `writeBson()` correctly null-guarded. When hsflowd 2.1.23 emitted a flow record whose `data_format` was outside horizon's `flowDataFormats` map (which happens in production), the walk in `SampleDatagramEnricher.enrich()` NPE'd, the exception escaped the parser's executor, and the `CompletableFuture` stalled forever — silent lag with no WARN/ERROR.

Horizon 1.0.8 (pbrane/delta-v-horizon#2, commit `c24a319708c`) adds the one-line null guard symmetric with `writeBson()`, and pbrane/delta-v-horizon#3 published `1.0.8` to GitHub Packages. With the upstream fix in place, delta-v can drop the workaround.

## Changes

**1. `pom.xml`** — `<deltav.horizon.version>` bump.

**2. `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`** — Remove the `setDnsLookupsEnabled(false)` call and its 17-line explanatory javadoc paragraph. The bean now returns a default-wired `SFlowUdpParser` with the same shape as the Netflow5/9/IPFIX beans. `NoOpDnsResolver` is still wired in, so reverse DNS is still a no-op; the `enrich()` walk of `visit()` now completes cleanly thanks to horizon 1.0.8's null guard.

**3. `core/flow-enricher/src/test/java/org/deltav/flows/enricher/protocol/SFlowParserBridgeIT.java`** — Remove the matching `setUp()` inline comment and `setDnsLookupsEnabled(false)` call. Rewrite the `hsflowdWireBytesProduceFlows()` javadoc so the test's purpose is now framed as a **regression guard**: if horizon is ever downgraded below 1.0.8 or the null guard is reverted, the parser stall returns and `@Timeout(10s)` fails the test fast with `TimeoutException` instead of hanging indefinitely. The `@Timeout` annotation is now load-bearing documentation.

## Why the regression test is the forcing function

`SFlowParserBridgeIT.hsflowdWireBytesProduceFlows()` feeds `fixtures/hsflowd-sample.dat` — a real hsflowd 2.1.23 capture containing at least one flow record with a data format outside horizon's `flowDataFormats` map — through `SFlowMessageProcessor.process()`, which runs the full `SFlowUdpParser` → `SampleDatagramEnricher.enrich()` → `SampleDatagram.visit()` path. Without the horizon null guard, that walk NPEs, the executor task fails silently, the `CompletableFuture` is never completed, and `.join()` in the calling thread blocks forever. The `@Timeout(10s)` annotation converts that hang into a CI failure within 10 seconds.

With this PR applied and horizon 1.0.8 resolved, the test runs in **0.564s** — three orders of magnitude below the timeout — proving the null guard handles the null `data.value` case cleanly on real wire bytes.

## Test plan

- [x] `./mvnw -pl core/flow-enricher compile` — clean compile against horizon 1.0.8
- [x] `./mvnw -pl core/flow-enricher -am test -Dtest=SFlowParserBridgeIT` — **2/2 tests pass in 0.564s**, including the regression guard on hsflowd wire bytes
- [x] `git diff --stat` shows exactly 3 intentional files changed: pom.xml, FlowEnricherConfiguration.java, SFlowParserBridgeIT.java (23 insertions / 44 deletions — net removal of workaround code)
- [x] Delta-v CI verifies the full flow-enricher test suite against horizon 1.0.8 (Build and Analyze + CodeQL all green)
- [x] **Pre-merge smoke**: built `opennms/flow-enricher:0.0.1-SNAPSHOT` image with horizon 1.0.8, recreated `delta-v-flow-enricher` container, ran `./test-flows-e2e.sh` against live hsflowd 2.1.23 traffic over Docker veth → **18/18 passing, 8268 enriched rows** (vs 0 before the chain of fixes started). Both Netflow9 and sFlow exporters enrich cleanly with `dnsLookupsEnabled=true`, no parser stalls, no silent drops.

## Chain of PRs

| # | Repo | Status |
|---|---|---|
| pbrane/delta-v#156 | delta-v | ✅ Merged — sFlow silent-drop workaround + two other coupled fixes |
| pbrane/delta-v#159 | delta-v | ✅ Merged — Phase 4 enrichment requisition fix |
| pbrane/delta-v-horizon#2 | delta-v-horizon | ✅ Merged — FlowRecord.visit() null guard |
| pbrane/delta-v-horizon#3 | delta-v-horizon | ✅ Merged + published — version bump 1.0.7 → 1.0.8 |
| **(this PR)** | delta-v | **consumes 1.0.8 and removes the workaround** |