### PR TITLE
docs: update READMEs for flow-enricher, Spring Boot Minion, layered JAR images

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ Delta-V code lives in the `org.deltav` package namespace with `org.deltav.core` 
 | **BSMd** | `daemon-boot-bsmd` | 3.3s | JPA + AlarmLifecycleListener + REST API |
 | **Pollerd** | `daemon-boot-pollerd` | 4.1s | JPA + Kafka RPC + Twin API + PassiveStatusKeeper |
 | **PerspectivePollerd** | `daemon-boot-perspectivepollerd` | 3.6s | JPA + Kafka RPC + perspective outages + event self-consumption |
-| **Telemetryd** | `daemon-boot-telemetryd` | 3s | Pure ingestion bridge, multi-bridge KafkaSink, Twin API for OpenConfig |
+| **Telemetryd** | `daemon-boot-telemetryd` | 3s | Pure ingestion bridge for non-flow telemetry (OpenConfig via Twin API). Flow protocols (Netflow5/9, IPFIX, sFlow) bypass Telemetryd — they route Minion → Kafka Sink → flow-enricher directly. |
 | **Enlinkd** | `daemon-boot-enlinkd` | 3.5s | JPA + Kafka RPC + LLDP/CDP/OSPF/ISIS/Bridge topology |
 | **Collectd** | `daemon-boot-collectd` | ~3s | JPA + Kafka RPC + SNMP collection + thresholding |
-| **Minion** | `daemon-boot-minion` | ~4s | Kafka RPC server + Kafka Sink + Twin API subscriber |
+| **flow-enricher** | `core/flow-enricher` | ~4s | Spring Cloud Stream + horizon UDP parsers (Netflow5/9, IPFIX, sFlow) on raw wire bytes via capturing dispatcher; per-flow enrichment (`JdbcNodeInfoLookup`, application classification, locality); publishes to ClickHouse via `deltav-flows` Kafka topic. 41 `flow_enricher_*` Prometheus meters exposed via `DropwizardToPrometheusBridge`. |
+| **Minion** | `daemon-boot-minion` | ~4s | Kafka RPC server + Kafka Sink + Twin API subscriber + UDP flow listener (port 4729) |
 
 ### Docker Images
 
@@ -136,10 +137,13 @@ Minion → Kafka Sink → Trapd/Syslogd
 | enlinkd | Spring Boot 4 | Enhanced link discovery (LLDP/CDP/OSPF/ISIS/Bridge) |
 | provisiond | Spring Boot 4 | Node provisioning and scanning (via Minion Kafka RPC) |
 | bsmd | Spring Boot 4 | Business service monitoring |
-| telemetryd | Spring Boot 4 | Telemetry/flow ingestion bridge (via Minion Kafka Sink) |
-| minion | Spring Boot 4 | Distributed data collection agent (Kafka RPC + Sink + Twin API) |
+| telemetryd | Spring Boot 4 | Non-flow telemetry ingestion bridge (OpenConfig via Twin API) |
+| flow-enricher | Spring Boot 4 + Spring Cloud Stream | Flow decode via horizon UDP parsers, per-flow enrichment, publish to ClickHouse |
+| minion | Spring Boot 4 | Distributed data collection agent (Kafka RPC + Sink + Twin API + UDP flow listener) |
 | db-init | Spring Boot 4 | One-shot Liquibase schema migration |
 | postgres | postgres:15 | PostgreSQL database (alarms only) |
+| clickhouse | clickhouse/clickhouse-server | Flow storage: `deltav.flows_raw` + 4 dimension materialized views (application, source_ip, conversation, dscp) |
+| clickhouse-init | one-shot | ClickHouse DDL bootstrap for `deltav.flows_raw` and dimension MVs |
 | kafka | Apache Kafka | Event transport backbone |
 
 ### Kafka Topics
@@ -150,7 +154,8 @@ Minion → Kafka Sink → Trapd/Syslogd
 | `opennms-ipc-events` | Daemon-to-daemon internal events (newSuspect, nodeScanCompleted, reloadDaemonConfig) |
 | `OpenNMS.Sink.Trap` | Minion → Trapd raw trap forwarding |
 | `OpenNMS.Sink.Syslog` | Minion → Syslogd raw syslog forwarding |
-| `OpenNMS.Sink.Telemetry-*` | Minion → Telemetryd per-protocol flow forwarding |
+| `OpenNMS.Sink.Telemetry-*` | Minion → flow-enricher per-protocol flow forwarding (Netflow5/9, IPFIX, sFlow) |
+| `deltav-flows` | flow-enricher → ClickHouse enriched flow records (ClickHouse Kafka engine table consumes this topic) |
 | `OpenNMS.twin.response` | Pollerd → Minion Twin API state sync (passive status, SNMPv3 users) |
 | `OpenNMS.twin.request` | Minion → Pollerd Twin API subscription requests |
 
