### PR TITLE
chore(ci): rename release tag convention from delta-v-* to v*

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -3,7 +3,7 @@
 # Builds all Delta-V Docker images (16 total) and pushes them to GitHub
 # Container Registry (GHCR) as multi-arch images (linux/amd64 + linux/arm64).
 #
-# Trigger: Push a tag matching 'delta-v-*' (e.g., delta-v-1.0.0)
+# Trigger: Push a tag matching 'v*' (e.g., v1.1.0)
 #          or run manually via workflow_dispatch.
 #
 # Images built:
@@ -51,7 +51,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'delta-v-*'
+      - 'v*'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/delta-v-release.yml
+++ b/.github/workflows/delta-v-release.yml
@@ -1,11 +1,11 @@
 name: Delta-V Release
 
-# Triggered by pushing tags like 'delta-v-1.0.0'
+# Triggered by pushing tags like 'v1.1.0'
 # Only repo owners can push tags, so GITHUB_REF_NAME is trusted input.
 on:
   push:
     tags:
-      - 'delta-v-*'
+      - 'v*'
 
 env:
   DOCKER_ORG: pbranestrategy
@@ -35,7 +35,7 @@ jobs:
           VERSION=$(.circleci/scripts/pom2version.sh pom.xml)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           # Tag name is safe — only repo owners can push tags
-          TAG_VERSION="${GITHUB_REF_NAME#delta-v-}"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
           echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary
Rename the delta-v release tag convention from \`delta-v-*\` to standard \`v*\` (e.g. \`delta-v-1.0.1\` -> \`v1.1.0\`). Updates both CI workflows that trigger on release tags.

## Motivation
- Standard convention across the broader ecosystem; cleaner image tags and \`git describe\` output.
- The \`delta-v-\` prefix was originally needed to disambiguate from fork-inherited upstream tags (\`opennms-35.x.y\`, \`meridian-foundation-*\`). Both of those use different prefixes entirely; \`v*\` does not collide with them either.
- Contributor feedback: the existing convention reads redundant (repo is already delta-v).

## Changes

### \`.github/workflows/delta-v-release.yml\`
- Trigger pattern: \`'delta-v-*'\` -> \`'v*'\`
- TAG_VERSION extraction: \`\${GITHUB_REF_NAME#delta-v-}\` -> \`\${GITHUB_REF_NAME#v}\` (strips the new prefix so Docker image tags like \`horizon:1.1.0\` remain correct)
- Doc comment updated to reference \`v1.1.0\` as the example tag

### \`.github/workflows/delta-v-build-images.yml\`
- Trigger pattern: \`'delta-v-*'\` -> \`'v*'\`
- Doc comment updated to reference \`v1.1.0\`
- **No internal logic changes needed** — this workflow extracts \`VERSION\` from \`pom.xml\` via \`mvnw help:evaluate\`, not from the tag name. Image tags are unaffected by the rename.

## Historical tags
The existing \`delta-v-1.0.0\` and \`delta-v-1.0.1\` tags stay put as archaeology. They are not retagged. The next release tag after this merge will be \`v1.1.0\`, marking Phase 2 complete (flow-enricher parser rework, ClickHouse persistence, Minion Boot4 telemetry listener, events.api classpath cleanup, 724 commits since 1.0.1).

## Test plan
- [x] Two-file diff reviewed; changes scoped to trigger patterns + one prefix strip + two doc comments
- [ ] Reviewer: confirm no other scripts or docs reference the \`delta-v-*\` tag pattern (I grepped and found none outside these two workflows, but a second set of eyes is good)
- [ ] After merge: push \`v1.1.0\` tag to verify both workflows fire under the new convention