### PR TITLE
feat(collectd): Kafka Time Series producer (Phase 0 — flag off)

### DIFF
--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -510,6 +510,15 @@
             <artifactId>testcontainers-kafka</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- commons-compress 1.28.0 (bundled with Testcontainers 2.x) requires
+             FileTimes.toUnixTime() which was added in commons-io 2.16.0.
+             Force the minimum compatible version so copyFileToContainer works. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <java.version>21</java.version>
+        <protoc.version>3.25.5</protoc.version>
     </properties>
 
     <dependencies>
@@ -433,6 +434,31 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- Kafka Time Series producer: protobuf wire format -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protoc.version}</version>
+        </dependency>
+
+        <!-- Kafka Time Series producer: Spring Cloud Stream Kafka binder for StreamBridge -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
+
+        <!-- Kafka Time Series producer: Prometheus metrics registry for /actuator/prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Actuator endpoint support (required for /actuator/prometheus) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -471,9 +497,30 @@
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- SCS test binder for Layer 3 integration tests -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-test-binder</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers Kafka for Layer 4 broker tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -481,6 +528,21 @@
                 <configuration>
                     <release>${java.version}</release>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -434,20 +434,19 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- Kafka Time Series producer: protobuf wire format -->
+        <!-- protobuf runtime (version managed by Spring Boot BOM; protoc binary pinned via ${protoc.version} in the plugin config below) -->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${protoc.version}</version>
         </dependency>
 
-        <!-- Kafka Time Series producer: Spring Cloud Stream Kafka binder for StreamBridge -->
+        <!-- Spring Cloud Stream Kafka binder starter (includes Kafka broker health indicator for /actuator/health) -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-stream-kafka</artifactId>
         </dependency>
 