@@ -174,6 +179,7 @@ cd opennms-container/delta-v
 ./test-collectd-e2e.sh     # Collectd: SNMP collection health
 ./test-perspective-e2e.sh  # Perspective: remote-location polling + outage lifecycle
 ./test-enlinkd-e2e.sh      # Enlinkd: LLDP topology via Containerlab cEOS
+./test-flows-e2e.sh        # Flows: softflowd + hsflowd → Minion → flow-enricher → ClickHouse (18 assertions across 4 phases)
 ```
 
 ### Prerequisites

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -2,7 +2,7 @@
 
 **Composable, containerized deployment of OpenNMS Horizon.**
 
-Delta-V decomposes the monolithic OpenNMS into 16 independently scalable services connected by Kafka and PostgreSQL. Each daemon runs in its own container as a Spring Boot fat JAR, communicating via Kafka event topics. There is no core container — schema migration is handled by a one-shot db-init container, and the webapp serves only the Web UI and REST API.
+Delta-V decomposes the monolithic OpenNMS into independently scalable services connected by Kafka, PostgreSQL, and (for the flow pipeline) ClickHouse. Each daemon runs in its own container as a Spring Boot fat JAR, communicating via Kafka event topics. There is no core container and no legacy webapp — schema migration is handled by one-shot `db-init` and `clickhouse-init` containers, and operator observability lives on each daemon's Spring Boot Actuator endpoints (`/actuator/health`, `/actuator/prometheus`).
 
 ```
                     ┌──────────────────────────────────────────────────┐
