### PR TITLE
fix(ci): drop javascript-typescript from CodeQL matrix (delta-v has no JS/TS)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java-kotlin', 'javascript-typescript' ]
+        # Delta-V is pure Java/Kotlin — the legacy webapp (opennms-webapp)
+        # and Vue UI (ui/) were removed in #28 and subsequent cleanups.
+        # Running the javascript-typescript extractor here produced a hard
+        # failure on every PR ("CodeQL detected code written in Java/Kotlin
+        # and GitHub Actions, but not any written in JavaScript/TypeScript").
+        # When JS/TS source returns to this repo, re-add the language here.
+        language: [ 'java-kotlin' ]
 
     steps:
     - name: Checkout repository
@@ -38,7 +44,6 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Java JDK
-      if: matrix.language == 'java-kotlin'
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: '21'
@@ -52,7 +57,6 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Configure Maven for GitHub Packages
-      if: matrix.language == 'java-kotlin'
       run: |
         mkdir -p ~/.m2
         cat > ~/.m2/settings.xml << SETTINGS
@@ -70,12 +74,7 @@ jobs:
         PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build all modules (Java)
-      if: matrix.language == 'java-kotlin'
       run: ./mvnw -B -DskipTests install
-
-    - name: Autobuild (Non-Java)
-      if: matrix.language != 'java-kotlin'
-      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Fix the CI check that has failed on every PR since the webapp was removed. Delta-V is pure Java/Kotlin — the legacy `opennms-webapp` and Vue `ui/` were excised in #28 and subsequent Karaf-removal cleanups. The CodeQL workflow matrix still had `javascript-typescript` though, so every PR failed the *Analyze (javascript-typescript)* check with:

```
Only found JavaScript or TypeScript files that were empty or contained syntax errors.

##[error] CodeQL detected code written in Java/Kotlin and GitHub Actions,
but not any written in JavaScript/TypeScript.
```

The failure was informational (not a required check for merge) but every PR carried a persistent red ❌ that masks real failures in the scanner tab.

## Change

- Remove `javascript-typescript` from the language matrix in `.github/workflows/codeql-analysis.yml` — keep only `java-kotlin`.
- Since there is now exactly one matrix entry, drop the per-language `if:` conditionals and the JS/TS-only Autobuild step. The workflow now runs Java JDK setup → Maven packages config → `mvnw install` → CodeQL analyze unconditionally.

When JS/TS source returns to this repo (e.g., if a future Vue admin UI ships), re-add the language and the scanner will self-configure.

## Test plan

- [ ] CI runs the `Analyze (java-kotlin)` job only; the `Analyze (javascript-typescript)` check disappears from PR status
- [ ] `Analyze (java-kotlin)` continues to pass (unchanged logic)