-        <!-- Kafka Time Series producer: Prometheus metrics registry for /actuator/prometheus -->
+        <!-- Prometheus meter registry for /actuator/prometheus -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionSetVisitor;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+
+/**
+ * Pure function that walks a horizon CollectionSet visitor tree and emits a
+ * TimeseriesBatch protobuf. No side effects, no Spring state, no logging.
+ * Callers translate per poll; concurrent calls are safe because each call
+ * uses a fresh VisitorState instance.
+ *
+ * <p>nodeId and location are captured from the first CollectionAgent encountered
+ * during the visitor walk (via reflection, because CollectionResource does not
+ * expose getAgent() on its public API in all horizon versions). For empty
+ * CollectionSets where no resources are visited, nodeId defaults to 0 and
+ * location defaults to "".
+ */
+public class CollectionSetToProtobufTranslator {
+
+    public TimeseriesBatch translate(CollectionSet set, String collectionPackage) {
+        if (set == null || set.getStatus() == CollectionStatus.FAILED) {
+            return TimeseriesBatch.newBuilder()
+                    .setProducer(ProducerType.PRODUCER_COLLECTD)
+                    .build();
+        }
+
+        VisitorState state = new VisitorState();
+        set.visit(state);
+
+        long timestampMs = set.getCollectionTimestamp() != null
+                ? set.getCollectionTimestamp().getTime()
+                : System.currentTimeMillis();
+
+        TimeseriesBatch.Builder batch = TimeseriesBatch.newBuilder()
+                .setTimestampMs(timestampMs)
+                .setNodeId(state.nodeId)
+                .setLocation(state.location != null ? state.location : "")
+                .setCollectionPackage(collectionPackage != null ? collectionPackage : "")
+                .setProducer(ProducerType.PRODUCER_COLLECTD);
+
+        for (ResourceAccumulator r : state.resources.values()) {
+            Resource.Builder resBuilder = Resource.newBuilder()
+                    .setResourceId(r.resourceId)
+                    .setType(r.type)
+                    .setInstance(r.instance);
+            for (AttributeGroupAccumulator g : r.groups.values()) {
+                if (g.attributes.isEmpty()) {
+                    continue;
+                }
+                AttributeGroup.Builder groupBuilder = AttributeGroup.newBuilder().setName(g.name);
+                g.attributes.forEach(groupBuilder::addAttributes);
+                resBuilder.addGroups(groupBuilder);
+            }
+            if (resBuilder.getGroupsCount() > 0) {
+                batch.addResources(resBuilder);
+            }
+        }
+
+        return batch.build();
+    }
+
+    private static class VisitorState implements CollectionSetVisitor {
+        int nodeId;
+        String location;
+        final Map<String, ResourceAccumulator> resources = new LinkedHashMap<>();
+        ResourceAccumulator currentResource;
+        AttributeGroupAccumulator currentGroup;
+
+        @Override
+        public void visitCollectionSet(CollectionSet set) {
+            // no-op: the outer translate() reads timestamp/status directly from the set
+        }
+
+        @Override
+        public void visitResource(CollectionResource resource) {
+            CollectionAgent agent = resourceAgent(resource);
+            if (agent != null) {
+                nodeId = agent.getNodeId();
+                location = agent.getLocationName();
+            }
+            String parent = String.valueOf(resource.getParent());
+            String typeName = resource.getResourceTypeName();
+            String inst = resource.getInstance();
+            String resourceId = (inst != null && !inst.isEmpty())
+                    ? parent + "." + typeName + "[" + inst + "]"
+                    : parent + "." + typeName;
+            currentResource = resources.computeIfAbsent(resourceId,
+                    id -> new ResourceAccumulator(id, typeName, inst != null ? inst : ""));
+        }
+
+        @Override
+        public void visitGroup(org.opennms.netmgt.collection.api.AttributeGroup group) {
+            if (currentResource == null) {
+                return;
+            }
+            currentGroup = currentResource.groups.computeIfAbsent(group.getName(),
+                    AttributeGroupAccumulator::new);
+        }
+
+        @Override
+        public void visitAttribute(CollectionAttribute attribute) {
+            if (currentGroup == null) {
+                return;
+            }
+            currentGroup.attributes.add(attributeToProto(attribute));
+        }
+
+        @Override
+        public void completeAttribute(CollectionAttribute attribute) {
+            // no-op
+        }
+
+        @Override
+        public void completeGroup(org.opennms.netmgt.collection.api.AttributeGroup group) {
+            currentGroup = null;
+        }
+
+        @Override
+        public void completeResource(CollectionResource resource) {
+            currentResource = null;
+        }
+
+        @Override
+        public void completeCollectionSet(CollectionSet set) {
+            // no-op
+        }
+
+        private static CollectionAgent resourceAgent(CollectionResource resource) {
+            // horizon CollectionResource does not expose getAgent() on the public
+            // interface in all versions. Try reflectively; if absent, return null
+            // and let the caller keep nodeId/location at their defaults.
+            try {
+                java.lang.reflect.Method m = resource.getClass().getMethod("getAgent");
+                Object val = m.invoke(resource);
+                return val instanceof CollectionAgent ? (CollectionAgent) val : null;
+            } catch (ReflectiveOperationException e) {
+                return null;
+            }
+        }
+    }
+
+    private static Attribute attributeToProto(CollectionAttribute attribute) {
+        Attribute.Builder builder = Attribute.newBuilder().setName(attribute.getName());
+        org.opennms.netmgt.collection.api.AttributeType t = attribute.getType();
+        if (t == org.opennms.netmgt.collection.api.AttributeType.STRING) {
+            String v = attribute.getStringValue();
+            builder.setText(v != null ? v : "").setType(AttributeType.ATTRIBUTE_TYPE_STRING);
+        } else if (t == org.opennms.netmgt.collection.api.AttributeType.COUNTER) {
+            Number n = attribute.getNumericValue();
+            builder.setNumeric(n != null ? n.doubleValue() : 0.0d)
+                   .setType(AttributeType.ATTRIBUTE_TYPE_COUNTER);
+        } else {
+            Number n = attribute.getNumericValue();
+            builder.setNumeric(n != null ? n.doubleValue() : 0.0d)
+                   .setType(AttributeType.ATTRIBUTE_TYPE_GAUGE);
+        }
+        return builder.build();
+    }
+
+    private static class ResourceAccumulator {
+        final String resourceId;
+        final String type;
+        final String instance;
+        final Map<String, AttributeGroupAccumulator> groups = new LinkedHashMap<>();
+
+        ResourceAccumulator(String resourceId, String type, String instance) {
+            this.resourceId = resourceId;
+            this.type = type;
+            this.instance = instance;
+        }
+    }
+
+    private static class AttributeGroupAccumulator {
+        final String name;
+        final List<Attribute> attributes = new ArrayList<>();
+
+        AttributeGroupAccumulator(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java
@@ -27,7 +27,6 @@ import org.deltav.timeseries.proto.AttributeType;
 import org.deltav.timeseries.proto.ProducerType;
 import org.deltav.timeseries.proto.Resource;
 import org.deltav.timeseries.proto.TimeseriesBatch;
-import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
@@ -37,21 +36,26 @@ import org.opennms.netmgt.collection.api.CollectionStatus;
 /**
  * Pure function that walks a horizon CollectionSet visitor tree and emits a
  * TimeseriesBatch protobuf. No side effects, no Spring state, no logging.
- * Callers translate per poll; concurrent calls are safe because each call
- * uses a fresh VisitorState instance.
  *
- * <p>nodeId and location are captured from the first CollectionAgent encountered
- * during the visitor walk (via reflection, because CollectionResource does not
- * expose getAgent() on its public API in all horizon versions). For empty
- * CollectionSets where no resources are visited, nodeId defaults to 0 and
- * location defaults to "".
+ * <p>The translator does NOT extract node identity from the CollectionSet —
+ * horizon's CollectionResource and CollectionSet interfaces do not expose
+ * the CollectionAgent publicly. Callers must supply {@code nodeId} and
+ * {@code location} from their own agent context (typically the
+ * CollectionAgent that was scheduled for collection).</p>
+ *
+ * <p>Each call uses a fresh VisitorState instance; concurrent calls are
+ * therefore safe.</p>
  */
 public class CollectionSetToProtobufTranslator {
 
-    public TimeseriesBatch translate(CollectionSet set, String collectionPackage) {
+    public TimeseriesBatch translate(CollectionSet set, String collectionPackage,
+                                     int nodeId, String location) {
         if (set == null || set.getStatus() == CollectionStatus.FAILED) {
             return TimeseriesBatch.newBuilder()
                     .setProducer(ProducerType.PRODUCER_COLLECTD)
+                    .setNodeId(nodeId)
+                    .setLocation(location != null ? location : "")
+                    .setCollectionPackage(collectionPackage != null ? collectionPackage : "")
                     .build();
         }
 
@@ -64,8 +68,8 @@ public class CollectionSetToProtobufTranslator {
 
         TimeseriesBatch.Builder batch = TimeseriesBatch.newBuilder()
                 .setTimestampMs(timestampMs)
-                .setNodeId(state.nodeId)
-                .setLocation(state.location != null ? state.location : "")
+                .setNodeId(nodeId)
+                .setLocation(location != null ? location : "")
                 .setCollectionPackage(collectionPackage != null ? collectionPackage : "")
                 .setProducer(ProducerType.PRODUCER_COLLECTD);
 
@@ -91,8 +95,6 @@ public class CollectionSetToProtobufTranslator {
     }
 
     private static class VisitorState implements CollectionSetVisitor {
-        int nodeId;
-        String location;
         final Map<String, ResourceAccumulator> resources = new LinkedHashMap<>();
         ResourceAccumulator currentResource;
         AttributeGroupAccumulator currentGroup;
@@ -104,11 +106,6 @@ public class CollectionSetToProtobufTranslator {
 
         @Override
         public void visitResource(CollectionResource resource) {
-            CollectionAgent agent = resourceAgent(resource);
-            if (agent != null) {
-                nodeId = agent.getNodeId();
-                location = agent.getLocationName();
-            }
             String parent = String.valueOf(resource.getParent());
             String typeName = resource.getResourceTypeName();
             String inst = resource.getInstance();
@@ -154,19 +151,6 @@ public class CollectionSetToProtobufTranslator {
         @Override
         public void completeCollectionSet(CollectionSet set) {
             // no-op
-        }
-
-        private static CollectionAgent resourceAgent(CollectionResource resource) {
-            // horizon CollectionResource does not expose getAgent() on the public
-            // interface in all versions. Try reflectively; if absent, return null
-            // and let the caller keep nodeId/location at their defaults.
-            try {
-                java.lang.reflect.Method m = resource.getClass().getMethod("getAgent");
-                Object val = m.invoke(resource);
-                return val instanceof CollectionAgent ? (CollectionAgent) val : null;
-            } catch (ReflectiveOperationException e) {
-                return null;
-            }
         }
     }
 

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import java.util.Map;
+
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.Persister;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+
+/**
+ * Thin horizon Persister adapter that hands every CollectionSet to the
+ * shared TimeseriesKafkaPublisher once, at completeCollectionSet(). All
+ * per-attribute visit/persistNumericAttribute/persistStringAttribute
+ * callbacks are no-ops — the translator does its own walk.
+ *
+ * <p>nodeId and location are extracted from ServiceParameters at
+ * construction time: keys {@code node-id} (parsed as int, falls back to 0
+ * on parse failure) and {@code location} (defaults to empty string).
+ * Collectd is responsible for populating these keys; when it doesn't,
+ * the produced batch carries the defaults and consumers will fall back
+ * to the deltav-node-context GlobalKTable lookup for identity.</p>
+ */
+public class TimeseriesKafkaPersister implements Persister {
+
+    private final TimeseriesKafkaPublisher publisher;
+    private final String collectionPackage;
+    private final int nodeId;
+    private final String location;
+    private CollectionSet capturedSet;
+
+    public TimeseriesKafkaPersister(TimeseriesKafkaPublisher publisher,
+                                     ServiceParameters serviceParameters) {
+        this.publisher = publisher;
+        Map<String, Object> params = serviceParameters.getParameters();
+        this.collectionPackage = asString(params.get("collection"), "default");
+        this.nodeId = parseIntOrZero(asString(params.get("node-id"), ""));
+        this.location = asString(params.get("location"), "");
+    }
+
+    private static String asString(Object value, String fallback) {
+        return value == null ? fallback : value.toString();
+    }
+
+    private static int parseIntOrZero(String value) {
+        if (value == null || value.isEmpty()) return 0;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public void visitCollectionSet(CollectionSet set) {
+        this.capturedSet = set;
+    }
+
+    @Override
+    public void visitResource(CollectionResource resource) { /* no-op */ }
+
+    @Override
+    public void visitGroup(AttributeGroup group) { /* no-op */ }
+
+    @Override
+    public void visitAttribute(CollectionAttribute attribute) { /* no-op */ }
+
+    @Override
+    public void completeAttribute(CollectionAttribute attribute) { /* no-op */ }
+
+    @Override
+    public void completeGroup(AttributeGroup group) { /* no-op */ }
+
+    @Override
+    public void completeResource(CollectionResource resource) { /* no-op */ }
+
+    @Override
+    public void completeCollectionSet(CollectionSet set) {
+        if (capturedSet != null) {
+            publisher.publish(capturedSet, collectionPackage, nodeId, location);
+        }
+        capturedSet = null;
+    }
+
+    @Override
+    public void persistNumericAttribute(CollectionAttribute attribute) { /* no-op */ }
+
+    @Override
+    public void persistStringAttribute(CollectionAttribute attribute) { /* no-op */ }
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import java.nio.charset.StandardCharsets;
+
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Orchestration layer: translate a CollectionSet to protobuf, serialize, build
+ * the partition key as "{location}@{nodeId}", and invoke
+ * {@link StreamBridge#send(String, Message)} on the "publishTimeseries-out-0"
+ * binding. Error-isolated: never throws to the caller so the persister chain
+ * is unaffected by Kafka hiccups.
+ *
+ * <p>The caller (typically {@link TimeseriesKafkaPersister}) supplies
+ * {@code nodeId} and {@code location} from its own agent context —
+ * horizon's CollectionSet interface does not expose a public
+ * CollectionAgent accessor, so identity must come from the caller.</p>
+ */
+public class TimeseriesKafkaPublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesKafkaPublisher.class);
+    private static final String BINDING_NAME = "publishTimeseries-out-0";
+    static final int SIZE_WARNING_THRESHOLD_BYTES = 800_000;
+
+    private final StreamBridge streamBridge;
+    private final CollectionSetToProtobufTranslator translator;
+    private final MeterRegistry meterRegistry;
+
+    public TimeseriesKafkaPublisher(StreamBridge streamBridge,
+                                     CollectionSetToProtobufTranslator translator,
+                                     MeterRegistry meterRegistry) {
+        this.streamBridge = streamBridge;
+        this.translator = translator;
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void publish(CollectionSet set, String collectionPackage, int nodeId, String location) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String loc = location != null ? location : "";
+        try {
+            TimeseriesBatch batch;
+            try {
+                batch = translator.translate(set, collectionPackage, nodeId, loc);
+            } catch (RuntimeException ex) {
+                LOG.warn("Translator failed for node {} / package {}; dropping CollectionSet",
+                        nodeId, collectionPackage, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", loc, "producer", "collectd",
+                        "reason", "translator_error").increment();
+                return;
+            }
+
+            if (batch.getResourcesCount() == 0) {
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", loc, "producer", "collectd",
+                        "reason", "empty_batch").increment();
+                return;
+            }
+
+            byte[] payload;
+            try {
+                payload = batch.toByteArray();
+            } catch (RuntimeException ex) {
+                LOG.warn("Serialization failed for node {} / package {}",
+                        batch.getNodeId(), collectionPackage, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", loc, "producer", "collectd",
+                        "reason", "serialization_error").increment();
+                return;
+            }
+
+            if (payload.length > SIZE_WARNING_THRESHOLD_BYTES) {
+                LOG.warn("Oversized TimeseriesBatch: {} bytes for node {} in package {}. "
+                        + "Kafka max.request.size default is 1 MB. Consider reducing poll "
+                        + "scope in collectd-configuration.xml.",
+                        payload.length, batch.getNodeId(), batch.getCollectionPackage());
+                meterRegistry.counter("deltav_timeseries_batch_size_warning_total",
+                        "location", loc).increment();
+            }
+
+            DistributionSummary.builder("deltav_timeseries_batch_size_bytes")
+                    .tags("location", loc, "producer", "collectd")
+                    .register(meterRegistry).record(payload.length);
+            DistributionSummary.builder("deltav_timeseries_resources_per_batch")
+                    .tags("location", loc, "producer", "collectd")
+                    .register(meterRegistry).record(batch.getResourcesCount());
+
+            byte[] key = (batch.getLocation() + "@" + batch.getNodeId()).getBytes(StandardCharsets.UTF_8);
+            Message<byte[]> message = MessageBuilder.withPayload(payload)
+                    .setHeader(KafkaHeaders.KEY, key)
+                    .build();
+
+            boolean sent;
+            try {
+                sent = streamBridge.send(BINDING_NAME, message);
+            } catch (RuntimeException ex) {
+                LOG.warn("streamBridge.send threw for node {} / package {}",
+                        batch.getNodeId(), collectionPackage, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", loc, "producer", "collectd",
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+            if (!sent) {
+                LOG.warn("streamBridge.send returned false for node {} / package {}",
+                        batch.getNodeId(), collectionPackage);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", loc, "producer", "collectd",
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+
+            meterRegistry.counter("deltav_timeseries_batches_published_total",
+                    "location", loc, "producer", "collectd").increment();
+        } finally {
+            sample.stop(Timer.builder("deltav_timeseries_publish_duration_seconds")
+                    .tags("location", loc, "producer", "collectd")
+                    .register(meterRegistry));
+        }
+    }
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.time.Duration;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.TopicConfig;
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.Persister;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+import org.opennms.netmgt.rrd.RrdRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.config.TopicBuilder;
+
+/**
+ * Feature-flagged configuration for the Kafka Time Series producer. When
+ * {@code deltav.timeseries.enabled=true}, publishes one TimeseriesBatch
+ * protobuf record per CollectionSet poll to the deltav-timeseries topic.
+ * When the flag is false (default), none of the beans are created and the
+ * persister chain stays on the existing InMemoryStorage-backed
+ * TimeseriesPersisterFactory path.
+ */
+@Configuration
+@ConditionalOnProperty(name = "deltav.timeseries.enabled", havingValue = "true")
+public class TimeseriesKafkaPublisherConfiguration {
+
+    @Bean
+    public CollectionSetToProtobufTranslator collectionSetToProtobufTranslator() {
+        return new CollectionSetToProtobufTranslator();
+    }
+
+    @Bean
+    public TimeseriesKafkaPublisher timeseriesKafkaPublisher(
+            StreamBridge streamBridge,
+            CollectionSetToProtobufTranslator translator,
+            MeterRegistry meterRegistry) {
+        return new TimeseriesKafkaPublisher(streamBridge, translator, meterRegistry);
+    }
+
+    @Bean
+    public NewTopic deltavTimeseriesTopic(
+            @Value("${deltav.timeseries.partitions:16}") int partitions,
+            @Value("${deltav.timeseries.replication-factor:1}") short replicationFactor,
+            @Value("${deltav.timeseries.retention-days:7}") int retentionDays) {
+        return TopicBuilder.name("deltav-timeseries")
+                .partitions(partitions)
+                .replicas(replicationFactor)
+                .config(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE)
+                .config(TopicConfig.RETENTION_MS_CONFIG,
+                        String.valueOf(Duration.ofDays(retentionDays).toMillis()))
+                .config(TopicConfig.COMPRESSION_TYPE_CONFIG, "lz4")
+                .build();
+    }
+
+    /**
+     * Initial dual-ownership per design doc: the deltav-node-context topic's
+     * producer is provisiond, shipping in a separate future PR. The NewTopic
+     * bean is declared here now so the topic is provisioned on first start;
+     * when provisiond's change-feed PR lands, this bean moves to that module
+     * and is deleted from here.
+     */
+    @Bean
+    public NewTopic deltavNodeContextTopic(
+            @Value("${deltav.node-context.partitions:8}") int partitions,
+            @Value("${deltav.node-context.replication-factor:1}") short replicationFactor) {
+        return TopicBuilder.name("deltav-node-context")
+                .partitions(partitions)
+                .replicas(replicationFactor)
+                .config(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
+                .config(TopicConfig.RETENTION_MS_CONFIG, "-1")
+                .config(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, "60000")
+                .config(TopicConfig.DELETE_RETENTION_MS_CONFIG, "86400000")
+                .build();
+    }
+
+    /**
+     * Composite factory that fans out each createPersister() call to both the
+     * existing InMemoryStorage-backed TimeseriesPersisterFactory and a fresh
+     * TimeseriesKafkaPersister. Declared @Primary so Collectd's constructor
+     * resolves to this bean when the feature flag is on.
+     */
+    @Bean
+    @Primary
+    public PersisterFactory compositePersisterFactory(
+            @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher) {
+        return new FanoutPersisterFactory(innerFactory, publisher);
+    }
+
+    /**
+     * Package-private composite factory. Kept as a static nested class so the
+     * public API of this module remains the four files listed in the spec.
+     */
+    static final class FanoutPersisterFactory implements PersisterFactory {
+        private final PersisterFactory innerFactory;
+        private final TimeseriesKafkaPublisher publisher;
+
+        FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher) {
+            this.innerFactory = innerFactory;
+            this.publisher = publisher;
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                                         boolean dontPersistCounters, boolean forceStoreByGroup,
+                                         boolean dontReorderAttributes) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository, dontPersistCounters,
+                            forceStoreByGroup, dontReorderAttributes),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+    }
+
+    /**
+     * Forwards each visitor callback to both delegate persisters. Errors in
+     * one delegate must not prevent the other from running: the Kafka path
+     * is already error-isolated in the publisher, and the inner factory is
+     * assumed well-behaved.
+     */
+    static final class FanoutPersister implements Persister {
+        private final Persister innerPersister;
+        private final TimeseriesKafkaPersister kafkaPersister;
+
+        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister) {
+            this.innerPersister = innerPersister;
+            this.kafkaPersister = kafkaPersister;
+        }
+
+        @Override
+        public void visitCollectionSet(CollectionSet s) {
+            innerPersister.visitCollectionSet(s);
+            kafkaPersister.visitCollectionSet(s);
+        }
+
+        @Override
+        public void visitResource(CollectionResource r) {
+            innerPersister.visitResource(r);
+            kafkaPersister.visitResource(r);
+        }
+
+        @Override
+        public void visitGroup(AttributeGroup g) {
+            innerPersister.visitGroup(g);
+            kafkaPersister.visitGroup(g);
+        }
+
+        @Override
+        public void visitAttribute(CollectionAttribute a) {
+            innerPersister.visitAttribute(a);
+            kafkaPersister.visitAttribute(a);
+        }
+
+        @Override
+        public void completeAttribute(CollectionAttribute a) {
+            innerPersister.completeAttribute(a);
+            kafkaPersister.completeAttribute(a);
+        }
+
+        @Override
+        public void completeGroup(AttributeGroup g) {
+            innerPersister.completeGroup(g);
+            kafkaPersister.completeGroup(g);
+        }
+
+        @Override
+        public void completeResource(CollectionResource r) {
+            innerPersister.completeResource(r);
+            kafkaPersister.completeResource(r);
+        }
+
+        @Override
+        public void completeCollectionSet(CollectionSet s) {
+            innerPersister.completeCollectionSet(s);
+            kafkaPersister.completeCollectionSet(s);
+        }
+
+        @Override
+        public void persistNumericAttribute(CollectionAttribute a) {
+            innerPersister.persistNumericAttribute(a);
+            kafkaPersister.persistNumericAttribute(a);
+        }
+
+        @Override
+        public void persistStringAttribute(CollectionAttribute a) {
+            innerPersister.persistStringAttribute(a);
+            kafkaPersister.persistStringAttribute(a);
+        }
+    }
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -146,10 +146,12 @@ public class TimeseriesKafkaPublisherConfiguration {
     }
 
     /**
-     * Forwards each visitor callback to both delegate persisters. Errors in
-     * one delegate must not prevent the other from running: the Kafka path
-     * is already error-isolated in the publisher, and the inner factory is
-     * assumed well-behaved.
+     * Forwards each visitor callback to both delegate persisters, inner first
+     * then Kafka. If the inner persister throws unexpectedly, the Kafka path
+     * is skipped for that poll cycle — this is an accepted tradeoff for
+     * Phase 0 because the inner TimeseriesPersisterFactory is assumed
+     * well-behaved. The Kafka side's own error paths are isolated inside
+     * {@link TimeseriesKafkaPublisher#publish} and never propagate up.
      */
     static final class FanoutPersister implements Persister {
         private final Persister innerPersister;

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/netmgt/collectd/boot/CollectdDaemonConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/netmgt/collectd/boot/CollectdDaemonConfiguration.java
@@ -315,13 +315,13 @@ public class CollectdDaemonConfiguration {
      * annotations for disambiguation, which we satisfy by passing the correct
      * beans explicitly.</p>
      */
-    @Bean
-    public PersisterFactory persisterFactory(MetaTagDataLoader metaTagDataLoader,
-                                              StatisticsCollector statisticsCollector,
-                                              TimeseriesStorageManager timeseriesStorageManager,
-                                              CacheConfig timeseriesPersisterMetaTagCache,
-                                              MetricRegistry kafkaRpcMetricRegistry,
-                                              TimeseriesWriterConfig timeseriesWriterConfig) {
+    @Bean(name = "timeseriesPersisterFactory")
+    public PersisterFactory timeseriesPersisterFactory(MetaTagDataLoader metaTagDataLoader,
+                                                         StatisticsCollector statisticsCollector,
+                                                         TimeseriesStorageManager timeseriesStorageManager,
+                                                         CacheConfig timeseriesPersisterMetaTagCache,
+                                                         MetricRegistry kafkaRpcMetricRegistry,
+                                                         TimeseriesWriterConfig timeseriesWriterConfig) {
         return new TimeseriesPersisterFactory(metaTagDataLoader, statisticsCollector,
                 timeseriesStorageManager, timeseriesPersisterMetaTagCache,
                 kafkaRpcMetricRegistry, timeseriesWriterConfig);

--- a/core/daemon-boot-collectd/src/main/proto/deltav-node-context.proto
+++ b/core/daemon-boot-collectd/src/main/proto/deltav-node-context.proto
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 BeaconStrategists, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// API version: 1
+//
+// Public contract for the deltav-node-context Kafka topic (compacted).
+//
+// Versioning: during Phase 1 (feature flag off in production) breaking
+// schema changes are permissible. Once Phase 2 ships (flag on by default),
+// only forward-compatible changes are allowed: new fields with new tag
+// numbers, new enum values at the end. Renaming or renumbering existing
+// fields, deleting fields, or changing field types are breaking changes
+// that require a deprecation cycle.
+//
+// Producer: provisiond change feed (future PR). This file is committed in
+// the Kafka Time Series producer PR for contract completeness and to allow
+// the NewTopic bean for deltav-node-context to be declared alongside the
+// deltav-timeseries topic.
+
+syntax = "proto3";
+
+package org.deltav.timeseries;
+
+option java_package = "org.deltav.timeseries.proto";
+option java_multiple_files = true;
+
+// One record per node, published to the deltav-node-context topic whenever a
+// node is provisioned, updated, deleted, or its metadata changes. The topic is
+// compacted (log.cleanup.policy=compact), so the latest record per key
+// survives forever and a new consumer can bootstrap from the beginning of the
+// topic to materialize the full current state.
+//
+// Keyed by "{location}@{node_id}" — same key shape as TimeseriesBatch so
+// consumers can join directly without a key transformer.
+message NodeContext {
+  // Numeric node ID. Matches TimeseriesBatch.node_id.
+  int32 node_id = 1;
+
+  // Location. Matches TimeseriesBatch.location.
+  string location = 2;
+
+  // Human-readable node label as displayed in the UI (e.g.
+  // "server-01.prod.example.com"). Comes from OnmsNode.label.
+  string node_label = 3;
+
+  // Provisioning foreign source (e.g. "provision-prod"). Empty if the
+  // node was not created via provisioning.
+  string foreign_source = 4;
+
+  // Provisioning foreign ID (e.g. "server-01"). Stable identifier for
+  // this node within its foreign source.
+  string foreign_id = 5;
+
+  // Categories assigned to the node. Typically 0-5 entries.
+  repeated string categories = 6;
+
+  // Full metadata map for the node. Keys follow OnmsMetaData convention:
+  // "context:key" (e.g. "requisition:sysLocation", "snmp:sysContact",
+  // "ip:hostname"). Values are whatever provisiond or SNMP discovery
+  // populated. Can be large — hundreds of entries for heavily-metadataed
+  // nodes is not unusual.
+  //
+  // Consumer responsibility: metadata values should be used as-is; don't
+  // attempt to parse or reinterpret them. If a consumer needs to filter
+  // by a metadata value, it filters on the string.
+  map<string, string> metadata = 7;
+
+  // Interface-level metadata, keyed by IP address (IPv4 or IPv6 string).
+  // For nodes with many interfaces this can grow — each entry carries
+  // its own metadata map. Empty map is a valid value meaning "no
+  // interface-scoped metadata for this node."
+  map<string, InterfaceContext> interface_metadata = 8;
+
+  // Service-level metadata, keyed by "{ip_address}/{service_name}" for
+  // stable uniqueness (e.g. "192.0.2.1/ICMP").
+  map<string, ServiceContext> service_metadata = 9;
+
+  // Wall-clock time when this record was produced, in epoch milliseconds.
+  // Consumers use this for freshness checks. Strictly informational —
+  // the topic's log compaction determines which record wins per key, not
+  // this timestamp.
+  int64 updated_at_ms = 10;
+
+  // Tombstone marker. When a node is deleted from provisioning, provisiond
+  // publishes a final NodeContext with deleted=true, allowing log
+  // compaction to eventually garbage-collect the key. Consumers should
+  // treat a tombstoned node as "not present."
+  bool deleted = 11;
+}
+
+// Interface-scoped metadata. Carried as a nested message so the map value
+// in NodeContext.interface_metadata can hold both a metadata map and any
+// future interface-level fields without schema churn.
+message InterfaceContext {
+  map<string, string> metadata = 1;
+  // Future: interface description, interface alias, snmp_ifindex, etc.
+  // Leaving space open (fields 2+) for incremental additions.
+}
+
+// Service-scoped metadata. Same structure as InterfaceContext.
+message ServiceContext {
+  map<string, string> metadata = 1;
+  // Future: service-level display name, criticality hint, etc.
+}

--- a/core/daemon-boot-collectd/src/main/proto/deltav-timeseries.proto
+++ b/core/daemon-boot-collectd/src/main/proto/deltav-timeseries.proto
@@ -1,9 +1,32 @@
-// Licensed to Delta-V under the GNU Affero General Public License v3.
-// See LICENSE.md in the repository root for full license text.
+// Copyright (C) 2026 BeaconStrategists, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// API version: 1
+//
+// Public contract for the deltav-timeseries Kafka topic.
+//
+// Versioning: during Phase 1 (feature flag off in production) breaking
+// schema changes are permissible. Once Phase 2 ships (flag on by default),
+// only forward-compatible changes are allowed: new fields with new tag
+// numbers, new enum values at the end. Renaming or renumbering existing
+// fields, deleting fields, or changing field types are breaking changes
+// that require a deprecation cycle.
 
 syntax = "proto3";
 
-package deltav.timeseries;
+package org.deltav.timeseries;
 
 option java_package = "org.deltav.timeseries.proto";
 option java_multiple_files = true;
@@ -50,28 +73,66 @@ enum ProducerType {
   PRODUCER_COLLECTD = 1;
   PRODUCER_POLLERD = 2;
   PRODUCER_PERSPECTIVE_POLLERD = 3;
-  PRODUCER_MINION_SNMP_COLLECTOR = 4;
-  PRODUCER_STREAMING_TELEMETRY = 5;
+  PRODUCER_MINION_SNMP_COLLECTOR = 4;  // Future phase
+  PRODUCER_STREAMING_TELEMETRY = 5;    // Future phase (gNMI/GPB)
 }
 
+// A single resource in the CollectionSet. For Collectd this maps 1:1 to
+// org.opennms.netmgt.collection.api.CollectionResource. For Pollerd this is
+// the monitored service; for PerspectivePollerd, the (service, perspective)
+// pair.
 message Resource {
+  // Stable resource identifier string. Format matches horizon's resource
+  // ID convention: "node[N]", "node[N].interfaceSnmp[eth0]", etc. Used
+  // for deduplication, display grouping, and as a Prometheus-style
+  // "instance" label component.
   string resource_id = 1;
+
+  // Resource type name (e.g. "node", "interfaceSnmp", "hrStorageIndex").
+  // Comes from the collectd-configuration.xml resource type definitions.
   string type = 2;
+
+  // Per-instance key for tabular resources (e.g. "eth0" for an interface,
+  // "1.3.6.1.2.1.25.2.3.1.1.1" for a storage row). Empty for non-tabular
+  // resources. Distinct from resource_id because instance is the raw
+  // collector-side key without the "node[N]." prefix.
   string instance = 3;
+
+  // Attribute groups defined in the collectd-configuration.xml datacollection
+  // config for this resource type.
   repeated AttributeGroup groups = 4;
 }
 
+// A named group of attributes. Matches horizon's AttributeGroup concept —
+// typically one per MIB table or one per logical grouping of metrics.
 message AttributeGroup {
+  // Group name, e.g. "mib2-tcp", "hrStorage", "response-time".
   string name = 1;
+
+  // The individual metrics in this group.
   repeated Attribute attributes = 2;
 }
 
+// One individual metric sample within a group.
+//
+// Invariant: when type == ATTRIBUTE_TYPE_STRING, the `text` arm of the
+// value oneof is set; for all other type values the `numeric` arm is set.
+// Producers MUST uphold this invariant; consumers MAY treat a violation
+// as a malformed record and drop it.
 message Attribute {
+  // Attribute name, e.g. "tcpActiveOpens", "hrStorageUsed", "response".
   string name = 1;
+
+  // The measured value. Use oneof because metrics are either numeric
+  // (gauge/counter) or string (stringAttribute in horizon terminology).
   oneof value {
     double numeric = 2;
     string text = 3;
   }
+
+  // Attribute type. Matches horizon's AttributeType enum. Consumers use
+  // this to decide how to treat the value (rate for counters, absolute
+  // for gauges, ignore for strings unless explicitly handled).
   AttributeType type = 4;
 }
 

--- a/core/daemon-boot-collectd/src/main/proto/deltav-timeseries.proto
+++ b/core/daemon-boot-collectd/src/main/proto/deltav-timeseries.proto
@@ -1,0 +1,83 @@
+// Licensed to Delta-V under the GNU Affero General Public License v3.
+// See LICENSE.md in the repository root for full license text.
+
+syntax = "proto3";
+
+package deltav.timeseries;
+
+option java_package = "org.deltav.timeseries.proto";
+option java_multiple_files = true;
+
+// One record per CollectionSet poll. Published to the deltav-timeseries topic,
+// keyed by "{location}@{node_id}". Deliberately producer-agnostic: the same
+// shape is valid whether the producer is Collectd, Pollerd, PerspectivePollerd,
+// or a future SnmpCollector-on-Minion deployment. No identity labels are
+// carried here — consumers join against the deltav-node-context GlobalKTable
+// at process time.
+message TimeseriesBatch {
+  // Milliseconds since Unix epoch when the poll was produced by the collector.
+  // "Collection time," not "publish time" — stamped by the producer before
+  // serialization and immutable through the pipeline.
+  int64 timestamp_ms = 1;
+
+  // Numeric node ID from the nodes table. Used as part of the partition key
+  // and as the join key against deltav-node-context.
+  int32 node_id = 2;
+
+  // Logical location name (e.g. "Default", "Site-A"). Part of the partition
+  // key. Redundant with NodeContext.location but carried here so consumers
+  // can derive the join key from the metric record alone.
+  string location = 3;
+
+  // The package that produced this batch (e.g. "default", "interfaceSnmp").
+  // Used by consumers to filter rules (e.g. "only evaluate threshold X on
+  // records from the 'critical-infra' package").
+  string collection_package = 4;
+
+  // The producer that emitted this batch. Identifies which daemon wrote the
+  // record so consumers can distinguish e.g. Collectd vs. Pollerd origin
+  // without adding a separate topic. Enum because the set is small and
+  // closed.
+  ProducerType producer = 5;
+
+  // The resource tree. A single CollectionSet usually has multiple resources
+  // (one per collected entity: node, interface, storage row, etc).
+  repeated Resource resources = 6;
+}
+
+enum ProducerType {
+  PRODUCER_UNSPECIFIED = 0;
+  PRODUCER_COLLECTD = 1;
+  PRODUCER_POLLERD = 2;
+  PRODUCER_PERSPECTIVE_POLLERD = 3;
+  PRODUCER_MINION_SNMP_COLLECTOR = 4;
+  PRODUCER_STREAMING_TELEMETRY = 5;
+}
+
+message Resource {
+  string resource_id = 1;
+  string type = 2;
+  string instance = 3;
+  repeated AttributeGroup groups = 4;
+}
+
+message AttributeGroup {
+  string name = 1;
+  repeated Attribute attributes = 2;
+}
+
+message Attribute {
+  string name = 1;
+  oneof value {
+    double numeric = 2;
+    string text = 3;
+  }
+  AttributeType type = 4;
+}
+
+enum AttributeType {
+  ATTRIBUTE_TYPE_UNSPECIFIED = 0;
+  ATTRIBUTE_TYPE_COUNTER = 1;
+  ATTRIBUTE_TYPE_GAUGE = 2;
+  ATTRIBUTE_TYPE_STRING = 3;
+}

--- a/core/daemon-boot-collectd/src/main/resources/application.yml
+++ b/core/daemon-boot-collectd/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: collectd
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
     username: ${SPRING_DATASOURCE_USERNAME:opennms}
@@ -14,6 +16,30 @@ spring:
     properties:
       hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
       hibernate.archive.autodetection: none
+  cloud:
+    stream:
+      bindings:
+        publishTimeseries-out-0:
+          destination: deltav-timeseries
+          producer:
+            partition-count: ${DELTAV_TIMESERIES_PARTITIONS:16}
+            use-native-encoding: true
+      kafka:
+        binder:
+          brokers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+          auto-create-topics: true
+        bindings:
+          publishTimeseries-out-0:
+            producer:
+              configuration:
+                key.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                value.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                compression.type: lz4
+                linger.ms: 50
+                batch.size: 65536
+                acks: all
+                enable.idempotence: true
+                max.in.flight.requests.per.connection: 5
 
 opennms:
   home: ${OPENNMS_HOME:/opt/deltav}
@@ -37,3 +63,22 @@ opennms:
       force-remote: ${OPENNMS_RPC_KAFKA_FORCE_REMOTE:false}
   timeseries:
     strategy: ${OPENNMS_TIMESERIES_STRATEGY:inmemory}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name:collectd}
+
+deltav:
+  timeseries:
+    enabled: ${DELTAV_TIMESERIES_ENABLED:false}
+    partitions: ${DELTAV_TIMESERIES_PARTITIONS:16}
+    replication-factor: ${DELTAV_TIMESERIES_REPLICATION_FACTOR:1}
+    retention-days: ${DELTAV_TIMESERIES_RETENTION_DAYS:7}
+  node-context:
+    partitions: ${DELTAV_NODE_CONTEXT_PARTITIONS:8}
+    replication-factor: ${DELTAV_NODE_CONTEXT_REPLICATION_FACTOR:1}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
@@ -180,4 +180,108 @@ class CollectionSetToProtobufTranslatorTest {
         when(attr.getStringValue()).thenReturn(value);
         return attr;
     }
+
+    @Test
+    void stringAttributeMapsToTextValue() {
+        CollectionAttribute attr = stringAttribute("sysDescr", "Linux 6.1.0");
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "mib2-system",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getType()).isEqualTo(AttributeType.ATTRIBUTE_TYPE_STRING);
+        assertThat(out.getText()).isEqualTo("Linux 6.1.0");
+        assertThat(out.getValueCase()).isEqualTo(Attribute.ValueCase.TEXT);
+    }
+
+    @Test
+    void structuredJsonStringAttributeIsCarriedVerbatim() {
+        String json = "{\"cpu\":42,\"mem\":{\"used\":1024,\"free\":2048}}";
+        CollectionAttribute attr = stringAttribute("structuredPayload", json);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "structured",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        assertThat(batch.getResources(0).getGroups(0).getAttributes(0).getText()).isEqualTo(json);
+    }
+
+    @Test
+    void unicodeAttributeAndGroupNamesSurviveRoundtripInProto() {
+        CollectionAttribute attr = numericAttribute("répondéz",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 1);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "αβγ-group",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        assertThat(batch.getResources(0).getGroups(0).getName()).isEqualTo("αβγ-group");
+        assertThat(batch.getResources(0).getGroups(0).getAttributes(0).getName()).isEqualTo("répondéz");
+    }
+
+    @Test
+    void statusFailedCollectionSetProducesEmptyBatch() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.FAILED);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        assertThat(batch.getResourcesList()).isEmpty();
+        // After the Task 4 fix, the failed-set early return now also stamps nodeId/location
+        // from the caller-provided values (previously they were zeroed on FAILED).
+        assertThat(batch.getNodeId()).isEqualTo(7);
+        assertThat(batch.getLocation()).isEqualTo("Default");
+    }
+
+    @Test
+    void nullCollectionSetYieldsEmptyBatchNotNpe() {
+        TimeseriesBatch batch = translator.translate(null, "default", 0, "");
+
+        assertThat(batch.getResourcesList()).isEmpty();
+        assertThat(batch.getProducer()).isEqualTo(ProducerType.PRODUCER_COLLECTD);
+    }
+
+    @Test
+    void resourceWithNoAttributesIsOmittedFromBatch() {
+        CollectionAttribute attr = numericAttribute("x",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 1);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "with-attr",
+                List.of(attr), 1700000000000L);
+        CollectionSet emptySet = oneResourceSet(7, "Default", "node", null, "empty-group",
+                List.of(), 1700000000000L);
+
+        TimeseriesBatch withAttr = translator.translate(set, "default", 7, "Default");
+        TimeseriesBatch withoutAttr = translator.translate(emptySet, "default", 7, "Default");
+
+        assertThat(withAttr.getResourcesCount()).isEqualTo(1);
+        assertThat(withoutAttr.getResourcesList()).isEmpty();
+    }
+
+    @Test
+    void interfaceScopedResourceEmitsInstanceAndResourceIdCorrectly() {
+        CollectionAttribute attr = numericAttribute("ifInOctets",
+                org.opennms.netmgt.collection.api.AttributeType.COUNTER, 1000L);
+        CollectionSet set = oneResourceSet(7, "Default", "interfaceSnmp", "eth0",
+                "mib2-interfaces", List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+        var resource = batch.getResources(0);
+
+        assertThat(resource.getType()).isEqualTo("interfaceSnmp");
+        assertThat(resource.getInstance()).isEqualTo("eth0");
+        assertThat(resource.getResourceId()).contains("interfaceSnmp[eth0]");
+    }
+
+    @Test
+    void packageNameIsCopiedIntoBatch() {
+        CollectionAttribute attr = numericAttribute("x",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 1);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "g",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "critical-infra", 7, "Default");
+
+        assertThat(batch.getCollectionPackage()).isEqualTo("critical-infra");
+    }
 }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+
+class CollectionSetToProtobufTranslatorTest {
+
+    private final CollectionSetToProtobufTranslator translator = new CollectionSetToProtobufTranslator();
+
+    /**
+     * Option B: CollectionSet has no getAgent() — nodeId and location can only be captured
+     * from the visitor callbacks when resources are visited. For an empty CollectionSet the
+     * visitor walk produces no resource callbacks, so nodeId stays 0 and location stays "".
+     * The translator reads timestamp, status, and package from the set directly.
+     */
+    @Test
+    void emptyCollectionSetProducesEmptyResourceList() {
+        CollectionSet set = mockCollectionSet(CollectionStatus.SUCCEEDED, 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        assertThat(batch.getNodeId()).isEqualTo(0);
+        assertThat(batch.getLocation()).isEqualTo("");
+        assertThat(batch.getCollectionPackage()).isEqualTo("default");
+        assertThat(batch.getTimestampMs()).isEqualTo(1700000000000L);
+        assertThat(batch.getProducer()).isEqualTo(ProducerType.PRODUCER_COLLECTD);
+        assertThat(batch.getResourcesList()).isEmpty();
+    }
+
+    // Helper factories used by all tests in this class.
+    // Keep them here (not in a separate fixture class) so test intent stays
+    // one-file-readable; pure boilerplate should not leak into production code.
+
+    static CollectionSet mockCollectionSet(CollectionStatus status, long timestampMs) {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(status);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(timestampMs));
+        return set;
+    }
+
+    static CollectionAgent mockAgent(int nodeId, String location) {
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(nodeId);
+        when(agent.getLocationName()).thenReturn(location);
+        return agent;
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -36,17 +35,11 @@ class CollectionSetToProtobufTranslatorTest {
 
     private final CollectionSetToProtobufTranslator translator = new CollectionSetToProtobufTranslator();
 
-    /**
-     * Option B: CollectionSet has no getAgent() — nodeId and location can only be captured
-     * from the visitor callbacks when resources are visited. For an empty CollectionSet the
-     * visitor walk produces no resource callbacks, so nodeId stays 0 and location stays "".
-     * The translator reads timestamp, status, and package from the set directly.
-     */
     @Test
     void emptyCollectionSetProducesEmptyResourceList() {
         CollectionSet set = mockCollectionSet(CollectionStatus.SUCCEEDED, 1700000000000L);
 
-        TimeseriesBatch batch = translator.translate(set, "default");
+        TimeseriesBatch batch = translator.translate(set, "default", 0, "");
 
         assertThat(batch.getNodeId()).isEqualTo(0);
         assertThat(batch.getLocation()).isEqualTo("");

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
@@ -23,10 +23,13 @@ import static org.mockito.Mockito.when;
 import java.util.Date;
 import java.util.List;
 
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeType;
 import org.deltav.timeseries.proto.ProducerType;
 import org.deltav.timeseries.proto.TimeseriesBatch;
 import org.junit.jupiter.api.Test;
 import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.CollectionStatus;
@@ -65,5 +68,116 @@ class CollectionSetToProtobufTranslatorTest {
         when(agent.getNodeId()).thenReturn(nodeId);
         when(agent.getLocationName()).thenReturn(location);
         return agent;
+    }
+
+    @Test
+    void gauge32AttributeMapsToNumericDouble() {
+        CollectionAttribute attr = numericAttribute("sysUpTime",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 123456);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "mib2-system",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        assertThat(batch.getResourcesCount()).isEqualTo(1);
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getType()).isEqualTo(AttributeType.ATTRIBUTE_TYPE_GAUGE);
+        assertThat(out.getNumeric()).isEqualTo(123456.0d);
+    }
+
+    @Test
+    void gauge64AttributeMapsToNumericDouble() {
+        CollectionAttribute attr = numericAttribute("ifHCInOctets",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 12345678901234L);
+        CollectionSet set = oneResourceSet(7, "Default", "interfaceSnmp", "eth0",
+                "mib2-interfaces", List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getNumeric()).isEqualTo(12345678901234.0d);
+    }
+
+    @Test
+    void counter64AttributeMapsToCounterType() {
+        CollectionAttribute attr = numericAttribute("ifHCInOctets",
+                org.opennms.netmgt.collection.api.AttributeType.COUNTER, 98765432109876L);
+        CollectionSet set = oneResourceSet(7, "Default", "interfaceSnmp", "eth0",
+                "mib2-interfaces", List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getType()).isEqualTo(AttributeType.ATTRIBUTE_TYPE_COUNTER);
+        assertThat(out.getNumeric()).isEqualTo(98765432109876.0d);
+    }
+
+    @Test
+    void negativeAndZeroNumericValuesAreCarriedUnchanged() {
+        CollectionAttribute neg = numericAttribute("someNeg",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, -42);
+        CollectionAttribute zero = numericAttribute("someZero",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 0);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "edge-cases",
+                List.of(neg, zero), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default", 7, "Default");
+
+        assertThat(batch.getResources(0).getGroups(0).getAttributesList())
+                .extracting(Attribute::getNumeric)
+                .containsExactly(-42.0d, 0.0d);
+    }
+
+    static CollectionSet oneResourceSet(int nodeId, String location, String resourceType,
+                                         String instance, String groupName,
+                                         List<CollectionAttribute> attributes,
+                                         long timestampMs) {
+        CollectionResource resource = mock(CollectionResource.class);
+        when(resource.getResourceTypeName()).thenReturn(resourceType);
+        when(resource.getInstance()).thenReturn(instance);
+        when(resource.getParent()).thenReturn(
+                org.opennms.netmgt.model.ResourcePath.get("node[" + nodeId + "]"));
+
+        org.opennms.netmgt.collection.api.AttributeGroup group =
+                mock(org.opennms.netmgt.collection.api.AttributeGroup.class);
+        when(group.getName()).thenReturn(groupName);
+
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(timestampMs));
+        org.mockito.Mockito.doAnswer(inv -> {
+            org.opennms.netmgt.collection.api.CollectionSetVisitor v = inv.getArgument(0);
+            v.visitCollectionSet(set);
+            v.visitResource(resource);
+            v.visitGroup(group);
+            attributes.forEach(a -> {
+                when(a.getResource()).thenReturn(resource);
+                v.visitAttribute(a);
+                v.completeAttribute(a);
+            });
+            v.completeGroup(group);
+            v.completeResource(resource);
+            v.completeCollectionSet(set);
+            return null;
+        }).when(set).visit(org.mockito.ArgumentMatchers.any());
+        return set;
+    }
+
+    static CollectionAttribute numericAttribute(String name,
+                                                 org.opennms.netmgt.collection.api.AttributeType type,
+                                                 Number value) {
+        CollectionAttribute attr = mock(CollectionAttribute.class);
+        when(attr.getName()).thenReturn(name);
+        when(attr.getType()).thenReturn(type);
+        when(attr.getNumericValue()).thenReturn(value);
+        return attr;
+    }
+
+    static CollectionAttribute stringAttribute(String name, String value) {
+        CollectionAttribute attr = mock(CollectionAttribute.class);
+        when(attr.getName()).thenReturn(name);
+        when(attr.getType()).thenReturn(org.opennms.netmgt.collection.api.AttributeType.STRING);
+        when(attr.getStringValue()).thenReturn(value);
+        return attr;
     }
 }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersister;
+import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersisterFactory;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.Persister;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+
+class FanoutPersisterTest {
+
+    @Test
+    void completeCollectionSetCallsInnerThenKafkaInOrder() {
+        Persister inner = mock(Persister.class);
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(new HashMap<>());
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
+        FanoutPersister fanout = new FanoutPersister(inner, kafka);
+
+        CollectionSet set = mock(CollectionSet.class);
+        fanout.visitCollectionSet(set);
+        fanout.completeCollectionSet(set);
+
+        InOrder order = inOrder(inner, publisher);
+        order.verify(inner).visitCollectionSet(set);
+        order.verify(inner).completeCollectionSet(set);
+        order.verify(publisher).publish(any(), any(), any(Integer.class), any());
+    }
+
+    @Test
+    void innerPersisterThrowingPropagatesAndSkipsKafkaDelegate() {
+        // This documents the Phase 0 tradeoff: if the inner persister throws
+        // during completeCollectionSet, the Kafka delegate is skipped for that
+        // poll. The inner factory is assumed well-behaved; if this assumption
+        // becomes wrong, the split-per-delegate try/catch is the fix.
+        Persister inner = mock(Persister.class);
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(new HashMap<>());
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
+        FanoutPersister fanout = new FanoutPersister(inner, kafka);
+
+        CollectionSet set = mock(CollectionSet.class);
+        doThrow(new RuntimeException("inner boom"))
+                .when(inner).completeCollectionSet(set);
+
+        fanout.visitCollectionSet(set);
+        try {
+            fanout.completeCollectionSet(set);
+        } catch (RuntimeException ignored) { /* expected */ }
+
+        verify(publisher, never()).publish(any(), any(), any(Integer.class), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void factoryCreatesFanoutWithIndependentKafkaPersisterPerCall() {
+        PersisterFactory innerFactory = mock(PersisterFactory.class);
+        Persister innerPersister1 = mock(Persister.class);
+        Persister innerPersister2 = mock(Persister.class);
+        when(innerFactory.createPersister(any(), any()))
+                .thenReturn(innerPersister1, innerPersister2);
+
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        FanoutPersisterFactory factory = new FanoutPersisterFactory(innerFactory, publisher);
+
+        ServiceParameters paramsA = mock(ServiceParameters.class);
+        Map<String, Object> mapA = new HashMap<>();
+        mapA.put("collection", "pkg-A");
+        mapA.put("node-id", "1");
+        when(paramsA.getParameters()).thenReturn((Map) mapA);
+
+        ServiceParameters paramsB = mock(ServiceParameters.class);
+        Map<String, Object> mapB = new HashMap<>();
+        mapB.put("collection", "pkg-B");
+        mapB.put("node-id", "2");
+        when(paramsB.getParameters()).thenReturn((Map) mapB);
+
+        Persister pA = factory.createPersister(paramsA, null);
+        Persister pB = factory.createPersister(paramsB, null);
+
+        // Both are distinct FanoutPersister instances wrapping different inner persisters
+        // and different TimeseriesKafkaPersister instances (different nodeId/package).
+        CollectionSet setA = mock(CollectionSet.class);
+        pA.visitCollectionSet(setA);
+        pA.completeCollectionSet(setA);
+
+        verify(innerPersister1).completeCollectionSet(setA);
+        verify(innerPersister2, never()).completeCollectionSet(any());
+        verify(publisher).publish(setA, "pkg-A", 1, "");
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaBrokerIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaBrokerIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionSetVisitor;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.model.ResourcePath;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Layer 4 broker integration test: validates real Kafka wire behaviour.
+ *
+ * <p>Uses an {@link ApplicationContextInitializer} to start the
+ * {@code apache/kafka:3.8.0} Testcontainers broker before the Spring Boot
+ * context loads, avoiding the Spring Boot 4 / JUnit 5 ordering issue where
+ * the Spring context bootstraps before the {@code @Testcontainers} extension
+ * runs {@code beforeAll}.</p>
+ *
+ * <p>Pinned to {@code apache/kafka:3.8.0} for reproducible IT runs. The
+ * delta-v Docker Compose uses {@code apache/kafka:latest} (same image family);
+ * Kafka's wire protocol is backwards-compatible so the Layer 4 and Layer 5
+ * brokers need not be identical.</p>
+ */
+@SpringBootTest(classes = TimeseriesKafkaBrokerIT.TestApp.class,
+        properties = {
+                "deltav.timeseries.enabled=true",
+                "spring.main.web-application-type=none",
+                "spring.main.banner-mode=off",
+                "spring.cloud.stream.kafka.binder.auto-create-topics=false"
+        })
+@ContextConfiguration(initializers = TimeseriesKafkaBrokerIT.KafkaInitializer.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class TimeseriesKafkaBrokerIT {
+
+    /**
+     * Shared Kafka container. Started once by {@link KafkaInitializer} before
+     * the Spring context loads; stopped automatically on JVM exit via TC's
+     * Ryuk reaper.
+     */
+    static final KafkaContainer KAFKA = new KafkaContainer(
+            DockerImageName.parse("apache/kafka:3.8.0"))
+            .withStartupTimeout(Duration.ofSeconds(120));
+
+    /**
+     * {@code ApplicationContextInitializer} that starts the Kafka container
+     * and injects {@code spring.cloud.stream.kafka.binder.brokers} before the
+     * Spring Boot context is loaded. This sidesteps the ordering problem where
+     * Spring Boot 4's test context bootstrapper runs before the JUnit 5
+     * {@code TestcontainersExtension.beforeAll}.
+     */
+    static class KafkaInitializer
+            implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(ConfigurableApplicationContext ctx) {
+            if (!KAFKA.isRunning()) {
+                KAFKA.start();
+            }
+            String brokers = KAFKA.getBootstrapServers();
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(ctx,
+                    "spring.cloud.stream.kafka.binder.brokers=" + brokers,
+                    "spring.kafka.bootstrap-servers=" + brokers);
+        }
+    }
+
+    @Autowired
+    TimeseriesKafkaPublisher publisher;
+
+    @Test
+    @Order(1)
+    void roundTripWithLz4Compression() throws Exception {
+        publisher.publish(stubSet(1), "default", 1, "Default");
+
+        try (KafkaConsumer<byte[], byte[]> consumer = consumer()) {
+            consumer.subscribe(Collections.singletonList("deltav-timeseries"));
+            ConsumerRecord<byte[], byte[]> record = awaitOne(consumer);
+            TimeseriesBatch batch = TimeseriesBatch.parseFrom(record.value());
+            assertThat(batch.getNodeId()).isEqualTo(1);
+            assertThat(batch.getLocation()).isEqualTo("Default");
+            assertThat(new String(record.key())).isEqualTo("Default@1");
+        }
+    }
+
+    @Test
+    @Order(2)
+    void newTopicsAreProvisionedWithCorrectConfiguration() throws Exception {
+        // Trigger publish first so Spring Kafka admin has a chance to provision topics
+        publisher.publish(stubSet(1), "default", 1, "Default");
+        Thread.sleep(500);
+
+        try (AdminClient admin = AdminClient.create(Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers()))) {
+            TopicDescription ts = admin.describeTopics(
+                    Collections.singletonList("deltav-timeseries")).allTopicNames().get()
+                    .get("deltav-timeseries");
+            assertThat(ts.partitions()).hasSize(16);
+
+            ConfigResource tsResource = new ConfigResource(ConfigResource.Type.TOPIC, "deltav-timeseries");
+            Config tsConfig = admin.describeConfigs(Collections.singletonList(tsResource))
+                    .all().get().get(tsResource);
+            assertThat(tsConfig.get("cleanup.policy").value()).isEqualTo("delete");
+            assertThat(tsConfig.get("compression.type").value()).isEqualTo("lz4");
+            assertThat(tsConfig.get("retention.ms").value())
+                    .isEqualTo(String.valueOf(Duration.ofDays(7).toMillis()));
+
+            TopicDescription ctxTs = admin.describeTopics(
+                    Collections.singletonList("deltav-node-context")).allTopicNames().get()
+                    .get("deltav-node-context");
+            assertThat(ctxTs.partitions()).hasSize(8);
+
+            ConfigResource ctxResource = new ConfigResource(ConfigResource.Type.TOPIC, "deltav-node-context");
+            Config ctxConfig = admin.describeConfigs(Collections.singletonList(ctxResource))
+                    .all().get().get(ctxResource);
+            assertThat(ctxConfig.get("cleanup.policy").value()).isEqualTo("compact");
+            assertThat(ctxConfig.get("min.compaction.lag.ms").value()).isEqualTo("60000");
+        }
+    }
+
+    @Test
+    @Order(3)
+    void partitionStickinessForSameKey() throws Exception {
+        byte[] targetKey = "Default@7".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        for (int i = 0; i < 5; i++) publisher.publish(stubSet(7), "default", 7, "Default");
+
+        try (KafkaConsumer<byte[], byte[]> consumer = consumer()) {
+            consumer.subscribe(Collections.singletonList("deltav-timeseries"));
+            long deadline = System.currentTimeMillis() + 10_000;
+            int partition = -1;
+            int seen = 0;
+            while (System.currentTimeMillis() < deadline && seen < 5) {
+                ConsumerRecords<byte[], byte[]> recs = consumer.poll(Duration.ofMillis(500));
+                for (ConsumerRecord<byte[], byte[]> r : recs) {
+                    // Only check records published by this test (key = "Default@7")
+                    if (!java.util.Arrays.equals(r.key(), targetKey)) continue;
+                    if (partition == -1) partition = r.partition();
+                    else assertThat(r.partition()).isEqualTo(partition);
+                    seen++;
+                }
+            }
+            assertThat(seen).isGreaterThanOrEqualTo(5);
+        }
+    }
+
+    private KafkaConsumer<byte[], byte[]> consumer() {
+        return new KafkaConsumer<>(Map.of(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers(),
+                ConsumerConfig.GROUP_ID_CONFIG, "ts-test-" + System.nanoTime(),
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class));
+    }
+
+    private ConsumerRecord<byte[], byte[]> awaitOne(KafkaConsumer<byte[], byte[]> consumer) {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<byte[], byte[]> recs = consumer.poll(Duration.ofMillis(500));
+            for (ConsumerRecord<byte[], byte[]> r : recs) return r;
+        }
+        throw new AssertionError("no record received in 10 s");
+    }
+
+    private CollectionSet stubSet(int nodeId) {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date());
+        org.mockito.Mockito.doAnswer(inv -> {
+            CollectionSetVisitor v = inv.getArgument(0);
+            CollectionResource res = mock(CollectionResource.class);
+            when(res.getResourceTypeName()).thenReturn("node");
+            when(res.getInstance()).thenReturn(null);
+            when(res.getParent()).thenReturn(ResourcePath.get("node[" + nodeId + "]"));
+            org.opennms.netmgt.collection.api.AttributeGroup g =
+                    mock(org.opennms.netmgt.collection.api.AttributeGroup.class);
+            when(g.getName()).thenReturn("mib2-system");
+            CollectionAttribute a = mock(CollectionAttribute.class);
+            when(a.getName()).thenReturn("sysUpTime");
+            when(a.getType()).thenReturn(org.opennms.netmgt.collection.api.AttributeType.GAUGE);
+            when(a.getNumericValue()).thenReturn(12345);
+            v.visitCollectionSet(set);
+            v.visitResource(res);
+            v.visitGroup(g);
+            v.visitAttribute(a);
+            v.completeAttribute(a);
+            v.completeGroup(g);
+            v.completeResource(res);
+            v.completeCollectionSet(set);
+            return null;
+        }).when(set).visit(org.mockito.ArgumentMatchers.any());
+        return set;
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @Import({TimeseriesKafkaPublisherConfiguration.class})
+    static class TestApp {
+        /**
+         * Composite factory needs an inner @Qualifier("timeseriesPersisterFactory") bean.
+         * Mock suffices for the broker IT — the real Timeseries persister path is
+         * tested separately in unit tests.
+         */
+        @Bean(name = "timeseriesPersisterFactory")
+        PersisterFactory stubInnerFactory() {
+            return mock(PersisterFactory.class);
+        }
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+
+class TimeseriesKafkaPersisterTest {
+
+    @Test
+    void completeCollectionSetInvokesPublisherWithPackageAndServiceParamsIdentity() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        Map<String, Object> params = new HashMap<>();
+        params.put("collection", "critical-infra");
+        params.put("node-id", "42");
+        params.put("location", "Site-A");
+        when(sp.getParameters()).thenReturn((Map) params);
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+        persister.completeCollectionSet(set);
+
+        verify(publisher).publish(eq(set), eq("critical-infra"), eq(42), eq("Site-A"));
+    }
+
+    @Test
+    void packageDefaultsToDefaultWhenServiceParameterMissing() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(new HashMap<>());
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+        persister.completeCollectionSet(set);
+
+        verify(publisher).publish(eq(set), eq("default"), eq(0), eq(""));
+    }
+
+    @Test
+    void nodeIdAndLocationMissingFromParamsFallBackToZeroAndEmpty() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        Map<String, Object> params = new HashMap<>();
+        params.put("collection", "default");
+        when(sp.getParameters()).thenReturn((Map) params);
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+        persister.completeCollectionSet(set);
+
+        verify(publisher).publish(eq(set), eq("default"), eq(0), eq(""));
+    }
+
+    @Test
+    void malformedNodeIdParsesToZeroFallback() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        Map<String, Object> params = new HashMap<>();
+        params.put("collection", "default");
+        params.put("node-id", "not-a-number");
+        params.put("location", "Default");
+        when(sp.getParameters()).thenReturn((Map) params);
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+        persister.completeCollectionSet(set);
+
+        verify(publisher).publish(eq(set), eq("default"), eq(0), eq("Default"));
+    }
+
+    @Test
+    void visitResourceVisitGroupVisitAttributeAreNoOps() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(new HashMap<>());
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        persister.visitResource(mock(org.opennms.netmgt.collection.api.CollectionResource.class));
+        persister.visitGroup(mock(org.opennms.netmgt.collection.api.AttributeGroup.class));
+        persister.visitAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+        persister.completeAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+        persister.completeGroup(mock(org.opennms.netmgt.collection.api.AttributeGroup.class));
+        persister.completeResource(mock(org.opennms.netmgt.collection.api.CollectionResource.class));
+
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void persistNumericAttributeAndPersistStringAttributeAreNoOps() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(new HashMap<>());
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        persister.persistNumericAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+        persister.persistStringAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+
+        verifyNoInteractions(publisher);
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Date;
+
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+
+class TimeseriesKafkaPublisherTest {
+
+    private StreamBridge streamBridge;
+    private CollectionSetToProtobufTranslator translator;
+    private MeterRegistry meterRegistry;
+    private TimeseriesKafkaPublisher publisher;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setup() {
+        streamBridge = mock(StreamBridge.class);
+        translator = mock(CollectionSetToProtobufTranslator.class);
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = new TimeseriesKafkaPublisher(streamBridge, translator, meterRegistry);
+        when(streamBridge.send(any(String.class), any(Message.class))).thenReturn(true);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void happyPathSendsOneMessageWithCorrectBindingAndKey() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(1700000000000L));
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(42).setLocation("Site-A").setCollectionPackage("default")
+                .setTimestampMs(1700000000000L)
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[42]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default", 42, "Site-A")).thenReturn(batch);
+
+        publisher.publish(set, "default", 42, "Site-A");
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(eq("publishTimeseries-out-0"), captor.capture());
+        Message<byte[]> sent = captor.getValue();
+        assertThat(sent.getPayload()).isEqualTo(batch.toByteArray());
+        assertThat(sent.getHeaders().get(KafkaHeaders.KEY)).isEqualTo("Site-A@42".getBytes());
+
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_published_total",
+                "location", "Site-A", "producer", "collectd").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void emptyBatchSkippedWithoutSend() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        TimeseriesBatch empty = TimeseriesBatch.newBuilder()
+                .setNodeId(42).setLocation("Site-A").build();
+        when(translator.translate(set, "default", 42, "Site-A")).thenReturn(empty);
+
+        publisher.publish(set, "default", 42, "Site-A");
+
+        verify(streamBridge, never()).send(any(String.class), any(Message.class));
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Site-A", "producer", "collectd", "reason", "empty_batch").count())
+                .isEqualTo(1.0);
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
@@ -98,4 +98,163 @@ class TimeseriesKafkaPublisherTest {
                 "location", "Site-A", "producer", "collectd", "reason", "empty_batch").count())
                 .isEqualTo(1.0);
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void translatorThrowingLogsAndIncrementsFailureCounter() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(translator.translate(set, "default", 42, "Site-A"))
+                .thenThrow(new RuntimeException("boom"));
+
+        publisher.publish(set, "default", 42, "Site-A");
+
+        verify(streamBridge, never()).send(any(String.class), any(Message.class));
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Site-A", "producer", "collectd", "reason", "translator_error").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void streamBridgeReturningFalseIncrementsFailureCounter() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default", 1, "Default")).thenReturn(batch);
+        when(streamBridge.send(any(String.class), any(Message.class))).thenReturn(false);
+
+        publisher.publish(set, "default", 1, "Default");
+
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Default", "producer", "collectd", "reason", "kafka_send_error")
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void streamBridgeThrowingIncrementsFailureCounter() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default", 1, "Default")).thenReturn(batch);
+        when(streamBridge.send(any(String.class), any(Message.class)))
+                .thenThrow(new RuntimeException("kafka unavailable"));
+
+        publisher.publish(set, "default", 1, "Default");
+
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Default", "producer", "collectd", "reason", "kafka_send_error")
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void oversizedBatchStillPublishedButWarningCounterIncrements() {
+        CollectionSet set = mock(CollectionSet.class);
+        var resourceBuilder = org.deltav.timeseries.proto.Resource.newBuilder()
+                .setResourceId("node[1]").setType("node");
+        var groupBuilder = org.deltav.timeseries.proto.AttributeGroup.newBuilder()
+                .setName("padding");
+        String bigString = "x".repeat(1000);
+        for (int i = 0; i < 900; i++) {
+            groupBuilder.addAttributes(org.deltav.timeseries.proto.Attribute.newBuilder()
+                    .setName("attr" + i).setText(bigString)
+                    .setType(org.deltav.timeseries.proto.AttributeType.ATTRIBUTE_TYPE_STRING)
+                    .build());
+        }
+        resourceBuilder.addGroups(groupBuilder);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(resourceBuilder).build();
+        when(translator.translate(set, "default", 1, "Default")).thenReturn(batch);
+
+        publisher.publish(set, "default", 1, "Default");
+
+        assertThat(batch.toByteArray().length).isGreaterThan(800_000);
+        verify(streamBridge).send(eq("publishTimeseries-out-0"), any(Message.class));
+        assertThat(meterRegistry.counter("deltav_timeseries_batch_size_warning_total",
+                "location", "Default").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void locationWithAtSignProducesValidPartitionKey() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(42).setLocation("weird@location").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[42]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default", 42, "weird@location")).thenReturn(batch);
+
+        publisher.publish(set, "default", 42, "weird@location");
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(any(String.class), captor.capture());
+        assertThat(captor.getValue().getHeaders().get(KafkaHeaders.KEY))
+                .isEqualTo("weird@location@42".getBytes());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void nodeIdZeroStillProducesPartitionKey() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(0).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[0]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default", 0, "Default")).thenReturn(batch);
+
+        publisher.publish(set, "default", 0, "Default");
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(any(String.class), captor.capture());
+        assertThat(captor.getValue().getHeaders().get(KafkaHeaders.KEY))
+                .isEqualTo("Default@0".getBytes());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void longLocationNameIsCarriedInPartitionKeyUnchanged() {
+        String longLocation = "a".repeat(256);
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation(longLocation).setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default", 1, longLocation)).thenReturn(batch);
+
+        publisher.publish(set, "default", 1, longLocation);
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(any(String.class), captor.capture());
+        assertThat(new String((byte[]) captor.getValue().getHeaders().get(KafkaHeaders.KEY)))
+                .isEqualTo(longLocation + "@1");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void publishDurationTimerIsRecorded() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default", 1, "Default")).thenReturn(batch);
+
+        publisher.publish(set, "default", 1, "Default");
+
+        assertThat(meterRegistry.find("deltav_timeseries_publish_duration_seconds")
+                .tag("location", "Default").tag("producer", "collectd").timer().count())
+                .isEqualTo(1L);
+    }
 }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {
+        TimeseriesPublisherFeatureFlagOffIT.TestApp.class
+})
+@TestPropertySource(properties = {
+        "deltav.timeseries.enabled=false",
+        "spring.main.web-application-type=none",
+        "spring.main.banner-mode=off"
+})
+class TimeseriesPublisherFeatureFlagOffIT {
+
+    /**
+     * Minimal boot application that enables Spring Boot auto-configuration. With
+     * deltav.timeseries.enabled=false, the @ConditionalOnProperty on
+     * TimeseriesKafkaPublisherConfiguration skips all beans — including the
+     * compositePersisterFactory which would otherwise require the Kafka binder.
+     */
+    @EnableAutoConfiguration
+    @Import({
+            TimeseriesKafkaPublisherConfiguration.class,
+            TestChannelBinderConfiguration.class
+    })
+    static class TestApp {
+    }
+
+    @Autowired
+    ApplicationContext ctx;
+
+    @Test
+    void publisherBeanIsAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(TimeseriesKafkaPublisher.class)).isEmpty();
+    }
+
+    @Test
+    void persisterBeanIsAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(TimeseriesKafkaPersister.class)).isEmpty();
+    }
+
+    @Test
+    void newTopicBeansAreAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(org.apache.kafka.clients.admin.NewTopic.class)).isEmpty();
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherStreamBinderIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherStreamBinderIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionSetVisitor;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {
+        TimeseriesPublisherStreamBinderIT.TestApp.class,
+        TimeseriesPublisherStreamBinderIT.Stubs.class
+})
+@TestPropertySource(properties = {
+        "deltav.timeseries.enabled=true",
+        "spring.main.web-application-type=none",
+        "spring.main.banner-mode=off"
+})
+class TimeseriesPublisherStreamBinderIT {
+
+    /**
+     * Minimal boot application that enables Spring Boot auto-configuration so that
+     * SCS BindingServiceConfiguration (which creates StreamBridge) is triggered.
+     * TestChannelBinderConfiguration provides the in-process test binder via
+     * @ConditionalOnMissingBean(Binder.class) — the Kafka binder is loaded lazily
+     * through the BinderFactory, not at startup, so no broker is needed.
+     */
+    @EnableAutoConfiguration
+    @Import({
+            TimeseriesKafkaPublisherConfiguration.class,
+            TestChannelBinderConfiguration.class
+    })
+    static class TestApp {
+    }
+
+    @Autowired
+    TimeseriesKafkaPublisher publisher;
+
+    @Autowired
+    OutputDestination output;
+
+    @Test
+    void publisherBeanIsPresentWhenFlagIsOn() {
+        assertThat(publisher).isNotNull();
+    }
+
+    @Test
+    void publishedMessageCarriesProtobufPayloadAndPartitionKey() throws Exception {
+        CollectionSet set = buildMockSet(1700000000000L);
+
+        publisher.publish(set, "default", 42, "Default");
+
+        Message<byte[]> received = output.receive(2000, "deltav-timeseries");
+        assertThat(received).isNotNull();
+        TimeseriesBatch batch = TimeseriesBatch.parseFrom(received.getPayload());
+        assertThat(batch.getNodeId()).isEqualTo(42);
+        assertThat(batch.getLocation()).isEqualTo("Default");
+        assertThat(received.getHeaders().get(KafkaHeaders.KEY)).isEqualTo("Default@42".getBytes());
+    }
+
+    private CollectionSet buildMockSet(long ts) {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(ts));
+        org.mockito.Mockito.doAnswer(inv -> {
+            CollectionSetVisitor visitor = inv.getArgument(0);
+            org.opennms.netmgt.collection.api.CollectionResource res =
+                    mock(org.opennms.netmgt.collection.api.CollectionResource.class);
+            when(res.getResourceTypeName()).thenReturn("node");
+            when(res.getInstance()).thenReturn(null);
+            when(res.getParent()).thenReturn(org.opennms.netmgt.model.ResourcePath.get("node[42]"));
+            org.opennms.netmgt.collection.api.AttributeGroup g =
+                    mock(org.opennms.netmgt.collection.api.AttributeGroup.class);
+            when(g.getName()).thenReturn("mib2-system");
+            org.opennms.netmgt.collection.api.CollectionAttribute a =
+                    mock(org.opennms.netmgt.collection.api.CollectionAttribute.class);
+            when(a.getName()).thenReturn("sysUpTime");
+            when(a.getType()).thenReturn(org.opennms.netmgt.collection.api.AttributeType.GAUGE);
+            when(a.getNumericValue()).thenReturn(12345);
+            visitor.visitCollectionSet(set);
+            visitor.visitResource(res);
+            visitor.visitGroup(g);
+            visitor.visitAttribute(a);
+            visitor.completeAttribute(a);
+            visitor.completeGroup(g);
+            visitor.completeResource(res);
+            visitor.completeCollectionSet(set);
+            return null;
+        }).when(set).visit(org.mockito.ArgumentMatchers.any());
+        return set;
+    }
+
+    @TestConfiguration
+    static class Stubs {
+        /**
+         * The composite PersisterFactory bean in TimeseriesKafkaPublisherConfiguration
+         * needs a @Qualifier("timeseriesPersisterFactory") inner PersisterFactory. In
+         * tests we don't have the real TimeseriesPersisterFactory on the classpath,
+         * so provide a mock stub.
+         */
+        @Bean(name = "timeseriesPersisterFactory")
+        PersisterFactory stubInnerFactory() {
+            return mock(PersisterFactory.class);
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-04-16-kafka-time-series-producer-collectd.md
+++ b/docs/superpowers/plans/2026-04-16-kafka-time-series-producer-collectd.md
@@ -1,0 +1,2983 @@
+# Kafka Time Series Producer (Collectd) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first Kafka time-series producer in delta-v: Collectd publishes a `TimeseriesBatch` protobuf record per CollectionSet poll to the `deltav-timeseries` topic, keyed `{location}@{node_id}`, gated by the `deltav.timeseries.enabled` feature flag (default off). Also ships the `NodeContext` protobuf schema + `deltav-node-context` compacted topic declaration for contract completeness; the provisiond change-feed producer is a future PR.
+
+**Architecture:** Producer-agnostic wire format. Identity labels live on the compacted `deltav-node-context` topic; metric records carry only `node_id` / `location` / `collection_package` / `producer` / resource tree. Consumers join via Kafka Streams `GlobalKTable` (future). Collectd wires a `TimeseriesKafkaPersister` into its existing `PersisterFactory` chain via a fanout composite, so both `InMemoryStorage` and Kafka writes run side-by-side when the flag is on.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.3, Spring Cloud Stream Kafka binder (function-binding precedent in flow-enricher, but this producer uses imperative `StreamBridge.send(...)` because the "input" is a per-poll callback from Collectd, not a Kafka consumer), protobuf 3.25.5 via `protobuf-maven-plugin` 0.6.1 + `os-maven-plugin` 1.7.1, Micrometer Prometheus, Testcontainers Kafka.
+
+**Design doc:** `docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md`
+**Next-session prompt:** `docs/superpowers/next-session-prompts/2026-04-16-kafka-time-series-producer.md`
+**Feature branch:** `feature/kafka-timeseries-producer-collectd` (already created; see Task 0)
+
+**Critical memory references:**
+- `feedback_never_pr_opennms` — delta-v PRs always use `gh pr create --repo pbrane/delta-v`. Never `OpenNMS/opennms`.
+- `feedback_feature_branches` — never commit directly to `develop`.
+- `feedback_pull_before_branching` — always `git pull` before branching (Task 0 already did this).
+- `feedback_deltav_package_namespace` — new code lives under `org.deltav.*` with delta-v copyright headers, not `org.opennms.*`.
+- `feedback_delta_v_uses_mvnw_not_compile_pl` — all builds use `./mvnw`, not `compile.pl` (that's a horizon-worktree artifact).
+- `feedback_delta_v_full_reactor_verify` — after every horizon version or cross-module change, run a full delta-v reactor build. For this PR a full reactor `./mvnw -pl core/daemon-boot-collectd -am -DskipTests install` followed by a full `./mvnw -DskipTests install` is mandatory before PR.
+- `feedback_rebuild_all_daemons` — before `build.sh deltav`, rebuild all 12 daemon boot JARs.
+- `project_no_newts` — this producer is the no-Newts persistence path; `InMemoryStorage` stays wired as the existing TSS backend.
+
+---
+
+## File Structure
+
+### New files (all under `core/daemon-boot-collectd/`)
+
+**Protobuf schemas** — generated Java lands in `org.deltav.timeseries.proto`:
+- Create: `src/main/proto/deltav-timeseries.proto` — `TimeseriesBatch` + `ProducerType` + `Resource` + `AttributeGroup` + `Attribute` + `AttributeType`
+- Create: `src/main/proto/deltav-node-context.proto` — `NodeContext` + `InterfaceContext` + `ServiceContext`
+
+**Production Java code** — under `src/main/java/org/deltav/collectd/timeseries/`:
+- Create: `CollectionSetToProtobufTranslator.java` — pure function, `CollectionSet` → `TimeseriesBatch` protobuf
+- Create: `TimeseriesKafkaPublisher.java` — orchestration: translate + serialize + size-check + `StreamBridge.send()`, error-isolated
+- Create: `TimeseriesKafkaPersister.java` — horizon `Persister` adapter, delegates to publisher
+- Create: `TimeseriesKafkaPublisherConfiguration.java` — `@Configuration` + `@ConditionalOnProperty("deltav.timeseries.enabled")`, declares publisher / translator / `NewTopic` beans + a `@Primary` composite `PersisterFactory` that fans out to the existing `TimeseriesPersisterFactory` plus a factory for `TimeseriesKafkaPersister`. Contains a package-private static `FanoutPersisterFactory` inner class to compose the two factories without leaking a 5th public class.
+
+**Test Java code** — under `src/test/java/org/deltav/collectd/timeseries/`:
+- Create: `CollectionSetToProtobufTranslatorTest.java` — ~20 unit tests (Layer 1)
+- Create: `TimeseriesKafkaPublisherTest.java` — ~14 unit tests (Layer 2)
+- Create: `TimeseriesPublisherStreamBinderIT.java` — ~8 SCS test-binder ITs (Layer 3)
+- Create: `TimeseriesKafkaBrokerIT.java` — ~6 Testcontainers-Kafka ITs (Layer 4)
+
+**E2E test script** — under `opennms-container/delta-v/`:
+- Create: `test-timeseries-e2e.sh` — Docker Compose golden-path smoke test (Layer 5)
+
+**Application config** — modifications:
+- Modify: `src/main/resources/application.yml` — add SCS output binding + Kafka producer configuration + `deltav.timeseries.*` flag block + `deltav.node-context.*` block
+- Modify: `src/main/java/org/deltav/netmgt/collectd/boot/CollectdDaemonConfiguration.java:318-328` — rename the existing `persisterFactory` bean to `timeseriesPersisterFactory` so the composite factory in the new configuration can @Primary over it without name collision
+- Modify: `pom.xml` — add `os-maven-plugin` build extension, `protobuf-maven-plugin` plugin, `<protoc.version>` property, dependencies on `protobuf-java`, `spring-cloud-starter-stream-kafka`, `micrometer-registry-prometheus`, `spring-cloud-stream-test-binder` (test), and `testcontainers-kafka` (test)
+- Modify: `opennms-container/delta-v/docker-compose.yml` — wire `DELTAV_TIMESERIES_ENABLED` env var for the `collectd` service (default `false`, opt-in via user override)
+- Modify: `opennms-container/delta-v/README.md` — operator documentation (env vars, Prometheus metrics, expected disk footprint, known limitations)
+
+**Memory updates** — `~/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/`:
+- Create: `project_collectd_scheduler_publisher_split.md` — futurework tracking for splitting Collectd scheduler/publisher (referenced in spec R5)
+- Modify: `MEMORY.md` — add index line for the new followup memory; update the `project_kafka_timeseries_producer_next_session.md` line to DONE status linking this PR
+
+---
+
+## Task 0: Confirm feature branch (already done — verify)
+
+**Files:** none — branch verification only.
+
+- [ ] **Step 1: Confirm branch and clean working tree**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+git branch --show-current
+git status --short
+```
+
+Expected: branch is `feature/kafka-timeseries-producer-collectd`; `git status` returns either empty or only files we've intentionally stashed (the requisition drift stash from session start — leave it stashed).
+
+If not on the feature branch, recover:
+
+```bash
+git switch feature/kafka-timeseries-producer-collectd \
+  || { git fetch origin && git switch develop && git pull --ff-only origin develop \
+       && git switch -c feature/kafka-timeseries-producer-collectd; }
+```
+
+---
+
+## Task 1: Add protobuf build tooling and new dependencies to `pom.xml`
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/pom.xml`
+
+This task only touches the pom; protobuf and schema creation happen in Task 2.
+
+- [ ] **Step 1: Add the `<protoc.version>` property**
+
+Open `core/daemon-boot-collectd/pom.xml`. Locate the `<properties>` block (currently lines 19-21 containing only `<java.version>21</java.version>`). Replace with:
+
+```xml
+    <properties>
+        <java.version>21</java.version>
+        <protoc.version>3.25.5</protoc.version>
+    </properties>
+```
+
+- [ ] **Step 2: Add production dependencies**
+
+After the existing `spring-boot-starter-web` dependency block (ends around line 434) and before the `<!-- Test -->` comment (line 436), insert the following block verbatim:
+
+```xml
+        <!-- Kafka Time Series producer: protobuf wire format -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protoc.version}</version>
+        </dependency>
+
+        <!-- Kafka Time Series producer: Spring Cloud Stream Kafka binder for StreamBridge -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
+
+        <!-- Kafka Time Series producer: Prometheus metrics registry for /actuator/prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Actuator endpoint support (required for /actuator/prometheus) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+```
+
+- [ ] **Step 3: Add test dependencies**
+
+After the existing `testcontainers-junit-jupiter` block (line 471-473) and before the closing `</dependencies>` tag (line 474), insert:
+
+```xml
+        <!-- SCS test binder for Layer 3 integration tests -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-test-binder</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers Kafka for Layer 4 broker tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+```
+
+- [ ] **Step 4: Add the `os-maven-plugin` build extension**
+
+Inside the `<build>` block (line 476) and before the `<plugins>` child (line 477), insert an `<extensions>` section:
+
+```xml
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+```
+
+- [ ] **Step 5: Add the `protobuf-maven-plugin` plugin**
+
+Inside the `<plugins>` block, immediately after the `maven-compiler-plugin` block (ends around line 484) and before `spring-boot-maven-plugin` (line 485), insert:
+
+```xml
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+```
+
+- [ ] **Step 6: Verify the pom parses and resolves**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+./mvnw -pl core/daemon-boot-collectd -am -DskipTests dependency:resolve -q 2>&1 | tail -20
+```
+
+Expected: no ERROR lines. May print `[WARNING]` lines about version overrides — those are fine. If `spring-cloud-starter-stream-kafka` fails to resolve, verify the horizon BOM / Spring Cloud BOM import chain via `./mvnw -pl core/daemon-boot-collectd help:effective-pom | grep -A1 spring-cloud-starter-stream-kafka` and confirm a version is managed upstream. If no managed version is found, add `<version>4.3.0</version>` to the dependency block (matching what flow-enricher uses).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/daemon-boot-collectd/pom.xml
+git commit -m "build(daemon-boot-collectd): add protobuf toolchain + SCS Kafka binder
+
+Wire protobuf-maven-plugin 0.6.1 + os-maven-plugin 1.7.1 (same versions flow-enricher
+uses) and add protobuf-java, spring-cloud-starter-stream-kafka, micrometer-registry-prometheus,
+spring-boot-starter-actuator as production deps. Add spring-cloud-stream-test-binder and
+testcontainers-kafka as test deps. Prepares daemon-boot-collectd for the Kafka time-series
+producer landing in subsequent commits on this branch.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 2: Create `deltav-timeseries.proto` schema
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/main/proto/deltav-timeseries.proto`
+
+- [ ] **Step 1: Create directory**
+
+```bash
+mkdir -p core/daemon-boot-collectd/src/main/proto
+```
+
+- [ ] **Step 2: Write the schema file**
+
+Create `core/daemon-boot-collectd/src/main/proto/deltav-timeseries.proto` with exactly the contents below. This matches the spec's "Schema 1: `TimeseriesBatch`" section. Preserve field numbers, comments, and whitespace — schema evolution rules require exact field numbers.
+
+```protobuf
+// Licensed to Delta-V under the GNU Affero General Public License v3.
+// See LICENSE.md in the repository root for full license text.
+
+syntax = "proto3";
+
+package deltav.timeseries;
+
+option java_package = "org.deltav.timeseries.proto";
+option java_multiple_files = true;
+
+// One record per CollectionSet poll. Published to the deltav-timeseries topic,
+// keyed by "{location}@{node_id}". Deliberately producer-agnostic: the same
+// shape is valid whether the producer is Collectd, Pollerd, PerspectivePollerd,
+// or a future SnmpCollector-on-Minion deployment. No identity labels are
+// carried here — consumers join against the deltav-node-context GlobalKTable
+// at process time.
+message TimeseriesBatch {
+  // Milliseconds since Unix epoch when the poll was produced by the collector.
+  // "Collection time," not "publish time" — stamped by the producer before
+  // serialization and immutable through the pipeline.
+  int64 timestamp_ms = 1;
+
+  // Numeric node ID from the nodes table. Used as part of the partition key
+  // and as the join key against deltav-node-context.
+  int32 node_id = 2;
+
+  // Logical location name (e.g. "Default", "Site-A"). Part of the partition
+  // key. Redundant with NodeContext.location but carried here so consumers
+  // can derive the join key from the metric record alone.
+  string location = 3;
+
+  // The package that produced this batch (e.g. "default", "interfaceSnmp").
+  // Used by consumers to filter rules (e.g. "only evaluate threshold X on
+  // records from the 'critical-infra' package").
+  string collection_package = 4;
+
+  // The producer that emitted this batch. Identifies which daemon wrote the
+  // record so consumers can distinguish e.g. Collectd vs. Pollerd origin
+  // without adding a separate topic. Enum because the set is small and
+  // closed.
+  ProducerType producer = 5;
+
+  // The resource tree. A single CollectionSet usually has multiple resources
+  // (one per collected entity: node, interface, storage row, etc).
+  repeated Resource resources = 6;
+}
+
+enum ProducerType {
+  PRODUCER_UNSPECIFIED = 0;
+  PRODUCER_COLLECTD = 1;
+  PRODUCER_POLLERD = 2;
+  PRODUCER_PERSPECTIVE_POLLERD = 3;
+  PRODUCER_MINION_SNMP_COLLECTOR = 4;
+  PRODUCER_STREAMING_TELEMETRY = 5;
+}
+
+message Resource {
+  string resource_id = 1;
+  string type = 2;
+  string instance = 3;
+  repeated AttributeGroup groups = 4;
+}
+
+message AttributeGroup {
+  string name = 1;
+  repeated Attribute attributes = 2;
+}
+
+message Attribute {
+  string name = 1;
+  oneof value {
+    double numeric = 2;
+    string text = 3;
+  }
+  AttributeType type = 4;
+}
+
+enum AttributeType {
+  ATTRIBUTE_TYPE_UNSPECIFIED = 0;
+  ATTRIBUTE_TYPE_COUNTER = 1;
+  ATTRIBUTE_TYPE_GAUGE = 2;
+  ATTRIBUTE_TYPE_STRING = 3;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/proto/deltav-timeseries.proto
+git commit -m "feat(daemon-boot-collectd): add deltav-timeseries.proto schema
+
+One record per CollectionSet poll. Producer-agnostic wire format: carries
+node_id, location, collection_package, producer type, and the resource tree.
+Identity labels live on the deltav-node-context compacted topic (separate
+schema), not on metric records — consumers join via Kafka Streams GlobalKTable.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 3: Create `deltav-node-context.proto` schema
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/main/proto/deltav-node-context.proto`
+
+The `NodeContext` producer (provisiond change feed) ships in a separate future PR. This PR commits the schema and will declare the `NewTopic` bean in Task 7 so the contract is complete and the topic is provisioned on first start.
+
+- [ ] **Step 1: Write the schema file**
+
+Create `core/daemon-boot-collectd/src/main/proto/deltav-node-context.proto` with exactly the contents below:
+
+```protobuf
+// Licensed to Delta-V under the GNU Affero General Public License v3.
+// See LICENSE.md in the repository root for full license text.
+
+syntax = "proto3";
+
+package deltav.timeseries;
+
+option java_package = "org.deltav.timeseries.proto";
+option java_multiple_files = true;
+
+// One record per node, published to the deltav-node-context topic whenever a
+// node is provisioned, updated, deleted, or its metadata changes. The topic is
+// compacted (log.cleanup.policy=compact), so the latest record per key
+// survives forever and a new consumer can bootstrap from the beginning of the
+// topic to materialize the full current state.
+//
+// Keyed by "{location}@{node_id}" — same key shape as TimeseriesBatch so
+// consumers can join directly without a key transformer.
+message NodeContext {
+  int32 node_id = 1;
+  string location = 2;
+  string node_label = 3;
+  string foreign_source = 4;
+  string foreign_id = 5;
+  repeated string categories = 6;
+  map<string, string> metadata = 7;
+  map<string, InterfaceContext> interface_metadata = 8;
+  map<string, ServiceContext> service_metadata = 9;
+  int64 updated_at_ms = 10;
+  bool deleted = 11;
+}
+
+message InterfaceContext {
+  map<string, string> metadata = 1;
+}
+
+message ServiceContext {
+  map<string, string> metadata = 1;
+}
+```
+
+- [ ] **Step 2: Verify protobuf compiles and generated classes are on the classpath**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -DskipTests compile -q 2>&1 | tail -10
+ls core/daemon-boot-collectd/target/generated-sources/protobuf/java/org/deltav/timeseries/proto/ 2>&1
+```
+
+Expected: no ERROR lines in the build output; the `ls` shows at minimum `TimeseriesBatch.java`, `Resource.java`, `AttributeGroup.java`, `Attribute.java`, `ProducerType.java`, `AttributeType.java`, `NodeContext.java`, `InterfaceContext.java`, `ServiceContext.java`.
+
+If the `generated-sources` directory does not exist, the `protobuf-maven-plugin` didn't run. Re-check Task 1 Step 5 wiring. The plugin binds to the `generate-sources` phase by default; `compile` invokes it transitively.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/proto/deltav-node-context.proto
+git commit -m "feat(daemon-boot-collectd): add deltav-node-context.proto schema
+
+Compacted-topic schema for per-node identity (node_label, foreign_source,
+foreign_id, categories) and the full OnmsMetaData surface (node-scoped,
+interface-scoped, service-scoped metadata maps). Producer is provisiond's
+change feed — separate future PR. Schema is committed here so the NewTopic
+declaration (Task 7) has a contract and downstream consumer services can be
+planned against a stable wire format.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 4: `CollectionSetToProtobufTranslator` — TDD for numeric attributes
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java`
+- Create: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java`
+
+This task covers the happy-path numeric cases (gauge, counter, Long-valued counter) and lays down the skeleton. Subsequent tasks add string and edge-case coverage.
+
+- [ ] **Step 1: Create package directories**
+
+```bash
+mkdir -p core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries
+mkdir -p core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries
+```
+
+- [ ] **Step 2: Write the initial failing test**
+
+Create `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+
+class CollectionSetToProtobufTranslatorTest {
+
+    private final CollectionSetToProtobufTranslator translator = new CollectionSetToProtobufTranslator();
+
+    @Test
+    void emptyCollectionSetProducesEmptyResourceList() {
+        CollectionSet set = mockCollectionSet(1, "Default", "default", CollectionStatus.SUCCEEDED,
+                1700000000000L, Collections.emptyList());
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        assertThat(batch.getNodeId()).isEqualTo(1);
+        assertThat(batch.getLocation()).isEqualTo("Default");
+        assertThat(batch.getCollectionPackage()).isEqualTo("default");
+        assertThat(batch.getTimestampMs()).isEqualTo(1700000000000L);
+        assertThat(batch.getProducer()).isEqualTo(ProducerType.PRODUCER_COLLECTD);
+        assertThat(batch.getResourcesList()).isEmpty();
+    }
+
+    // Helper factories used by all tests in this class.
+    // Keep them here (not in a separate fixture class) so test intent stays
+    // one-file-readable; pure boilerplate should not leak into production code.
+
+    static CollectionSet mockCollectionSet(int nodeId, String location, String pkg,
+                                            CollectionStatus status, long timestampMs,
+                                            List<CollectionResource> resources) {
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(nodeId);
+        when(agent.getLocationName()).thenReturn(location);
+
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(status);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(timestampMs));
+        // visitor walk driven by the CollectionSet; the translator uses the walker,
+        // not the raw list. Tests below stub visit() to emit the given resources.
+        // For this empty case the set is visited but emits no resources.
+        return set;
+    }
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails with a class-not-found error**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=CollectionSetToProtobufTranslatorTest test -q 2>&1 | tail -20
+```
+
+Expected: test compilation fails with `cannot find symbol: class CollectionSetToProtobufTranslator`. This confirms the test is correctly wired and the implementation is missing.
+
+- [ ] **Step 4: Write the minimum production implementation**
+
+Create `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionSetVisitor;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+
+/**
+ * Pure function that walks a horizon CollectionSet visitor tree and emits a
+ * TimeseriesBatch protobuf. No side effects, no Spring state, no logging.
+ * Callers translate per poll; concurrent calls are safe because each call
+ * uses a fresh VisitorState instance.
+ */
+public class CollectionSetToProtobufTranslator {
+
+    public TimeseriesBatch translate(CollectionSet set, String collectionPackage) {
+        if (set == null || set.getStatus() == CollectionStatus.FAILED) {
+            return TimeseriesBatch.newBuilder()
+                    .setProducer(ProducerType.PRODUCER_COLLECTD)
+                    .build();
+        }
+
+        VisitorState state = new VisitorState();
+        set.visit(state);
+
+        long timestampMs = set.getCollectionTimestamp() != null
+                ? set.getCollectionTimestamp().getTime()
+                : System.currentTimeMillis();
+
+        TimeseriesBatch.Builder batch = TimeseriesBatch.newBuilder()
+                .setTimestampMs(timestampMs)
+                .setNodeId(state.nodeId)
+                .setLocation(state.location != null ? state.location : "")
+                .setCollectionPackage(collectionPackage != null ? collectionPackage : "")
+                .setProducer(ProducerType.PRODUCER_COLLECTD);
+
+        for (ResourceAccumulator r : state.resources.values()) {
+            Resource.Builder resBuilder = Resource.newBuilder()
+                    .setResourceId(r.resourceId)
+                    .setType(r.type)
+                    .setInstance(r.instance);
+            for (AttributeGroupAccumulator g : r.groups.values()) {
+                if (g.attributes.isEmpty()) continue;
+                AttributeGroup.Builder groupBuilder = AttributeGroup.newBuilder().setName(g.name);
+                g.attributes.forEach(groupBuilder::addAttributes);
+                resBuilder.addGroups(groupBuilder);
+            }
+            if (resBuilder.getGroupsCount() > 0) {
+                batch.addResources(resBuilder);
+            }
+        }
+
+        return batch.build();
+    }
+
+    private static class VisitorState implements CollectionSetVisitor {
+        int nodeId;
+        String location;
+        // preserve insertion order of resources and groups to keep tests deterministic
+        final Map<String, ResourceAccumulator> resources = new java.util.LinkedHashMap<>();
+        ResourceAccumulator currentResource;
+        AttributeGroupAccumulator currentGroup;
+
+        @Override public void visitCollectionSet(CollectionSet set) {
+            // no-op: the outer translate() reads timestamp/status directly from the set
+        }
+        @Override public void visitResource(CollectionResource resource) {
+            CollectionAgent agent = resourceAgent(resource);
+            if (agent != null) {
+                nodeId = agent.getNodeId();
+                location = agent.getLocationName();
+            }
+            String resourceId = resource.getInstance() != null
+                    ? resource.getParent() + "." + resource.getResourceTypeName() + "[" + resource.getInstance() + "]"
+                    : resource.getParent() + "." + resource.getResourceTypeName();
+            currentResource = resources.computeIfAbsent(resourceId,
+                    id -> new ResourceAccumulator(id, resource.getResourceTypeName(),
+                            resource.getInstance() != null ? resource.getInstance() : ""));
+        }
+        @Override public void visitGroup(org.opennms.netmgt.collection.api.AttributeGroup group) {
+            if (currentResource == null) return;
+            currentGroup = currentResource.groups.computeIfAbsent(group.getName(),
+                    AttributeGroupAccumulator::new);
+        }
+        @Override public void visitAttribute(CollectionAttribute attribute) {
+            if (currentGroup == null) return;
+            currentGroup.attributes.add(attributeToProto(attribute));
+        }
+        @Override public void completeAttribute(CollectionAttribute attribute) { /* no-op */ }
+        @Override public void completeGroup(org.opennms.netmgt.collection.api.AttributeGroup group) {
+            currentGroup = null;
+        }
+        @Override public void completeResource(CollectionResource resource) {
+            currentResource = null;
+        }
+        @Override public void completeCollectionSet(CollectionSet set) { /* no-op */ }
+
+        private static CollectionAgent resourceAgent(CollectionResource resource) {
+            // horizon CollectionResource exposes the agent via a non-public path on some
+            // implementations; use the interface method when available. If null we fall
+            // back to whatever nodeId was set by an earlier resource.
+            try {
+                java.lang.reflect.Method m = resource.getClass().getMethod("getAgent");
+                Object val = m.invoke(resource);
+                return val instanceof CollectionAgent ? (CollectionAgent) val : null;
+            } catch (ReflectiveOperationException e) {
+                return null;
+            }
+        }
+    }
+
+    private static Attribute attributeToProto(CollectionAttribute attribute) {
+        Attribute.Builder builder = Attribute.newBuilder().setName(attribute.getName());
+        org.opennms.netmgt.collection.api.AttributeType t = attribute.getType();
+        if (t == org.opennms.netmgt.collection.api.AttributeType.STRING) {
+            String v = attribute.getStringValue();
+            builder.setText(v != null ? v : "").setType(AttributeType.ATTRIBUTE_TYPE_STRING);
+        } else if (t == org.opennms.netmgt.collection.api.AttributeType.COUNTER) {
+            Number n = attribute.getNumericValue();
+            builder.setNumeric(n != null ? n.doubleValue() : 0.0d)
+                   .setType(AttributeType.ATTRIBUTE_TYPE_COUNTER);
+        } else {
+            Number n = attribute.getNumericValue();
+            builder.setNumeric(n != null ? n.doubleValue() : 0.0d)
+                   .setType(AttributeType.ATTRIBUTE_TYPE_GAUGE);
+        }
+        return builder.build();
+    }
+
+    private static class ResourceAccumulator {
+        final String resourceId;
+        final String type;
+        final String instance;
+        final Map<String, AttributeGroupAccumulator> groups = new java.util.LinkedHashMap<>();
+
+        ResourceAccumulator(String resourceId, String type, String instance) {
+            this.resourceId = resourceId;
+            this.type = type;
+            this.instance = instance;
+        }
+    }
+
+    private static class AttributeGroupAccumulator {
+        final String name;
+        final List<Attribute> attributes = new ArrayList<>();
+
+        AttributeGroupAccumulator(String name) { this.name = name; }
+    }
+}
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=CollectionSetToProtobufTranslatorTest#emptyCollectionSetProducesEmptyResourceList test -q 2>&1 | tail -15
+```
+
+Expected: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
+git commit -m "feat(collectd/timeseries): add CollectionSetToProtobufTranslator skeleton
+
+Pure function that walks a horizon CollectionSet visitor tree and emits a
+TimeseriesBatch protobuf. First test covers the empty-CollectionSet case;
+numeric/string/edge-case coverage added in subsequent commits.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 5: Translator — numeric attribute coverage (gauge, counter, Long value)
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java`
+
+Reviewer feedback (captured in the next-session prompt): tests must explicitly cover Counter 64-bit, Gauge 32-bit, Gauge 64-bit variants. All collapse to protobuf `double`, but the tests prove no silent truncation.
+
+- [ ] **Step 1: Add a shared mock helper at the bottom of the test class**
+
+Append this private helper method inside the existing test class (before the closing `}`):
+
+```java
+    /**
+     * Build a mock CollectionResource with a single AttributeGroup containing the
+     * given attributes, and a CollectionSet whose visit() calls the visitor with
+     * that single resource. Returns the CollectionSet.
+     */
+    static CollectionSet oneResourceSet(int nodeId, String location, String resourceType,
+                                         String instance, String groupName,
+                                         List<CollectionAttribute> attributes,
+                                         long timestampMs) {
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(nodeId);
+        when(agent.getLocationName()).thenReturn(location);
+
+        CollectionResource resource = mock(CollectionResource.class);
+        when(resource.getResourceTypeName()).thenReturn(resourceType);
+        when(resource.getInstance()).thenReturn(instance);
+        when(resource.getParent()).thenReturn(org.opennms.netmgt.model.ResourcePath.get("node[" + nodeId + "]"));
+
+        org.opennms.netmgt.collection.api.AttributeGroup group =
+                mock(org.opennms.netmgt.collection.api.AttributeGroup.class);
+        when(group.getName()).thenReturn(groupName);
+
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(timestampMs));
+        org.mockito.Mockito.doAnswer(inv -> {
+            org.opennms.netmgt.collection.api.CollectionSetVisitor v = inv.getArgument(0);
+            v.visitCollectionSet(set);
+            v.visitResource(resource);
+            v.visitGroup(group);
+            attributes.forEach(a -> {
+                when(a.getResource()).thenReturn(resource);
+                v.visitAttribute(a);
+                v.completeAttribute(a);
+            });
+            v.completeGroup(group);
+            v.completeResource(resource);
+            v.completeCollectionSet(set);
+            return null;
+        }).when(set).visit(org.mockito.ArgumentMatchers.any());
+        return set;
+    }
+
+    static CollectionAttribute numericAttribute(String name,
+                                                 org.opennms.netmgt.collection.api.AttributeType type,
+                                                 Number value) {
+        CollectionAttribute attr = mock(CollectionAttribute.class);
+        when(attr.getName()).thenReturn(name);
+        when(attr.getType()).thenReturn(type);
+        when(attr.getNumericValue()).thenReturn(value);
+        return attr;
+    }
+
+    static CollectionAttribute stringAttribute(String name, String value) {
+        CollectionAttribute attr = mock(CollectionAttribute.class);
+        when(attr.getName()).thenReturn(name);
+        when(attr.getType()).thenReturn(org.opennms.netmgt.collection.api.AttributeType.STRING);
+        when(attr.getStringValue()).thenReturn(value);
+        return attr;
+    }
+```
+
+- [ ] **Step 2: Add the numeric attribute tests**
+
+Append inside the test class:
+
+```java
+    @Test
+    void gauge32AttributeMapsToNumericDouble() {
+        CollectionAttribute attr = numericAttribute("sysUpTime",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 123456);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "mib2-system",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        assertThat(batch.getResourcesCount()).isEqualTo(1);
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getType()).isEqualTo(AttributeType.ATTRIBUTE_TYPE_GAUGE);
+        assertThat(out.getNumeric()).isEqualTo(123456.0d);
+    }
+
+    @Test
+    void gauge64AttributeMapsToNumericDouble() {
+        CollectionAttribute attr = numericAttribute("ifHCInOctets",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 12345678901234L);
+        CollectionSet set = oneResourceSet(7, "Default", "interfaceSnmp", "eth0",
+                "mib2-interfaces", List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getNumeric()).isEqualTo(12345678901234.0d);
+    }
+
+    @Test
+    void counter64AttributeMapsToCounterType() {
+        CollectionAttribute attr = numericAttribute("ifHCInOctets",
+                org.opennms.netmgt.collection.api.AttributeType.COUNTER, 98765432109876L);
+        CollectionSet set = oneResourceSet(7, "Default", "interfaceSnmp", "eth0",
+                "mib2-interfaces", List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getType()).isEqualTo(AttributeType.ATTRIBUTE_TYPE_COUNTER);
+        assertThat(out.getNumeric()).isEqualTo(98765432109876.0d);
+    }
+
+    @Test
+    void negativeAndZeroNumericValuesAreCarriedUnchanged() {
+        CollectionAttribute neg = numericAttribute("someNeg",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, -42);
+        CollectionAttribute zero = numericAttribute("someZero",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 0);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "edge-cases",
+                List.of(neg, zero), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        assertThat(batch.getResources(0).getGroups(0).getAttributesList())
+                .extracting(Attribute::getNumeric)
+                .containsExactly(-42.0d, 0.0d);
+    }
+```
+
+- [ ] **Step 3: Run the subset and verify pass**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=CollectionSetToProtobufTranslatorTest test -q 2>&1 | tail -10
+```
+
+Expected: `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
+git commit -m "test(collectd/timeseries): cover gauge 32-/64-bit and counter 64-bit variants
+
+Explicit coverage per reviewer feedback in spec-approval PR #167: all horizon
+AttributeType numeric variants (Counter 64-bit, Gauge 32-bit, Gauge 64-bit)
+must flatten to protobuf double without truncation. String coverage added in
+next commit."
+```
+
+---
+
+## Task 6: Translator — string attributes, edge cases, STATUS_FAILED
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java`
+
+- [ ] **Step 1: Add remaining tests**
+
+Append to the test class:
+
+```java
+    @Test
+    void stringAttributeMapsToTextValue() {
+        CollectionAttribute attr = stringAttribute("sysDescr", "Linux 6.1.0");
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "mib2-system",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        Attribute out = batch.getResources(0).getGroups(0).getAttributes(0);
+        assertThat(out.getType()).isEqualTo(AttributeType.ATTRIBUTE_TYPE_STRING);
+        assertThat(out.getText()).isEqualTo("Linux 6.1.0");
+        assertThat(out.getValueCase()).isEqualTo(Attribute.ValueCase.TEXT);
+    }
+
+    @Test
+    void structuredJsonStringAttributeIsCarriedVerbatim() {
+        String json = "{\"cpu\":42,\"mem\":{\"used\":1024,\"free\":2048}}";
+        CollectionAttribute attr = stringAttribute("structuredPayload", json);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "structured",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        assertThat(batch.getResources(0).getGroups(0).getAttributes(0).getText()).isEqualTo(json);
+    }
+
+    @Test
+    void unicodeAttributeAndGroupNamesSurviveRoundtripInProto() {
+        CollectionAttribute attr = numericAttribute("répondéz",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 1);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "αβγ-group",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        assertThat(batch.getResources(0).getGroups(0).getName()).isEqualTo("αβγ-group");
+        assertThat(batch.getResources(0).getGroups(0).getAttributes(0).getName()).isEqualTo("répondéz");
+    }
+
+    @Test
+    void statusFailedCollectionSetProducesEmptyBatch() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.FAILED);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+
+        assertThat(batch.getResourcesList()).isEmpty();
+        assertThat(batch.getNodeId()).isZero();
+    }
+
+    @Test
+    void nullCollectionSetYieldsEmptyBatchNotNpe() {
+        TimeseriesBatch batch = translator.translate(null, "default");
+
+        assertThat(batch.getResourcesList()).isEmpty();
+        assertThat(batch.getProducer()).isEqualTo(ProducerType.PRODUCER_COLLECTD);
+    }
+
+    @Test
+    void resourceWithNoAttributesIsOmittedFromBatch() {
+        CollectionAttribute attr = numericAttribute("x",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 1);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "with-attr",
+                List.of(attr), 1700000000000L);
+        CollectionSet emptySet = oneResourceSet(7, "Default", "node", null, "empty-group",
+                List.of(), 1700000000000L);
+
+        TimeseriesBatch withAttr = translator.translate(set, "default");
+        TimeseriesBatch withoutAttr = translator.translate(emptySet, "default");
+
+        assertThat(withAttr.getResourcesCount()).isEqualTo(1);
+        assertThat(withoutAttr.getResourcesList()).isEmpty();
+    }
+
+    @Test
+    void interfaceScopedResourceEmitsInstanceAndResourceIdCorrectly() {
+        CollectionAttribute attr = numericAttribute("ifInOctets",
+                org.opennms.netmgt.collection.api.AttributeType.COUNTER, 1000L);
+        CollectionSet set = oneResourceSet(7, "Default", "interfaceSnmp", "eth0",
+                "mib2-interfaces", List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "default");
+        var resource = batch.getResources(0);
+
+        assertThat(resource.getType()).isEqualTo("interfaceSnmp");
+        assertThat(resource.getInstance()).isEqualTo("eth0");
+        assertThat(resource.getResourceId()).contains("interfaceSnmp[eth0]");
+    }
+
+    @Test
+    void packageNameIsCopiedIntoBatch() {
+        CollectionAttribute attr = numericAttribute("x",
+                org.opennms.netmgt.collection.api.AttributeType.GAUGE, 1);
+        CollectionSet set = oneResourceSet(7, "Default", "node", null, "g",
+                List.of(attr), 1700000000000L);
+
+        TimeseriesBatch batch = translator.translate(set, "critical-infra");
+
+        assertThat(batch.getCollectionPackage()).isEqualTo("critical-infra");
+    }
+```
+
+- [ ] **Step 2: Run the full test class and verify all pass**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=CollectionSetToProtobufTranslatorTest test -q 2>&1 | tail -10
+```
+
+Expected: `Tests run: 13, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 3: If any test fails, inspect the failure and adjust the translator. Common adjustments:**
+  - If `resource.getParent()` mock returns `null` and the translator NPEs, make `visitResource` in the translator null-safe (`resource.getParent() != null ? resource.getParent() + "." : ""`).
+  - If `STATUS_FAILED` test fails because the empty batch still has `timestamp_ms` set, adjust `translate()` to return the empty-batch early for FAILED status (already wired in Task 4 Step 4 — verify).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslatorTest.java
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectionSetToProtobufTranslator.java
+git commit -m "test(collectd/timeseries): string, JSON, unicode, failed-status, null, empty-group
+
+Complete the Layer 1 test surface for CollectionSetToProtobufTranslator.
+Total 13 tests covering all AttributeType variants, edge cases the reviewer
+flagged (structured JSON, unicode), and failure modes (STATUS_FAILED,
+null-set, empty resource)."
+```
+
+---
+
+## Task 7: `TimeseriesKafkaPublisher` — happy path + metrics
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java`
+- Create: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java`
+
+- [ ] **Step 1: Write failing test**
+
+Create `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+
+class TimeseriesKafkaPublisherTest {
+
+    private StreamBridge streamBridge;
+    private CollectionSetToProtobufTranslator translator;
+    private MeterRegistry meterRegistry;
+    private TimeseriesKafkaPublisher publisher;
+
+    @BeforeEach
+    void setup() {
+        streamBridge = mock(StreamBridge.class);
+        translator = mock(CollectionSetToProtobufTranslator.class);
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = new TimeseriesKafkaPublisher(streamBridge, translator, meterRegistry);
+        when(streamBridge.send(any(String.class), any(Message.class))).thenReturn(true);
+    }
+
+    @Test
+    void happyPathSendsOneMessageWithCorrectBindingAndKey() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(1700000000000L));
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(42).setLocation("Site-A").setCollectionPackage("default")
+                .setTimestampMs(1700000000000L).build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+
+        publisher.publish(set, "default");
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(eq("publishTimeseries-out-0"), captor.capture());
+        Message<byte[]> sent = captor.getValue();
+        assertThat(sent.getPayload()).isEqualTo(batch.toByteArray());
+        assertThat(sent.getHeaders().get(KafkaHeaders.KEY)).isEqualTo("Site-A@42".getBytes());
+
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_published_total",
+                "location", "Site-A", "producer", "collectd").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void emptyBatchSkippedWithoutSend() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        TimeseriesBatch empty = TimeseriesBatch.newBuilder()
+                .setNodeId(42).setLocation("Site-A").build();
+        when(translator.translate(set, "default")).thenReturn(empty);
+
+        publisher.publish(set, "default");
+
+        verify(streamBridge, never()).send(any(String.class), any(Message.class));
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Site-A", "producer", "collectd", "reason", "empty_batch").count())
+                .isEqualTo(1.0);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails (class not yet present)**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=TimeseriesKafkaPublisherTest test -q 2>&1 | tail -10
+```
+
+Expected: compile error `cannot find symbol: class TimeseriesKafkaPublisher`.
+
+- [ ] **Step 3: Write the production class**
+
+Create `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import java.nio.charset.StandardCharsets;
+
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Orchestration layer: translate a CollectionSet to protobuf, serialize, build
+ * the partition key as "{location}@{node_id}", and invoke
+ * {@link StreamBridge#send(String, Message)} on the "publishTimeseries-out-0"
+ * binding. Error-isolated: never throws to the caller so the persister chain
+ * is unaffected by Kafka hiccups.
+ */
+public class TimeseriesKafkaPublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesKafkaPublisher.class);
+    private static final String BINDING_NAME = "publishTimeseries-out-0";
+    static final int SIZE_WARNING_THRESHOLD_BYTES = 800_000;
+
+    private final StreamBridge streamBridge;
+    private final CollectionSetToProtobufTranslator translator;
+    private final MeterRegistry meterRegistry;
+
+    public TimeseriesKafkaPublisher(StreamBridge streamBridge,
+                                     CollectionSetToProtobufTranslator translator,
+                                     MeterRegistry meterRegistry) {
+        this.streamBridge = streamBridge;
+        this.translator = translator;
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void publish(CollectionSet set, String collectionPackage) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String location = "";
+        try {
+            TimeseriesBatch batch;
+            try {
+                batch = translator.translate(set, collectionPackage);
+            } catch (RuntimeException ex) {
+                LOG.warn("Translator failed for package {}; dropping CollectionSet",
+                        collectionPackage, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", "", "producer", "collectd",
+                        "reason", "translator_error").increment();
+                return;
+            }
+            location = batch.getLocation();
+
+            if (batch.getResourcesCount() == 0) {
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", location, "producer", "collectd",
+                        "reason", "empty_batch").increment();
+                return;
+            }
+
+            byte[] payload;
+            try {
+                payload = batch.toByteArray();
+            } catch (RuntimeException ex) {
+                LOG.warn("Serialization failed for node {} / package {}",
+                        batch.getNodeId(), collectionPackage, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", location, "producer", "collectd",
+                        "reason", "serialization_error").increment();
+                return;
+            }
+
+            if (payload.length > SIZE_WARNING_THRESHOLD_BYTES) {
+                LOG.warn("Oversized TimeseriesBatch: {} bytes for node {} in package {}. "
+                        + "Kafka max.request.size default is 1 MB. Consider reducing poll "
+                        + "scope in collectd-configuration.xml.",
+                        payload.length, batch.getNodeId(), batch.getCollectionPackage());
+                meterRegistry.counter("deltav_timeseries_batch_size_warning_total",
+                        "location", location).increment();
+            }
+
+            DistributionSummary.builder("deltav_timeseries_batch_size_bytes")
+                    .tags("location", location, "producer", "collectd")
+                    .register(meterRegistry).record(payload.length);
+            DistributionSummary.builder("deltav_timeseries_resources_per_batch")
+                    .tags("location", location, "producer", "collectd")
+                    .register(meterRegistry).record(batch.getResourcesCount());
+
+            byte[] key = (batch.getLocation() + "@" + batch.getNodeId()).getBytes(StandardCharsets.UTF_8);
+            Message<byte[]> message = MessageBuilder.withPayload(payload)
+                    .setHeader(KafkaHeaders.KEY, key)
+                    .build();
+
+            boolean sent;
+            try {
+                sent = streamBridge.send(BINDING_NAME, message);
+            } catch (RuntimeException ex) {
+                LOG.warn("streamBridge.send threw for node {} / package {}",
+                        batch.getNodeId(), collectionPackage, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", location, "producer", "collectd",
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+            if (!sent) {
+                LOG.warn("streamBridge.send returned false for node {} / package {}",
+                        batch.getNodeId(), collectionPackage);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", location, "producer", "collectd",
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+
+            meterRegistry.counter("deltav_timeseries_batches_published_total",
+                    "location", location, "producer", "collectd").increment();
+        } finally {
+            sample.stop(Timer.builder("deltav_timeseries_publish_duration_seconds")
+                    .tags("location", location, "producer", "collectd")
+                    .register(meterRegistry));
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=TimeseriesKafkaPublisherTest test -q 2>&1 | tail -10
+```
+
+Expected: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
+git commit -m "feat(collectd/timeseries): add TimeseriesKafkaPublisher
+
+Orchestration layer: translate + serialize + partition-key + StreamBridge.send.
+Error-isolated — never throws to caller. Micrometer metrics for all paths.
+Happy-path + empty-batch tests land here; failure-path + size-warning tests
+added in follow-up commit.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 8: Publisher — failure paths + R7 oversize warning
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java`
+
+- [ ] **Step 1: Append failure-path tests**
+
+```java
+    @Test
+    void translatorThrowingLogsAndIncrementsFailureCounter() {
+        CollectionSet set = mock(CollectionSet.class);
+        when(translator.translate(set, "default"))
+                .thenThrow(new RuntimeException("boom"));
+
+        publisher.publish(set, "default");
+
+        verify(streamBridge, never()).send(any(String.class), any(Message.class));
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "", "producer", "collectd", "reason", "translator_error").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void streamBridgeReturningFalseIncrementsFailureCounter() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+        when(streamBridge.send(any(String.class), any(Message.class))).thenReturn(false);
+
+        publisher.publish(set, "default");
+
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Default", "producer", "collectd", "reason", "kafka_send_error")
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void streamBridgeThrowingIncrementsFailureCounter() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+        when(streamBridge.send(any(String.class), any(Message.class)))
+                .thenThrow(new RuntimeException("kafka unavailable"));
+
+        publisher.publish(set, "default");
+
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Default", "producer", "collectd", "reason", "kafka_send_error")
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void oversizedBatchStillPublishedButWarningCounterIncrements() {
+        CollectionSet set = mock(CollectionSet.class);
+        // Build an oversized batch by adding a large repeated string attribute
+        var resourceBuilder = org.deltav.timeseries.proto.Resource.newBuilder()
+                .setResourceId("node[1]").setType("node");
+        var groupBuilder = org.deltav.timeseries.proto.AttributeGroup.newBuilder()
+                .setName("padding");
+        String bigString = "x".repeat(1000);
+        for (int i = 0; i < 900; i++) {
+            groupBuilder.addAttributes(org.deltav.timeseries.proto.Attribute.newBuilder()
+                    .setName("attr" + i).setText(bigString)
+                    .setType(org.deltav.timeseries.proto.AttributeType.ATTRIBUTE_TYPE_STRING)
+                    .build());
+        }
+        resourceBuilder.addGroups(groupBuilder);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(resourceBuilder).build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+
+        publisher.publish(set, "default");
+
+        assertThat(batch.toByteArray().length).isGreaterThan(800_000);
+        verify(streamBridge).send(eq("publishTimeseries-out-0"), any(Message.class));
+        assertThat(meterRegistry.counter("deltav_timeseries_batch_size_warning_total",
+                "location", "Default").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void locationWithAtSignProducesValidPartitionKey() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(42).setLocation("weird@location").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[42]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+
+        publisher.publish(set, "default");
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(any(String.class), captor.capture());
+        assertThat(captor.getValue().getHeaders().get(KafkaHeaders.KEY))
+                .isEqualTo("weird@location@42".getBytes());
+    }
+
+    @Test
+    void nodeIdZeroStillProducesPartitionKey() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(0).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[0]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+
+        publisher.publish(set, "default");
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(any(String.class), captor.capture());
+        assertThat(captor.getValue().getHeaders().get(KafkaHeaders.KEY))
+                .isEqualTo("Default@0".getBytes());
+    }
+
+    @Test
+    void longLocationNameIsCarriedInPartitionKeyUnchanged() {
+        String longLocation = "a".repeat(256);
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation(longLocation).setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+
+        publisher.publish(set, "default");
+
+        ArgumentCaptor<Message<byte[]>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(streamBridge).send(any(String.class), captor.capture());
+        assertThat(new String((byte[]) captor.getValue().getHeaders().get(KafkaHeaders.KEY)))
+                .isEqualTo(longLocation + "@1");
+    }
+
+    @Test
+    void publishDurationTimerIsRecorded() {
+        CollectionSet set = mock(CollectionSet.class);
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(1).setLocation("Default").setCollectionPackage("default")
+                .addResources(org.deltav.timeseries.proto.Resource.newBuilder()
+                        .setResourceId("node[1]").setType("node").build())
+                .build();
+        when(translator.translate(set, "default")).thenReturn(batch);
+
+        publisher.publish(set, "default");
+
+        assertThat(meterRegistry.find("deltav_timeseries_publish_duration_seconds")
+                .tag("location", "Default").tag("producer", "collectd").timer().count())
+                .isEqualTo(1L);
+    }
+```
+
+- [ ] **Step 2: Run tests, verify pass**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=TimeseriesKafkaPublisherTest test -q 2>&1 | tail -10
+```
+
+Expected: `Tests run: 10, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
+git commit -m "test(collectd/timeseries): publisher failure paths, R7 oversize, partition keys
+
+Cover translator exception, StreamBridge returning false, StreamBridge
+throwing, oversize (>800 KB) still-publishes-with-warning path, timer
+recording, and partition-key edge cases (location with '@', nodeId=0,
+long 256-char location name). Together with Task 7 this exhausts the
+Layer 2 orchestration surface (10 tests)."
+```
+
+---
+
+## Task 9: `TimeseriesKafkaPersister` (horizon Persister adapter)
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java`
+- Create: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java`
+
+The persister is a `CollectionSetVisitor`. When Collectd walks a CollectionSet through it, it snapshots the set in `visitCollectionSet()` and publishes once in `completeCollectionSet()`. No per-attribute state.
+
+- [ ] **Step 1: Write failing test**
+
+Create `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+
+class TimeseriesKafkaPersisterTest {
+
+    @Test
+    void completeCollectionSetInvokesPublisherWithPackage() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(java.util.Map.of("collection", "critical-infra"));
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+        persister.completeCollectionSet(set);
+
+        verify(publisher).publish(eq(set), eq("critical-infra"));
+    }
+
+    @Test
+    void packageDefaultsToDefaultWhenServiceParameterMissing() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(java.util.Map.of());
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+        persister.completeCollectionSet(set);
+
+        verify(publisher).publish(eq(set), eq("default"));
+    }
+
+    @Test
+    void visitResourceVisitGroupVisitAttributeAreNoOps() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(java.util.Map.of());
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        persister.visitResource(mock(org.opennms.netmgt.collection.api.CollectionResource.class));
+        persister.visitGroup(mock(org.opennms.netmgt.collection.api.AttributeGroup.class));
+        persister.visitAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+        persister.completeAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+        persister.completeGroup(mock(org.opennms.netmgt.collection.api.AttributeGroup.class));
+        persister.completeResource(mock(org.opennms.netmgt.collection.api.CollectionResource.class));
+
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void persistNumericAttributeAndPersistStringAttributeAreNoOps() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        ServiceParameters sp = mock(ServiceParameters.class);
+        when(sp.getParameters()).thenReturn(java.util.Map.of());
+        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+
+        persister.persistNumericAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+        persister.persistStringAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+
+        verifyNoInteractions(publisher);
+    }
+}
+```
+
+- [ ] **Step 2: Verify failing compile**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=TimeseriesKafkaPersisterTest test -q 2>&1 | tail -10
+```
+
+Expected: compile fail, `cannot find symbol: class TimeseriesKafkaPersister`.
+
+- [ ] **Step 3: Write the production class**
+
+Create `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.Persister;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+
+/**
+ * Thin horizon Persister adapter that hands every CollectionSet to the
+ * shared TimeseriesKafkaPublisher once, at completeCollectionSet(). All
+ * per-attribute visit*/persistNumericAttribute/persistStringAttribute
+ * callbacks are no-ops — the translator does its own walk.
+ */
+public class TimeseriesKafkaPersister implements Persister {
+
+    private final TimeseriesKafkaPublisher publisher;
+    private final String collectionPackage;
+    private CollectionSet capturedSet;
+
+    public TimeseriesKafkaPersister(TimeseriesKafkaPublisher publisher,
+                                      ServiceParameters serviceParameters) {
+        this.publisher = publisher;
+        this.collectionPackage = serviceParameters.getParameters().getOrDefault("collection", "default");
+    }
+
+    @Override public void visitCollectionSet(CollectionSet set) { this.capturedSet = set; }
+    @Override public void visitResource(CollectionResource resource) { /* no-op */ }
+    @Override public void visitGroup(AttributeGroup group) { /* no-op */ }
+    @Override public void visitAttribute(CollectionAttribute attribute) { /* no-op */ }
+    @Override public void completeAttribute(CollectionAttribute attribute) { /* no-op */ }
+    @Override public void completeGroup(AttributeGroup group) { /* no-op */ }
+    @Override public void completeResource(CollectionResource resource) { /* no-op */ }
+    @Override public void completeCollectionSet(CollectionSet set) {
+        if (capturedSet != null) publisher.publish(capturedSet, collectionPackage);
+        capturedSet = null;
+    }
+    @Override public void persistNumericAttribute(CollectionAttribute attribute) { /* no-op */ }
+    @Override public void persistStringAttribute(CollectionAttribute attribute) { /* no-op */ }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest=TimeseriesKafkaPersisterTest test -q 2>&1 | tail -10
+```
+
+Expected: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
+git commit -m "feat(collectd/timeseries): add TimeseriesKafkaPersister horizon adapter
+
+Thin Persister (CollectionSetVisitor) implementation that snapshots the
+CollectionSet in visitCollectionSet() and delegates to
+TimeseriesKafkaPublisher in completeCollectionSet(). Other visitor
+callbacks are no-ops because the translator does its own walk.
+"
+```
+
+---
+
+## Task 10: `TimeseriesKafkaPublisherConfiguration` + composite `PersisterFactory`
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Write the configuration class**
+
+Create `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.time.Duration;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.TopicConfig;
+import org.opennms.netmgt.collection.api.Persister;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.collection.api.ServiceParameters;
+import org.opennms.netmgt.rrd.RrdRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.config.TopicBuilder;
+
+/**
+ * Feature-flagged configuration for the Kafka Time Series producer. When
+ * {@code deltav.timeseries.enabled=true}, publishes one TimeseriesBatch
+ * protobuf record per CollectionSet poll to the deltav-timeseries topic.
+ * When the flag is false (default), none of the beans are created and the
+ * persister chain stays on the existing InMemoryStorage-backed
+ * TimeseriesPersisterFactory path.
+ */
+@Configuration
+@ConditionalOnProperty(name = "deltav.timeseries.enabled", havingValue = "true")
+public class TimeseriesKafkaPublisherConfiguration {
+
+    @Bean
+    public CollectionSetToProtobufTranslator collectionSetToProtobufTranslator() {
+        return new CollectionSetToProtobufTranslator();
+    }
+
+    @Bean
+    public TimeseriesKafkaPublisher timeseriesKafkaPublisher(
+            StreamBridge streamBridge,
+            CollectionSetToProtobufTranslator translator,
+            MeterRegistry meterRegistry) {
+        return new TimeseriesKafkaPublisher(streamBridge, translator, meterRegistry);
+    }
+
+    @Bean
+    public NewTopic deltavTimeseriesTopic(
+            @Value("${deltav.timeseries.partitions:16}") int partitions,
+            @Value("${deltav.timeseries.replication-factor:1}") short replicationFactor,
+            @Value("${deltav.timeseries.retention-days:7}") int retentionDays) {
+        return TopicBuilder.name("deltav-timeseries")
+                .partitions(partitions)
+                .replicas(replicationFactor)
+                .config(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE)
+                .config(TopicConfig.RETENTION_MS_CONFIG,
+                        String.valueOf(Duration.ofDays(retentionDays).toMillis()))
+                .config(TopicConfig.COMPRESSION_TYPE_CONFIG, "lz4")
+                .build();
+    }
+
+    /**
+     * Initial dual-ownership per design doc: the deltav-node-context topic's
+     * producer is provisiond, shipping in a separate future PR. The NewTopic
+     * bean is declared here now so the topic is provisioned on first start;
+     * when provisiond's change-feed PR lands, this bean moves to that module
+     * and is deleted from here.
+     */
+    @Bean
+    public NewTopic deltavNodeContextTopic(
+            @Value("${deltav.node-context.partitions:8}") int partitions,
+            @Value("${deltav.node-context.replication-factor:1}") short replicationFactor) {
+        return TopicBuilder.name("deltav-node-context")
+                .partitions(partitions)
+                .replicas(replicationFactor)
+                .config(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
+                .config(TopicConfig.RETENTION_MS_CONFIG, "-1")
+                .config(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, "60000")
+                .config(TopicConfig.DELETE_RETENTION_MS_CONFIG, "86400000")
+                .build();
+    }
+
+    /**
+     * Composite factory that fans out each createPersister() call to both the
+     * existing InMemoryStorage-backed TimeseriesPersisterFactory and a fresh
+     * TimeseriesKafkaPersister. Declared @Primary so Collectd's constructor
+     * resolves to this bean when the feature flag is on.
+     */
+    @Bean
+    @Primary
+    public PersisterFactory compositePersisterFactory(
+            @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher) {
+        return new FanoutPersisterFactory(innerFactory, publisher);
+    }
+
+    /**
+     * Package-private composite factory. Kept as a static nested class so the
+     * public API of this module remains the four files listed in the spec.
+     */
+    static final class FanoutPersisterFactory implements PersisterFactory {
+        private final PersisterFactory innerFactory;
+        private final TimeseriesKafkaPublisher publisher;
+
+        FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher) {
+            this.innerFactory = innerFactory;
+            this.publisher = publisher;
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                                         boolean dontPersistCounters, boolean forceStoreByGroup,
+                                         boolean dontReorderAttributes) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository, dontPersistCounters,
+                            forceStoreByGroup, dontReorderAttributes),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+    }
+
+    /**
+     * Forwards each visitor callback to both delegate persisters. Errors in
+     * one delegate must not prevent the other from running: the Kafka path
+     * is already error-isolated in the publisher, and the inner factory is
+     * assumed well-behaved.
+     */
+    static final class FanoutPersister implements Persister {
+        private final Persister innerPersister;
+        private final TimeseriesKafkaPersister kafkaPersister;
+
+        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister) {
+            this.innerPersister = innerPersister;
+            this.kafkaPersister = kafkaPersister;
+        }
+
+        @Override public void visitCollectionSet(org.opennms.netmgt.collection.api.CollectionSet s) {
+            innerPersister.visitCollectionSet(s); kafkaPersister.visitCollectionSet(s);
+        }
+        @Override public void visitResource(org.opennms.netmgt.collection.api.CollectionResource r) {
+            innerPersister.visitResource(r); kafkaPersister.visitResource(r);
+        }
+        @Override public void visitGroup(org.opennms.netmgt.collection.api.AttributeGroup g) {
+            innerPersister.visitGroup(g); kafkaPersister.visitGroup(g);
+        }
+        @Override public void visitAttribute(org.opennms.netmgt.collection.api.CollectionAttribute a) {
+            innerPersister.visitAttribute(a); kafkaPersister.visitAttribute(a);
+        }
+        @Override public void completeAttribute(org.opennms.netmgt.collection.api.CollectionAttribute a) {
+            innerPersister.completeAttribute(a); kafkaPersister.completeAttribute(a);
+        }
+        @Override public void completeGroup(org.opennms.netmgt.collection.api.AttributeGroup g) {
+            innerPersister.completeGroup(g); kafkaPersister.completeGroup(g);
+        }
+        @Override public void completeResource(org.opennms.netmgt.collection.api.CollectionResource r) {
+            innerPersister.completeResource(r); kafkaPersister.completeResource(r);
+        }
+        @Override public void completeCollectionSet(org.opennms.netmgt.collection.api.CollectionSet s) {
+            innerPersister.completeCollectionSet(s); kafkaPersister.completeCollectionSet(s);
+        }
+        @Override public void persistNumericAttribute(org.opennms.netmgt.collection.api.CollectionAttribute a) {
+            innerPersister.persistNumericAttribute(a); kafkaPersister.persistNumericAttribute(a);
+        }
+        @Override public void persistStringAttribute(org.opennms.netmgt.collection.api.CollectionAttribute a) {
+            innerPersister.persistStringAttribute(a); kafkaPersister.persistStringAttribute(a);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify compile-only**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -DskipTests compile -q 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESS`. If a missing import surfaces (e.g. `RrdRepository`), check the horizon artifact's package and adjust the import to match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+git commit -m "feat(collectd/timeseries): add feature-flagged Kafka publisher configuration
+
+@Configuration class gated on deltav.timeseries.enabled=true. Declares
+CollectionSetToProtobufTranslator, TimeseriesKafkaPublisher, and the two
+NewTopic beans (deltav-timeseries delete-policy/7-day/lz4 and
+deltav-node-context compacted/infinite/min-compaction-lag). A composite
+@Primary PersisterFactory bean fans out each createPersister() call to
+both the existing TimeseriesPersisterFactory and a fresh
+TimeseriesKafkaPersister, so Kafka writes run alongside the
+InMemoryStorage path. Composite/fanout classes are package-private nested
+static classes to keep the module's public API at the four files listed
+in the spec.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 11: Rename existing `persisterFactory` bean to `timeseriesPersisterFactory`
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/netmgt/collectd/boot/CollectdDaemonConfiguration.java`
+
+The composite factory needs the inner factory qualified by name so `@Primary` ordering is deterministic.
+
+- [ ] **Step 1: Rename the bean**
+
+In `CollectdDaemonConfiguration.java` at lines 318-328, change:
+
+```java
+    @Bean
+    public PersisterFactory persisterFactory(MetaTagDataLoader metaTagDataLoader,
+```
+
+to:
+
+```java
+    @Bean(name = "timeseriesPersisterFactory")
+    public PersisterFactory timeseriesPersisterFactory(MetaTagDataLoader metaTagDataLoader,
+```
+
+The method body is unchanged. Spring injects by type where possible; naming the bean only affects `@Qualifier("timeseriesPersisterFactory")` resolution.
+
+- [ ] **Step 2: Verify the `Collectd` bean still wires**
+
+Search the file for `persisterFactory` references. At line 375 the `collectd(...)` constructor takes `PersisterFactory persisterFactory`. Since the argument is still of type `PersisterFactory`, Spring resolves it by type; with the feature flag off there is only one bean (the renamed `timeseriesPersisterFactory`), and with the flag on the `@Primary compositePersisterFactory` wins. Either way, `collectd` picks up the right one.
+
+- [ ] **Step 3: Verify compile**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -DskipTests compile -q 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/netmgt/collectd/boot/CollectdDaemonConfiguration.java
+git commit -m "refactor(daemon-boot-collectd): rename persisterFactory bean to timeseriesPersisterFactory
+
+Explicit bean name gives the feature-flagged composite PersisterFactory in
+TimeseriesKafkaPublisherConfiguration a stable @Qualifier handle. No
+behavior change when the flag is off — Collectd still gets the same
+TimeseriesPersisterFactory by type. When the flag is on, @Primary on the
+composite resolves ambiguity."
+```
+
+---
+
+## Task 12: Extend `application.yml` with SCS binding + feature flags
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/resources/application.yml`
+
+- [ ] **Step 1: Add Spring Cloud Stream + feature flag blocks**
+
+Open `core/daemon-boot-collectd/src/main/resources/application.yml`. After the existing `spring:` block (which currently only contains `datasource` and `jpa`), append the following top-level sections. The resulting file contains the existing content followed by these additions:
+
+```yaml
+spring:
+  # ... (existing datasource / jpa sections unchanged) ...
+  cloud:
+    stream:
+      bindings:
+        publishTimeseries-out-0:
+          destination: deltav-timeseries
+          producer:
+            partition-count: ${DELTAV_TIMESERIES_PARTITIONS:16}
+            use-native-encoding: true
+      kafka:
+        binder:
+          brokers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+          # Topics are declared via NewTopic beans — explicit provisioning
+          # per R8 of the design doc. Auto-create remains on only as a
+          # safety net for dev-Compose reruns.
+          auto-create-topics: true
+        bindings:
+          publishTimeseries-out-0:
+            producer:
+              configuration:
+                key.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                value.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                compression.type: lz4
+                linger.ms: 50
+                batch.size: 65536
+                acks: all
+                enable.idempotence: true
+                max.in.flight.requests.per.connection: 5
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name:collectd}
+
+deltav:
+  timeseries:
+    enabled: ${DELTAV_TIMESERIES_ENABLED:false}
+    partitions: ${DELTAV_TIMESERIES_PARTITIONS:16}
+    replication-factor: ${DELTAV_TIMESERIES_REPLICATION_FACTOR:1}
+    retention-days: ${DELTAV_TIMESERIES_RETENTION_DAYS:7}
+  node-context:
+    partitions: ${DELTAV_NODE_CONTEXT_PARTITIONS:8}
+    replication-factor: ${DELTAV_NODE_CONTEXT_REPLICATION_FACTOR:1}
+```
+
+Read the existing file before editing to find the exact indentation pattern and preserve it. If `spring.application.name` is not already set in the existing file, add it:
+
+```yaml
+spring:
+  application:
+    name: collectd
+```
+
+at the top of the `spring:` block.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -DskipTests compile -q 2>&1 | tail -5
+# boot a brief "validate" step
+./mvnw -pl core/daemon-boot-collectd -am -DskipTests validate -q 2>&1 | tail -5
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/resources/application.yml
+git commit -m "feat(daemon-boot-collectd): wire SCS output binding + actuator prometheus
+
+Add spring.cloud.stream.bindings.publishTimeseries-out-0 → deltav-timeseries
+with use-native-encoding=true (pass byte[] payload through unchanged).
+Kafka producer: compression.type=lz4, linger.ms=50, batch.size=65536,
+acks=all, enable.idempotence=true, max.in.flight=5 — maximum durability
+under idempotence. Management endpoints expose /actuator/prometheus.
+deltav.timeseries.enabled default false (opt-in kill switch).
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 13: Layer 3 — SCS test binder integration tests
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherStreamBinderIT.java`
+
+- [ ] **Step 1: Write the integration test class**
+
+Create `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherStreamBinderIT.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {
+        TimeseriesKafkaPublisherConfiguration.class,
+        TestChannelBinderConfiguration.class
+})
+@TestPropertySource(properties = {
+        "deltav.timeseries.enabled=true",
+        "spring.main.web-application-type=none",
+        "spring.main.banner-mode=off"
+})
+class TimeseriesPublisherStreamBinderIT {
+
+    @Autowired(required = false)
+    TimeseriesKafkaPublisher publisher;
+
+    @Autowired(required = false)
+    OutputDestination output;
+
+    @Autowired
+    DefaultListableBeanFactory beanFactory;
+
+    @Test
+    void publisherBeanIsPresentWhenFlagIsOn() {
+        assertThat(publisher).isNotNull();
+    }
+
+    @Test
+    void publishedMessageCarriesProtobufPayloadAndPartitionKey() {
+        CollectionSet set = buildMockSet(42, "Default", 1700000000000L);
+
+        publisher.publish(set, "default");
+
+        Message<byte[]> received = output.receive(2000, "deltav-timeseries");
+        assertThat(received).isNotNull();
+        TimeseriesBatch batch = TimeseriesBatch.parseFrom(received.getPayload());
+        assertThat(batch.getNodeId()).isEqualTo(42);
+        assertThat(batch.getLocation()).isEqualTo("Default");
+        assertThat(received.getHeaders().get(KafkaHeaders.KEY)).isEqualTo("Default@42".getBytes());
+    }
+
+    private CollectionSet buildMockSet(int nodeId, String location, long ts) {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date(ts));
+        when(set.visit(org.mockito.ArgumentMatchers.any())).then(invocation -> {
+            org.opennms.netmgt.collection.api.CollectionSetVisitor visitor =
+                    invocation.getArgument(0);
+            org.opennms.netmgt.collection.api.CollectionResource res =
+                    mock(org.opennms.netmgt.collection.api.CollectionResource.class);
+            when(res.getResourceTypeName()).thenReturn("node");
+            when(res.getInstance()).thenReturn(null);
+            when(res.getParent()).thenReturn(
+                    org.opennms.netmgt.model.ResourcePath.get("node[" + nodeId + "]"));
+            org.opennms.netmgt.collection.api.AttributeGroup g =
+                    mock(org.opennms.netmgt.collection.api.AttributeGroup.class);
+            when(g.getName()).thenReturn("mib2-system");
+            org.opennms.netmgt.collection.api.CollectionAttribute a =
+                    mock(org.opennms.netmgt.collection.api.CollectionAttribute.class);
+            when(a.getName()).thenReturn("sysUpTime");
+            when(a.getType()).thenReturn(org.opennms.netmgt.collection.api.AttributeType.GAUGE);
+            when(a.getNumericValue()).thenReturn(12345);
+            org.opennms.netmgt.collection.api.CollectionAgent agent =
+                    mock(org.opennms.netmgt.collection.api.CollectionAgent.class);
+            when(agent.getNodeId()).thenReturn(nodeId);
+            when(agent.getLocationName()).thenReturn(location);
+            // stub getAgent() via ReflectiveOperationException-friendly path
+            visitor.visitCollectionSet(set);
+            visitor.visitResource(res);
+            visitor.visitGroup(g);
+            visitor.visitAttribute(a);
+            visitor.completeAttribute(a);
+            visitor.completeGroup(g);
+            visitor.completeResource(res);
+            visitor.completeCollectionSet(set);
+            return null;
+        });
+        return set;
+    }
+}
+```
+
+- [ ] **Step 2: Write the feature-flag-off kill-switch test**
+
+Create a companion test file `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {
+        TimeseriesKafkaPublisherConfiguration.class,
+        TestChannelBinderConfiguration.class
+})
+@TestPropertySource(properties = {
+        "deltav.timeseries.enabled=false",
+        "spring.main.web-application-type=none",
+        "spring.main.banner-mode=off"
+})
+class TimeseriesPublisherFeatureFlagOffIT {
+
+    @Autowired
+    ApplicationContext ctx;
+
+    @Test
+    void publisherBeanIsAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(TimeseriesKafkaPublisher.class)).isEmpty();
+    }
+
+    @Test
+    void persisterBeanIsAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(TimeseriesKafkaPersister.class)).isEmpty();
+    }
+
+    @Test
+    void newTopicBeansAreAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(org.apache.kafka.clients.admin.NewTopic.class)).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 3: Run both ITs**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dtest='TimeseriesPublisher*IT' test -q 2>&1 | tail -15
+```
+
+Expected: all tests pass. If Spring context fails to load because a bean expected upstream (e.g., `PersisterFactory` inner) is missing, provide a minimal `@TestConfiguration` that registers a stub inner `PersisterFactory` bean under the qualifier `timeseriesPersisterFactory`:
+
+```java
+@org.springframework.boot.test.context.TestConfiguration
+static class Stubs {
+    @org.springframework.context.annotation.Bean(name = "timeseriesPersisterFactory")
+    PersisterFactory stubInner() { return org.mockito.Mockito.mock(PersisterFactory.class); }
+}
+```
+
+…and reference it in the `@SpringBootTest(classes = { ... })` list.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherStreamBinderIT.java
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java
+git commit -m "test(collectd/timeseries): Layer 3 SCS test-binder ITs + flag kill switch
+
+TimeseriesPublisherStreamBinderIT validates SCS wiring: bean presence,
+partition key format, protobuf round-trip via OutputDestination.
+TimeseriesPublisherFeatureFlagOffIT verifies @ConditionalOnProperty acts as
+a clean kill switch — no publisher, persister, or NewTopic beans when
+deltav.timeseries.enabled=false.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 14: Layer 4 — Testcontainers Kafka broker IT
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaBrokerIT.java`
+
+- [ ] **Step 1: Write the broker IT**
+
+Create `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaBrokerIT.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(classes = TimeseriesKafkaPublisherConfiguration.class,
+        properties = {
+                "deltav.timeseries.enabled=true",
+                "spring.main.web-application-type=none",
+                "spring.cloud.stream.kafka.binder.auto-create-topics=false"
+        })
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TimeseriesKafkaBrokerIT {
+
+    // Pinned to apache/kafka:3.8.0 for reproducible IT runs. The delta-v
+    // Docker Compose uses apache/kafka:latest (same image family); both ship
+    // kafka-console-consumer.sh, and Kafka's wire protocol is backwards
+    // compatible so the Layer 4 and Layer 5 brokers need not be identical.
+    @Container
+    static final KafkaContainer KAFKA = new KafkaContainer(
+            DockerImageName.parse("apache/kafka:3.8.0"));
+
+    @DynamicPropertySource
+    static void kafkaProps(DynamicPropertyRegistry r) {
+        r.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+    }
+
+    @Autowired TimeseriesKafkaPublisher publisher;
+    @Autowired ApplicationContext ctx;
+
+    @Test
+    void roundTripWithLz4Compression() throws Exception {
+        org.opennms.netmgt.collection.api.CollectionSet set = stubSet(1, "Default");
+        publisher.publish(set, "default");
+
+        try (KafkaConsumer<byte[], byte[]> consumer = consumer()) {
+            consumer.subscribe(Collections.singletonList("deltav-timeseries"));
+            ConsumerRecord<byte[], byte[]> record = awaitOne(consumer);
+            TimeseriesBatch batch = TimeseriesBatch.parseFrom(record.value());
+            assertThat(batch.getNodeId()).isEqualTo(1);
+            assertThat(batch.getLocation()).isEqualTo("Default");
+            assertThat(new String(record.key())).isEqualTo("Default@1");
+        }
+    }
+
+    @Test
+    void newTopicsAreProvisionedWithCorrectConfiguration() throws Exception {
+        try (AdminClient admin = AdminClient.create(Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers()))) {
+            TopicDescription ts = admin.describeTopics(
+                    Collections.singletonList("deltav-timeseries")).allTopicNames().get()
+                    .get("deltav-timeseries");
+            assertThat(ts.partitions()).hasSize(16);
+
+            Config tsConfig = admin.describeConfigs(Collections.singletonList(
+                    new ConfigResource(ConfigResource.Type.TOPIC, "deltav-timeseries")))
+                    .all().get().get(new ConfigResource(ConfigResource.Type.TOPIC, "deltav-timeseries"));
+            assertThat(tsConfig.get("cleanup.policy").value()).isEqualTo("delete");
+            assertThat(tsConfig.get("compression.type").value()).isEqualTo("lz4");
+            assertThat(tsConfig.get("retention.ms").value())
+                    .isEqualTo(String.valueOf(Duration.ofDays(7).toMillis()));
+
+            TopicDescription ctxTs = admin.describeTopics(
+                    Collections.singletonList("deltav-node-context")).allTopicNames().get()
+                    .get("deltav-node-context");
+            assertThat(ctxTs.partitions()).hasSize(8);
+
+            Config ctxConfig = admin.describeConfigs(Collections.singletonList(
+                    new ConfigResource(ConfigResource.Type.TOPIC, "deltav-node-context")))
+                    .all().get().get(new ConfigResource(ConfigResource.Type.TOPIC, "deltav-node-context"));
+            assertThat(ctxConfig.get("cleanup.policy").value()).isEqualTo("compact");
+            assertThat(ctxConfig.get("min.compaction.lag.ms").value()).isEqualTo("60000");
+        }
+    }
+
+    @Test
+    void partitionStickinessForSameKey() throws Exception {
+        for (int i = 0; i < 5; i++) publisher.publish(stubSet(7, "Default"), "default");
+
+        try (KafkaConsumer<byte[], byte[]> consumer = consumer()) {
+            consumer.subscribe(Collections.singletonList("deltav-timeseries"));
+            long deadline = System.currentTimeMillis() + 5_000;
+            int partition = -1;
+            int seen = 0;
+            while (System.currentTimeMillis() < deadline && seen < 5) {
+                ConsumerRecords<byte[], byte[]> recs = consumer.poll(Duration.ofMillis(500));
+                for (ConsumerRecord<byte[], byte[]> r : recs) {
+                    if (partition == -1) partition = r.partition();
+                    else assertThat(r.partition()).isEqualTo(partition);
+                    seen++;
+                }
+            }
+            assertThat(seen).isGreaterThanOrEqualTo(5);
+        }
+    }
+
+    private KafkaConsumer<byte[], byte[]> consumer() {
+        KafkaConsumer<byte[], byte[]> c = new KafkaConsumer<>(Map.of(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers(),
+                ConsumerConfig.GROUP_ID_CONFIG, "ts-test-" + System.nanoTime(),
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class));
+        return c;
+    }
+
+    private ConsumerRecord<byte[], byte[]> awaitOne(KafkaConsumer<byte[], byte[]> consumer) {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<byte[], byte[]> recs = consumer.poll(Duration.ofMillis(500));
+            for (ConsumerRecord<byte[], byte[]> r : recs) return r;
+        }
+        throw new AssertionError("no record received in 10 s");
+    }
+
+    private org.opennms.netmgt.collection.api.CollectionSet stubSet(int nodeId, String location) {
+        // reuse helper pattern from TimeseriesPublisherStreamBinderIT
+        return new IntegrationFixtures().oneAttributeSet(nodeId, location);
+    }
+}
+```
+
+And a small fixture class — because the publisher needs a real `CollectionSet` → `TimeseriesBatch` path through the translator, the stub must produce a non-empty batch:
+
+Create `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/IntegrationFixtures.java`:
+
+```java
+/*
+ * Licensed to Delta-V under the GNU Affero General Public License v3.
+ * See LICENSE.md in the repository root for full license text.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.AttributeType;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectionSetVisitor;
+import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.opennms.netmgt.model.ResourcePath;
+
+class IntegrationFixtures {
+
+    CollectionSet oneAttributeSet(int nodeId, String location) {
+        CollectionSet set = mock(CollectionSet.class);
+        when(set.getStatus()).thenReturn(CollectionStatus.SUCCEEDED);
+        when(set.getCollectionTimestamp()).thenReturn(new Date());
+        CollectionResource res = mock(CollectionResource.class);
+        when(res.getResourceTypeName()).thenReturn("node");
+        when(res.getInstance()).thenReturn(null);
+        when(res.getParent()).thenReturn(ResourcePath.get("node[" + nodeId + "]"));
+        AttributeGroup g = mock(AttributeGroup.class);
+        when(g.getName()).thenReturn("mib2-system");
+        CollectionAttribute a = mock(CollectionAttribute.class);
+        when(a.getName()).thenReturn("sysUpTime");
+        when(a.getType()).thenReturn(AttributeType.GAUGE);
+        when(a.getNumericValue()).thenReturn(12345);
+        when(a.getResource()).thenReturn(res);
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(nodeId);
+        when(agent.getLocationName()).thenReturn(location);
+
+        org.mockito.Mockito.doAnswer(inv -> {
+            CollectionSetVisitor v = inv.getArgument(0);
+            v.visitCollectionSet(set);
+            v.visitResource(res);
+            v.visitGroup(g);
+            v.visitAttribute(a);
+            v.completeAttribute(a);
+            v.completeGroup(g);
+            v.completeResource(res);
+            v.completeCollectionSet(set);
+            return null;
+        }).when(set).visit(org.mockito.ArgumentMatchers.any());
+        return set;
+    }
+}
+```
+
+- [ ] **Step 2: Configure failsafe to treat `*IT` classes as integration tests**
+
+The existing `maven-failsafe-plugin` (lines 533-568 of pom.xml) already binds to the `*IT.java` naming convention. Failsafe needs `verify` to run; surefire runs only `*Test.java`.
+
+- [ ] **Step 3: Run the broker IT**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -Dit.test=TimeseriesKafkaBrokerIT verify -q 2>&1 | tail -20
+```
+
+Expected: all 3 tests pass. This pulls the Docker image `apache/kafka:3.8.0` on first run, so it may take a minute. If Docker is not available on the build host, the test will fail — Testcontainers automatically skips in CI only when `TESTCONTAINERS_HOST_OVERRIDE` is set; locally it requires a running Docker daemon.
+
+**Note on idempotent-retry testing:** the spec's Layer 4 test list mentions "drop one connection, verify no duplicates land" as a test case. Real-world idempotence is driven by `enable.idempotence=true` on the producer, which Testcontainers exercises on every send; explicitly forcing a mid-send broker disconnect is fragile to reproduce deterministically and adds ~10 s to the test suite. **Deferred to a Phase 1 enhancement** — leave a comment in the IT class header pointing to this deferral so the gap is visible:
+
+```java
+// NOTE: per the design doc Layer 4 test list, an idempotent-retry test
+// (drop one connection, verify no duplicates) is deferred. enable.idempotence=true
+// is verified in the @SpringBootTest properties; mid-send disconnect
+// simulation is fragile in Testcontainers and not load-bearing for Phase 0.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaBrokerIT.java
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/IntegrationFixtures.java
+git commit -m "test(collectd/timeseries): Layer 4 Testcontainers Kafka broker IT
+
+Real-broker validation: lz4 compression, partition stickiness for
+{location}@{node_id} key, and AdminClient.describeConfigs verifies both
+NewTopic beans provision with the expected configuration (16 partitions /
+7-day delete policy / lz4 for deltav-timeseries; 8 partitions / compact /
+1-minute min-compaction-lag for deltav-node-context).
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 15: Layer 5 — Docker Compose E2E script
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+- Create: `opennms-container/delta-v/test-timeseries-e2e.sh`
+
+- [ ] **Step 1: Wire the env var in `docker-compose.yml`**
+
+Open `opennms-container/delta-v/docker-compose.yml`. Find the `collectd:` service block (similar to other daemon-boot services). In its `environment:` section, add:
+
+```yaml
+      DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-false}
+```
+
+If the existing `environment:` section lists `KAFKA_BOOTSTRAP_SERVERS`, `KAFKA_EVENT_TOPIC`, etc., append the new variable alongside so it follows the same pattern. Defaults to `false` — opt-in via user `docker compose up -e DELTAV_TIMESERIES_ENABLED=true`.
+
+- [ ] **Step 2: Write the E2E script**
+
+Create `opennms-container/delta-v/test-timeseries-e2e.sh`. Make it executable with `chmod +x` after saving.
+
+```bash
+#!/usr/bin/env bash
+# Licensed to Delta-V under the GNU Affero General Public License v3.
+# Layer 5 end-to-end smoke test for the Kafka Time Series producer. Starts
+# the delta-v Docker Compose stack with DELTAV_TIMESERIES_ENABLED=true,
+# provisions a test node, waits for Collectd to poll it, taps the
+# deltav-timeseries topic via kcat, and asserts a record arrives whose
+# protobuf parses as a TimeseriesBatch with the expected node_id and
+# location. Also scrapes /actuator/prometheus on Collectd to verify the
+# batches_published_total counter incremented and batches_failed_total
+# stayed at zero. Tears down cleanly on success or failure.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+COMPOSE_ENV="DELTAV_TIMESERIES_ENABLED=true"
+TEST_REQUISITION="timeseries-e2e"
+TEST_NODE_ID=""
+STACK_READY_TIMEOUT=180
+POLL_TIMEOUT=120
+
+cleanup() {
+    echo "==> Tearing down stack"
+    docker compose down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "==> Starting delta-v Docker Compose with DELTAV_TIMESERIES_ENABLED=true"
+env "${COMPOSE_ENV}" docker compose up -d --build
+
+echo "==> Waiting for collectd actuator /actuator/health"
+deadline=$(( $(date +%s) + STACK_READY_TIMEOUT ))
+while (( $(date +%s) < deadline )); do
+    if docker compose exec -T collectd curl -sf http://localhost:8080/actuator/health >/dev/null; then
+        echo "==> collectd healthy"
+        break
+    fi
+    sleep 3
+done
+if (( $(date +%s) >= deadline )); then
+    echo "ERROR: collectd did not become healthy within ${STACK_READY_TIMEOUT} s"
+    docker compose logs collectd | tail -60
+    exit 1
+fi
+
+echo "==> Provisioning test requisition ${TEST_REQUISITION}"
+# Use horizon-core REST (same pattern used by test-flows-e2e.sh). Requisition
+# contents: one node with SNMP. The Docker Compose stack should have provisiond
+# wired to pick this up and add the node to the monitoring set, so Collectd
+# will begin polling.
+docker compose exec -T horizon-core curl -sf -u admin:admin \
+    -H "Content-Type: application/xml" \
+    -X POST -d '<model-import foreign-source="timeseries-e2e">
+        <node foreign-id="ts-1" node-label="timeseries-e2e-node-1">
+            <interface ip-addr="127.0.0.1">
+                <monitored-service service-name="ICMP"/>
+            </interface>
+        </node>
+    </model-import>' \
+    "http://localhost:8980/opennms/rest/requisitions"
+docker compose exec -T horizon-core curl -sf -u admin:admin \
+    -X PUT "http://localhost:8980/opennms/rest/requisitions/timeseries-e2e/import"
+
+echo "==> Waiting for a record on deltav-timeseries (up to ${POLL_TIMEOUT} s)"
+# kcat installed in the test tools container (opennms-container/delta-v-test-tools).
+# If your setup uses a different tap, adjust the next line accordingly.
+timeout "${POLL_TIMEOUT}" docker compose exec -T kafka kafka-console-consumer.sh \
+    --bootstrap-server kafka:9092 \
+    --topic deltav-timeseries \
+    --from-beginning \
+    --max-messages 1 \
+    --formatter kafka.tools.DefaultMessageFormatter \
+    --property print.key=true > /tmp/ts-e2e-msg.bin
+if [ ! -s /tmp/ts-e2e-msg.bin ]; then
+    echo "ERROR: no record received on deltav-timeseries within ${POLL_TIMEOUT} s"
+    docker compose logs collectd | tail -60
+    exit 1
+fi
+echo "==> Received record on deltav-timeseries"
+
+echo "==> Asserting /actuator/prometheus metrics"
+metrics=$(docker compose exec -T collectd curl -sf http://localhost:8080/actuator/prometheus)
+if ! echo "${metrics}" | grep -E '^deltav_timeseries_batches_published_total.*producer="collectd"' | \
+       awk '{print $NF}' | head -1 | grep -qE '^[1-9]'; then
+    echo "ERROR: deltav_timeseries_batches_published_total not > 0"
+    echo "${metrics}" | grep deltav_timeseries || true
+    exit 1
+fi
+if echo "${metrics}" | grep -E '^deltav_timeseries_batches_failed_total' | \
+       awk '{print $NF}' | grep -qE '^[1-9]'; then
+    echo "ERROR: deltav_timeseries_batches_failed_total is non-zero"
+    echo "${metrics}" | grep deltav_timeseries_batches_failed_total || true
+    exit 1
+fi
+
+echo "==> PASS"
+exit 0
+```
+
+- [ ] **Step 3: Make executable and commit**
+
+```bash
+chmod +x opennms-container/delta-v/test-timeseries-e2e.sh
+git add opennms-container/delta-v/docker-compose.yml opennms-container/delta-v/test-timeseries-e2e.sh
+git commit -m "test(e2e): Layer 5 Docker Compose smoke test for Kafka Time Series producer
+
+docker-compose.yml wires DELTAV_TIMESERIES_ENABLED env var into the collectd
+service (default false). test-timeseries-e2e.sh runs the golden path:
+provisions one node, waits up to 120s for a record on deltav-timeseries,
+asserts the Prometheus batches_published_total counter is > 0 and the
+batches_failed_total counter stays at zero. Mirrors the test-flows-e2e.sh
+pattern.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+- [ ] **Step 4: Run the E2E script end-to-end**
+
+This task should not be gated by the CI pipeline; it is a local-dev smoke test.
+
+```bash
+cd opennms-container/delta-v
+./test-timeseries-e2e.sh 2>&1 | tail -30
+```
+
+Expected: final line says `==> PASS`. If the kcat tap line does not match your local tooling (e.g., you use `kafkacat`), adjust the script line that reads from the topic and recommit.
+
+If the script fails because `collectd-configuration.xml` does not contain a package that polls 127.0.0.1 by default, provide a minimal ICMP package or add a small SNMP package fixture in `opennms-container/delta-v/provisiond-overlay/etc/imports/`. Do NOT commit requisition `last-import=` drift — clean it up before pushing.
+
+---
+
+## Task 16: Operator documentation
+
+**Files:**
+- Modify: `opennms-container/delta-v/README.md` (if it exists; otherwise create under a `Producing Time-series to Kafka` section in the most prominent top-level README in `opennms-container/delta-v/`)
+
+- [ ] **Step 1: Add a new section**
+
+Append (or create) a section in the README:
+
+```markdown
+## Kafka Time-Series Producer (Collectd)
+
+### Enabling
+
+The Kafka Time-Series producer in the Collectd daemon is off by default. To
+enable, set:
+
+```bash
+export DELTAV_TIMESERIES_ENABLED=true
+docker compose up -d
+```
+
+When enabled, Collectd publishes one `TimeseriesBatch` protobuf record per
+CollectionSet poll to the `deltav-timeseries` Kafka topic, keyed
+`{location}@{node_id}`. The existing `InMemoryStorage` TSS backend continues
+to run alongside — the Kafka publisher is additive, not a replacement.
+
+### Topic provisioning
+
+Both topics are declared as Spring Boot `NewTopic` beans in the Collectd
+application and are created with the following default configuration the
+first time Collectd starts with the flag on:
+
+| Topic | Partitions | Retention | Cleanup | Compression |
+|-------|-----------|-----------|---------|-------------|
+| `deltav-timeseries` | 16 | 7 days | delete | lz4 |
+| `deltav-node-context` | 8 | infinite | compact | default |
+
+Do **not** rely on Kafka broker auto-create: defaults are 1 partition / 1
+replica, which silently defeats the 16-partition design.
+
+### Tunables (environment variables)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DELTAV_TIMESERIES_ENABLED` | `false` | Kill switch — opt-in feature flag |
+| `DELTAV_TIMESERIES_PARTITIONS` | `16` | `deltav-timeseries` partition count |
+| `DELTAV_TIMESERIES_REPLICATION_FACTOR` | `1` dev / `3` prod | `deltav-timeseries` replication |
+| `DELTAV_TIMESERIES_RETENTION_DAYS` | `7` | Time-series record retention |
+| `DELTAV_NODE_CONTEXT_PARTITIONS` | `8` | Context topic partitions |
+| `DELTAV_NODE_CONTEXT_REPLICATION_FACTOR` | `1` dev / `3` prod | Context topic replication |
+
+### Observability
+
+Collectd's `/actuator/prometheus` endpoint exposes:
+
+| Metric | Type | Purpose |
+|---|---|---|
+| `deltav_timeseries_batches_published_total` | counter | Successful publishes |
+| `deltav_timeseries_batches_failed_total{reason}` | counter | Failures by reason (`serialization_error`, `kafka_send_error`, `empty_batch`, `translator_error`) |
+| `deltav_timeseries_batch_size_bytes` | distribution summary | Wire size per record |
+| `deltav_timeseries_batch_size_warning_total` | counter | Records over 800 KB (R7) |
+| `deltav_timeseries_resources_per_batch` | distribution summary | Resource count per record |
+| `deltav_timeseries_publish_duration_seconds` | timer | End-to-end publish latency |
+
+### Expected disk footprint
+
+A 1,000-node deployment polling every 5 minutes with default settings
+produces roughly 140 GB of `deltav-timeseries` log on disk before the 7-day
+retention window rolls. Adjust `DELTAV_TIMESERIES_RETENTION_DAYS` to shape
+this, or reduce per-poll scope in `collectd-configuration.xml` for dense
+nodes.
+
+### Known limitations (schema v1)
+
+- Collectd is a singleton service today: there is no horizontal scale and no
+  leader election. If Collectd restarts mid-poll, the current CollectionSet
+  may not reach Kafka. The scheduler/publisher split that addresses this is
+  tracked separately.
+- The wire format is subject to breaking changes during Phase 1 (dev-only).
+  Once Phase 2 ships (production-enabled), only forward-compatible schema
+  changes are allowed.
+- The `deltav-node-context` topic has no producer in this release —
+  provisiond's change feed ships in a separate follow-up PR. Consumers that
+  depend on context joining will need to wait for that PR or tolerate
+  "unknown node" fallback behavior.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add opennms-container/delta-v/README.md
+git commit -m "docs: operator guide for Kafka Time Series producer
+
+Document DELTAV_TIMESERIES_ENABLED and related environment variables, the
+six Prometheus metrics, the two NewTopic configurations, expected Kafka
+disk footprint, and the schema-v1 limitations.
+
+Refs docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md"
+```
+
+---
+
+## Task 17: Follow-up memory for Collectd scheduler/publisher split
+
+**Files:**
+- Create: `~/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/project_collectd_scheduler_publisher_split.md`
+- Modify: `~/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/MEMORY.md`
+
+- [ ] **Step 1: Write the memory**
+
+Create the file with this content:
+
+```markdown
+---
+name: Collectd scheduler/publisher split followup
+description: Future architecture — separate Collectd scheduling from metric publishing to address R5 (restart resilience + horizontal publisher scale) from the Kafka Time Series producer design
+type: project
+---
+
+# Collectd scheduler / publisher split
+
+**Status:** FUTURE — tracked as R5 of the Kafka Time Series producer design
+(`docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md`).
+
+## The problem
+
+Collectd today is a single-process daemon: one JVM both schedules polls and
+publishes their results. Consequences:
+
+1. If Collectd restarts mid-poll, the in-flight CollectionSet never reaches
+   Kafka. `deltav-timeseries` loses that data point.
+2. Collectd cannot horizontally scale. Work distribution is singleton — no
+   leader election, no work-stealing, no partitioning.
+3. The publisher is in the same JVM as the scheduler, so a slow Kafka broker
+   back-pressures poll scheduling.
+
+**Why:** The original Collectd design predates the Kafka-based architecture
+direction of delta-v. The Kafka publisher was added as an additional
+persister in the existing chain — it did not restructure the daemon.
+
+**How to apply:** When the producer ships and Phase 1 metrics surface either
+(a) sustained publish latency drops poll scheduling, or (b) an operator
+requests horizontal scale, treat this memory as the entry point for the
+follow-on design phase. Likely shape: split into `collectd-scheduler`
+(stateful, singleton, persists poll intent to Kafka) and
+`collectd-publisher` (stateless, horizontally scalable Kafka Streams
+consumer that reads poll intents, dispatches to Minion via Twin, and
+produces `TimeseriesBatch`). Minion SnmpCollector migration (see
+`project_minion_snmp_collector_future.md`) is a prerequisite for the clean
+scheduler/publisher boundary.
+```
+
+- [ ] **Step 2: Update `MEMORY.md`**
+
+Add one line to the appropriate section (near `project_minion_snmp_collector_future.md`):
+
+```markdown
+- [project_collectd_scheduler_publisher_split.md](project_collectd_scheduler_publisher_split.md) — FUTURE: Separate Collectd scheduling from metric publishing (R5 of Kafka TS producer design)
+```
+
+Also update the existing Nephron-replacement-phase entry for `project_kafka_timeseries_producer_next_session.md` from `QUEUED` to `DONE` with a reference to this PR once the PR number is known (Task 19 will return). For now, leave `QUEUED` and mark it DONE in Task 19.
+
+- [ ] **Step 3: Commit is NOT done for memory files** — they live outside the repo. Verify the files exist and move on.
+
+```bash
+ls ~/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/project_collectd_scheduler_publisher_split.md
+```
+
+Expected: path prints. Nothing to commit.
+
+---
+
+## Task 18: Full-reactor verification + E2E rerun
+
+**Files:** none — build verification only.
+
+- [ ] **Step 1: Full module `verify` (unit + IT)**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -am -DskipITs=false verify 2>&1 | tail -30
+```
+
+Expected: all 13 translator tests + 10 publisher tests + 4 persister tests + 2 SCS-binder ITs + 3 feature-flag-off ITs + 3 broker ITs = ~35 tests pass. BUILD SUCCESS.
+
+If any test fails, address root cause before proceeding — never skip failing ITs.
+
+- [ ] **Step 2: Full delta-v reactor build (skipping ITs for speed)**
+
+```bash
+./mvnw -DskipTests -T 1C install 2>&1 | tail -30
+```
+
+Expected: BUILD SUCCESS across all modules. This catches the regression class flagged by `feedback_delta_v_full_reactor_verify` — sibling module breakage after a cross-cutting dependency change.
+
+- [ ] **Step 3: Rebuild all 12 daemon boot JARs** (per `feedback_rebuild_all_daemons`)
+
+```bash
+./mvnw -pl 'core/daemon-boot-*' -am -DskipTests install 2>&1 | tail -10
+```
+
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Rerun the E2E smoke test**
+
+```bash
+cd opennms-container/delta-v
+./build.sh deltav
+./test-timeseries-e2e.sh 2>&1 | tail -10
+cd ../..
+```
+
+Expected: `==> PASS`.
+
+- [ ] **Step 5: Clean up any requisition `last-import=` drift**
+
+```bash
+git status --short opennms-container/delta-v/provisiond-overlay/etc/imports/ 2>&1
+```
+
+If the test run polluted the imports directory (see `feedback_provisiond_requisition_drift`), discard:
+
+```bash
+git checkout -- opennms-container/delta-v/provisiond-overlay/etc/imports/
+```
+
+Do NOT commit requisition drift. If the E2E script needs a fixture requisition that does not yet exist, add it as a static file without a `last-import` attribute.
+
+---
+
+## Task 19: Push feature branch and open PR
+
+**Files:** none — git operations only.
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feature/kafka-timeseries-producer-collectd
+```
+
+- [ ] **Step 2: Open PR against `pbrane/delta-v`** (per `feedback_never_pr_opennms`)
+
+```bash
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "feat(collectd): Kafka Time Series producer (Phase 0 — flag off)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Ships the first Kafka time-series producer in delta-v: Collectd publishes a
+`TimeseriesBatch` protobuf record per CollectionSet poll to the
+`deltav-timeseries` topic, keyed `{location}@{node_id}`. Gated by the
+`deltav.timeseries.enabled` feature flag — **default off, Phase 0 of the
+rollout plan**.
+
+Also commits the `NodeContext` protobuf schema + `deltav-node-context`
+compacted-topic `NewTopic` bean for contract completeness. The provisiond
+change-feed producer is a separate future PR.
+
+## Design
+
+Approved spec: [`docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md`](docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md) (merged in #167).
+
+Implementation plan: [`docs/superpowers/plans/2026-04-16-kafka-time-series-producer-collectd.md`](docs/superpowers/plans/2026-04-16-kafka-time-series-producer-collectd.md).
+
+## Key points
+
+- Producer-agnostic wire format. Identity labels live on the compacted
+  `deltav-node-context` topic (compacted, 8 partitions, 1-minute min
+  compaction lag); metric records carry only `node_id` / `location` /
+  `collection_package` / `producer` / resource tree.
+- `TimeseriesKafkaPersister` wires into Collectd's `PersisterFactory` chain
+  via a `@Primary` composite factory declared only when the feature flag
+  is on — when off, the persister chain is exactly the pre-flag
+  `TimeseriesPersisterFactory` (`InMemoryStorage` backend).
+- Size safety check at 800 KB (80% of Kafka default `max.request.size`).
+  Oversize records are logged with a warning counter; they are **not**
+  dropped — operator fix is to reduce poll scope in
+  `collectd-configuration.xml`.
+- Full error isolation: `TimeseriesKafkaPublisher` never throws to the
+  caller. Translator/serialization/send failures each increment a distinct
+  `deltav_timeseries_batches_failed_total{reason=...}` counter and continue.
+
+## Test plan
+
+- [x] Layer 1: `CollectionSetToProtobufTranslatorTest` — 13 unit tests
+  (all `AttributeType` variants, edge cases)
+- [x] Layer 2: `TimeseriesKafkaPublisherTest` — 10 unit tests
+  (happy/empty/translator-throw/send-false/send-throw/oversize/key-with-at/key-nodeId-zero/key-long-location/timer)
+- [x] Layer 2: `TimeseriesKafkaPersisterTest` — 4 unit tests (adapter no-ops)
+- [x] Layer 3: `TimeseriesPublisherStreamBinderIT` + `TimeseriesPublisherFeatureFlagOffIT` — SCS test-binder ITs incl. feature-flag kill-switch
+- [x] Layer 4: `TimeseriesKafkaBrokerIT` — Testcontainers real broker
+  (compression, partition stickiness, `AdminClient.describeConfigs` on both
+  `NewTopic` beans)
+- [x] Layer 5: `test-timeseries-e2e.sh` — Docker Compose golden path
+
+## Rollback
+
+Trivial: set `DELTAV_TIMESERIES_ENABLED=false`, restart Collectd.
+`@ConditionalOnProperty` means the publisher/persister/NewTopic beans do
+not exist when off; the persister chain returns to the
+`TimeseriesPersisterFactory`-only state. No data to unwind.
+
+## Non-goals (explicit)
+
+- Pollerd / PerspectivePollerd producers — follow-up PR.
+- Consumer services (Thresholder, Prometheus Write, Streaming Telemetry) —
+  separate phases.
+- `provisiond` change feed populating `deltav-node-context` — separate PR.
+- Collectd scheduler/publisher split — tracked in
+  `project_collectd_scheduler_publisher_split.md` memory.
+EOF
+)"
+```
+
+- [ ] **Step 3: Copy the PR URL from `gh pr create` output back to the `project_kafka_timeseries_producer_next_session.md` memory**
+
+Mark that memory DONE with a reference to the PR number:
+
+```bash
+# sed the status line + append 'DONE (delta-v#<N>)' — do this via Edit tool, not sed
+```
+
+Also update the index line for `project_kafka_timeseries_producer_next_session.md` in `MEMORY.md` to reflect the DONE status.
+
+---
+
+## Notes on execution ordering
+
+- Tasks 1–3 (pom + protobuf) must run before any Java compile. They are mechanical and low-risk.
+- Tasks 4–6 and Tasks 7–8 each close at a passing test run; they are TDD and can be pipelined by a single executor.
+- Tasks 9, 10, 11 are the horizon wiring — compile-only verification until Task 13 brings SCS binder ITs online.
+- Task 12 is independent of the Java code; could run before or after 9–11.
+- Task 13 and Task 14 are independent ITs; either order is fine. Task 14 requires Docker.
+- Task 15 (E2E) requires a running stack — hold until everything else passes.
+- Task 18 is the gate for push; Task 19 is the push itself.
+- Task 17 (memory) is a side quest; can land at any time but the `MEMORY.md` index update ideally happens after the PR number is known (Task 19).
+
+## Rollback from partial execution
+
+If the branch needs to be abandoned mid-way:
+
+```bash
+git switch develop
+git branch -D feature/kafka-timeseries-producer-collectd
+```
+
+Because every commit is self-contained and sits on a feature branch, `develop` is untouched.

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -225,6 +225,65 @@ Running all services requires significant memory. If Docker Desktop runs out of 
 | passive | ~13      | ~10 GB          |
 | full    | all      | ~12 GB          |
 
+## Kafka Time-Series Producer (Collectd)
+
+### Enabling
+
+The Kafka Time-Series producer in the Collectd daemon is off by default. To enable:
+
+```bash
+export DELTAV_TIMESERIES_ENABLED=true
+docker compose up -d
+```
+
+When enabled, Collectd publishes one `TimeseriesBatch` protobuf record per CollectionSet poll to the `deltav-timeseries` Kafka topic, keyed `{location}@{node_id}`. The existing `InMemoryStorage` TSS backend continues to run alongside — the Kafka publisher is additive, not a replacement.
+
+### Topic provisioning
+
+Both topics are declared as Spring Boot `NewTopic` beans in the Collectd application and are created with the following default configuration the first time Collectd starts with the flag on:
+
+| Topic | Partitions | Retention | Cleanup | Compression |
+|-------|-----------|-----------|---------|-------------|
+| `deltav-timeseries` | 16 | 7 days | delete | lz4 |
+| `deltav-node-context` | 8 | infinite | compact | default |
+
+Do **not** rely on Kafka broker auto-create: defaults are 1 partition / 1 replica, which silently defeats the 16-partition design.
+
+### Tunables (environment variables)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DELTAV_TIMESERIES_ENABLED` | `false` | Kill switch — opt-in feature flag |
+| `DELTAV_TIMESERIES_PARTITIONS` | `16` | `deltav-timeseries` partition count |
+| `DELTAV_TIMESERIES_REPLICATION_FACTOR` | `1` dev / `3` prod | `deltav-timeseries` replication |
+| `DELTAV_TIMESERIES_RETENTION_DAYS` | `7` | Time-series record retention |
+| `DELTAV_NODE_CONTEXT_PARTITIONS` | `8` | Context topic partitions |
+| `DELTAV_NODE_CONTEXT_REPLICATION_FACTOR` | `1` dev / `3` prod | Context topic replication |
+
+### Observability
+
+Collectd's `/actuator/prometheus` endpoint exposes:
+
+| Metric | Type | Purpose |
+|---|---|---|
+| `deltav_timeseries_batches_published_total` | counter | Successful publishes |
+| `deltav_timeseries_batches_failed_total{reason}` | counter | Failures by reason (`serialization_error`, `kafka_send_error`, `empty_batch`, `translator_error`) |
+| `deltav_timeseries_batch_size_bytes` | distribution summary | Wire size per record |
+| `deltav_timeseries_batch_size_warning_total` | counter | Records over 800 KB |
+| `deltav_timeseries_resources_per_batch` | distribution summary | Resource count per record |
+| `deltav_timeseries_publish_duration_seconds` | timer | End-to-end publish latency |
+
+### Expected disk footprint
+
+A 1,000-node deployment polling every 5 minutes with default settings produces roughly 140 GB of `deltav-timeseries` log on disk before the 7-day retention window rolls. Adjust `DELTAV_TIMESERIES_RETENTION_DAYS` to shape this, or reduce per-poll scope in `collectd-configuration.xml` for dense nodes.
+
+### Known limitations (schema v1)
+
+- Collectd is a singleton service today: there is no horizontal scale and no leader election. If Collectd restarts mid-poll, the current CollectionSet may not reach Kafka. The scheduler/publisher split that addresses this is tracked separately.
+- The wire format is subject to breaking changes during Phase 1 (dev-only). Once Phase 2 ships (production-enabled), only forward-compatible schema changes are allowed.
+- The `deltav-node-context` topic has no producer in this release — provisiond's change feed ships in a separate follow-up PR. Consumers that depend on context joining will need to wait for that PR or tolerate "unknown node" fallback behavior.
+- Node identity on the wire (`node_id`, `location`) is sourced from Collectd's `ServiceParameters` keys `node-id` and `location`. If Collectd does not populate these keys in a given deployment, records land with `node_id=0` / `location=""`; consumers must still be able to join via the `deltav-node-context` GlobalKTable to resolve identity.
+
 ## Troubleshooting
 
 **Images not found:** Run `./build.sh` to build all images. Verify with `docker images | grep opennms`.

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -173,6 +173,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
       OPENNMS_TIMESERIES_STRATEGY: inmemory
+      DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-false}
     volumes:
       - ./collectd-daemon-overlay/etc:/opt/deltav/etc:ro
     stop_grace_period: 60s

--- a/opennms-container/delta-v/test-timeseries-e2e.sh
+++ b/opennms-container/delta-v/test-timeseries-e2e.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 BeaconStrategists, Inc.
+# Licensed under the GNU Affero General Public License v3.
+# See LICENSE.md in the repository root for full license text.
+#
+# Layer 5 end-to-end smoke test for the Kafka Time Series producer. Starts
+# the delta-v Docker Compose stack with DELTAV_TIMESERIES_ENABLED=true,
+# provisions a test node, waits for Collectd to poll it, taps the
+# deltav-timeseries topic, and asserts a record arrives whose protobuf
+# parses as a TimeseriesBatch with the expected node_id and location.
+# Also scrapes /actuator/prometheus on Collectd to verify the
+# batches_published_total counter incremented and batches_failed_total
+# stayed at zero. Tears down cleanly on success or failure.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+export DELTAV_TIMESERIES_ENABLED=true
+TEST_REQUISITION="timeseries-e2e"
+STACK_READY_TIMEOUT=180
+POLL_TIMEOUT=120
+
+cleanup() {
+    echo "==> Tearing down stack"
+    docker compose down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "==> Starting delta-v Docker Compose with DELTAV_TIMESERIES_ENABLED=true"
+docker compose up -d --build
+
+echo "==> Waiting for collectd /actuator/health (up to ${STACK_READY_TIMEOUT} s)"
+deadline=$(( $(date +%s) + STACK_READY_TIMEOUT ))
+while (( $(date +%s) < deadline )); do
+    if docker compose exec -T collectd curl -sf http://localhost:8080/actuator/health >/dev/null 2>&1; then
+        echo "==> collectd healthy"
+        break
+    fi
+    sleep 3
+done
+if (( $(date +%s) >= deadline )); then
+    echo "ERROR: collectd did not become healthy within ${STACK_READY_TIMEOUT} s"
+    docker compose logs collectd | tail -60
+    exit 1
+fi
+
+echo "==> Provisioning test requisition ${TEST_REQUISITION}"
+docker compose exec -T horizon-core curl -sf -u admin:admin \
+    -H "Content-Type: application/xml" \
+    -X POST -d '<model-import foreign-source="timeseries-e2e">
+        <node foreign-id="ts-1" node-label="timeseries-e2e-node-1">
+            <interface ip-addr="127.0.0.1">
+                <monitored-service service-name="ICMP"/>
+            </interface>
+        </node>
+    </model-import>' \
+    "http://localhost:8980/opennms/rest/requisitions" || {
+        echo "WARN: requisition POST failed; horizon-core may be on a different port"
+        echo "      checking alternate ports..."
+    }
+docker compose exec -T horizon-core curl -sf -u admin:admin \
+    -X PUT "http://localhost:8980/opennms/rest/requisitions/${TEST_REQUISITION}/import" || true
+
+echo "==> Waiting for a record on deltav-timeseries (up to ${POLL_TIMEOUT} s)"
+timeout "${POLL_TIMEOUT}" docker compose exec -T kafka \
+    /opt/kafka/bin/kafka-console-consumer.sh \
+        --bootstrap-server kafka:9092 \
+        --topic deltav-timeseries \
+        --from-beginning \
+        --max-messages 1 \
+        --formatter kafka.tools.DefaultMessageFormatter \
+        --property print.key=true > /tmp/ts-e2e-msg.bin || {
+    echo "ERROR: no record received on deltav-timeseries within ${POLL_TIMEOUT} s"
+    docker compose logs collectd | tail -60
+    exit 1
+}
+if [ ! -s /tmp/ts-e2e-msg.bin ]; then
+    echo "ERROR: /tmp/ts-e2e-msg.bin is empty"
+    exit 1
+fi
+echo "==> Received record on deltav-timeseries ($(wc -c < /tmp/ts-e2e-msg.bin) bytes)"
+
+echo "==> Asserting /actuator/prometheus metrics"
+metrics=$(docker compose exec -T collectd curl -sf http://localhost:8080/actuator/prometheus)
+if ! echo "${metrics}" | grep -E '^deltav_timeseries_batches_published_total.*producer="collectd"' | \
+       awk '{print $NF}' | head -1 | grep -qE '^[1-9]'; then
+    echo "ERROR: deltav_timeseries_batches_published_total not > 0"
+    echo "${metrics}" | grep deltav_timeseries || true
+    exit 1
+fi
+if echo "${metrics}" | grep -E '^deltav_timeseries_batches_failed_total' | \
+       awk '{print $NF}' | grep -qE '^[1-9]'; then
+    echo "ERROR: deltav_timeseries_batches_failed_total is non-zero"
+    echo "${metrics}" | grep deltav_timeseries_batches_failed_total || true
+    exit 1
+fi
+
+echo "==> PASS"
+exit 0

--- a/opennms-container/delta-v/test-timeseries-e2e.sh
+++ b/opennms-container/delta-v/test-timeseries-e2e.sh
@@ -5,12 +5,15 @@
 #
 # Layer 5 end-to-end smoke test for the Kafka Time Series producer. Starts
 # the delta-v Docker Compose stack with DELTAV_TIMESERIES_ENABLED=true,
-# provisions a test node, waits for Collectd to poll it, taps the
-# deltav-timeseries topic, and asserts a record arrives whose protobuf
-# parses as a TimeseriesBatch with the expected node_id and location.
-# Also scrapes /actuator/prometheus on Collectd to verify the
-# batches_published_total counter incremented and batches_failed_total
-# stayed at zero. Tears down cleanly on success or failure.
+# provisions a test node, waits for Collectd to poll it, then asserts:
+#   1. at least one record arrives on the deltav-timeseries topic
+#      (via kafka-console-consumer, payload not deserialized)
+#   2. deltav_timeseries_batches_published_total{producer="collectd"} > 0
+#      on the Collectd /actuator/prometheus endpoint
+#   3. deltav_timeseries_batches_failed_total counters stay at zero
+# Protobuf deserialization is out of scope for Phase 0; the Prometheus
+# counter assertion is the load-bearing check. Tears down cleanly on
+# success or failure.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Ships the first Kafka time-series producer in delta-v: Collectd publishes a `TimeseriesBatch` protobuf record per CollectionSet poll to the `deltav-timeseries` topic, keyed `{location}@{node_id}`. Gated by the `deltav.timeseries.enabled` feature flag — **default off, Phase 0 of the rollout plan**.

Also commits the `NodeContext` protobuf schema + `deltav-node-context` compacted-topic `NewTopic` bean for contract completeness. The provisiond change-feed producer is a separate future PR.

## Design

- Approved spec: [`docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md`](docs/superpowers/specs/2026-04-15-kafka-time-series-producer-design.md) (merged in #167)
- Implementation plan: [`docs/superpowers/plans/2026-04-16-kafka-time-series-producer-collectd.md`](docs/superpowers/plans/2026-04-16-kafka-time-series-producer-collectd.md)

## Key points

- **Producer-agnostic wire format.** Identity labels live on the compacted `deltav-node-context` topic (8 partitions, min-compaction-lag=60s); metric records carry only \`node_id\` / \`location\` / \`collection_package\` / \`producer\` / resource tree.
- **Feature-flagged wiring.** \`TimeseriesKafkaPersister\` attaches to Collectd's \`PersisterFactory\` chain via a \`@Primary\` composite factory declared only when \`deltav.timeseries.enabled=true\`. When off, the persister chain is exactly the pre-flag \`TimeseriesPersisterFactory\` (\`InMemoryStorage\` backend) — kill-switch verified by IT.
- **Identity sourcing.** Horizon's \`CollectionSet\` interface exposes no public agent accessor. \`TimeseriesKafkaPersister\` reads \`node-id\` / \`location\` from \`ServiceParameters.getParameters()\`. When Collectd does not populate those keys, records land with \`nodeId=0\` / \`location=\"\"\` — consumers fall back to \`deltav-node-context\` GlobalKTable lookup.
- **Size safety.** 800 KB threshold (80% of Kafka default \`max.request.size\`). Oversize records logged + counter-incremented; **not** dropped. Operator fix is to reduce poll scope in \`collectd-configuration.xml\`.
- **Error isolation.** \`TimeseriesKafkaPublisher\` never throws to the caller. Translator / serialization / send failures each increment a distinct \`deltav_timeseries_batches_failed_total{reason=...}\` counter and continue.

## Test plan

- [x] **Layer 1** — \`CollectionSetToProtobufTranslatorTest\`: 13 unit tests (all \`AttributeType\` variants incl. Counter 64-bit and Gauge 32-/64-bit, structured JSON, unicode, STATUS_FAILED, null-set, empty-group, package propagation).
- [x] **Layer 2** — \`TimeseriesKafkaPublisherTest\`: 10 unit tests (happy / empty / translator-throw / send-false / send-throw / oversize / key-with-@ / key-nodeId-zero / key-256-char-location / timer).
- [x] **Layer 2** — \`TimeseriesKafkaPersisterTest\`: 6 unit tests (adapter no-ops + ServiceParameters identity extraction).
- [x] **Layer 3** — \`TimeseriesPublisherStreamBinderIT\` + \`TimeseriesPublisherFeatureFlagOffIT\`: 5 SCS test-binder ITs (bean wiring, protobuf round-trip, partition key, flag kill-switch).
- [x] **Layer 4** — \`TimeseriesKafkaBrokerIT\`: 3 Testcontainers Kafka ITs (lz4 compression round-trip, \`AdminClient.describeConfigs\` verifies both \`NewTopic\` beans, partition stickiness).
- [ ] **Layer 5** — \`test-timeseries-e2e.sh\`: Docker Compose golden-path smoke test. Committed but not run in this PR build — run manually with \`DELTAV_TIMESERIES_ENABLED=true\` before Phase 1.

**Total:** 37 unit + IT tests, all green. Full delta-v reactor build green.

## Metrics exposed on \`/actuator/prometheus\`

- \`deltav_timeseries_batches_published_total{location,producer}\`
- \`deltav_timeseries_batches_failed_total{location,producer,reason}\`
- \`deltav_timeseries_batch_size_bytes{location,producer}\`
- \`deltav_timeseries_batch_size_warning_total{location}\`
- \`deltav_timeseries_resources_per_batch{location,producer}\`
- \`deltav_timeseries_publish_duration_seconds{location,producer}\`

## Rollback

Trivial: set \`DELTAV_TIMESERIES_ENABLED=false\`, restart Collectd. \`@ConditionalOnProperty\` means the publisher / persister / \`NewTopic\` beans do not exist when off; the persister chain returns to the \`TimeseriesPersisterFactory\`-only state. No data to unwind.

## Non-goals (explicit)

- Pollerd / PerspectivePollerd producers — follow-up PR.
- Consumer services (Thresholder, Prometheus Write, Streaming Telemetry) — separate phases.
- \`provisiond\` change feed populating \`deltav-node-context\` — separate PR.
- Collectd scheduler/publisher split — tracked in the \`project_collectd_scheduler_publisher_split.md\` memory.
- Populating \`ServiceParameters\` identity keys (\`node-id\`, \`location\`) from Collectd — noted in README "Known limitations"; interim patch tracked in the scheduler/publisher split memory.