@@ -50,24 +50,30 @@ With all 12 daemons on Spring Boot, the Karaf-based Sentinel image (`opennms/dae
 
 ## Services
 
-| Service          | Image                          | Purpose                                       | Host Port |
-|------------------|--------------------------------|-----------------------------------------------|-----------|
-| postgres         | postgres:15                    | Shared database                               | 5432      |
-| kafka            | apache/kafka                   | Event bus (KRaft mode)                        | 19092     |
-| db-init          | opennms/db-init                | One-shot schema migration (exits after init)  | —         |
-| minion           | opennms/minion-deltav          | Distributed data collection agent (Karaf)     | —         |
-| alarmd           | opennms/daemon-deltav-springboot | Alarm processing (Kafka consumer)           | —         |
-| pollerd          | opennms/daemon-deltav-springboot | Service polling via Minion RPC              | —         |
-| collectd         | opennms/daemon-deltav-springboot | SNMP data collection via Minion SNMP proxy  | —         |
-| discovery        | opennms/daemon-deltav-springboot | Network discovery via Minion RPC            | —         |
-| provisiond       | opennms/daemon-deltav-springboot | Node provisioning and detection             | —         |
-| trapd            | opennms/daemon-deltav-springboot | SNMP trap reception (Kafka Sink)            | —         |
-| syslogd          | opennms/daemon-deltav-springboot | Syslog reception (Kafka Sink)               | —         |
-| eventtranslator  | opennms/daemon-deltav-springboot | Event transformation rules                  | —         |
-| enlinkd          | opennms/daemon-deltav-springboot | Link discovery (CDP, LLDP, OSPF, IS-IS, Bridge) | —  |
-| bsmd             | opennms/daemon-deltav-springboot | Business Service Monitor                    | 8180      |
-| perspectivepollerd | opennms/daemon-deltav-springboot | Perspective polling from remote locations | —         |
-| telemetryd       | opennms/daemon-deltav-springboot | Telemetry ingestion bridge                  | —         |
+| Service            | Image                         | Purpose                                                                  | Host Port |
+|--------------------|-------------------------------|--------------------------------------------------------------------------|-----------|
+| postgres           | postgres:15                   | Shared database (alarms only)                                            | 5432      |
+| kafka              | apache/kafka                  | Event bus (KRaft mode)                                                   | 19092     |
+| db-init            | opennms/db-init               | One-shot PostgreSQL schema migration (exits after init)                  | —         |
+| clickhouse         | clickhouse/clickhouse-server  | Flow storage: `deltav.flows_raw` + 4 dimension MVs                       | 8123      |
+| clickhouse-init    | one-shot                      | One-shot ClickHouse DDL bootstrap                                         | —         |
+| minion             | opennms/minion-boot           | Spring Boot 4 distributed data collection agent + UDP flow listener      | 4729/udp  |
+| snmp-agent         | tandrup/netsnmp               | Local SNMP test target for Collectd / detectors                          | —         |
+| alarmd             | opennms/alarmd                | Alarm processing (Kafka consumer)                                        | —         |
+| pollerd            | opennms/pollerd               | Service polling via Minion RPC                                           | —         |
+| collectd           | opennms/collectd              | SNMP data collection via Minion SNMP proxy                               | —         |
+| discovery          | opennms/discovery             | Network discovery via Minion RPC                                         | —         |
+| provisiond         | opennms/provisiond            | Node provisioning and detection                                          | —         |
+| trapd              | opennms/trapd                 | SNMP trap reception (Kafka Sink)                                         | —         |
+| syslogd            | opennms/syslogd               | Syslog reception (Kafka Sink)                                            | —         |
+| eventtranslator    | opennms/eventtranslator       | Event transformation rules                                               | —         |
+| enlinkd            | opennms/enlinkd               | Link discovery (CDP, LLDP, OSPF, IS-IS, Bridge)                          | —         |
+| bsmd               | opennms/bsmd                  | Business Service Monitor                                                 | 8180      |
+| perspectivepollerd | opennms/perspectivepollerd    | Perspective polling from remote locations                                | —         |
+| telemetryd         | opennms/telemetryd            | Non-flow telemetry ingestion (OpenConfig via Twin API)                   | —         |
+| flow-enricher      | opennms/flow-enricher         | Flow decode (horizon UDP parsers) + enrich + publish to ClickHouse       | 8080      |
+
+All daemon containers extend a shared `opennms/daemon-base` image built on top of `opennms/jre-deltav:21` (a jlink custom JRE on `alpine:3.21`). Each per-daemon image adds only the libraries unique to that daemon via layered Docker image deduplication.
 
 ## Quick Start
 
@@ -108,7 +114,16 @@ cd opennms-container/delta-v
 ./deploy.sh test
 ```
 
-Web UI: **http://localhost:8980/opennms** (admin / admin)
+**No Web UI.** The legacy OpenNMS JSP webapp has been removed from the Maven reactor (`opennms-webapp` + `opennms-webapp-rest`). Operator observability lives on each daemon's Spring Boot Actuator:
+
+```bash
+# Per-daemon health (reachable when the daemon exposes a management port)
+curl http://localhost:8180/actuator/health       # bsmd
+docker compose exec flow-enricher wget -qO- http://localhost:8080/actuator/health
+
+# Prometheus metrics from the flow-enricher (41 flow_enricher_* meters)
+docker compose exec flow-enricher wget -qO- http://localhost:8080/actuator/prometheus | grep '^flow_enricher_'
+```
 
 ### Manage
 
@@ -126,18 +141,20 @@ Web UI: **http://localhost:8980/opennms** (admin / admin)
 
 ## E2E Tests
 
-Six end-to-end test suites validate the full pipeline:
+Nine end-to-end test suites validate the full pipeline:
 
 ```bash
 cd opennms-container/delta-v
 
-bash test-collectd-e2e.sh        # SNMP data collection via Minion
+bash test-e2e.sh                 # Full alarm create/clear via SNMP traps
 bash test-minion-e2e.sh          # Trap → Minion → Kafka → Alarmd lifecycle
-bash test-minion-rpc-e2e.sh      # Detector + Monitor via Minion RPC (Phase 3 canary)
+bash test-minion-rpc-e2e.sh      # Detector + Monitor via Minion RPC
 bash test-syslog-e2e.sh          # Syslog → Minion → Kafka → Alarmd lifecycle
 bash test-passive-e2e.sh         # Passive status via EventTranslator + Pollerd
+bash test-collectd-e2e.sh        # SNMP data collection via Minion
+bash test-perspective-e2e.sh     # Perspective polling from remote locations + outage lifecycle
 bash test-enlinkd-e2e.sh         # LLDP/CDP link discovery on Containerlab cEOS
-bash test-e2e.sh                 # Full alarm create/clear via SNMP traps
+bash test-flows-e2e.sh           # softflowd + hsflowd → Minion → flow-enricher → ClickHouse (18 assertions across 4 phases)
 ```
 
 All scripts support:


### PR DESCRIPTION
## Summary

- Update the root `README.md` and `opennms-container/delta-v/README.md` to reflect the flow-enricher microservice + ClickHouse flow pipeline, the Spring Boot 4 migration of Minion, the per-daemon layered-JAR image architecture, and the webapp removal
- 11 targeted edits across 2 files. No structural changes, no rewrites of architecture diagrams, no new sections

## Motivation

Both READMEs predate the flow-enricher Phase 1/1.5/2 work (PRs #139, #142, #149, #151, #153, #156, #157, #159, #160, #161) and the per-daemon layered-JAR image refactor. A new contributor reading either README cold would not know that:

- delta-v has a flow processing microservice (`flow-enricher`) that consumes the `OpenNMS.Sink.Telemetry-*` topics and publishes to ClickHouse
- ClickHouse is part of the stack, backing `deltav.flows_raw` and 4 dimension materialized views
- Minion runs on Spring Boot 4 (`opennms/minion-boot`), not Karaf
- Each daemon ships as its own layered image (`opennms/alarmd`, `opennms/pollerd`, etc.), not a shared `opennms/daemon-deltav-springboot` monolith
- The legacy OpenNMS JSP webapp has been removed from the Maven reactor — the ``http://localhost:8980/opennms`` URL no longer works
- `test-flows-e2e.sh` exists and validates the full flow pipeline (18 assertions across 4 phases)

## Root `README.md` — 6 edits

1. **Spring Boot 4 migration table**: add `flow-enricher` row between Collectd and Minion. Documents the capturing-dispatcher parser bridge pattern, the `JdbcNodeInfoLookup` enrichment, the `deltav-flows` Kafka output topic, and the 41 `flow_enricher_*` Prometheus meters exposed via `DropwizardToPrometheusBridge`.

2. **Telemetryd description**: previous text *"Pure ingestion bridge, multi-bridge KafkaSink, Twin API for OpenConfig"* implied Telemetryd still handles flow protocols. Updated to clarify that Netflow5/9, IPFIX, and sFlow bypass Telemetryd entirely — they route Minion → Kafka Sink → flow-enricher directly.

3. **Services table**: add `flow-enricher`, `clickhouse`, and `clickhouse-init` rows. Clickhouse description notes the `deltav.flows_raw` table and the 4 dimension MVs.

4. **Kafka topics table**: add `deltav-flows` row explaining it carries enriched flow records from flow-enricher to ClickHouse's Kafka engine table.

5. **`OpenNMS.Sink.Telemetry-*` description**: update from *"Minion → Telemetryd per-protocol flow forwarding"* to *"Minion → flow-enricher per-protocol flow forwarding (Netflow5/9, IPFIX, sFlow)"*.

6. **E2E test list**: add `test-flows-e2e.sh` — softflowd + hsflowd → Minion → flow-enricher → ClickHouse, 18 assertions across 4 phases.

## `opennms-container/delta-v/README.md` — 5 edits

1. **Lead paragraph**: dropped the stale *"16 independently scalable services"* count (actually ~20 now), added ClickHouse as a second database backend, called out the webapp removal and the shift to Spring Boot Actuator endpoints for operator observability.

2. **Services table**:
   - Added `flow-enricher`, `clickhouse`, `clickhouse-init`, `snmp-agent` rows
   - Fixed `minion` image from `opennms/minion-deltav` to `opennms/minion-boot` and dropped the *"(Karaf)"* label — the root README already correctly documents Minion as Spring Boot 4 in the `daemon-boot-minion` module
   - Fixed all 12 daemon rows from `opennms/daemon-deltav-springboot` (which never shipped) to per-daemon layered images (`opennms/alarmd`, `opennms/pollerd`, etc.) matching the actual layered Docker build
   - Added a note explaining the `opennms/daemon-base` + per-daemon overlay architecture

3. **Web UI URL**: the previous *"Web UI: http://localhost:8980/opennms (admin / admin)"* line no longer works — the `opennms-webapp` and `opennms-webapp-rest` modules have been removed from the Maven reactor (documented in the root README's "Other Components Removed" section). Replaced with concrete `curl` examples for Actuator `/actuator/health` and the flow-enricher's `/actuator/prometheus` endpoint (which now exposes 41 `flow_enricher_*` meters after PR #161).

4. **E2E tests**: the section header said *"Six end-to-end test suites"* but the body listed seven scripts, and both `test-flows-e2e.sh` and `test-perspective-e2e.sh` were missing from the body. Fixed the count to *"Nine"* (matching the 9 actual `test-*.sh` scripts on disk) and added both missing entries.

## Out of scope

- No changes to `tools/local_development/README.md` — grepped for my staleness markers (`1.0.7`, `FlowEnricherMicrometerBridge`, `setDnsLookupsEnabled`, old daemon image names); no hits.
- No changes to `opennms-container/README.md` — legacy container-build instructions unrelated to flow processing.
- No changes to `CLAUDE.md` — actively maintained during sessions; current content is correct.
- No changes to session planning docs under `docs/plans/` and `docs/superpowers/` — those are historical records, not public-facing docs.

## Test plan

- [x] `git diff --stat` — exactly 2 files changed, 52 insertions, 29 deletions. No accidental requisition last-import drift committed.
- [x] Visual review of both READMEs — no broken Markdown tables, no broken links, no stale cross-references.
- [x] Cross-checked service list against `opennms-container/delta-v/docker-compose.yml` — all 20 top-level services match the updated container README.
- [x] Cross-checked E2E test list against `ls test-*.sh` — 9 scripts, all present in the updated container README.
- [ ] CI: docs-only PR, no build impact; CodeQL and Build-and-Analyze should complete without issue.