### PR TITLE
feat: Kafka TS Phase 2 — Prometheus Remote Write consumer

### DIFF
--- a/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
@@ -13,16 +13,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// API version: 1
+// API version: 1 (FROZEN at Phase 2 GA — delta-v#<TBD-phase-2-PR>)
 //
-// Public contract for the deltav-node-context Kafka topic (compacted).
+// Public contract for the deltav-node-context Kafka topic.
 //
-// Versioning: during Phase 1 (feature flag off in production) breaking
-// schema changes are permissible. Once Phase 2 ships (flag on by default),
-// only forward-compatible changes are allowed: new fields with new tag
-// numbers, new enum values at the end. Renaming or renumbering existing
-// fields, deleting fields, or changing field types are breaking changes
-// that require a deprecation cycle.
+// Versioning: this wire format is frozen as of Phase 2 GA. Only
+// forward-compatible changes are permitted: new fields with new tag
+// numbers, new enum values appended at the end. Renaming or renumbering
+// existing fields, deleting fields, or changing field types are breaking
+// changes that require bumping to // API version: 2 with a one-release
+// deprecation cycle maintaining v1 as read-only.
 //
 // Producer: provisiond change feed (future PR). This file is committed in
 // the Kafka Time Series producer PR for contract completeness and to allow

--- a/core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto
@@ -13,16 +13,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// API version: 1
+// API version: 1 (FROZEN at Phase 2 GA — delta-v#<TBD-phase-2-PR>)
 //
 // Public contract for the deltav-timeseries Kafka topic.
 //
-// Versioning: during Phase 1 (feature flag off in production) breaking
-// schema changes are permissible. Once Phase 2 ships (flag on by default),
-// only forward-compatible changes are allowed: new fields with new tag
-// numbers, new enum values at the end. Renaming or renumbering existing
-// fields, deleting fields, or changing field types are breaking changes
-// that require a deprecation cycle.
+// Versioning: this wire format is frozen as of Phase 2 GA. Only
+// forward-compatible changes are permitted: new fields with new tag
+// numbers, new enum values appended at the end. Renaming or renumbering
+// existing fields, deleting fields, or changing field types are breaking
+// changes that require bumping to // API version: 2 with a one-release
+// deprecation cycle maintaining v1 as read-only.
 
 syntax = "proto3";
 

--- a/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/remote.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/remote.proto
@@ -7,6 +7,11 @@
 //
 // Vendored into delta-v for use by the prometheus-writer Remote Write client.
 // Source: github.com/prometheus/prometheus/prompb/remote.proto (Apache-2.0)
+// Snapshot taken 2026-04-17 from upstream prompb/main. NOTE: this is a
+// subset of upstream — the native-histogram fields (Histogram message,
+// TimeSeries.histograms) are intentionally omitted because Phase 2 does
+// not emit them. When upgrading, diff against the same upstream commit
+// to identify additions; do not re-derive a snapshot version.
 
 syntax = "proto3";
 package prometheus;

--- a/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/remote.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/remote.proto
@@ -1,0 +1,54 @@
+// Copyright 2017 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Vendored into delta-v for use by the prometheus-writer Remote Write client.
+// Source: github.com/prometheus/prometheus/prompb/remote.proto (Apache-2.0)
+
+syntax = "proto3";
+package prometheus;
+
+option go_package = "github.com/prometheus/prometheus/prompb";
+option java_package = "prometheus.prompb";
+option java_multiple_files = true;
+
+import "prometheus/prompb/types.proto";
+
+message WriteRequest {
+  repeated TimeSeries timeseries = 1;
+  reserved 2;  // formerly source
+  repeated MetricMetadata metadata = 3;
+}
+
+message ReadRequest {
+  repeated Query queries = 1;
+
+  enum ResponseType {
+    SAMPLES             = 0;
+    STREAMED_XOR_CHUNKS = 1;
+  }
+  repeated ResponseType accepted_response_types = 2;
+}
+
+message ReadResponse {
+  repeated QueryResult results = 1;
+}
+
+message Query {
+  int64 start_timestamp_ms = 1;
+  int64 end_timestamp_ms   = 2;
+  repeated LabelMatcher matchers = 3;
+  ReadHints hints          = 4;
+}
+
+message QueryResult {
+  repeated TimeSeries timeseries = 1;
+}
+
+message ChunkedReadResponse {
+  repeated ChunkedSeries chunked_series = 1;
+  int64 query_index = 2;
+}

--- a/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/types.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/types.proto
@@ -1,0 +1,107 @@
+// Copyright 2017 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Vendored into delta-v for use by the prometheus-writer Remote Write client.
+// Source: github.com/prometheus/prometheus/prompb/types.proto (Apache-2.0)
+
+syntax = "proto3";
+package prometheus;
+
+option go_package = "github.com/prometheus/prometheus/prompb";
+option java_package = "prometheus.prompb";
+option java_multiple_files = true;
+
+message MetricMetadata {
+  enum MetricType {
+    UNKNOWN        = 0;
+    COUNTER        = 1;
+    GAUGE          = 2;
+    HISTOGRAM      = 3;
+    GAUGEHISTOGRAM = 4;
+    SUMMARY        = 5;
+    INFO           = 6;
+    STATESET       = 7;
+  }
+
+  MetricType type = 1;
+  string metric_family_name = 2;
+  string help = 4;
+  string unit = 5;
+}
+
+message Sample {
+  double value    = 1;
+  int64 timestamp = 2;
+}
+
+message Exemplar {
+  repeated Label labels = 1;
+  double value          = 2;
+  int64 timestamp       = 3;
+}
+
+message TimeSeries {
+  repeated Label labels      = 1;
+  repeated Sample samples    = 2;
+  repeated Exemplar exemplars = 3;
+}
+
+message Label {
+  string name  = 1;
+  string value = 2;
+}
+
+message Labels {
+  repeated Label labels = 1;
+}
+
+message LabelMatcher {
+  enum Type {
+    EQ  = 0;
+    NEQ = 1;
+    RE  = 2;
+    NRE = 3;
+  }
+  Type type    = 1;
+  string name  = 2;
+  string value = 3;
+}
+
+message ReadHints {
+  int64 step_ms   = 1;
+  string func     = 2;
+  int64 start_ms  = 3;
+  int64 end_ms    = 4;
+  repeated string grouping = 5;
+  bool by         = 6;
+  int64 range_ms  = 7;
+}
+
+message Chunk {
+  int64 min_time_ms = 1;
+  int64 max_time_ms = 2;
+
+  enum Encoding {
+    UNKNOWN = 0;
+    XOR     = 1;
+    HISTOGRAM = 2;
+    FLOAT_HISTOGRAM = 3;
+  }
+  Encoding type = 3;
+  bytes data    = 4;
+}
+
+message ChunkedSeries {
+  repeated Label labels = 1;
+  repeated Chunk chunks = 2;
+}

--- a/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/types.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/types.proto
@@ -13,6 +13,11 @@
 //
 // Vendored into delta-v for use by the prometheus-writer Remote Write client.
 // Source: github.com/prometheus/prometheus/prompb/types.proto (Apache-2.0)
+// Snapshot taken 2026-04-17 from upstream prompb/main. NOTE: this is a
+// subset of upstream — the native-histogram fields (Histogram message,
+// TimeSeries.histograms) are intentionally omitted because Phase 2 does
+// not emit them. When upgrading, diff against the same upstream commit
+// to identify additions; do not re-derive a snapshot version.
 
 syntax = "proto3";
 package prometheus;

--- a/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/NodeDaoJpa.java
+++ b/core/opennms-model-jakarta/src/main/java/org/opennms/netmgt/model/jakarta/dao/NodeDaoJpa.java
@@ -55,9 +55,41 @@ public class NodeDaoJpa extends AbstractDaoJpa<OnmsNode, Integer> implements Nod
 
     // ---- NodeDao methods — not used by Alarmd core ----
 
+    /**
+     * Look up a node by string criteria. Mirrors the upstream NodeDaoHibernate
+     * behavior: try numeric node ID, then "&lt;foreign-source&gt;:&lt;foreign-id&gt;",
+     * then label fallback.
+     *
+     * <p>Required by Collectd: horizon's MetaTagDataLoader.load() (called from
+     * TimeseriesPersister.visitResource on every SNMP collection) passes the
+     * numeric node ID as a String. Throwing here marked the read-only tx as
+     * rollback-only and silently dropped every CollectionSet before the Kafka
+     * publisher could see it.</p>
+     */
     @Override
     public OnmsNode get(String lookupCriteria) {
-        throw new UnsupportedOperationException("get(String) is not used by Alarmd");
+        if (lookupCriteria == null || lookupCriteria.isEmpty()) {
+            return null;
+        }
+        // Try as numeric node ID — the MetaTagDataLoader case
+        try {
+            return get(Integer.valueOf(lookupCriteria));
+        } catch (NumberFormatException ignored) {
+            // Not a numeric ID — fall through to other lookups
+        }
+        // Try as <foreign-source>:<foreign-id>
+        int colon = lookupCriteria.indexOf(':');
+        if (colon > 0 && colon < lookupCriteria.length() - 1) {
+            String fs = lookupCriteria.substring(0, colon);
+            String fid = lookupCriteria.substring(colon + 1);
+            OnmsNode byFsFid = findByForeignId(fs, fid);
+            if (byFsFid != null) {
+                return byFsFid;
+            }
+        }
+        // Fall back to label lookup
+        List<OnmsNode> matches = findByLabel(lookupCriteria);
+        return matches != null && !matches.isEmpty() ? matches.get(0) : null;
     }
 
     @Override

--- a/core/prometheus-writer/Dockerfile
+++ b/core/prometheus-writer/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright (C) 2026 BeaconStrategists, Inc.
+# Licensed under the GNU Affero General Public License v3.
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache curl && \
+    addgroup -g 10001 deltav && \
+    adduser -u 10001 -G deltav -D deltav
+
+COPY --chown=deltav:deltav target/prometheus-writer.jar /app/prometheus-writer.jar
+
+USER deltav
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/prometheus-writer.jar"]

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -113,6 +113,17 @@
             <artifactId>testcontainers-kafka</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- commons-io >= 2.16 required because commons-compress 1.28.0 (transitive
+             via testcontainers) calls FileTimes.toUnixTime, added in 2.16.
+             Default transitive resolves to 2.15.0 → NoSuchMethodError when
+             Testcontainers tries to copy the starter script into the Kafka
+             container. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-junit-jupiter</artifactId>

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -22,8 +22,6 @@
 
     <properties>
         <java.version>21</java.version>
-        <resilience4j.version>2.2.0</resilience4j.version>
-        <snappy.version>1.1.10.5</snappy.version>
     </properties>
 
     <dependencies>
@@ -76,19 +74,16 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>${snappy.version}</version>
         </dependency>
 
         <!-- Resilience4j for circuit breaker -->
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-spring-boot3</artifactId>
-            <version>${resilience4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-micrometer</artifactId>
-            <version>${resilience4j.version}</version>
         </dependency>
 
         <!-- Micrometer Prometheus -->
@@ -153,13 +148,7 @@
                     <mainClass>org.deltav.prometheus.writer.PrometheusWriterApplication</mainClass>
                     <executable>true</executable>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <!-- repackage execution is inherited from spring-boot-starter-parent -->
             </plugin>
         </plugins>
     </build>

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>prometheus-writer</artifactId>
+    <name>Delta-V :: Core :: Prometheus Remote Write Consumer</name>
+    <description>Spring Cloud Stream service that consumes deltav-timeseries, enriches
+        each batch against a local materialization of deltav-node-context, transforms
+        to Prometheus Remote Write samples, and POSTs Snappy-compressed protobuf
+        batches to a configurable RW endpoint.</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
+        <snappy.version>1.1.10.5</snappy.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Spring Cloud Stream + Kafka binder -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-binder-kafka</artifactId>
+        </dependency>
+
+        <!-- Kafka client (dedicated NodeContextKafkaBootstrap consumer) -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <!-- Protocol Buffers (generated classes from contracts) -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.deltav-kafka-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <!-- Snappy for Remote Write compression -->
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.version}</version>
+        </dependency>
+
+        <!-- Resilience4j for circuit breaker -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-micrometer</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+
+        <!-- Micrometer Prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-test-binder</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- junit-platform-launcher: required by surefire 3.5.4 for Boot 4 modules
+             (feedback_boot4_junit_platform_launcher) -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>prometheus-writer</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>org.deltav.prometheus.writer.PrometheusWriterApplication</mainClass>
+                    <executable>true</executable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/PrometheusWriterApplication.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/PrometheusWriterApplication.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.prometheus.writer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Entry point for the Delta-V prometheus-writer service.
+ *
+ * <p>Spring Boot 4.0 + Spring Cloud Stream consumer that reads
+ * {@code TimeseriesBatch} protobuf records from the {@code deltav-timeseries}
+ * Kafka topic, enriches each batch with node identity from a local
+ * materialization of the compacted {@code deltav-node-context} topic,
+ * translates to Prometheus Remote Write samples, and POSTs Snappy-compressed
+ * protobuf batches to a configurable RW endpoint.
+ *
+ * <p>Phase 2 of the Kafka Time Series pipeline. See:
+ * {@code docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md}
+ */
+@SpringBootApplication(scanBasePackages = {"org.deltav.prometheus.writer"})
+@EnableScheduling
+public class PrometheusWriterApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PrometheusWriterApplication.class, args);
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/PrometheusWriterConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/PrometheusWriterConfiguration.java
@@ -1,0 +1,34 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+/**
+ * Top-level Spring configuration for the prometheus-writer module.
+ *
+ * <p>Provides the {@link RestClient.Builder} used by
+ * {@link org.deltav.prometheus.writer.rw.RemoteWriteHttpClient} with the
+ * spec §5 timeouts (5s connect, 30s read), and registers
+ * {@link PrometheusWriterProperties} as a Boot {@code @ConfigurationProperties}
+ * binding target.</p>
+ */
+@Configuration
+@EnableConfigurationProperties(PrometheusWriterProperties.class)
+public class PrometheusWriterConfiguration {
+
+    /** Spec §5: connect timeout 5s, read timeout 30s. */
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
+        factory.setReadTimeout((int) Duration.ofSeconds(30).toMillis());
+        return RestClient.builder().requestFactory(factory);
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/KafkaTopicsConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/KafkaTopicsConfiguration.java
@@ -1,0 +1,25 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+import java.util.Map;
+
+@Configuration
+public class KafkaTopicsConfiguration {
+
+    @Bean
+    public NewTopic deltavPrometheusWriterDlqTopic() {
+        return TopicBuilder.name("deltav-prometheus-writer-dlq")
+                .partitions(16)
+                .replicas(1)
+                .configs(Map.of(
+                        "cleanup.policy", "delete",
+                        "retention.ms", "604800000",          // 7 days
+                        "compression.type", "lz4"))
+                .build();
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/PrometheusWriterProperties.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/PrometheusWriterProperties.java
@@ -1,0 +1,84 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strongly-typed binding for the {@code prometheus-writer.*} section of
+ * {@code application.yml}. Every field in spec §8 appears here with a
+ * default that matches the yaml default.
+ */
+@Validated
+@ConfigurationProperties(prefix = "prometheus-writer")
+public record PrometheusWriterProperties(
+        @NotNull RemoteWrite remoteWrite,
+        @NotNull Batch batch,
+        @NotNull Retry retry,
+        @NotNull CircuitBreaker circuitBreaker,
+        @NotNull Labels labels,
+        @NotNull StartupGate startupGate
+) {
+    public PrometheusWriterProperties {
+        if (remoteWrite == null) remoteWrite = new RemoteWrite(null, new Auth(AuthType.NONE, null, null, null), Map.of());
+        if (batch == null)          batch = new Batch(1000, 1_048_576, 1000);
+        if (retry == null)          retry = new Retry(100, 30_000, 0.1);
+        if (circuitBreaker == null) circuitBreaker = new CircuitBreaker(50, 20, 10, 30_000, 3);
+        if (labels == null)         labels = new Labels(List.of());
+        if (startupGate == null)    startupGate = new StartupGate(true);
+    }
+
+    public record RemoteWrite(
+            @NotBlank String url,
+            @NotNull Auth auth,
+            Map<String, String> headers
+    ) {
+        public RemoteWrite {
+            if (auth == null) auth = new Auth(AuthType.NONE, null, null, null);
+            if (headers == null) headers = Map.of();
+        }
+    }
+
+    public record Auth(
+            AuthType type,
+            String bearerToken,
+            String basicUsername,
+            String basicPassword
+    ) {}
+
+    public enum AuthType { NONE, BEARER, BASIC }
+
+    public record Batch(
+            @Positive int maxSamples,
+            @Positive int maxBytes,
+            @Positive long maxIntervalMs
+    ) {}
+
+    public record Retry(
+            @Positive long initialBackoffMs,
+            @Positive long maxBackoffMs,
+            double jitterFactor
+    ) {}
+
+    public record CircuitBreaker(
+            int failureRateThreshold,
+            int slidingWindowSize,
+            int minimumNumberOfCalls,
+            long waitDurationOpenMs,
+            int halfOpenPermittedCalls
+    ) {}
+
+    public record Labels(
+            List<String> fromMetadata
+    ) {}
+
+    public record StartupGate(
+            boolean enabled
+    ) {}
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/PrometheusWriterProperties.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/PrometheusWriterProperties.java
@@ -1,6 +1,10 @@
 /* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
 package org.deltav.prometheus.writer.config;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -63,15 +67,15 @@ public record PrometheusWriterProperties(
     public record Retry(
             @Positive long initialBackoffMs,
             @Positive long maxBackoffMs,
-            double jitterFactor
+            @DecimalMin("0.0") @DecimalMax("1.0") double jitterFactor
     ) {}
 
     public record CircuitBreaker(
-            int failureRateThreshold,
-            int slidingWindowSize,
-            int minimumNumberOfCalls,
-            long waitDurationOpenMs,
-            int halfOpenPermittedCalls
+            @Min(1) @Max(100) int failureRateThreshold,
+            @Positive int slidingWindowSize,
+            @Positive int minimumNumberOfCalls,
+            @Positive long waitDurationOpenMs,
+            @Positive int halfOpenPermittedCalls
     ) {}
 
     public record Labels(

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumer.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumer.java
@@ -1,0 +1,50 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.consume;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.rw.BatchingRwWriter;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.deltav.prometheus.writer.translate.TimeseriesToPromTranslator;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+@Configuration
+public class TimeseriesConsumer {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesConsumer.class);
+
+    @Bean
+    public Consumer<Message<byte[]>> timeseriesConsumer(
+            NodeContextCache cache,
+            TimeseriesToPromTranslator translator,
+            BatchingRwWriter writer,
+            MeterRegistry metrics) {
+        Counter consumed = metrics.counter("deltav.prometheus.writer.records.consumed");
+        Counter samplesIn = metrics.counter("deltav.prometheus.writer.samples.in");
+        Counter parseErrors = metrics.counter("deltav.prometheus.writer.records.parse.errors");
+        return message -> {
+            try {
+                TimeseriesBatch batch = TimeseriesBatch.parseFrom(message.getPayload());
+                String key = batch.getLocation() + "@" + batch.getNodeId();
+                Optional<NodeContext> nc = cache.get(key);
+                List<PromSample> samples = translator.translate(batch, nc);
+                consumed.increment();
+                samplesIn.increment(samples.size());
+                samples.forEach(writer::add);
+            } catch (Exception e) {
+                LOG.warn("Failed to process TimeseriesBatch — dropping", e);
+                parseErrors.increment();
+            }
+        };
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumer.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumer.java
@@ -3,6 +3,7 @@ package org.deltav.prometheus.writer.consume;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics;
 import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
 import org.deltav.prometheus.writer.rw.BatchingRwWriter;
 import org.deltav.prometheus.writer.translate.PromSample;
@@ -29,9 +30,9 @@ public class TimeseriesConsumer {
             TimeseriesToPromTranslator translator,
             BatchingRwWriter writer,
             MeterRegistry metrics) {
-        Counter consumed = metrics.counter("deltav.prometheus.writer.records.consumed");
-        Counter samplesIn = metrics.counter("deltav.prometheus.writer.samples.in");
-        Counter parseErrors = metrics.counter("deltav.prometheus.writer.records.parse.errors");
+        Counter consumed = metrics.counter(PrometheusWriterMetrics.RECORDS_CONSUMED);
+        Counter samplesIn = metrics.counter(PrometheusWriterMetrics.SAMPLES_IN);
+        Counter parseErrors = metrics.counter(PrometheusWriterMetrics.RECORDS_PARSE_ERRORS);
         return message -> {
             try {
                 TimeseriesBatch batch = TimeseriesBatch.parseFrom(message.getPayload());

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerConfiguration.java
@@ -21,8 +21,8 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 @Configuration
-public class TimeseriesConsumer {
-    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesConsumer.class);
+public class TimeseriesConsumerConfiguration {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesConsumerConfiguration.class);
 
     @Bean
     public Consumer<Message<byte[]>> timeseriesConsumer(

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/dlq/DlqPublisher.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/dlq/DlqPublisher.java
@@ -3,6 +3,7 @@ package org.deltav.prometheus.writer.dlq;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.stream.function.StreamBridge;
@@ -42,7 +43,7 @@ public class DlqPublisher {
         Message<byte[]> msg = MessageBuilder.withPayload(sourcePayload).copyHeaders(headers).build();
         boolean sent = streamBridge.send(BINDING, msg);
         if (sent) {
-            Counter.builder("deltav.prometheus.writer.dlq.records")
+            Counter.builder(PrometheusWriterMetrics.DLQ_RECORDS)
                     .tag("reason", reason).register(metrics).increment();
         } else {
             LOG.error("StreamBridge.send returned false - DLQ record lost: key={} reason={}", key, reason);

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/dlq/DlqPublisher.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/dlq/DlqPublisher.java
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.dlq;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class DlqPublisher {
+    private static final Logger LOG = LoggerFactory.getLogger(DlqPublisher.class);
+    private static final String BINDING = "publishDlq-out-0";
+
+    private final StreamBridge streamBridge;
+    private final MeterRegistry metrics;
+
+    public DlqPublisher(StreamBridge streamBridge, MeterRegistry metrics) {
+        this.streamBridge = streamBridge;
+        this.metrics = metrics;
+    }
+
+    public void publish(byte[] sourcePayload, String key, String reason, int httpStatus,
+                        String endpoint, String errorMessage) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(KafkaHeaders.KEY, key.getBytes());
+        headers.put("x-dlq-reason", reason);
+        headers.put("x-dlq-http-status", Integer.toString(httpStatus));
+        headers.put("x-dlq-endpoint", endpoint);
+        headers.put("x-dlq-timestamp-ms", Long.toString(System.currentTimeMillis()));
+        headers.put("x-dlq-error-message", truncate(errorMessage, 1024));
+        headers.put("x-dlq-writer-version",
+                Optional.ofNullable(getClass().getPackage().getImplementationVersion()).orElse("dev"));
+        Message<byte[]> msg = MessageBuilder.withPayload(sourcePayload).copyHeaders(headers).build();
+        boolean sent = streamBridge.send(BINDING, msg);
+        if (sent) {
+            Counter.builder("deltav.prometheus.writer.dlq.records")
+                    .tag("reason", reason).register(metrics).increment();
+        } else {
+            LOG.error("StreamBridge.send returned false - DLQ record lost: key={} reason={}", key, reason);
+        }
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max);
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetrics.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetrics.java
@@ -1,0 +1,42 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.metrics;
+
+/**
+ * Canonical Micrometer meter names for the prometheus-writer. Every meter
+ * declared here MUST appear at /actuator/prometheus once the service is fully
+ * wired. {@link PrometheusWriterMetricsTest} pins the list.
+ */
+public final class PrometheusWriterMetrics {
+    private PrometheusWriterMetrics() {}
+
+    // ingestion
+    public static final String RECORDS_CONSUMED        = "deltav.prometheus.writer.records.consumed";
+    public static final String SAMPLES_IN              = "deltav.prometheus.writer.samples.in";
+    public static final String RECORDS_PARSE_ERRORS    = "deltav.prometheus.writer.records.parse.errors";
+
+    // enrichment
+    public static final String ENRICHMENT_HIT          = "deltav.prometheus.writer.enrichment.hit";
+    public static final String ENRICHMENT_MISSING      = "deltav.prometheus.writer.enrichment.missing";
+    public static final String NC_CACHE_SIZE           = "deltav.prometheus.writer.node.context.cache.size";
+    public static final String NC_CACHE_READY          = "deltav.prometheus.writer.node.context.cache.ready";
+    public static final String NC_BOOTSTRAP_DURATION   = "deltav.prometheus.writer.node.context.bootstrap.duration";
+
+    // sample dropouts
+    public static final String SAMPLES_DROPPED         = "deltav.prometheus.writer.samples.dropped";
+
+    // rw output
+    public static final String BATCHES_SENT            = "deltav.prometheus.writer.batches.sent";
+    public static final String SAMPLES_SENT            = "deltav.prometheus.writer.samples.sent";
+    public static final String BATCHES_FAILED          = "deltav.prometheus.writer.batches.failed";
+    public static final String BATCH_SIZE_BYTES        = "deltav.prometheus.writer.batch.size.bytes";
+    public static final String BATCH_SAMPLE_COUNT      = "deltav.prometheus.writer.batch.sample.count";
+    public static final String FLUSH_DURATION          = "deltav.prometheus.writer.flush.duration";
+    public static final String RETRY_ATTEMPTS          = "deltav.prometheus.writer.retry.attempts";
+
+    // dlq
+    public static final String DLQ_RECORDS             = "deltav.prometheus.writer.dlq.records";
+
+    // circuit + consumer state
+    public static final String CIRCUIT_STATE           = "deltav.prometheus.writer.circuit.state";
+    public static final String CONSUMER_PAUSED         = "deltav.prometheus.writer.consumer.paused";
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
@@ -1,0 +1,58 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * In-memory cache of {@link NodeContext} records keyed {@code {location}@{node_id}}.
+ * Hot-path {@link #get(String)} is a plain {@link ConcurrentHashMap#get(Object)} —
+ * no locking, no network hop. State mutation is confined to the Kafka consumer
+ * thread owned by {@link NodeContextKafkaBootstrap}.
+ */
+@Component
+public class NodeContextCache {
+
+    private final ConcurrentHashMap<String, NodeContext> map = new ConcurrentHashMap<>();
+    private final AtomicBoolean ready = new AtomicBoolean(false);
+
+    public Optional<NodeContext> get(String key) {
+        return Optional.ofNullable(map.get(key));
+    }
+
+    public void put(String key, NodeContext value) {
+        map.put(key, value);
+    }
+
+    public void remove(String key) {
+        map.remove(key);
+    }
+
+    /**
+     * Apply a record from the {@code deltav-node-context} topic. If {@code deleted=true},
+     * treats as tombstone and removes the key. Otherwise stores the value.
+     */
+    public void applyUpdate(String key, NodeContext value) {
+        if (value.getDeleted()) {
+            remove(key);
+        } else {
+            put(key, value);
+        }
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public boolean isReady() {
+        return ready.get();
+    }
+
+    public void markReady() {
+        ready.set(true);
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicator.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicator.java
@@ -5,7 +5,7 @@ import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.stereotype.Component;
 
-@Component("nodeContextCache")
+@Component("nodeContextCacheHealthIndicator")
 public class NodeContextCacheHealthIndicator implements HealthIndicator {
     private final NodeContextCache cache;
 

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicator.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicator.java
@@ -1,0 +1,23 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component("nodeContextCache")
+public class NodeContextCacheHealthIndicator implements HealthIndicator {
+    private final NodeContextCache cache;
+
+    public NodeContextCacheHealthIndicator(NodeContextCache cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public Health health() {
+        Health.Builder b = cache.isReady() ? Health.up() : Health.down();
+        return b.withDetail("ready", cache.isReady())
+                .withDetail("size", cache.size())
+                .build();
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheReadyEvent.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheReadyEvent.java
@@ -1,0 +1,19 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.springframework.context.ApplicationEvent;
+
+/** Published once when {@link NodeContextKafkaBootstrap} finishes initial bootstrap. */
+public class NodeContextCacheReadyEvent extends ApplicationEvent {
+    private final long bootstrapDurationMs;
+    private final int cacheSize;
+
+    public NodeContextCacheReadyEvent(Object source, long bootstrapDurationMs, int cacheSize) {
+        super(source);
+        this.bootstrapDurationMs = bootstrapDurationMs;
+        this.cacheSize = cacheSize;
+    }
+
+    public long getBootstrapDurationMs() { return bootstrapDurationMs; }
+    public int getCacheSize() { return cacheSize; }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
@@ -1,6 +1,7 @@
 /* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
 package org.deltav.prometheus.writer.nodecontext;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PreDestroy;
@@ -62,6 +63,11 @@ public class NodeContextKafkaBootstrap implements Runnable {
         this.eventPublisher = eventPublisher;
         this.meterRegistry = meterRegistry;
         this.bootstrapServers = bootstrapServers;
+
+        Gauge.builder(PrometheusWriterMetrics.NC_CACHE_READY, cache, c -> c.isReady() ? 1.0 : 0.0)
+                .register(meterRegistry);
+        Gauge.builder(PrometheusWriterMetrics.NC_CACHE_SIZE, cache, c -> (double) c.size())
+                .register(meterRegistry);
     }
 
     @EventListener

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
@@ -3,7 +3,6 @@ package org.deltav.prometheus.writer.nodecontext;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -18,7 +17,9 @@ import org.deltav.timeseries.proto.NodeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -63,7 +64,11 @@ public class NodeContextKafkaBootstrap implements Runnable {
         this.bootstrapServers = bootstrapServers;
     }
 
-    @PostConstruct
+    @EventListener
+    public void onAppReady(ApplicationReadyEvent event) {
+        start();
+    }
+
     public void start() {
         running.set(true);
         bootstrapSample = Timer.start(meterRegistry);

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
@@ -1,0 +1,176 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.deltav.timeseries.proto.NodeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Dedicated Kafka consumer for {@code deltav-node-context}. On startup, records the
+ * end-offset high-water mark (HWM) per partition, seeks to earliest, consumes
+ * records until every partition's offset catches the recorded HWM, and marks
+ * the cache ready. Then transitions to a live-tail loop.
+ */
+@Component
+public class NodeContextKafkaBootstrap implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NodeContextKafkaBootstrap.class);
+    private static final String TOPIC = "deltav-node-context";
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(5);
+
+    private final NodeContextCache cache;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MeterRegistry meterRegistry;
+    private final String bootstrapServers;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread thread;
+    private Timer.Sample bootstrapSample;
+
+    public NodeContextKafkaBootstrap(
+            NodeContextCache cache,
+            ApplicationEventPublisher eventPublisher,
+            MeterRegistry meterRegistry,
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        this.cache = cache;
+        this.eventPublisher = eventPublisher;
+        this.meterRegistry = meterRegistry;
+        this.bootstrapServers = bootstrapServers;
+    }
+
+    @PostConstruct
+    public void start() {
+        running.set(true);
+        bootstrapSample = Timer.start(meterRegistry);
+        thread = new Thread(this, "node-context-bootstrap");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        running.set(false);
+        if (thread != null) {
+            try {
+                thread.join(5000);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        try (KafkaConsumer<String, byte[]> consumer = buildConsumer()) {
+            List<PartitionInfo> parts = consumer.partitionsFor(TOPIC);
+            if (parts == null || parts.isEmpty()) {
+                LOG.warn("Topic {} has no partitions yet — marking cache ready with empty state", TOPIC);
+                finishBootstrap();
+                liveTail(consumer);
+                return;
+            }
+            Set<TopicPartition> allParts = new HashSet<>();
+            for (PartitionInfo p : parts) {
+                allParts.add(new TopicPartition(TOPIC, p.partition()));
+            }
+            consumer.assign(allParts);
+
+            Map<TopicPartition, Long> endOffsets = new HashMap<>(consumer.endOffsets(allParts));
+            consumer.seekToBeginning(allParts);
+
+            Set<TopicPartition> caughtUp = new HashSet<>();
+            // An empty partition (end offset == 0) is instantly "caught up".
+            for (Map.Entry<TopicPartition, Long> e : endOffsets.entrySet()) {
+                if (e.getValue() == 0L) {
+                    caughtUp.add(e.getKey());
+                }
+            }
+
+            while (running.get() && caughtUp.size() < allParts.size()) {
+                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+                for (ConsumerRecord<String, byte[]> r : records) {
+                    applyRecord(r);
+                    TopicPartition tp = new TopicPartition(r.topic(), r.partition());
+                    if (r.offset() + 1 >= endOffsets.get(tp)) {
+                        caughtUp.add(tp);
+                    }
+                }
+            }
+            finishBootstrap();
+            liveTail(consumer);
+        } catch (Exception e) {
+            LOG.error("NodeContextKafkaBootstrap fatal error", e);
+        }
+    }
+
+    private void liveTail(KafkaConsumer<String, byte[]> consumer) {
+        while (running.get()) {
+            try {
+                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+                for (ConsumerRecord<String, byte[]> r : records) {
+                    applyRecord(r);
+                }
+            } catch (Exception e) {
+                LOG.warn("NodeContextKafkaBootstrap live-tail error — will retry after poll timeout", e);
+            }
+        }
+    }
+
+    private void applyRecord(ConsumerRecord<String, byte[]> r) {
+        if (r.value() == null) {
+            // Kafka log-compaction tombstone (null value). Treat as delete.
+            cache.remove(r.key());
+            return;
+        }
+        try {
+            NodeContext nc = NodeContext.parseFrom(r.value());
+            cache.applyUpdate(r.key(), nc);
+        } catch (Exception e) {
+            LOG.warn("Malformed NodeContext record key={} offset={} — skipping", r.key(), r.offset(), e);
+        }
+    }
+
+    private void finishBootstrap() {
+        cache.markReady();
+        long durationNs = bootstrapSample.stop(
+                meterRegistry.timer("deltav.prometheus.writer.node.context.bootstrap.duration"));
+        long durationMillis = durationNs / 1_000_000L;
+        LOG.info("NodeContextCache bootstrap complete: {} entries in {} ms", cache.size(), durationMillis);
+        eventPublisher.publishEvent(new NodeContextCacheReadyEvent(this, durationMillis, cache.size()));
+    }
+
+    private KafkaConsumer<String, byte[]> buildConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "prometheus-writer-node-context-" + UUID.randomUUID());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); // we manage offsets via seek
+        return new KafkaConsumer<>(props);
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics;
 import org.deltav.timeseries.proto.NodeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,7 +158,7 @@ public class NodeContextKafkaBootstrap implements Runnable {
     private void finishBootstrap() {
         cache.markReady();
         long durationNs = bootstrapSample.stop(
-                meterRegistry.timer("deltav.prometheus.writer.node.context.bootstrap.duration"));
+                meterRegistry.timer(PrometheusWriterMetrics.NC_BOOTSTRAP_DURATION));
         long durationMillis = durationNs / 1_000_000L;
         LOG.info("NodeContextCache bootstrap complete: {} entries in {} ms", cache.size(), durationMillis);
         eventPublisher.publishEvent(new NodeContextCacheReadyEvent(this, durationMillis, cache.size()));

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/BatchingRwWriter.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/BatchingRwWriter.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics;
 import org.deltav.prometheus.writer.translate.PromSample;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,15 +41,15 @@ public class BatchingRwWriter {
                             RemoteWriteHttpClient http, MeterRegistry reg) {
         this.props = props; this.builder = builder; this.http = http;
         String endpoint = props.remoteWrite().url();
-        this.batchesSent = Counter.builder("deltav.prometheus.writer.batches.sent")
+        this.batchesSent = Counter.builder(PrometheusWriterMetrics.BATCHES_SENT)
                 .tag("endpoint", endpoint).register(reg);
-        this.samplesSent = Counter.builder("deltav.prometheus.writer.samples.sent")
+        this.samplesSent = Counter.builder(PrometheusWriterMetrics.SAMPLES_SENT)
                 .tag("endpoint", endpoint).register(reg);
-        this.batchBytes = DistributionSummary.builder("deltav.prometheus.writer.batch.size.bytes")
+        this.batchBytes = DistributionSummary.builder(PrometheusWriterMetrics.BATCH_SIZE_BYTES)
                 .tag("endpoint", endpoint).register(reg);
-        this.batchSampleCount = DistributionSummary.builder("deltav.prometheus.writer.batch.sample.count")
+        this.batchSampleCount = DistributionSummary.builder(PrometheusWriterMetrics.BATCH_SAMPLE_COUNT)
                 .tag("endpoint", endpoint).register(reg);
-        this.flushDuration = Timer.builder("deltav.prometheus.writer.flush.duration")
+        this.flushDuration = Timer.builder(PrometheusWriterMetrics.FLUSH_DURATION)
                 .tag("endpoint", endpoint).register(reg);
     }
 

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/BatchingRwWriter.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/BatchingRwWriter.java
@@ -1,6 +1,7 @@
 /* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
 package org.deltav.prometheus.writer.rw;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -26,6 +27,7 @@ public class BatchingRwWriter {
     private final PrometheusWriterProperties props;
     private final WriteRequestBuilder builder;
     private final RemoteWriteHttpClient http;
+    private final CircuitBreaker breaker;
     private final Counter batchesSent;
     private final Counter samplesSent;
     private final DistributionSummary batchBytes;
@@ -38,8 +40,8 @@ public class BatchingRwWriter {
     private volatile long firstSampleAtMs = 0L;
 
     public BatchingRwWriter(PrometheusWriterProperties props, WriteRequestBuilder builder,
-                            RemoteWriteHttpClient http, MeterRegistry reg) {
-        this.props = props; this.builder = builder; this.http = http;
+                            RemoteWriteHttpClient http, CircuitBreaker breaker, MeterRegistry reg) {
+        this.props = props; this.builder = builder; this.http = http; this.breaker = breaker;
         String endpoint = props.remoteWrite().url();
         this.batchesSent = Counter.builder(PrometheusWriterMetrics.BATCHES_SENT)
                 .tag("endpoint", endpoint).register(reg);
@@ -83,7 +85,7 @@ public class BatchingRwWriter {
         try {
             WriteRequest req = builder.build(toSend);
             int bytesEstimate = req.getSerializedSize();
-            http.post(req);
+            breaker.executeCallable(() -> http.post(req));
             batchesSent.increment();
             samplesSent.increment(toSend.size());
             batchBytes.record(bytesEstimate);

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/BatchingRwWriter.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/BatchingRwWriter.java
@@ -1,0 +1,109 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import prometheus.prompb.WriteRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+public class BatchingRwWriter {
+    private static final Logger LOG = LoggerFactory.getLogger(BatchingRwWriter.class);
+
+    private final PrometheusWriterProperties props;
+    private final WriteRequestBuilder builder;
+    private final RemoteWriteHttpClient http;
+    private final Counter batchesSent;
+    private final Counter samplesSent;
+    private final DistributionSummary batchBytes;
+    private final DistributionSummary batchSampleCount;
+    private final Timer flushDuration;
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final List<PromSample> buffer = new ArrayList<>();
+    private final AtomicLong approxBytes = new AtomicLong(0);
+    private volatile long firstSampleAtMs = 0L;
+
+    public BatchingRwWriter(PrometheusWriterProperties props, WriteRequestBuilder builder,
+                            RemoteWriteHttpClient http, MeterRegistry reg) {
+        this.props = props; this.builder = builder; this.http = http;
+        String endpoint = props.remoteWrite().url();
+        this.batchesSent = Counter.builder("deltav.prometheus.writer.batches.sent")
+                .tag("endpoint", endpoint).register(reg);
+        this.samplesSent = Counter.builder("deltav.prometheus.writer.samples.sent")
+                .tag("endpoint", endpoint).register(reg);
+        this.batchBytes = DistributionSummary.builder("deltav.prometheus.writer.batch.size.bytes")
+                .tag("endpoint", endpoint).register(reg);
+        this.batchSampleCount = DistributionSummary.builder("deltav.prometheus.writer.batch.sample.count")
+                .tag("endpoint", endpoint).register(reg);
+        this.flushDuration = Timer.builder("deltav.prometheus.writer.flush.duration")
+                .tag("endpoint", endpoint).register(reg);
+    }
+
+    public void add(PromSample sample) {
+        lock.lock();
+        try {
+            if (buffer.isEmpty()) firstSampleAtMs = System.currentTimeMillis();
+            buffer.add(sample);
+            approxBytes.addAndGet(estimateSize(sample));
+            if (shouldFlushNow()) flushNow();
+        } finally { lock.unlock(); }
+    }
+
+    @Scheduled(fixedDelay = 100)
+    public void flushIfStale() {
+        lock.lock();
+        try {
+            if (!buffer.isEmpty()
+                    && System.currentTimeMillis() - firstSampleAtMs >= props.batch().maxIntervalMs()) {
+                flushNow();
+            }
+        } finally { lock.unlock(); }
+    }
+
+    public void flushNow() {
+        if (buffer.isEmpty()) return;
+        List<PromSample> toSend = new ArrayList<>(buffer);
+        buffer.clear();
+        approxBytes.set(0);
+        Timer.Sample sample = Timer.start();
+        try {
+            WriteRequest req = builder.build(toSend);
+            int bytesEstimate = req.getSerializedSize();
+            http.post(req);
+            batchesSent.increment();
+            samplesSent.increment(toSend.size());
+            batchBytes.record(bytesEstimate);
+            batchSampleCount.record(toSend.size());
+        } catch (Exception e) {
+            // Flush failures propagate to caller's retry/DLQ/circuit logic (Task 14/16).
+            throw new RuntimeException(e);
+        } finally {
+            sample.stop(flushDuration);
+        }
+    }
+
+    private boolean shouldFlushNow() {
+        return buffer.size() >= props.batch().maxSamples()
+                || approxBytes.get() >= props.batch().maxBytes();
+    }
+
+    private long estimateSize(PromSample s) {
+        long total = 16;
+        total += s.name().length();
+        for (var e : s.labels().entrySet()) total += e.getKey().length() + e.getValue().length() + 2;
+        return total;
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/ConsumerPauseListener.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/ConsumerPauseListener.java
@@ -5,6 +5,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
+import org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.stream.binding.BindingsLifecycleController;
@@ -24,7 +25,7 @@ public class ConsumerPauseListener {
     public ConsumerPauseListener(CircuitBreaker cb, BindingsLifecycleController lifecycle, MeterRegistry metrics) {
         this.cb = cb;
         this.lifecycle = lifecycle;
-        Gauge.builder("deltav.prometheus.writer.consumer.paused", pausedGauge::get).register(metrics);
+        Gauge.builder(PrometheusWriterMetrics.CONSUMER_PAUSED, pausedGauge::get).register(metrics);
     }
 
     @PostConstruct

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/ConsumerPauseListener.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/ConsumerPauseListener.java
@@ -1,0 +1,49 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.binding.BindingsLifecycleController;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class ConsumerPauseListener {
+    private static final Logger LOG = LoggerFactory.getLogger(ConsumerPauseListener.class);
+    private static final String BINDING = "timeseriesConsumer-in-0";
+
+    private final CircuitBreaker cb;
+    private final BindingsLifecycleController lifecycle;
+    private final AtomicInteger pausedGauge = new AtomicInteger(0);
+
+    public ConsumerPauseListener(CircuitBreaker cb, BindingsLifecycleController lifecycle, MeterRegistry metrics) {
+        this.cb = cb;
+        this.lifecycle = lifecycle;
+        Gauge.builder("deltav.prometheus.writer.consumer.paused", pausedGauge::get).register(metrics);
+    }
+
+    @PostConstruct
+    public void wire() {
+        cb.getEventPublisher().onStateTransition(e -> {
+            var from = e.getStateTransition().getFromState();
+            var to = e.getStateTransition().getToState();
+            boolean pauseNow = to == CircuitBreaker.State.OPEN
+                    && (from == CircuitBreaker.State.CLOSED || from == CircuitBreaker.State.HALF_OPEN);
+            boolean resumeNow = from == CircuitBreaker.State.HALF_OPEN && to == CircuitBreaker.State.CLOSED;
+            if (pauseNow) {
+                LOG.warn("Circuit opened — pausing binding {}", BINDING);
+                lifecycle.pause(BINDING);
+                pausedGauge.set(1);
+            } else if (resumeNow) {
+                LOG.info("Circuit closed — resuming binding {}", BINDING);
+                lifecycle.resume(BINDING);
+                pausedGauge.set(0);
+            }
+        });
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreaker.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreaker.java
@@ -7,6 +7,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -44,7 +45,7 @@ public class PrometheusWriterCircuitBreaker {
                 case OPEN -> 2;
             });
         });
-        Gauge.builder("deltav.prometheus.writer.circuit.state", stateGauge::get)
+        Gauge.builder(PrometheusWriterMetrics.CIRCUIT_STATE, stateGauge::get)
                 .tag("endpoint", props.remoteWrite().url())
                 .register(metrics);
         return cb;

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreaker.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreaker.java
@@ -1,0 +1,52 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Configuration
+public class PrometheusWriterCircuitBreaker {
+
+    public static final String NAME = "prometheus-writer";
+
+    @Bean
+    public CircuitBreakerRegistry circuitBreakerRegistry(PrometheusWriterProperties props) {
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .failureRateThreshold(props.circuitBreaker().failureRateThreshold())
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(props.circuitBreaker().slidingWindowSize())
+                .minimumNumberOfCalls(props.circuitBreaker().minimumNumberOfCalls())
+                .waitDurationInOpenState(Duration.ofMillis(props.circuitBreaker().waitDurationOpenMs()))
+                .permittedNumberOfCallsInHalfOpenState(props.circuitBreaker().halfOpenPermittedCalls())
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .build();
+        return CircuitBreakerRegistry.of(config);
+    }
+
+    @Bean
+    public CircuitBreaker prometheusWriterCircuitBreaker(
+            CircuitBreakerRegistry registry, MeterRegistry metrics, PrometheusWriterProperties props) {
+        CircuitBreaker cb = registry.circuitBreaker(NAME);
+        AtomicInteger stateGauge = new AtomicInteger(0);
+        cb.getEventPublisher().onStateTransition(e -> {
+            stateGauge.set(switch (e.getStateTransition().getToState()) {
+                case CLOSED, METRICS_ONLY, DISABLED, FORCED_OPEN -> 0;
+                case HALF_OPEN -> 1;
+                case OPEN -> 2;
+            });
+        });
+        Gauge.builder("deltav.prometheus.writer.circuit.state", stateGauge::get)
+                .tag("endpoint", props.remoteWrite().url())
+                .register(metrics);
+        return cb;
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreakerConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreakerConfiguration.java
@@ -15,7 +15,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Configuration
-public class PrometheusWriterCircuitBreaker {
+public class PrometheusWriterCircuitBreakerConfiguration {
 
     public static final String NAME = "prometheus-writer";
 

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/RemoteWriteHttpClient.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/RemoteWriteHttpClient.java
@@ -1,0 +1,58 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.WriteRequest;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class RemoteWriteHttpClient {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoteWriteHttpClient.class);
+    private final RestClient client;
+    private final PrometheusWriterProperties props;
+
+    public RemoteWriteHttpClient(RestClient.Builder builder, PrometheusWriterProperties props) {
+        this.props = props;
+        this.client = builder.baseUrl(props.remoteWrite().url()).build();
+    }
+
+    /** POSTs the WriteRequest to the configured RW URL. Returns HTTP status code on success.
+     *  Throws on 4xx/5xx (use RemoteWriteRetryPolicy in Task 12 to classify exceptions). */
+    public int post(WriteRequest request) throws Exception {
+        byte[] compressed = Snappy.compress(request.toByteArray());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("application/x-protobuf"));
+        headers.set("Content-Encoding", "snappy");
+        headers.set("X-Prometheus-Remote-Write-Version", "0.1.0");
+        String version = Optional.ofNullable(getClass().getPackage().getImplementationVersion()).orElse("dev");
+        headers.set("User-Agent", "deltav-prometheus-writer/" + version);
+
+        var auth = props.remoteWrite().auth();
+        switch (auth.type()) {
+            case BEARER -> headers.setBearerAuth(auth.bearerToken());
+            case BASIC  -> headers.setBasicAuth(auth.basicUsername(), auth.basicPassword());
+            case NONE   -> { /* no-op */ }
+        }
+        for (Map.Entry<String, String> e : props.remoteWrite().headers().entrySet()) {
+            headers.add(e.getKey(), e.getValue());
+        }
+
+        ResponseEntity<Void> resp = client.post()
+                .uri(props.remoteWrite().url())
+                .headers(h -> h.addAll(headers))
+                .body(compressed)
+                .retrieve()
+                .toBodilessEntity();
+        return resp.getStatusCode().value();
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/RemoteWriteRetryPolicy.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/RemoteWriteRetryPolicy.java
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.springframework.stereotype.Component;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+@Component
+public class RemoteWriteRetryPolicy {
+    public enum Action { SUCCESS, RETRY_WITH_BACKOFF, POISON_DLQ, CIRCUIT_OPEN }
+
+    public Action classifyStatus(int status) {
+        if (status == 200 || status == 204) return Action.SUCCESS;
+        if (status == 429) return Action.RETRY_WITH_BACKOFF;
+        if (status >= 500) return Action.RETRY_WITH_BACKOFF;
+        if (status == 400 || status == 413) return Action.POISON_DLQ;
+        if (status == 401 || status == 403 || status == 404) return Action.CIRCUIT_OPEN;
+        if (status >= 400 && status < 500) return Action.POISON_DLQ;
+        return Action.POISON_DLQ;
+    }
+
+    public Action classifyException(Throwable t) {
+        if (t instanceof SocketTimeoutException
+                || t instanceof ConnectException
+                || t instanceof UnknownHostException) return Action.RETRY_WITH_BACKOFF;
+        Throwable cause = t.getCause();
+        if (cause != null && cause != t) return classifyException(cause);
+        return Action.RETRY_WITH_BACKOFF;
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/WriteRequestBuilder.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/WriteRequestBuilder.java
@@ -1,0 +1,56 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.springframework.stereotype.Component;
+import prometheus.prompb.Label;
+import prometheus.prompb.Sample;
+import prometheus.prompb.TimeSeries;
+import prometheus.prompb.WriteRequest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class WriteRequestBuilder {
+    public WriteRequest build(List<PromSample> samples) {
+        Map<SeriesKey, List<Sample>> bySeries = new LinkedHashMap<>();
+        Map<SeriesKey, List<Label>> seriesLabels = new HashMap<>();
+        for (PromSample s : samples) {
+            Map<String, String> withName = new LinkedHashMap<>();
+            withName.put("__name__", s.name());
+            withName.putAll(s.labels());
+            SeriesKey key = SeriesKey.from(withName);
+            bySeries.computeIfAbsent(key, k -> new ArrayList<>())
+                    .add(Sample.newBuilder().setValue(s.value()).setTimestamp(s.timestampMs()).build());
+            seriesLabels.computeIfAbsent(key, k -> toLabels(withName));
+        }
+        WriteRequest.Builder req = WriteRequest.newBuilder();
+        for (Map.Entry<SeriesKey, List<Sample>> e : bySeries.entrySet()) {
+            req.addTimeseries(TimeSeries.newBuilder()
+                    .addAllLabels(seriesLabels.get(e.getKey()))
+                    .addAllSamples(e.getValue()));
+        }
+        return req.build();
+    }
+
+    private static List<Label> toLabels(Map<String, String> m) {
+        List<Label> out = new ArrayList<>(m.size());
+        m.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(e -> out.add(Label.newBuilder().setName(e.getKey()).setValue(e.getValue()).build()));
+        return out;
+    }
+
+    private record SeriesKey(String canonical) {
+        static SeriesKey from(Map<String, String> labels) {
+            StringBuilder sb = new StringBuilder();
+            labels.entrySet().stream().sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> sb.append(e.getKey()).append('=').append(e.getValue()).append('|'));
+            return new SeriesKey(sb.toString());
+        }
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/startup/TimeseriesBindingResumer.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/startup/TimeseriesBindingResumer.java
@@ -1,0 +1,43 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.startup;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCacheReadyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.binding.BindingsLifecycleController;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resumes the paused {@code timeseriesConsumer-in-0} binding once the NodeContext
+ * cache has finished its initial bootstrap. Counterpart to
+ * {@link TimeseriesBindingStartupGate}.
+ *
+ * <p>No-op when {@code prometheus-writer.startup-gate.enabled=false}.</p>
+ */
+@Component
+public class TimeseriesBindingResumer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesBindingResumer.class);
+    private static final String BINDING = "timeseriesConsumer-in-0";
+
+    private final BindingsLifecycleController lifecycle;
+    private final PrometheusWriterProperties props;
+
+    public TimeseriesBindingResumer(BindingsLifecycleController lifecycle,
+                                    PrometheusWriterProperties props) {
+        this.lifecycle = lifecycle;
+        this.props = props;
+    }
+
+    @EventListener
+    public void onReady(NodeContextCacheReadyEvent event) {
+        if (!props.startupGate().enabled()) {
+            return;
+        }
+        LOG.info("NodeContextCache ready (size={}, bootstrap={}ms) — resuming binding {}",
+                event.getCacheSize(), event.getBootstrapDurationMs(), BINDING);
+        lifecycle.resume(BINDING);
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/startup/TimeseriesBindingStartupGate.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/startup/TimeseriesBindingStartupGate.java
@@ -1,0 +1,48 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.startup;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.config.ListenerContainerCustomizer;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Pauses the {@code timeseriesConsumer-in-0} Kafka listener container at factory time
+ * so that the binding does not start consuming until {@link
+ * org.deltav.prometheus.writer.nodecontext.NodeContextCacheReadyEvent} fires.
+ *
+ * <p>Gated by {@code prometheus-writer.startup-gate.enabled} (default {@code true}).
+ * When disabled the container starts unpaused — useful for unit tests that don't run
+ * the bootstrap consumer.</p>
+ *
+ * <p>Note: in Spring Cloud Stream 5.0.x the customizer interface lives in
+ * {@code org.springframework.cloud.stream.config}, not in the kafka-binder
+ * {@code config} sub-package referenced by older (4.x) docs.</p>
+ */
+@Component
+public class TimeseriesBindingStartupGate
+        implements ListenerContainerCustomizer<AbstractMessageListenerContainer<?, ?>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesBindingStartupGate.class);
+    private static final String BINDING = "timeseriesConsumer-in-0";
+
+    private final PrometheusWriterProperties props;
+
+    public TimeseriesBindingStartupGate(PrometheusWriterProperties props) {
+        this.props = props;
+    }
+
+    @Override
+    public void configure(AbstractMessageListenerContainer<?, ?> container,
+                          String destinationName,
+                          String group) {
+        if (!props.startupGate().enabled()) {
+            LOG.info("Startup gate disabled; timeseries binding will start unpaused");
+            return;
+        }
+        LOG.info("Pausing timeseries binding '{}' — will resume on NodeContextCacheReadyEvent", BINDING);
+        container.pause();
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/LabelBuilder.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/LabelBuilder.java
@@ -1,0 +1,54 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class LabelBuilder {
+    private final NameSanitizer sanitizer;
+    public LabelBuilder(NameSanitizer sanitizer) { this.sanitizer = sanitizer; }
+
+    public Map<String, String> build(TimeseriesBatch batch, Resource resource,
+                                     Optional<NodeContext> nc, List<String> metadataAllowlist) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("node_id", Integer.toString(batch.getNodeId()));
+        labels.put("location", nullToEmpty(batch.getLocation()));
+        labels.put("node_label", nc.map(NodeContext::getNodeLabel).orElse(""));
+        labels.put("foreign_source", nc.map(NodeContext::getForeignSource).orElse(""));
+        labels.put("categories", nc.map(x -> {
+            List<String> sorted = new ArrayList<>(x.getCategoriesList());
+            Collections.sort(sorted);
+            return String.join(",", sorted);
+        }).orElse(""));
+        labels.put("resource_type", nullToEmpty(resource.getType()));
+        labels.put("resource_instance", nullToEmpty(resource.getInstance()));
+        labels.put("collection_package", nullToEmpty(batch.getCollectionPackage()));
+        labels.put("producer", producerLabel(batch.getProducer()));
+
+        for (String metaKey : metadataAllowlist) {
+            String labelName = sanitizer.sanitize(metaKey);
+            String value = nc.map(n -> n.getMetadataMap().getOrDefault(metaKey, "")).orElse("");
+            labels.put(labelName, value);
+        }
+        return labels;
+    }
+
+    private static String producerLabel(ProducerType p) {
+        String name = p.name();
+        return name.startsWith("PRODUCER_") ? name.substring("PRODUCER_".length()).toLowerCase(Locale.ROOT) : name.toLowerCase(Locale.ROOT);
+    }
+
+    private static String nullToEmpty(String s) { return s == null ? "" : s; }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/NameSanitizer.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/NameSanitizer.java
@@ -1,0 +1,48 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Component
+public class NameSanitizer {
+    private static final Logger LOG = LoggerFactory.getLogger(NameSanitizer.class);
+
+    public String sanitize(String input) {
+        if (input == null || input.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(input.length());
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if ((c >= 'A' && c <= 'Z')) sb.append((char)(c + ('a' - 'A')));
+            else if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) sb.append(c);
+            else sb.append('_');
+        }
+        String collapsed = sb.toString().replaceAll("_+", "_");
+        if (collapsed.isEmpty()) return "";
+        if (Character.isDigit(collapsed.charAt(0))) collapsed = "_" + collapsed;
+        return collapsed;
+    }
+
+    /** Detects collisions in a name set; returns map of sanitized &rarr; list of originals where &gt; 1. */
+    public Map<String, List<String>> detectCollisions(List<String> originals) {
+        Map<String, List<String>> buckets = new TreeMap<>();
+        for (String orig : originals) {
+            String clean = sanitize(orig);
+            buckets.computeIfAbsent(clean, k -> new java.util.ArrayList<>()).add(orig);
+        }
+        Map<String, List<String>> collisions = new HashMap<>();
+        for (Map.Entry<String, List<String>> e : buckets.entrySet()) {
+            if (e.getValue().size() > 1) {
+                collisions.put(e.getKey(), e.getValue());
+                LOG.warn("Name sanitization collision: {} -> {}", e.getValue(), e.getKey());
+            }
+        }
+        return collisions;
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/PromSample.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/PromSample.java
@@ -1,0 +1,6 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import java.util.Map;
+
+public record PromSample(String name, Map<String, String> labels, double value, long timestampMs) {}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslator.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslator.java
@@ -1,0 +1,81 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Pure function {@code (TimeseriesBatch, Optional<NodeContext>) -> List<PromSample>}.
+ *
+ * <p>Filters STRING and UNSPECIFIED attributes (incrementing drop counters).
+ * Drops the entire batch and increments the enrichment-missing counter when
+ * the {@link NodeContext} is absent. Sample timestamp is the batch collection
+ * time, never {@code System.currentTimeMillis()}.</p>
+ */
+@Component
+public class TimeseriesToPromTranslator {
+    private final NameSanitizer sanitizer;
+    private final LabelBuilder labelBuilder;
+    private final PrometheusWriterProperties props;
+    private final Counter droppedString;
+    private final Counter droppedUnspecified;
+    private final Counter enrichmentMissing;
+
+    public TimeseriesToPromTranslator(NameSanitizer sanitizer, LabelBuilder labelBuilder,
+                                      PrometheusWriterProperties props, MeterRegistry reg) {
+        this.sanitizer = sanitizer;
+        this.labelBuilder = labelBuilder;
+        this.props = props;
+        this.droppedString = reg.counter("deltav.prometheus.writer.samples.dropped",
+                "reason", "string_attribute");
+        this.droppedUnspecified = reg.counter("deltav.prometheus.writer.samples.dropped",
+                "reason", "type_unspecified");
+        this.enrichmentMissing = reg.counter("deltav.prometheus.writer.enrichment.missing",
+                "reason", "never_seen");
+    }
+
+    public List<PromSample> translate(TimeseriesBatch batch, Optional<NodeContext> nc) {
+        if (nc.isEmpty()) {
+            enrichmentMissing.increment();
+            return List.of();
+        }
+        List<PromSample> out = new ArrayList<>();
+        List<String> allowlist = props.labels().fromMetadata();
+        for (Resource r : batch.getResourcesList()) {
+            Map<String, String> labels = labelBuilder.build(batch, r, nc, allowlist);
+            for (AttributeGroup g : r.getGroupsList()) {
+                for (Attribute a : g.getAttributesList()) {
+                    if (a.getType() == AttributeType.ATTRIBUTE_TYPE_STRING) {
+                        droppedString.increment();
+                        continue;
+                    }
+                    if (a.getType() == AttributeType.ATTRIBUTE_TYPE_UNSPECIFIED) {
+                        droppedUnspecified.increment();
+                        continue;
+                    }
+                    String name = buildMetricName(g.getName(), a.getName(), a.getType());
+                    out.add(new PromSample(name, labels, a.getNumeric(), batch.getTimestampMs()));
+                }
+            }
+        }
+        return out;
+    }
+
+    private String buildMetricName(String groupName, String attrName, AttributeType type) {
+        String base = "opennms_" + sanitizer.sanitize(groupName) + "_" + sanitizer.sanitize(attrName);
+        return type == AttributeType.ATTRIBUTE_TYPE_COUNTER ? base + "_total" : base;
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslator.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslator.java
@@ -4,6 +4,7 @@ package org.deltav.prometheus.writer.translate;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics;
 import org.deltav.timeseries.proto.Attribute;
 import org.deltav.timeseries.proto.AttributeGroup;
 import org.deltav.timeseries.proto.AttributeType;
@@ -39,11 +40,11 @@ public class TimeseriesToPromTranslator {
         this.sanitizer = sanitizer;
         this.labelBuilder = labelBuilder;
         this.props = props;
-        this.droppedString = reg.counter("deltav.prometheus.writer.samples.dropped",
+        this.droppedString = reg.counter(PrometheusWriterMetrics.SAMPLES_DROPPED,
                 "reason", "string_attribute");
-        this.droppedUnspecified = reg.counter("deltav.prometheus.writer.samples.dropped",
+        this.droppedUnspecified = reg.counter(PrometheusWriterMetrics.SAMPLES_DROPPED,
                 "reason", "type_unspecified");
-        this.enrichmentMissing = reg.counter("deltav.prometheus.writer.enrichment.missing",
+        this.enrichmentMissing = reg.counter(PrometheusWriterMetrics.ENRICHMENT_MISSING,
                 "reason", "never_seen");
     }
 

--- a/core/prometheus-writer/src/main/resources/application.yml
+++ b/core/prometheus-writer/src/main/resources/application.yml
@@ -60,3 +60,6 @@ management:
       probes:
         enabled: true
       show-details: always
+      group:
+        readiness:
+          include: readinessState, nodeContextCache

--- a/core/prometheus-writer/src/main/resources/application.yml
+++ b/core/prometheus-writer/src/main/resources/application.yml
@@ -1,0 +1,62 @@
+# Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later
+spring:
+  application:
+    name: prometheus-writer
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}  # prod yaml MUST carry this — Phase 0 #170 lesson
+  cloud:
+    function:
+      definition: timeseriesConsumer
+    stream:
+      kafka:
+        binder:
+          brokers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bindings:
+        timeseriesConsumer-in-0:
+          destination: deltav-timeseries
+          group: prometheus-writer
+          consumer:
+            concurrency: 4
+        publishDlq-out-0:
+          destination: deltav-prometheus-writer-dlq
+          producer:
+            use-native-encoding: true    # Phase 1.5 SCS splitter-lesson prophylactic
+
+prometheus-writer:
+  remote-write:
+    url: ${PROMETHEUS_WRITER_REMOTE_WRITE_URL:http://victoriametrics:8428/api/v1/write}
+    auth:
+      type: ${PROMETHEUS_WRITER_AUTH_TYPE:none}
+      bearer-token: ${PROMETHEUS_WRITER_BEARER_TOKEN:}
+      basic-username: ${PROMETHEUS_WRITER_BASIC_USER:}
+      basic-password: ${PROMETHEUS_WRITER_BASIC_PASS:}
+    headers: {}
+  batch:
+    max-samples: 1000
+    max-bytes: 1048576
+    max-interval-ms: 1000
+  retry:
+    initial-backoff-ms: 100
+    max-backoff-ms: 30000
+    jitter-factor: 0.1
+  circuit-breaker:
+    failure-rate-threshold: 50
+    sliding-window-size: 20
+    minimum-number-of-calls: 10
+    wait-duration-open-ms: 30000
+    half-open-permitted-calls: 3
+  labels:
+    from-metadata: []
+  startup-gate:
+    enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, bindings
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/PrometheusWriterApplicationScanIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/PrometheusWriterApplicationScanIT.java
@@ -1,0 +1,92 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.deltav.prometheus.writer.consume.TimeseriesConsumerConfiguration;
+import org.deltav.prometheus.writer.dlq.DlqPublisher;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCacheHealthIndicator;
+import org.deltav.prometheus.writer.nodecontext.NodeContextKafkaBootstrap;
+import org.deltav.prometheus.writer.rw.BatchingRwWriter;
+import org.deltav.prometheus.writer.rw.ConsumerPauseListener;
+import org.deltav.prometheus.writer.rw.RemoteWriteHttpClient;
+import org.deltav.prometheus.writer.rw.RemoteWriteRetryPolicy;
+import org.deltav.prometheus.writer.rw.WriteRequestBuilder;
+import org.deltav.prometheus.writer.startup.TimeseriesBindingResumer;
+import org.deltav.prometheus.writer.startup.TimeseriesBindingStartupGate;
+import org.deltav.prometheus.writer.translate.LabelBuilder;
+import org.deltav.prometheus.writer.translate.NameSanitizer;
+import org.deltav.prometheus.writer.translate.TimeseriesToPromTranslator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-main-class integration test. Boots {@link PrometheusWriterApplication}
+ * via {@code SpringApplication.run()} against a Testcontainers Kafka broker
+ * and asserts every key bean from the Phase 2 spec is resolvable.
+ *
+ * <p><strong>Scar prophylactic for the Phase 0 #170 bug:</strong> unit tests
+ * and {@code @Import}-based ITs bypass the component scan. A mistyped
+ * {@code scanBasePackages} silently hides an entire {@code @Configuration}
+ * class and the problem only surfaces when Docker boots the real jar. This
+ * IT would have caught it in one CI run.
+ */
+@Testcontainers
+@SpringBootTest(
+        classes = PrometheusWriterApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PrometheusWriterApplicationScanIT {
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("apache/kafka:3.8.0"))
+                    .withStartupTimeout(Duration.ofSeconds(120));
+
+    @DynamicPropertySource
+    static void kafkaProps(DynamicPropertyRegistry reg) {
+        reg.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        reg.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+        reg.add("prometheus-writer.remote-write.url", () -> "http://localhost:1/unused");
+    }
+
+    @Autowired ApplicationContext ctx;
+
+    @Test
+    void all_key_beans_resolve() {
+        // Node-context subsystem
+        assertThat(ctx.getBean(NodeContextCache.class)).isNotNull();
+        assertThat(ctx.getBean(NodeContextKafkaBootstrap.class)).isNotNull();
+        assertThat(ctx.getBean(NodeContextCacheHealthIndicator.class)).isNotNull();
+        // Translation
+        assertThat(ctx.getBean(NameSanitizer.class)).isNotNull();
+        assertThat(ctx.getBean(LabelBuilder.class)).isNotNull();
+        assertThat(ctx.getBean(TimeseriesToPromTranslator.class)).isNotNull();
+        // RW output
+        assertThat(ctx.getBean(WriteRequestBuilder.class)).isNotNull();
+        assertThat(ctx.getBean(RemoteWriteHttpClient.class)).isNotNull();
+        assertThat(ctx.getBean(RemoteWriteRetryPolicy.class)).isNotNull();
+        assertThat(ctx.getBean(BatchingRwWriter.class)).isNotNull();
+        assertThat(ctx.getBean(CircuitBreaker.class)).isNotNull();
+        assertThat(ctx.getBean(ConsumerPauseListener.class)).isNotNull();
+        // Consumer + startup gate
+        assertThat(ctx.getBean(TimeseriesConsumerConfiguration.class)).isNotNull();
+        assertThat(ctx.getBean(TimeseriesBindingStartupGate.class)).isNotNull();
+        assertThat(ctx.getBean(TimeseriesBindingResumer.class)).isNotNull();
+        // DLQ
+        assertThat(ctx.getBean(DlqPublisher.class)).isNotNull();
+        assertThat(ctx.getBean("deltavPrometheusWriterDlqTopic", NewTopic.class)).isNotNull();
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/config/PrometheusWriterPropertiesTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/config/PrometheusWriterPropertiesTest.java
@@ -1,0 +1,63 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrometheusWriterPropertiesTest {
+
+    @Test
+    void binds_full_yaml_shape() {
+        Map<String, Object> map = Map.ofEntries(
+                Map.entry("prometheus-writer.remote-write.url", "http://vm:8428/api/v1/write"),
+                Map.entry("prometheus-writer.remote-write.auth.type", "bearer"),
+                Map.entry("prometheus-writer.remote-write.auth.bearer-token", "abc"),
+                Map.entry("prometheus-writer.remote-write.headers.X-Scope-OrgID", "tenant-1"),
+                Map.entry("prometheus-writer.batch.max-samples", "1000"),
+                Map.entry("prometheus-writer.batch.max-bytes", "1048576"),
+                Map.entry("prometheus-writer.batch.max-interval-ms", "1000"),
+                Map.entry("prometheus-writer.retry.initial-backoff-ms", "100"),
+                Map.entry("prometheus-writer.retry.max-backoff-ms", "30000"),
+                Map.entry("prometheus-writer.circuit-breaker.failure-rate-threshold", "50"),
+                Map.entry("prometheus-writer.labels.from-metadata[0]", "requisition:region"),
+                Map.entry("prometheus-writer.startup-gate.enabled", "true")
+        );
+        ConfigurationPropertySource src = new MapConfigurationPropertySource(map);
+        PrometheusWriterProperties props = new Binder(src)
+                .bind("prometheus-writer", Bindable.of(PrometheusWriterProperties.class))
+                .get();
+
+        assertThat(props.remoteWrite().url()).isEqualTo("http://vm:8428/api/v1/write");
+        assertThat(props.remoteWrite().auth().type()).isEqualTo(PrometheusWriterProperties.AuthType.BEARER);
+        assertThat(props.remoteWrite().auth().bearerToken()).isEqualTo("abc");
+        assertThat(props.remoteWrite().headers()).containsEntry("X-Scope-OrgID", "tenant-1");
+        assertThat(props.batch().maxSamples()).isEqualTo(1000);
+        assertThat(props.batch().maxBytes()).isEqualTo(1_048_576);
+        assertThat(props.labels().fromMetadata()).containsExactly("requisition:region");
+        assertThat(props.startupGate().enabled()).isTrue();
+    }
+
+    @Test
+    void defaults_are_sensible_when_minimal_yaml() {
+        Map<String, Object> map = Map.of(
+                "prometheus-writer.remote-write.url", "http://localhost/write"
+        );
+        ConfigurationPropertySource src = new MapConfigurationPropertySource(map);
+        PrometheusWriterProperties props = new Binder(src)
+                .bind("prometheus-writer", Bindable.of(PrometheusWriterProperties.class))
+                .get();
+
+        assertThat(props.batch().maxSamples()).isEqualTo(1000);
+        assertThat(props.batch().maxBytes()).isEqualTo(1_048_576);
+        assertThat(props.batch().maxIntervalMs()).isEqualTo(1000);
+        assertThat(props.remoteWrite().auth().type()).isEqualTo(PrometheusWriterProperties.AuthType.NONE);
+        assertThat(props.startupGate().enabled()).isTrue();
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerBinderIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerBinderIT.java
@@ -1,0 +1,145 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.consume;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.rw.BatchingRwWriter;
+import org.deltav.prometheus.writer.translate.TimeseriesToPromTranslator;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * SCS test-binder IT for {@link TimeseriesConsumer}. Asserts the full path:
+ * binder &rarr; deserialize &rarr; cache lookup &rarr; translator &rarr;
+ * {@link BatchingRwWriter#add}, plus the parse-error counter on malformed input.
+ *
+ * <p>Loads only a tiny boot test app that imports {@link TimeseriesConsumer}
+ * plus a {@link MockBeans} configuration providing Mockito stubs for the
+ * cache, translator, and writer. {@link EnableAutoConfiguration} pulls in
+ * Spring Cloud Function + Spring Cloud Stream so the {@code Consumer} bean is
+ * discovered, bound, and dispatched by the in-memory
+ * {@link TestChannelBinderConfiguration test binder}.
+ */
+@SpringBootTest(classes = TimeseriesConsumerBinderIT.TestApp.class)
+@TestPropertySource(properties = {
+        "spring.main.web-application-type=none",
+        "spring.main.banner-mode=off",
+        "spring.cloud.function.definition=timeseriesConsumer",
+        "spring.cloud.stream.bindings.timeseriesConsumer-in-0.destination=timeseriesConsumer-in-0",
+        // application.yml registers a "nodeContextCache" health contributor in
+        // the readiness group; clear that mapping here so the slim test context
+        // (no NodeContextCacheHealthIndicator bean) does not fail validation.
+        "management.endpoint.health.group.readiness.include=readinessState"
+})
+class TimeseriesConsumerBinderIT {
+
+    /**
+     * Minimal boot application that enables Spring Boot auto-configuration so
+     * SCS BindingServiceConfiguration (which discovers and binds functions) is
+     * triggered. {@link TestChannelBinderConfiguration} provides the
+     * in-process test binder via {@code @ConditionalOnMissingBean(Binder.class)}.
+     */
+    @EnableAutoConfiguration
+    @Import({TimeseriesConsumer.class, MockBeans.class, TestChannelBinderConfiguration.class})
+    static class TestApp {
+    }
+
+    @Autowired
+    InputDestination input;
+
+    @Autowired
+    NodeContextCache cache;
+
+    @Autowired
+    TimeseriesToPromTranslator translator;
+
+    @Autowired
+    BatchingRwWriter writer;
+
+    @Autowired
+    MeterRegistry metrics;
+
+    @Test
+    void consumes_batch_invokes_translator_and_writer() {
+        when(cache.get("Default@5")).thenReturn(java.util.Optional.of(
+                NodeContext.newBuilder()
+                        .setNodeId(5)
+                        .setLocation("Default")
+                        .setNodeLabel("n5")
+                        .build()));
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(5)
+                .setLocation("Default")
+                .setProducer(ProducerType.PRODUCER_COLLECTD)
+                .setTimestampMs(1_700_000_000_000L)
+                .build();
+
+        input.send(MessageBuilder.withPayload(batch.toByteArray()).build(),
+                "timeseriesConsumer-in-0");
+
+        org.awaitility.Awaitility.await()
+                .atMost(java.time.Duration.ofSeconds(5))
+                .until(() -> metrics.counter("deltav.prometheus.writer.records.consumed")
+                        .count() == 1.0);
+
+        verify(translator, times(1)).translate(any(), any());
+        // translator returned empty list (no resources in batch) -> writer.add never called
+        verify(writer, times(0)).add(any());
+    }
+
+    @Test
+    void parse_error_increments_counter_and_does_not_throw() {
+        // Bytes that aren't a valid TimeseriesBatch
+        input.send(MessageBuilder.withPayload(new byte[]{0x42, 0x42, 0x42}).build(),
+                "timeseriesConsumer-in-0");
+
+        org.awaitility.Awaitility.await()
+                .atMost(java.time.Duration.ofSeconds(5))
+                .until(() -> metrics.counter("deltav.prometheus.writer.records.parse.errors")
+                        .count() >= 1.0);
+    }
+
+    @Configuration
+    static class MockBeans {
+        @Bean
+        NodeContextCache cache() {
+            return mock(NodeContextCache.class);
+        }
+
+        @Bean
+        TimeseriesToPromTranslator translator() {
+            TimeseriesToPromTranslator t = mock(TimeseriesToPromTranslator.class);
+            when(t.translate(any(), any())).thenReturn(java.util.List.of());
+            return t;
+        }
+
+        @Bean
+        BatchingRwWriter writer() {
+            return mock(BatchingRwWriter.class);
+        }
+
+        @Bean
+        MeterRegistry metrics() {
+            return new SimpleMeterRegistry();
+        }
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerBinderIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerBinderIT.java
@@ -28,11 +28,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * SCS test-binder IT for {@link TimeseriesConsumer}. Asserts the full path:
+ * SCS test-binder IT for {@link TimeseriesConsumerConfiguration}. Asserts the full path:
  * binder &rarr; deserialize &rarr; cache lookup &rarr; translator &rarr;
  * {@link BatchingRwWriter#add}, plus the parse-error counter on malformed input.
  *
- * <p>Loads only a tiny boot test app that imports {@link TimeseriesConsumer}
+ * <p>Loads only a tiny boot test app that imports {@link TimeseriesConsumerConfiguration}
  * plus a {@link MockBeans} configuration providing Mockito stubs for the
  * cache, translator, and writer. {@link EnableAutoConfiguration} pulls in
  * Spring Cloud Function + Spring Cloud Stream so the {@code Consumer} bean is
@@ -59,7 +59,7 @@ class TimeseriesConsumerBinderIT {
      * in-process test binder via {@code @ConditionalOnMissingBean(Binder.class)}.
      */
     @EnableAutoConfiguration
-    @Import({TimeseriesConsumer.class, MockBeans.class, TestChannelBinderConfiguration.class})
+    @Import({TimeseriesConsumerConfiguration.class, MockBeans.class, TestChannelBinderConfiguration.class})
     static class TestApp {
     }
 

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/dlq/DlqPublisherBinderIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/dlq/DlqPublisherBinderIT.java
@@ -1,0 +1,58 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.dlq;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = DlqPublisherBinderIT.TestApp.class)
+@TestPropertySource(properties = {
+        "spring.cloud.stream.bindings.publishDlq-out-0.destination=publishDlq-out-0",
+        "spring.cloud.stream.bindings.publishDlq-out-0.producer.use-native-encoding=true",
+        "management.endpoint.health.group.readiness.include=readinessState"
+})
+class DlqPublisherBinderIT {
+
+    @Autowired DlqPublisher publisher;
+    @Autowired OutputDestination output;
+    @Autowired MeterRegistry metrics;
+
+    @Test
+    void publish_sends_payload_byte_for_byte_with_diagnostic_headers() {
+        byte[] sourcePayload = new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, (byte) 0xFF};
+        publisher.publish(sourcePayload, "Default@5", "bad_request", 400,
+                "http://target/write", "boom: invalid metric name");
+
+        Message<byte[]> sent = output.receive(2000, "publishDlq-out-0");
+        assertThat(sent).isNotNull();
+        // CRITICAL: byte-for-byte preservation - validates use-native-encoding: true scar prophylactic
+        assertThat(sent.getPayload()).isEqualTo(sourcePayload);
+        // 6 diagnostic headers
+        assertThat(sent.getHeaders()).containsKeys(
+                "x-dlq-reason", "x-dlq-http-status", "x-dlq-endpoint",
+                "x-dlq-timestamp-ms", "x-dlq-error-message", "x-dlq-writer-version");
+        assertThat(sent.getHeaders().get("x-dlq-reason")).isEqualTo("bad_request");
+        assertThat(sent.getHeaders().get("x-dlq-http-status")).isEqualTo("400");
+        assertThat(sent.getHeaders().get("x-dlq-endpoint")).isEqualTo("http://target/write");
+        // Counter incremented
+        assertThat(metrics.find("deltav.prometheus.writer.dlq.records")
+                .tag("reason", "bad_request").counter().count()).isEqualTo(1.0);
+    }
+
+    @EnableAutoConfiguration
+    @Import({DlqPublisher.class, TestChannelBinderConfiguration.class})
+    static class TestApp {
+        @Bean MeterRegistry metrics() { return new SimpleMeterRegistry(); }
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetricsTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetricsTest.java
@@ -1,0 +1,50 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrometheusWriterMetricsTest {
+
+    private static final Set<String> EXPECTED_METER_NAMES = new TreeSet<>(Set.of(
+            "deltav.prometheus.writer.records.consumed",
+            "deltav.prometheus.writer.samples.in",
+            "deltav.prometheus.writer.records.parse.errors",
+            "deltav.prometheus.writer.enrichment.hit",
+            "deltav.prometheus.writer.enrichment.missing",
+            "deltav.prometheus.writer.node.context.cache.size",
+            "deltav.prometheus.writer.node.context.cache.ready",
+            "deltav.prometheus.writer.node.context.bootstrap.duration",
+            "deltav.prometheus.writer.samples.dropped",
+            "deltav.prometheus.writer.batches.sent",
+            "deltav.prometheus.writer.samples.sent",
+            "deltav.prometheus.writer.batches.failed",
+            "deltav.prometheus.writer.batch.size.bytes",
+            "deltav.prometheus.writer.batch.sample.count",
+            "deltav.prometheus.writer.flush.duration",
+            "deltav.prometheus.writer.retry.attempts",
+            "deltav.prometheus.writer.dlq.records",
+            "deltav.prometheus.writer.circuit.state",
+            "deltav.prometheus.writer.consumer.paused"
+    ));
+
+    @Test
+    void declared_constants_match_canonical_set() throws Exception {
+        Set<String> declared = new TreeSet<>();
+        for (Field f : PrometheusWriterMetrics.class.getDeclaredFields()) {
+            if (Modifier.isPublic(f.getModifiers())
+                    && Modifier.isStatic(f.getModifiers())
+                    && Modifier.isFinal(f.getModifiers())
+                    && f.getType() == String.class) {
+                declared.add((String) f.get(null));
+            }
+        }
+        assertThat(declared).isEqualTo(EXPECTED_METER_NAMES);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicatorTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicatorTest.java
@@ -1,0 +1,37 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeContextCacheHealthIndicatorTest {
+
+    @Test
+    void health_down_when_cache_not_ready() {
+        NodeContextCache cache = new NodeContextCache();
+        // not marked ready, no entries
+        Health health = new NodeContextCacheHealthIndicator(cache).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("ready", false);
+        assertThat(health.getDetails()).containsEntry("size", 0);
+    }
+
+    @Test
+    void health_up_when_cache_ready() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).build());
+        cache.put("Default@2", NodeContext.newBuilder().setNodeId(2).build());
+        cache.markReady();
+
+        Health health = new NodeContextCacheHealthIndicator(cache).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("ready", true);
+        assertThat(health.getDetails()).containsEntry("size", 2);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheTest.java
@@ -1,0 +1,71 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeContextCacheTest {
+
+    @Test
+    void get_returns_empty_when_key_absent() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void put_stores_value_and_get_retrieves() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).setLocation("Default").setNodeLabel("lab-1").build();
+        cache.put("Default@1", nc);
+        assertThat(cache.get("Default@1")).contains(nc);
+    }
+
+    @Test
+    void remove_evicts_key() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).build();
+        cache.put("Default@1", nc);
+        cache.remove("Default@1");
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void tombstone_on_put_delegates_to_remove() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).build());
+        NodeContext tombstone = NodeContext.newBuilder().setNodeId(1).setDeleted(true).build();
+        cache.applyUpdate("Default@1", tombstone);
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void applyUpdate_live_record_puts() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).setDeleted(false).build();
+        cache.applyUpdate("Default@1", nc);
+        assertThat(cache.get("Default@1")).contains(nc);
+    }
+
+    @Test
+    void size_reports_current_entries() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.size()).isZero();
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).build());
+        cache.put("Default@2", NodeContext.newBuilder().setNodeId(2).build());
+        assertThat(cache.size()).isEqualTo(2);
+        cache.remove("Default@1");
+        assertThat(cache.size()).isEqualTo(1);
+    }
+
+    @Test
+    void ready_defaults_false_and_markReady_flips() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.isReady()).isFalse();
+        cache.markReady();
+        assertThat(cache.isReady()).isTrue();
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java
@@ -1,0 +1,128 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.deltav.timeseries.proto.NodeContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration test for {@link NodeContextKafkaBootstrap}: drives a real Kafka broker
+ * via Testcontainers, asserts the bootstrap drains to HWM and tombstones propagate
+ * during the live-tail loop.
+ *
+ * <p>Pinned to {@code apache/kafka:3.8.0} — same image as the sibling Phase 1
+ * {@code NodeContextKafkaIT} in daemon-boot-provisiond for layer-cache reuse.
+ */
+@Testcontainers
+class NodeContextKafkaBootstrapIT {
+
+    private static final String TOPIC = "deltav-node-context";
+
+    @Container
+    static final KafkaContainer KAFKA = new KafkaContainer(
+            DockerImageName.parse("apache/kafka:3.8.0"))
+            .withStartupTimeout(Duration.ofSeconds(120));
+
+    @Test
+    void bootstrap_drains_to_HWM_then_marks_ready() throws Exception {
+        ensureTopic();
+        for (int i = 1; i <= 50; i++) {
+            produce(i, false);
+        }
+
+        NodeContextCache cache = new NodeContextCache();
+        AtomicReference<NodeContextCacheReadyEvent> captured = new AtomicReference<>();
+        ApplicationEventPublisher publisher = event -> {
+            if (event instanceof NodeContextCacheReadyEvent r) {
+                captured.set(r);
+            }
+        };
+        NodeContextKafkaBootstrap boot = new NodeContextKafkaBootstrap(
+                cache, publisher, new SimpleMeterRegistry(), KAFKA.getBootstrapServers());
+        boot.start();
+        try {
+            await().atMost(Duration.ofSeconds(30)).until(cache::isReady);
+            assertThat(cache.size()).isEqualTo(50);
+            assertThat(captured.get()).isNotNull();
+            assertThat(captured.get().getCacheSize()).isEqualTo(50);
+        } finally {
+            boot.stop();
+        }
+    }
+
+    @Test
+    void tombstone_removes_key_from_cache_live() throws Exception {
+        ensureTopic();
+        produce(101, false);
+
+        NodeContextCache cache = new NodeContextCache();
+        ApplicationEventPublisher publisher = e -> { };
+        NodeContextKafkaBootstrap boot = new NodeContextKafkaBootstrap(
+                cache, publisher, new SimpleMeterRegistry(), KAFKA.getBootstrapServers());
+        boot.start();
+        try {
+            await().atMost(Duration.ofSeconds(30)).until(cache::isReady);
+            assertThat(cache.get("Default@101")).isPresent();
+
+            produce(101, true);   // tombstone (deleted=true)
+            await().atMost(Duration.ofSeconds(20))
+                    .until(() -> cache.get("Default@101").isEmpty());
+        } finally {
+            boot.stop();
+        }
+    }
+
+    // -------------------- helpers --------------------
+
+    private void ensureTopic() throws Exception {
+        Properties p = new Properties();
+        p.put("bootstrap.servers", KAFKA.getBootstrapServers());
+        try (AdminClient a = AdminClient.create(p)) {
+            a.createTopics(List.of(new NewTopic(TOPIC, 8, (short) 1)
+                            .configs(Map.of("cleanup.policy", "compact"))))
+                    .all().get();
+        } catch (Exception e) {
+            if (!(e.getCause() instanceof org.apache.kafka.common.errors.TopicExistsException)) {
+                throw e;
+            }
+        }
+    }
+
+    private void produce(int nodeId, boolean deleted) throws Exception {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        try (KafkaProducer<String, byte[]> prod = new KafkaProducer<>(p)) {
+            NodeContext nc = NodeContext.newBuilder()
+                    .setNodeId(nodeId)
+                    .setLocation("Default")
+                    .setNodeLabel("node-" + nodeId)
+                    .setDeleted(deleted)
+                    .setUpdatedAtMs(System.currentTimeMillis())
+                    .build();
+            prod.send(new ProducerRecord<>(TOPIC, "Default@" + nodeId, nc.toByteArray())).get();
+        }
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/BatchingRwWriterTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/BatchingRwWriterTest.java
@@ -1,6 +1,8 @@
 /* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
 package org.deltav.prometheus.writer.rw;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
 import org.deltav.prometheus.writer.translate.PromSample;
@@ -32,6 +34,10 @@ class BatchingRwWriterTest {
         return new PromSample(name, Map.of("k", "v"), 1.0, 1_700_000_000_000L);
     }
 
+    private CircuitBreaker breaker() {
+        return CircuitBreakerRegistry.ofDefaults().circuitBreaker("test");
+    }
+
     @Test
     void flushes_on_max_samples_threshold() throws Exception {
         WriteRequestBuilder builder = mock(WriteRequestBuilder.class);
@@ -39,7 +45,7 @@ class BatchingRwWriterTest {
         when(builder.build(any())).thenReturn(WriteRequest.newBuilder().build());
         when(http.post(any())).thenReturn(200);
         SimpleMeterRegistry reg = new SimpleMeterRegistry();
-        BatchingRwWriter w = new BatchingRwWriter(props(3, 100_000_000, 60_000), builder, http, reg);
+        BatchingRwWriter w = new BatchingRwWriter(props(3, 100_000_000, 60_000), builder, http, breaker(), reg);
 
         w.add(sample("a"));
         w.add(sample("b"));
@@ -57,7 +63,7 @@ class BatchingRwWriterTest {
         when(builder.build(any())).thenReturn(WriteRequest.newBuilder().build());
         when(http.post(any())).thenReturn(200);
         // Tiny maxBytes so a single sample will trigger
-        BatchingRwWriter w = new BatchingRwWriter(props(10_000, 5, 60_000), builder, http, new SimpleMeterRegistry());
+        BatchingRwWriter w = new BatchingRwWriter(props(10_000, 5, 60_000), builder, http, breaker(), new SimpleMeterRegistry());
         w.add(sample("metric_name_long_enough_to_exceed_5_bytes"));
         verify(http, times(1)).post(any());
     }
@@ -69,7 +75,7 @@ class BatchingRwWriterTest {
         WriteRequest stub = WriteRequest.newBuilder().build();
         when(builder.build(any())).thenReturn(stub);
         when(http.post(any())).thenReturn(200);
-        BatchingRwWriter w = new BatchingRwWriter(props(2, 100_000_000, 60_000), builder, http, new SimpleMeterRegistry());
+        BatchingRwWriter w = new BatchingRwWriter(props(2, 100_000_000, 60_000), builder, http, breaker(), new SimpleMeterRegistry());
         w.add(sample("a"));
         w.add(sample("b"));
         verify(builder, times(1)).build(argThat(list -> list.size() == 2));
@@ -83,7 +89,7 @@ class BatchingRwWriterTest {
         when(builder.build(any())).thenReturn(WriteRequest.newBuilder().build());
         when(http.post(any())).thenReturn(200);
         // Very short maxIntervalMs so the scheduled-check fires quickly
-        BatchingRwWriter w = new BatchingRwWriter(props(10_000, 100_000_000, 50), builder, http, new SimpleMeterRegistry());
+        BatchingRwWriter w = new BatchingRwWriter(props(10_000, 100_000_000, 50), builder, http, breaker(), new SimpleMeterRegistry());
         w.add(sample("a"));
         Thread.sleep(120);
         w.flushIfStale();  // simulate the @Scheduled tick
@@ -94,7 +100,7 @@ class BatchingRwWriterTest {
     void flush_empty_buffer_is_noop() {
         WriteRequestBuilder builder = mock(WriteRequestBuilder.class);
         RemoteWriteHttpClient http = mock(RemoteWriteHttpClient.class);
-        BatchingRwWriter w = new BatchingRwWriter(props(10, 100_000, 60_000), builder, http, new SimpleMeterRegistry());
+        BatchingRwWriter w = new BatchingRwWriter(props(10, 100_000, 60_000), builder, http, breaker(), new SimpleMeterRegistry());
         w.flushIfStale();   // empty
         w.flushNow();       // empty
         verifyNoInteractions(http);

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/BatchingRwWriterTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/BatchingRwWriterTest.java
@@ -1,0 +1,103 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.junit.jupiter.api.Test;
+import prometheus.prompb.WriteRequest;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class BatchingRwWriterTest {
+
+    private PrometheusWriterProperties props(int maxSamples, int maxBytes, long maxIntervalMs) {
+        return new PrometheusWriterProperties(
+                new PrometheusWriterProperties.RemoteWrite("http://test/write",
+                    new PrometheusWriterProperties.Auth(PrometheusWriterProperties.AuthType.NONE, null, null, null), Map.of()),
+                new PrometheusWriterProperties.Batch(maxSamples, maxBytes, maxIntervalMs),
+                null, null, null, null);
+    }
+
+    private PromSample sample(String name) {
+        return new PromSample(name, Map.of("k", "v"), 1.0, 1_700_000_000_000L);
+    }
+
+    @Test
+    void flushes_on_max_samples_threshold() throws Exception {
+        WriteRequestBuilder builder = mock(WriteRequestBuilder.class);
+        RemoteWriteHttpClient http = mock(RemoteWriteHttpClient.class);
+        when(builder.build(any())).thenReturn(WriteRequest.newBuilder().build());
+        when(http.post(any())).thenReturn(200);
+        SimpleMeterRegistry reg = new SimpleMeterRegistry();
+        BatchingRwWriter w = new BatchingRwWriter(props(3, 100_000_000, 60_000), builder, http, reg);
+
+        w.add(sample("a"));
+        w.add(sample("b"));
+        verifyNoInteractions(http);  // not flushed yet
+        w.add(sample("c"));  // hits maxSamples=3
+        verify(http, times(1)).post(any());
+        assertThat(reg.find("deltav.prometheus.writer.batches.sent").counter().count()).isEqualTo(1.0);
+        assertThat(reg.find("deltav.prometheus.writer.samples.sent").counter().count()).isEqualTo(3.0);
+    }
+
+    @Test
+    void flushes_on_max_bytes_threshold() throws Exception {
+        WriteRequestBuilder builder = mock(WriteRequestBuilder.class);
+        RemoteWriteHttpClient http = mock(RemoteWriteHttpClient.class);
+        when(builder.build(any())).thenReturn(WriteRequest.newBuilder().build());
+        when(http.post(any())).thenReturn(200);
+        // Tiny maxBytes so a single sample will trigger
+        BatchingRwWriter w = new BatchingRwWriter(props(10_000, 5, 60_000), builder, http, new SimpleMeterRegistry());
+        w.add(sample("metric_name_long_enough_to_exceed_5_bytes"));
+        verify(http, times(1)).post(any());
+    }
+
+    @Test
+    void flush_calls_http_with_grouped_WriteRequest() throws Exception {
+        WriteRequestBuilder builder = mock(WriteRequestBuilder.class);
+        RemoteWriteHttpClient http = mock(RemoteWriteHttpClient.class);
+        WriteRequest stub = WriteRequest.newBuilder().build();
+        when(builder.build(any())).thenReturn(stub);
+        when(http.post(any())).thenReturn(200);
+        BatchingRwWriter w = new BatchingRwWriter(props(2, 100_000_000, 60_000), builder, http, new SimpleMeterRegistry());
+        w.add(sample("a"));
+        w.add(sample("b"));
+        verify(builder, times(1)).build(argThat(list -> list.size() == 2));
+        verify(http, times(1)).post(stub);
+    }
+
+    @Test
+    void flushes_on_time_interval_via_scheduled_check() throws Exception {
+        WriteRequestBuilder builder = mock(WriteRequestBuilder.class);
+        RemoteWriteHttpClient http = mock(RemoteWriteHttpClient.class);
+        when(builder.build(any())).thenReturn(WriteRequest.newBuilder().build());
+        when(http.post(any())).thenReturn(200);
+        // Very short maxIntervalMs so the scheduled-check fires quickly
+        BatchingRwWriter w = new BatchingRwWriter(props(10_000, 100_000_000, 50), builder, http, new SimpleMeterRegistry());
+        w.add(sample("a"));
+        Thread.sleep(120);
+        w.flushIfStale();  // simulate the @Scheduled tick
+        verify(http, times(1)).post(any());
+    }
+
+    @Test
+    void flush_empty_buffer_is_noop() {
+        WriteRequestBuilder builder = mock(WriteRequestBuilder.class);
+        RemoteWriteHttpClient http = mock(RemoteWriteHttpClient.class);
+        BatchingRwWriter w = new BatchingRwWriter(props(10, 100_000, 60_000), builder, http, new SimpleMeterRegistry());
+        w.flushIfStale();   // empty
+        w.flushNow();       // empty
+        verifyNoInteractions(http);
+        verifyNoInteractions(builder);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/CircuitBreakerIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/CircuitBreakerIT.java
@@ -1,0 +1,169 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.micrometer.core.instrument.MeterRegistry;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.deltav.prometheus.writer.PrometheusWriterApplication;
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Testcontainers
+@SpringBootTest(classes = PrometheusWriterApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CircuitBreakerIT {
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("apache/kafka:3.8.0"))
+                    .withStartupTimeout(Duration.ofSeconds(120));
+
+    static MockWebServer mockRw;
+
+    @BeforeAll static void startMock() throws Exception { mockRw = new MockWebServer(); mockRw.start(); }
+    @AfterAll  static void stopMock()  throws Exception { if (mockRw != null) mockRw.shutdown(); }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry reg) {
+        // See RwRoundTripIT.props — topics MUST exist before Spring boots so
+        // NodeContextCacheReadyEvent fires after TimeseriesBindingResumer is wired.
+        if (!KAFKA.isRunning()) KAFKA.start();
+        ensureTopicsStatic();
+        reg.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        reg.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+        reg.add("prometheus-writer.remote-write.url", () -> mockRw.url("/api/v1/write").toString());
+        reg.add("prometheus-writer.batch.max-interval-ms", () -> "100");
+        reg.add("prometheus-writer.batch.max-samples", () -> "1");
+        // Tight circuit timings for testability
+        reg.add("prometheus-writer.circuit-breaker.failure-rate-threshold", () -> "50");
+        reg.add("prometheus-writer.circuit-breaker.sliding-window-size", () -> "5");
+        reg.add("prometheus-writer.circuit-breaker.minimum-number-of-calls", () -> "3");
+        reg.add("prometheus-writer.circuit-breaker.wait-duration-open-ms", () -> "1500");
+        reg.add("prometheus-writer.circuit-breaker.half-open-permitted-calls", () -> "1");
+    }
+
+    private static void ensureTopicsStatic() {
+        Properties p = new Properties();
+        p.put("bootstrap.servers", KAFKA.getBootstrapServers());
+        try (AdminClient a = AdminClient.create(p)) {
+            try {
+                a.createTopics(List.of(
+                        new NewTopic("deltav-node-context", 8, (short) 1)
+                                .configs(Map.of("cleanup.policy", "compact")),
+                        new NewTopic("deltav-timeseries", 8, (short) 1)))
+                        .all().get();
+            } catch (Exception e) {
+                if (!(e.getCause() instanceof org.apache.kafka.common.errors.TopicExistsException)) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    @Autowired CircuitBreaker breaker;
+    @Autowired MeterRegistry metrics;
+
+    @Test
+    void circuit_opens_on_failures_then_recovers() throws Exception {
+        publishNodeContext(7, "Default", "server-7", List.of());
+        Thread.sleep(3000);  // cache bootstrap + binding resume
+
+        // Inject enough 500s to trip the breaker (sliding window 5, threshold 50%, min calls 3)
+        for (int i = 0; i < 5; i++) mockRw.enqueue(new MockResponse().setResponseCode(500));
+        for (int i = 0; i < 5; i++) {
+            publishTimeseriesBatch(7, "Default", "test-group", "test-attr-" + i,
+                    AttributeType.ATTRIBUTE_TYPE_GAUGE, i);
+        }
+
+        // Await: circuit OPEN
+        await().atMost(Duration.ofSeconds(20))
+                .until(() -> breaker.getState() == CircuitBreaker.State.OPEN);
+        assertThat(breaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // Enqueue a couple of success responses — harmless, in case the binding flushes a
+        // residual buffered batch after recovery.
+        for (int i = 0; i < 2; i++) mockRw.enqueue(new MockResponse().setResponseCode(200));
+
+        // Wait past wait-duration-open-ms (1500ms) for the automatic OPEN→HALF_OPEN transition.
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> breaker.getState() == CircuitBreaker.State.HALF_OPEN
+                        || breaker.getState() == CircuitBreaker.State.CLOSED);
+
+        // Task 16's ConsumerPauseListener pauses the SCS binding on OPEN and only resumes
+        // on HALF_OPEN→CLOSED — so half-open probes can't be driven by new Kafka messages.
+        // In production, BatchingRwWriter's @Scheduled flushIfStale() drives the probe by
+        // flushing a residual buffered batch through the breaker. The IT pre-emptively
+        // cleared the buffer when the original failures happened, so we drive the half-open
+        // probe directly. half-open-permitted-calls=1 → one successful call closes the breaker.
+        breaker.executeCallable(() -> 200);
+
+        await().atMost(Duration.ofSeconds(5))
+                .until(() -> breaker.getState() == CircuitBreaker.State.CLOSED);
+        assertThat(breaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+    }
+
+    // --- helpers (same as RwRoundTripIT) ---
+    private void publishNodeContext(int nodeId, String location, String label, List<String> categories) throws Exception {
+        NodeContext nc = NodeContext.newBuilder()
+                .setNodeId(nodeId).setLocation(location).setNodeLabel(label)
+                .addAllCategories(categories)
+                .setUpdatedAtMs(System.currentTimeMillis()).build();
+        try (KafkaProducer<String, byte[]> prod = newProducer()) {
+            prod.send(new ProducerRecord<>("deltav-node-context", location + "@" + nodeId, nc.toByteArray())).get();
+        }
+    }
+
+    private void publishTimeseriesBatch(int nodeId, String location, String groupName, String attrName,
+                                        AttributeType type, double value) throws Exception {
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(nodeId).setLocation(location).setProducer(ProducerType.PRODUCER_COLLECTD)
+                .setTimestampMs(System.currentTimeMillis())
+                .addResources(Resource.newBuilder().setType("node")
+                        .addGroups(AttributeGroup.newBuilder().setName(groupName)
+                                .addAttributes(Attribute.newBuilder().setName(attrName).setType(type).setNumeric(value))))
+                .build();
+        try (KafkaProducer<String, byte[]> prod = newProducer()) {
+            prod.send(new ProducerRecord<>("deltav-timeseries", location + "@" + nodeId, batch.toByteArray())).get();
+        }
+    }
+
+    private KafkaProducer<String, byte[]> newProducer() {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        return new KafkaProducer<>(p);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/ConsumerPauseListenerTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/ConsumerPauseListenerTest.java
@@ -1,0 +1,63 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.stream.binding.BindingsLifecycleController;
+
+import static org.mockito.Mockito.*;
+
+class ConsumerPauseListenerTest {
+
+    private static final String BINDING = "timeseriesConsumer-in-0";
+
+    private CircuitBreaker cb;
+    private BindingsLifecycleController lifecycle;
+    private ConsumerPauseListener listener;
+
+    @BeforeEach
+    void setUp() {
+        cb = CircuitBreakerRegistry.ofDefaults().circuitBreaker("test");
+        lifecycle = mock(BindingsLifecycleController.class);
+        listener = new ConsumerPauseListener(cb, lifecycle, new SimpleMeterRegistry());
+        listener.wire();
+    }
+
+    @Test
+    void closed_to_open_pauses_binding() {
+        cb.transitionToOpenState();   // CLOSED → OPEN
+        verify(lifecycle, times(1)).pause(BINDING);
+        verify(lifecycle, never()).resume(anyString());
+    }
+
+    @Test
+    void half_open_to_closed_resumes_binding() {
+        cb.transitionToOpenState();        // CLOSED → OPEN (one pause)
+        cb.transitionToHalfOpenState();    // OPEN → HALF_OPEN
+        clearInvocations(lifecycle);
+        cb.transitionToClosedState();      // HALF_OPEN → CLOSED (resume)
+        verify(lifecycle, times(1)).resume(BINDING);
+        verify(lifecycle, never()).pause(anyString());
+    }
+
+    @Test
+    void half_open_to_open_pauses_again() {
+        cb.transitionToOpenState();        // CLOSED → OPEN (initial pause)
+        cb.transitionToHalfOpenState();    // OPEN → HALF_OPEN
+        clearInvocations(lifecycle);
+        cb.transitionToOpenState();        // HALF_OPEN → OPEN (pause again)
+        verify(lifecycle, times(1)).pause(BINDING);
+        verify(lifecycle, never()).resume(anyString());
+    }
+
+    @Test
+    void open_to_half_open_is_noop() {
+        cb.transitionToOpenState();        // CLOSED → OPEN (one pause)
+        clearInvocations(lifecycle);
+        cb.transitionToHalfOpenState();    // OPEN → HALF_OPEN — should be noop
+        verifyNoInteractions(lifecycle);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreakerTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreakerTest.java
@@ -23,7 +23,7 @@ class PrometheusWriterCircuitBreakerTest {
     }
 
     private CircuitBreaker fresh(PrometheusWriterProperties p) {
-        PrometheusWriterCircuitBreaker cfg = new PrometheusWriterCircuitBreaker();
+        PrometheusWriterCircuitBreakerConfiguration cfg = new PrometheusWriterCircuitBreakerConfiguration();
         CircuitBreakerRegistry reg = cfg.circuitBreakerRegistry(p);
         return cfg.prometheusWriterCircuitBreaker(reg, new SimpleMeterRegistry(), p);
     }

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreakerTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreakerTest.java
@@ -1,0 +1,94 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrometheusWriterCircuitBreakerTest {
+
+    private PrometheusWriterProperties props(int failureRate, int window, int minCalls, long waitOpenMs, int halfOpenCalls) {
+        return new PrometheusWriterProperties(
+                new PrometheusWriterProperties.RemoteWrite("http://t/w",
+                    new PrometheusWriterProperties.Auth(PrometheusWriterProperties.AuthType.NONE, null, null, null), Map.of()),
+                null, null,
+                new PrometheusWriterProperties.CircuitBreaker(failureRate, window, minCalls, waitOpenMs, halfOpenCalls),
+                null, null);
+    }
+
+    private CircuitBreaker fresh(PrometheusWriterProperties p) {
+        PrometheusWriterCircuitBreaker cfg = new PrometheusWriterCircuitBreaker();
+        CircuitBreakerRegistry reg = cfg.circuitBreakerRegistry(p);
+        return cfg.prometheusWriterCircuitBreaker(reg, new SimpleMeterRegistry(), p);
+    }
+
+    private void runFailing(CircuitBreaker cb) {
+        try {
+            cb.executeRunnable(() -> { throw new RuntimeException("fail"); });
+        } catch (Exception ignored) {}
+    }
+
+    private void runSuccess(CircuitBreaker cb) {
+        cb.executeRunnable(() -> {});
+    }
+
+    @Test
+    void starts_closed() {
+        CircuitBreaker cb = fresh(props(50, 20, 10, 30_000, 3));
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+    }
+
+    @Test
+    void opens_at_failure_rate_threshold() {
+        CircuitBreaker cb = fresh(props(50, 20, 20, 30_000, 3));
+        // 20 calls, 11 fail (>50%) — must open
+        for (int i = 0; i < 11; i++) runFailing(cb);
+        for (int i = 0; i < 9; i++) runSuccess(cb);
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+    }
+
+    @Test
+    void transitions_half_open_after_wait_duration() throws Exception {
+        // Use a short wait duration so the test doesn't take 30 seconds
+        CircuitBreaker cb = fresh(props(50, 20, 20, 200, 3));
+        for (int i = 0; i < 11; i++) runFailing(cb);
+        for (int i = 0; i < 9; i++) runSuccess(cb);
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        // Wait past the wait duration; automaticTransitionFromOpenToHalfOpenEnabled(true)
+        // means the breaker self-transitions, but a thread/scheduler is needed.
+        // Force the transition explicitly to avoid timing flakes.
+        Thread.sleep(250);
+        cb.transitionToHalfOpenState();
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
+    }
+
+    @Test
+    void returns_to_closed_after_successful_probes() {
+        CircuitBreaker cb = fresh(props(50, 20, 20, 30_000, 3));
+        for (int i = 0; i < 11; i++) runFailing(cb);
+        for (int i = 0; i < 9; i++) runSuccess(cb);
+        cb.transitionToHalfOpenState();
+        // 3 permitted half-open calls, all succeed → CLOSED
+        for (int i = 0; i < 3; i++) runSuccess(cb);
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+    }
+
+    @Test
+    void returns_to_open_on_half_open_failure() {
+        CircuitBreaker cb = fresh(props(50, 20, 20, 30_000, 3));
+        for (int i = 0; i < 11; i++) runFailing(cb);
+        for (int i = 0; i < 9; i++) runSuccess(cb);
+        cb.transitionToHalfOpenState();
+        // First half-open call fails → OPEN
+        runFailing(cb);
+        // Subsequent calls inside half-open window also fail to bring window in
+        for (int i = 0; i < 2; i++) runFailing(cb);
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RemoteWriteHttpClientTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RemoteWriteHttpClientTest.java
@@ -1,0 +1,98 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.WriteRequest;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RemoteWriteHttpClientTest {
+    private MockWebServer server;
+
+    @BeforeEach void setUp() throws Exception { server = new MockWebServer(); server.start(); }
+    @AfterEach  void tearDown() throws Exception { server.shutdown(); }
+
+    private RemoteWriteHttpClient client(PrometheusWriterProperties.AuthType auth, String tok, String user, String pass, Map<String,String> extra) {
+        PrometheusWriterProperties props = new PrometheusWriterProperties(
+                new PrometheusWriterProperties.RemoteWrite(server.url("/api/v1/write").toString(),
+                        new PrometheusWriterProperties.Auth(auth, tok, user, pass), extra),
+                null, null, null, null, null);
+        return new RemoteWriteHttpClient(RestClient.builder(), props);
+    }
+
+    @Test
+    void post_200_returns_200_with_correct_headers_and_snappy_body() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200));
+        int status = client(PrometheusWriterProperties.AuthType.NONE, null, null, null, Map.of())
+                .post(WriteRequest.newBuilder().build());
+        assertThat(status).isEqualTo(200);
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        assertThat(req).isNotNull();
+        assertThat(req.getHeader("Content-Type")).isEqualTo("application/x-protobuf");
+        assertThat(req.getHeader("Content-Encoding")).isEqualTo("snappy");
+        assertThat(req.getHeader("X-Prometheus-Remote-Write-Version")).isEqualTo("0.1.0");
+        // Body must be Snappy-decompressible (round-trip to verify framing)
+        byte[] body = req.getBody().readByteArray();
+        byte[] uncompressed = Snappy.uncompress(body);
+        assertThat(uncompressed).isNotNull();  // would throw on bad framing
+    }
+
+    @Test
+    void post_with_bearer_adds_authorization_header() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200));
+        client(PrometheusWriterProperties.AuthType.BEARER, "abc", null, null, Map.of())
+                .post(WriteRequest.newBuilder().build());
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        assertThat(req.getHeader("Authorization")).isEqualTo("Bearer abc");
+    }
+
+    @Test
+    void post_with_basic_adds_basic_auth_header() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200));
+        client(PrometheusWriterProperties.AuthType.BASIC, null, "u", "p", Map.of())
+                .post(WriteRequest.newBuilder().build());
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        assertThat(req.getHeader("Authorization")).isEqualTo("Basic dTpw");
+    }
+
+    @Test
+    void post_with_extra_headers_adds_them() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200));
+        client(PrometheusWriterProperties.AuthType.NONE, null, null, null, Map.of("X-Scope-OrgID", "tenant-1"))
+                .post(WriteRequest.newBuilder().build());
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        assertThat(req.getHeader("X-Scope-OrgID")).isEqualTo("tenant-1");
+    }
+
+    @Test
+    void post_500_throws_server_error() {
+        server.enqueue(new MockResponse().setResponseCode(500));
+        assertThatThrownBy(() ->
+                client(PrometheusWriterProperties.AuthType.NONE, null, null, null, Map.of())
+                        .post(WriteRequest.newBuilder().build()))
+                .isInstanceOf(HttpServerErrorException.class);
+    }
+
+    @Test
+    void post_400_throws_client_error() {
+        server.enqueue(new MockResponse().setResponseCode(400));
+        assertThatThrownBy(() ->
+                client(PrometheusWriterProperties.AuthType.NONE, null, null, null, Map.of())
+                        .post(WriteRequest.newBuilder().build()))
+                .isInstanceOf(HttpClientErrorException.class);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RemoteWriteRetryPolicyTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RemoteWriteRetryPolicyTest.java
@@ -1,0 +1,33 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RemoteWriteRetryPolicyTest {
+    private final RemoteWriteRetryPolicy p = new RemoteWriteRetryPolicy();
+
+    @Test void success_200() { assertThat(p.classifyStatus(200)).isEqualTo(RemoteWriteRetryPolicy.Action.SUCCESS); }
+    @Test void success_204() { assertThat(p.classifyStatus(204)).isEqualTo(RemoteWriteRetryPolicy.Action.SUCCESS); }
+    @Test void retry_429() { assertThat(p.classifyStatus(429)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_500() { assertThat(p.classifyStatus(500)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_502() { assertThat(p.classifyStatus(502)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_503() { assertThat(p.classifyStatus(503)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_504() { assertThat(p.classifyStatus(504)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void poison_400() { assertThat(p.classifyStatus(400)).isEqualTo(RemoteWriteRetryPolicy.Action.POISON_DLQ); }
+    @Test void poison_413() { assertThat(p.classifyStatus(413)).isEqualTo(RemoteWriteRetryPolicy.Action.POISON_DLQ); }
+    @Test void circuit_401() { assertThat(p.classifyStatus(401)).isEqualTo(RemoteWriteRetryPolicy.Action.CIRCUIT_OPEN); }
+    @Test void circuit_403() { assertThat(p.classifyStatus(403)).isEqualTo(RemoteWriteRetryPolicy.Action.CIRCUIT_OPEN); }
+    @Test void circuit_404() { assertThat(p.classifyStatus(404)).isEqualTo(RemoteWriteRetryPolicy.Action.CIRCUIT_OPEN); }
+    @Test void unknown_4xx_defaults_to_poison() { assertThat(p.classifyStatus(418)).isEqualTo(RemoteWriteRetryPolicy.Action.POISON_DLQ); }
+    @Test void unknown_5xx_defaults_to_retry() { assertThat(p.classifyStatus(599)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void network_exception_retries() {
+        assertThat(p.classifyException(new java.net.ConnectException("refused")))
+                .isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF);
+    }
+    @Test void read_timeout_retries() {
+        assertThat(p.classifyException(new java.net.SocketTimeoutException("timeout")))
+                .isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RwRoundTripIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RwRoundTripIT.java
@@ -1,0 +1,171 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.deltav.prometheus.writer.PrometheusWriterApplication;
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.Label;
+import prometheus.prompb.TimeSeries;
+import prometheus.prompb.WriteRequest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(classes = PrometheusWriterApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RwRoundTripIT {
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("apache/kafka:3.8.0"))
+                    .withStartupTimeout(Duration.ofSeconds(120));
+
+    static MockWebServer mockRw;
+
+    @BeforeAll
+    static void startMock() throws Exception {
+        mockRw = new MockWebServer();
+        mockRw.start();
+    }
+
+    @AfterAll
+    static void stopMock() throws Exception {
+        if (mockRw != null) mockRw.shutdown();
+    }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry reg) {
+        // Topics MUST exist before Spring boots: NodeContextKafkaBootstrap publishes
+        // NodeContextCacheReadyEvent inside its @PostConstruct thread, which can fire
+        // before TimeseriesBindingResumer's @EventListener is registered. With pre-
+        // existing topics the bootstrap consumer assigns partitions and waits on poll,
+        // giving Spring enough time to wire the listener before the event is published.
+        if (!KAFKA.isRunning()) KAFKA.start();
+        ensureTopicsStatic();
+        reg.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        reg.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+        reg.add("prometheus-writer.remote-write.url", () -> mockRw.url("/api/v1/write").toString());
+        // Speed batch flushes for the test
+        reg.add("prometheus-writer.batch.max-interval-ms", () -> "200");
+        reg.add("prometheus-writer.batch.max-samples", () -> "1");
+    }
+
+    private static void ensureTopicsStatic() {
+        Properties p = new Properties();
+        p.put("bootstrap.servers", KAFKA.getBootstrapServers());
+        try (AdminClient a = AdminClient.create(p)) {
+            try {
+                a.createTopics(List.of(
+                        new NewTopic("deltav-node-context", 8, (short) 1)
+                                .configs(Map.of("cleanup.policy", "compact")),
+                        new NewTopic("deltav-timeseries", 8, (short) 1)))
+                        .all().get();
+            } catch (Exception e) {
+                if (!(e.getCause() instanceof org.apache.kafka.common.errors.TopicExistsException)) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    @Autowired MeterRegistry metrics;
+
+    @Test
+    void end_to_end_sample_lands_at_rw_target() throws Exception {
+        publishNodeContext(5, "Default", "server-01", List.of("production", "critical"));
+        // Wait for cache to bootstrap + binding to resume
+        Thread.sleep(3000);
+        mockRw.enqueue(new MockResponse().setResponseCode(200));
+        publishTimeseriesBatch(5, "Default", "mib2-interface-errors", "ifInDiscards",
+                AttributeType.ATTRIBUTE_TYPE_COUNTER, 42.0);
+
+        RecordedRequest req = mockRw.takeRequest(15, TimeUnit.SECONDS);
+        assertThat(req).isNotNull();
+        assertThat(req.getHeader("Content-Type")).isEqualTo("application/x-protobuf");
+        assertThat(req.getHeader("Content-Encoding")).isEqualTo("snappy");
+
+        byte[] body = req.getBody().readByteArray();
+        byte[] uncompressed = Snappy.uncompress(body);
+        WriteRequest wr = WriteRequest.parseFrom(uncompressed);
+        assertThat(wr.getTimeseriesCount()).isEqualTo(1);
+        TimeSeries ts = wr.getTimeseries(0);
+        Map<String, String> labels = ts.getLabelsList().stream()
+                .collect(Collectors.toMap(Label::getName, Label::getValue));
+        assertThat(labels).containsEntry("__name__", "opennms_mib2_interface_errors_ifindiscards_total");
+        assertThat(labels).containsEntry("node_id", "5");
+        assertThat(labels).containsEntry("node_label", "server-01");
+        assertThat(labels).containsEntry("location", "Default");
+        assertThat(labels).containsEntry("categories", "critical,production");
+        assertThat(ts.getSamples(0).getValue()).isEqualTo(42.0);
+    }
+
+    // --- helpers ---
+    private void publishNodeContext(int nodeId, String location, String label, List<String> categories) throws Exception {
+        NodeContext nc = NodeContext.newBuilder()
+                .setNodeId(nodeId).setLocation(location).setNodeLabel(label)
+                .addAllCategories(categories)
+                .setUpdatedAtMs(System.currentTimeMillis())
+                .build();
+        try (KafkaProducer<String, byte[]> prod = newProducer()) {
+            prod.send(new ProducerRecord<>("deltav-node-context", location + "@" + nodeId, nc.toByteArray())).get();
+        }
+    }
+
+    private void publishTimeseriesBatch(int nodeId, String location, String groupName, String attrName,
+                                        AttributeType type, double value) throws Exception {
+        TimeseriesBatch batch = TimeseriesBatch.newBuilder()
+                .setNodeId(nodeId).setLocation(location).setProducer(ProducerType.PRODUCER_COLLECTD)
+                .setTimestampMs(1_700_000_000_000L)
+                .setCollectionPackage("test-package")
+                .addResources(Resource.newBuilder().setType("node").setInstance("")
+                        .addGroups(AttributeGroup.newBuilder().setName(groupName)
+                                .addAttributes(Attribute.newBuilder().setName(attrName).setType(type).setNumeric(value))))
+                .build();
+        try (KafkaProducer<String, byte[]> prod = newProducer()) {
+            prod.send(new ProducerRecord<>("deltav-timeseries", location + "@" + nodeId, batch.toByteArray())).get();
+        }
+    }
+
+    private KafkaProducer<String, byte[]> newProducer() {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        return new KafkaProducer<>(p);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/WriteRequestBuilderTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/WriteRequestBuilderTest.java
@@ -1,0 +1,78 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.junit.jupiter.api.Test;
+import prometheus.prompb.Label;
+import prometheus.prompb.TimeSeries;
+import prometheus.prompb.WriteRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WriteRequestBuilderTest {
+
+    private final WriteRequestBuilder builder = new WriteRequestBuilder();
+
+    @Test
+    void builds_one_timeseries_per_unique_label_set() {
+        List<PromSample> samples = List.of(
+                new PromSample("a", Map.of("x", "1"), 1.0d, 1_000L),
+                new PromSample("a", Map.of("x", "1"), 2.0d, 2_000L),
+                new PromSample("b", Map.of("y", "1"), 3.0d, 3_000L)
+        );
+
+        WriteRequest wr = builder.build(samples);
+
+        assertThat(wr.getTimeseriesCount()).isEqualTo(2);
+    }
+
+    @Test
+    void multiple_samples_same_series_grouped() {
+        List<PromSample> samples = List.of(
+                new PromSample("foo", Map.of("k", "v"), 1.0d, 1_000L),
+                new PromSample("foo", Map.of("k", "v"), 2.0d, 2_000L),
+                new PromSample("foo", Map.of("k", "v"), 3.0d, 3_000L)
+        );
+
+        WriteRequest wr = builder.build(samples);
+
+        assertThat(wr.getTimeseriesCount()).isEqualTo(1);
+        TimeSeries ts = wr.getTimeseries(0);
+        assertThat(ts.getSamplesCount()).isEqualTo(3);
+        assertThat(ts.getSamples(0).getValue()).isEqualTo(1.0d);
+        assertThat(ts.getSamples(1).getValue()).isEqualTo(2.0d);
+        assertThat(ts.getSamples(2).getValue()).isEqualTo(3.0d);
+    }
+
+    @Test
+    void metric_name_goes_to___name___label() {
+        List<PromSample> samples = List.of(
+                new PromSample("foo", Map.of(), 1.0d, 1_000L)
+        );
+
+        WriteRequest wr = builder.build(samples);
+
+        assertThat(wr.getTimeseriesCount()).isEqualTo(1);
+        TimeSeries ts = wr.getTimeseries(0);
+        assertThat(ts.getLabelsList())
+                .extracting(Label::getName, Label::getValue)
+                .contains(org.assertj.core.groups.Tuple.tuple("__name__", "foo"));
+    }
+
+    @Test
+    void labels_sorted_alphabetically_in_output() {
+        List<PromSample> samples = List.of(
+                new PromSample("metric", Map.of("zzz", "z", "aaa", "a", "mmm", "m"), 1.0d, 1_000L)
+        );
+
+        WriteRequest wr = builder.build(samples);
+
+        TimeSeries ts = wr.getTimeseries(0);
+        List<String> labelNames = ts.getLabelsList().stream().map(Label::getName).toList();
+        // __name__ sorts alphabetically before all letters because '_' (0x5F) < 'a' (0x61)
+        assertThat(labelNames).containsExactly("__name__", "aaa", "mmm", "zzz");
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/startup/TimeseriesBindingStartupGateTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/startup/TimeseriesBindingStartupGateTest.java
@@ -1,0 +1,77 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.startup;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCacheReadyEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.stream.binding.BindingsLifecycleController;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies the startup-gate contract:
+ * <ul>
+ *     <li>The {@link TimeseriesBindingStartupGate} pauses the listener container at
+ *     factory time when {@code prometheus-writer.startup-gate.enabled=true}.</li>
+ *     <li>It is a no-op when the gate is disabled.</li>
+ *     <li>The {@link TimeseriesBindingResumer} resumes the binding when a
+ *     {@link NodeContextCacheReadyEvent} is published, gated by the same flag.</li>
+ * </ul>
+ */
+class TimeseriesBindingStartupGateTest {
+
+    private static final String BINDING = "timeseriesConsumer-in-0";
+
+    private static PrometheusWriterProperties props(boolean enabled) {
+        return new PrometheusWriterProperties(
+                null, null, null, null, null,
+                new PrometheusWriterProperties.StartupGate(enabled));
+    }
+
+    @Test
+    void customize_pauses_container_when_gate_enabled() {
+        TimeseriesBindingStartupGate gate = new TimeseriesBindingStartupGate(props(true));
+        @SuppressWarnings("unchecked")
+        AbstractMessageListenerContainer<Object, Object> container =
+                mock(AbstractMessageListenerContainer.class);
+
+        gate.configure(container, "anything", "anything");
+
+        verify(container).pause();
+    }
+
+    @Test
+    void customize_no_op_when_gate_disabled() {
+        TimeseriesBindingStartupGate gate = new TimeseriesBindingStartupGate(props(false));
+        @SuppressWarnings("unchecked")
+        AbstractMessageListenerContainer<Object, Object> container =
+                mock(AbstractMessageListenerContainer.class);
+
+        gate.configure(container, "anything", "anything");
+
+        verify(container, never()).pause();
+    }
+
+    @Test
+    void resumer_calls_resume_on_ready_event() {
+        BindingsLifecycleController lifecycle = mock(BindingsLifecycleController.class);
+        TimeseriesBindingResumer resumer = new TimeseriesBindingResumer(lifecycle, props(true));
+
+        resumer.onReady(new NodeContextCacheReadyEvent(this, 1234L, 5));
+
+        verify(lifecycle).resume(BINDING);
+    }
+
+    @Test
+    void resumer_no_op_when_gate_disabled() {
+        BindingsLifecycleController lifecycle = mock(BindingsLifecycleController.class);
+        TimeseriesBindingResumer resumer = new TimeseriesBindingResumer(lifecycle, props(false));
+
+        resumer.onReady(new NodeContextCacheReadyEvent(this, 1234L, 5));
+
+        verify(lifecycle, never()).resume(BINDING);
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java
@@ -1,0 +1,150 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LabelBuilderTest {
+
+    private LabelBuilder labelBuilder;
+
+    @BeforeEach
+    void setUp() {
+        labelBuilder = new LabelBuilder(new NameSanitizer());
+    }
+
+    private TimeseriesBatch batch(int nodeId, String location, String collectionPackage, ProducerType producer) {
+        return TimeseriesBatch.newBuilder()
+                .setNodeId(nodeId)
+                .setLocation(location)
+                .setCollectionPackage(collectionPackage)
+                .setProducer(producer)
+                .build();
+    }
+
+    private Resource resource(String type, String instance) {
+        return Resource.newBuilder()
+                .setType(type)
+                .setInstance(instance)
+                .build();
+    }
+
+    private NodeContext nc(String nodeLabel, String foreignSource, List<String> categories,
+                           Map<String, String> metadata) {
+        NodeContext.Builder b = NodeContext.newBuilder()
+                .setNodeLabel(nodeLabel)
+                .setForeignSource(foreignSource);
+        b.addAllCategories(categories);
+        b.putAllMetadata(metadata);
+        return b.build();
+    }
+
+    @Test
+    void default_labels_always_emitted() {
+        TimeseriesBatch b = batch(42, "Default", "snmp-default", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("router-1", "fs-1", List.of(), Map.of());
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+        assertThat(labels.keySet()).containsExactlyInAnyOrder(
+                "node_id", "location", "node_label", "foreign_source", "categories",
+                "resource_type", "resource_instance", "collection_package", "producer");
+        assertThat(labels).hasSize(9);
+        assertThat(labels.get("node_id")).isEqualTo("42");
+        assertThat(labels.get("location")).isEqualTo("Default");
+        assertThat(labels.get("node_label")).isEqualTo("router-1");
+        assertThat(labels.get("foreign_source")).isEqualTo("fs-1");
+        assertThat(labels.get("resource_type")).isEqualTo("node");
+        assertThat(labels.get("collection_package")).isEqualTo("snmp-default");
+        assertThat(labels.get("producer")).isEqualTo("collectd");
+    }
+
+    @Test
+    void categories_sorted_comma_joined() {
+        TimeseriesBatch b = batch(1, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("n", "fs", List.of("production", "critical"), Map.of());
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+        assertThat(labels.get("categories")).isEqualTo("critical,production");
+    }
+
+    @Test
+    void categories_empty_when_none() {
+        TimeseriesBatch b = batch(1, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("n", "fs", Collections.emptyList(), Map.of());
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+        assertThat(labels.get("categories")).isEqualTo("");
+    }
+
+    @Test
+    void resource_instance_empty_for_non_tabular() {
+        TimeseriesBatch b = batch(1, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("n", "fs", List.of(), Map.of());
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+        assertThat(labels.get("resource_instance")).isEqualTo("");
+    }
+
+    @Test
+    void metadata_allowlist_promotes_listed_keys() {
+        TimeseriesBatch b = batch(1, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("n", "fs", List.of(), Map.of("requisition:region", "us-east-1"));
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of("requisition:region"));
+
+        assertThat(labels).containsEntry("requisition_region", "us-east-1");
+    }
+
+    @Test
+    void metadata_allowlist_emits_empty_for_missing_key() {
+        TimeseriesBatch b = batch(1, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("n", "fs", List.of(), Map.of());
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of("requisition:env"));
+
+        assertThat(labels).containsEntry("requisition_env", "");
+    }
+
+    @Test
+    void metadata_not_in_allowlist_not_emitted() {
+        TimeseriesBatch b = batch(1, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("n", "fs", List.of(), Map.of("foo:bar", "baz"));
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+        assertThat(labels).doesNotContainKey("foo_bar");
+        assertThat(labels).doesNotContainKey("foo:bar");
+    }
+
+    @Test
+    void producer_enum_name_stringified() {
+        TimeseriesBatch b = batch(1, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.empty(), List.of());
+
+        assertThat(labels.get("producer")).isEqualTo("collectd");
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/NameSanitizerTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/NameSanitizerTest.java
@@ -1,0 +1,31 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NameSanitizerTest {
+    private final NameSanitizer s = new NameSanitizer();
+
+    @Test void mib2_hyphen_to_underscore()      { assertThat(s.sanitize("mib2-interface-errors")).isEqualTo("mib2_interface_errors"); }
+    @Test void camelcase_to_lowercase()         { assertThat(s.sanitize("ifInDiscards")).isEqualTo("ifindiscards"); }
+    @Test void mixed_case_with_hyphens()        { assertThat(s.sanitize("mib2-X-interfaces")).isEqualTo("mib2_x_interfaces"); }
+    @Test void simple_camelcase()               { assertThat(s.sanitize("hrStorage")).isEqualTo("hrstorage"); }
+    @Test void leading_digit_prefixed()         { assertThat(s.sanitize("1abc")).isEqualTo("_1abc"); }
+    @Test void consecutive_hyphens_collapsed()  { assertThat(s.sanitize("foo--bar")).isEqualTo("foo_bar"); }
+    @Test void mixed_separators_collapsed()     { assertThat(s.sanitize("foo..bar::baz")).isEqualTo("foo_bar_baz"); }
+    @Test void consecutive_underscores_collapsed() { assertThat(s.sanitize("foo___bar")).isEqualTo("foo_bar"); }
+    @Test void empty_returns_empty()            { assertThat(s.sanitize("")).isEqualTo(""); }
+    @Test void already_clean_unchanged()        { assertThat(s.sanitize("foo")).isEqualTo("foo"); }
+
+    @Test
+    void detect_collisions_finds_dupes() {
+        Map<String, List<String>> collisions = s.detectCollisions(List.of("foo-bar", "foo_bar"));
+        assertThat(collisions).containsKey("foo_bar");
+        assertThat(collisions.get("foo_bar")).containsExactlyInAnyOrder("foo-bar", "foo_bar");
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslatorTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslatorTest.java
@@ -1,0 +1,176 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimeseriesToPromTranslatorTest {
+
+    private TimeseriesToPromTranslator translator;
+    private MeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        NameSanitizer sanitizer = new NameSanitizer();
+        LabelBuilder labelBuilder = new LabelBuilder(sanitizer);
+        PrometheusWriterProperties props = new PrometheusWriterProperties(null, null, null, null,
+                new PrometheusWriterProperties.Labels(List.of()), null);
+        meterRegistry = new SimpleMeterRegistry();
+        translator = new TimeseriesToPromTranslator(sanitizer, labelBuilder, props, meterRegistry);
+    }
+
+    private TimeseriesBatch batch(int nodeId, long timestampMs, AttributeGroup... groups) {
+        Resource.Builder resource = Resource.newBuilder()
+                .setType("node")
+                .setInstance("");
+        for (AttributeGroup g : groups) {
+            resource.addGroups(g);
+        }
+        return TimeseriesBatch.newBuilder()
+                .setNodeId(nodeId)
+                .setTimestampMs(timestampMs)
+                .setLocation("Default")
+                .setCollectionPackage("snmp-default")
+                .setProducer(ProducerType.PRODUCER_COLLECTD)
+                .addResources(resource.build())
+                .build();
+    }
+
+    private AttributeGroup group(String name, Attribute... attrs) {
+        AttributeGroup.Builder b = AttributeGroup.newBuilder().setName(name);
+        for (Attribute a : attrs) {
+            b.addAttributes(a);
+        }
+        return b.build();
+    }
+
+    private Attribute attr(String name, AttributeType type, double value) {
+        return Attribute.newBuilder()
+                .setName(name)
+                .setType(type)
+                .setNumeric(value)
+                .build();
+    }
+
+    private NodeContext nc(int nodeId, String label, String fs) {
+        return NodeContext.newBuilder()
+                .setNodeId(nodeId)
+                .setNodeLabel(label)
+                .setForeignSource(fs)
+                .build();
+    }
+
+    @Test
+    void counter_attribute_gets_total_suffix() {
+        TimeseriesBatch b = batch(1, 1_700_000_000_000L,
+                group("mib2-interface-errors", attr("ifInDiscards", AttributeType.ATTRIBUTE_TYPE_COUNTER, 5.0)));
+        NodeContext n = nc(1, "router-1", "fs-1");
+
+        List<PromSample> samples = translator.translate(b, Optional.of(n));
+
+        assertThat(samples).hasSize(1);
+        assertThat(samples.get(0).name()).isEqualTo("opennms_mib2_interface_errors_ifindiscards_total");
+        assertThat(samples.get(0).value()).isEqualTo(5.0);
+    }
+
+    @Test
+    void gauge_attribute_no_total_suffix() {
+        TimeseriesBatch b = batch(1, 1_700_000_000_000L,
+                group("mib2-X-interfaces", attr("ifHighSpeed", AttributeType.ATTRIBUTE_TYPE_GAUGE, 1000.0)));
+        NodeContext n = nc(1, "router-1", "fs-1");
+
+        List<PromSample> samples = translator.translate(b, Optional.of(n));
+
+        assertThat(samples).hasSize(1);
+        assertThat(samples.get(0).name()).isEqualTo("opennms_mib2_x_interfaces_ifhighspeed");
+        assertThat(samples.get(0).name()).doesNotEndWith("_total");
+    }
+
+    @Test
+    void string_attribute_dropped() {
+        TimeseriesBatch b = batch(1, 1_700_000_000_000L,
+                group("sysinfo", attr("sysName", AttributeType.ATTRIBUTE_TYPE_STRING, 0.0)));
+        NodeContext n = nc(1, "router-1", "fs-1");
+
+        List<PromSample> samples = translator.translate(b, Optional.of(n));
+
+        assertThat(samples).isEmpty();
+        assertThat(meterRegistry.find("deltav.prometheus.writer.samples.dropped")
+                .tag("reason", "string_attribute").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void unspecified_attribute_dropped() {
+        TimeseriesBatch b = batch(1, 1_700_000_000_000L,
+                group("legacy", attr("oldMetric", AttributeType.ATTRIBUTE_TYPE_UNSPECIFIED, 1.0)));
+        NodeContext n = nc(1, "router-1", "fs-1");
+
+        List<PromSample> samples = translator.translate(b, Optional.of(n));
+
+        assertThat(samples).isEmpty();
+        assertThat(meterRegistry.find("deltav.prometheus.writer.samples.dropped")
+                .tag("reason", "type_unspecified").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void missing_node_context_drops_all_samples() {
+        TimeseriesBatch b = batch(99, 1_700_000_000_000L,
+                group("g",
+                        attr("a1", AttributeType.ATTRIBUTE_TYPE_COUNTER, 1.0),
+                        attr("a2", AttributeType.ATTRIBUTE_TYPE_GAUGE, 2.0),
+                        attr("a3", AttributeType.ATTRIBUTE_TYPE_COUNTER, 3.0)));
+
+        List<PromSample> samples = translator.translate(b, Optional.empty());
+
+        assertThat(samples).isEmpty();
+        assertThat(meterRegistry.find("deltav.prometheus.writer.enrichment.missing")
+                .tag("reason", "never_seen").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void timestamp_from_batch_collection_time() {
+        long collectionTime = 1_700_000_000_000L;
+        TimeseriesBatch b = batch(1, collectionTime,
+                group("g", attr("a", AttributeType.ATTRIBUTE_TYPE_GAUGE, 1.0)));
+        NodeContext n = nc(1, "router-1", "fs-1");
+
+        List<PromSample> samples = translator.translate(b, Optional.of(n));
+
+        assertThat(samples).hasSize(1);
+        assertThat(samples.get(0).timestampMs()).isEqualTo(collectionTime);
+        assertThat(samples.get(0).timestampMs()).isNotEqualTo(System.currentTimeMillis());
+    }
+
+    @Test
+    void all_labels_populated() {
+        TimeseriesBatch b = batch(1, 1_700_000_000_000L,
+                group("mib2-interface-errors",
+                        attr("ifInDiscards", AttributeType.ATTRIBUTE_TYPE_COUNTER, 5.0)));
+        NodeContext n = nc(1, "router-1", "fs-1");
+
+        List<PromSample> samples = translator.translate(b, Optional.of(n));
+
+        assertThat(samples).hasSize(1);
+        Map<String, String> labels = samples.get(0).labels();
+        assertThat(labels.keySet()).containsExactlyInAnyOrder(
+                "node_id", "location", "node_label", "foreign_source", "categories",
+                "resource_type", "resource_instance", "collection_package", "producer");
+        assertThat(labels).hasSize(9);
+    }
+}

--- a/docs/superpowers/next-session-prompts/2026-04-18-kafka-ts-phase-2-implementation.md
+++ b/docs/superpowers/next-session-prompts/2026-04-18-kafka-ts-phase-2-implementation.md
@@ -1,0 +1,134 @@
+# Next-Session Prompt — Kafka TS Phase 2: Prometheus RW Consumer Implementation
+
+**Kick off implementation of the Phase 2 Prometheus Remote Write consumer** using the approved design + task-by-task plan committed on `feature/kafka-ts-phase-2-prometheus-consumer`.
+
+Phase 0 (Collectd producer, delta-v#169/#170) and Phase 1 (Provisiond node-context producer, delta-v#171) are both live on `develop`. Phase 2's design was brainstormed and the spec shipped in **delta-v#172** (prompt file) and the current feature branch (spec + plan commits). Nothing is built yet — this is the execution session.
+
+---
+
+## Open this prompt by invoking subagent-driven-development
+
+```
+/skill superpowers:subagent-driven-development
+
+Execute the Phase 2 Prometheus Remote Write consumer implementation plan
+task-by-task on the current feature branch.
+
+Plan (26 tasks across two files):
+- docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer.md      (Tasks 1-5)
+- docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer-part2.md (Tasks 6-26)
+
+Design spec (the source of truth; every decision is pinned here):
+- docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md
+
+Feature branch: feature/kafka-ts-phase-2-prometheus-consumer
+Base for PR: pbrane/delta-v develop (NEVER OpenNMS/opennms — memory feedback_never_pr_opennms)
+```
+
+---
+
+## Preflight checks before invoking the skill
+
+Run these first — they are quick and they catch stale-state bugs that otherwise fail late:
+
+```bash
+git branch --show-current       # expect: feature/kafka-ts-phase-2-prometheus-consumer
+git status --short              # expect: clean (the delta-v.xml requisition drift is expected;
+                                #         discard if present via git checkout --)
+git log --oneline -3            # expect: latest commit is the Phase 2 spec (a0936466b67)
+docker ps | grep -i kafka       # expect: no leftover Kafka from a previous session
+```
+
+Then:
+
+```bash
+./mvnw -version                  # expect: Maven 3.9.x, Java 21
+docker --version                 # expect: Docker running (Testcontainers + E2E need it)
+```
+
+---
+
+## Memory to load first
+
+These memories carry load-bearing context not in the codebase. Read them before starting Task 1:
+
+- `project_kafka_timeseries_pipeline` — overall pipeline map (Phase 0/1 done, Phase 2 in progress)
+- `project_node_context_phase1_done` — Phase 1 shipping details + the 3 runtime bugs E2E caught that unit tests missed
+- `project_kafka_timeseries_producer_next_session` — Phase 0 shipping details + #169→#170 cascade
+- `feedback_spring_boot_scan_package_trap` — why Task 19 (real-main-class IT) is non-negotiable
+- `feedback_spring_cloud_stream_splitter` — why Task 17 sets `use-native-encoding: true` on the DLQ binding
+- `feedback_delta_v_full_reactor_verify` — why Task 25 runs the full-reactor build before push
+- `feedback_deltav_package_namespace` — `org.deltav.*` + BeaconStrategists copyright
+- `feedback_delta_v_uses_mvnw_not_compile_pl` — all builds use `./mvnw`
+- `feedback_never_pr_opennms` — PR goes to `pbrane/delta-v`, never `OpenNMS/opennms`
+- `feedback_rebuild_all_daemons` — `./build.sh deltav` expects all 13 daemon-boot jars + flow-enricher + prometheus-writer current
+
+---
+
+## Guardrails for this implementation session
+
+1. **Task ordering is dependency-driven; do not reorder.** Task 5 (`NodeContextKafkaBootstrap`) depends on Task 4 (`NodeContextCache`). Task 15 (`TimeseriesConsumer`) depends on Tasks 4, 10, 13. Task 19 (real-main-class IT) must come after everything it asserts is wired. Task 26 (PR) is last.
+2. **Every task ends with a commit.** Don't bundle commits across tasks — the plan's commit messages are pre-written; use them verbatim (with minor adjustments if a task step deviates).
+3. **TDD order within each task:** failing test → run-fail → implement → run-pass → commit. The plan's Step numbering reinforces this. Don't short-circuit.
+4. **Scar prophylactics** are not "nice to have" — they are tasks or explicit acceptance criteria. Task 3 (yaml parity), Task 17 (`use-native-encoding: true`), Task 19 (real-main-class IT), Task 24 (pipefail-safe grep), Task 25 (full-reactor verify), Task 26 (final verify-all checklist). Phase 0 #170 cost 4 post-merge commits because one of these (scan-package) was skipped at planning time — don't repeat that.
+5. **Before each subagent dispatch:** re-read the task's "Files" list and the TDD steps. Subagents need explicit file paths and test class names.
+6. **Between tasks, human/lead review:** run any new tests + `./mvnw -pl core/prometheus-writer test` to confirm nothing regressed. Full-reactor build at Task 25 — not sooner — because a full reactor build is ~3-5 minutes and we don't need to pay it every task.
+7. **Do NOT touch `develop`.** Stay on `feature/kafka-ts-phase-2-prometheus-consumer`. All commits + push + PR open against this branch.
+8. **If an unexpected issue surfaces** (e.g. a horizon classpath gap, Spring Boot 4 incompatibility), STOP and document in a memory note before patching. Phase 0/1 established this pattern — silent runtime surprises are the #1 cost driver.
+
+---
+
+## Task-level plan summary (for context — the plan is canonical)
+
+1. Vendor Prometheus `remote.proto` + `types.proto` into `core/deltav-kafka-contracts`
+2. Create `core/prometheus-writer/` module skeleton + root-pom inclusion + main class
+3. `PrometheusWriterProperties` + `application.yml` (yaml-parity prophylactic)
+4. `NodeContextCache` POJO + unit tests
+5. `NodeContextKafkaBootstrap` + Testcontainers IT
+6. `NodeContextCacheHealthIndicator` + unit test
+7. Startup gate (pause binding + resume on cache-ready event)
+8. `NameSanitizer` + unit tests
+9. `LabelBuilder` + unit tests
+10. `PromSample` + `TimeseriesToPromTranslator` + unit tests
+11. `WriteRequestBuilder` + `RemoteWriteHttpClient` + MockWebServer tests
+12. `RemoteWriteRetryPolicy` + unit tests
+13. `BatchingRwWriter` + unit tests
+14. `PrometheusWriterCircuitBreaker` (Resilience4j) + unit tests
+15. `TimeseriesConsumer` SCS function + SCS test-binder IT
+16. `ConsumerPauseListener` + unit tests
+17. `DlqPublisher` + DLQ `NewTopic` bean + SCS test-binder IT (`use-native-encoding` prophylactic)
+18. `PrometheusWriterMetrics` central declaration + meter-name pin test
+19. `PrometheusWriterConfiguration` wiring + `PrometheusWriterApplicationScanIT` real-main-class (scan-package prophylactic)
+20. Full-stack round-trip Testcontainers IT (`RwRoundTripIT` + `CircuitBreakerIT`)
+21. `Dockerfile.prometheus-writer`
+22. `docker-compose.yml` additions (writer service + VictoriaMetrics v1.106.1 pinned)
+23. `build.sh` — `do_prometheus_writer_image()`
+24. `test-prometheus-writer-e2e.sh` 6-step (pipefail-safe prophylactic)
+25. Freeze both proto headers + README update + full-reactor verify gate
+26. Final acceptance checklist + PR open against `pbrane/delta-v` `develop`
+
+---
+
+## Success criteria
+
+The session is DONE when:
+
+- [ ] All 26 tasks committed on `feature/kafka-ts-phase-2-prometheus-consumer`
+- [ ] `./mvnw -pl core/prometheus-writer verify` all green (unit + ITs + real-main-class IT)
+- [ ] `./mvnw clean install -DskipTests -fae` (full reactor) all green
+- [ ] `./opennms-container/delta-v/build.sh` produces `opennms/prometheus-writer:<version>` alongside the 13 daemon-boot images + flow-enricher
+- [ ] `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` exits 0 with `ALL ASSERTIONS PASSED`
+- [ ] PR opened against `pbrane/delta-v` base `develop`, title starts `feat: Kafka TS Phase 2 —`
+- [ ] PR description includes the rebuild-checklist + scar-prophylactic verification sections
+- [ ] Memory updated: `project_kafka_timeseries_pipeline` (Phase 2 IN PROGRESS → awaiting merge); once merged, add a `project_phase2_prometheus_writer_done` note capturing any runtime bugs that only surfaced in E2E (the Phase 0/1 tradition)
+
+---
+
+## After Phase 2 ships
+
+Out of scope for this session but good to queue:
+
+- Extract `NodeContextCache` as `core/deltav-node-context-cache` starter when consumer #2 (Thresholder) lands (YAGNI'd in Phase 2)
+- `staleness-emitter` dedicated consumer if operators ask for immediate series cleanup on node delete
+- Phase 3: Thresholder (spec spawns from `project_thresholder_brainstorm`)
+- Phase 3+: Pollerd + PerspectivePollerd latency producers to `deltav-timeseries`

--- a/docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer-part2.md
+++ b/docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer-part2.md
@@ -1,0 +1,2284 @@
+# Kafka TS Phase 2 — Prometheus RW Consumer — Implementation Plan (Part 2)
+
+> Continues from `2026-04-17-kafka-ts-phase-2-prometheus-consumer.md`. Tasks 6 through 26.
+> **Tasks are more terse than Part 1 — pattern (TDD: failing test → run → implement → run → commit) is established.** Each task still names exact files, test class names, and key code shapes so an executor can follow without guessing.
+
+---
+
+## Task 6: `NodeContextCacheHealthIndicator`
+
+**Goal:** Actuator `HealthIndicator` that returns `UP` iff `NodeContextCache.isReady()`. Ties to Spring Boot readiness probe.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicator.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheHealthIndicatorTest.java`
+
+- [ ] **Step 1: Write failing test** with 2 cases:
+  - `health_down_when_cache_not_ready` — new cache, assert `Health.Status.DOWN` and detail `ready=false`, `size=0`
+  - `health_up_when_cache_ready` — mark ready + add entries, assert `Health.Status.UP` and detail `ready=true`, `size=N`
+
+- [ ] **Step 2: Run test, expect compile failure.**
+
+- [ ] **Step 3: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.availability.ReadinessStateHealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component("nodeContextCache")
+public class NodeContextCacheHealthIndicator implements HealthIndicator {
+    private final NodeContextCache cache;
+    public NodeContextCacheHealthIndicator(NodeContextCache cache) { this.cache = cache; }
+
+    @Override
+    public Health health() {
+        Health.Builder b = cache.isReady() ? Health.up() : Health.down();
+        return b.withDetail("ready", cache.isReady())
+                .withDetail("size", cache.size())
+                .build();
+    }
+}
+```
+
+Also add in `application.yml` (modify Task 3's file):
+```yaml
+management:
+  endpoint:
+    health:
+      group:
+        readiness:
+          include: readinessState, nodeContextCache  # includes the indicator above
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(prometheus-writer): NodeContextCacheHealthIndicator for readiness probe
+
+Contributes 'nodeContextCache' to the readiness group. /actuator/health/readiness
+stays DOWN until NodeContextCache.isReady() flips — ties the startup gate
+(Task 7) to Kubernetes-style readiness probing."
+```
+
+---
+
+## Task 7: Startup gate (binding paused until cache ready)
+
+**Goal:** `deltav-timeseries` binding starts paused; resumed on `NodeContextCacheReadyEvent`. Gated by `prometheus-writer.startup-gate.enabled` (default true).
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/startup/TimeseriesBindingStartupGate.java`
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/startup/TimeseriesBindingResumer.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/startup/TimeseriesBindingStartupGateTest.java`
+
+- [ ] **Step 1: Write failing test**
+
+`TimeseriesBindingStartupGateTest` asserts:
+- `customize_pauses_container_when_gate_enabled` — create gate with `enabled=true`, invoke `configure(mockContainer, "timeseriesConsumer-in-0")`, assert `mockContainer.pause()` called.
+- `customize_no_op_for_other_binding_names` — gate does nothing if binding name != `timeseriesConsumer-in-0`.
+- `resumer_calls_resume_on_ready_event` — inject mock `BindingsLifecycleController`, publish `NodeContextCacheReadyEvent`, assert `controller.resume("timeseriesConsumer-in-0")` called.
+- `resumer_no_op_when_gate_disabled` — gate disabled, publish event, assert `controller.resume` NOT called.
+
+- [ ] **Step 2: Run, expect compile failure.**
+
+- [ ] **Step 3: Implement `TimeseriesBindingStartupGate`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.startup;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.binder.kafka.config.ListenerContainerCustomizer;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimeseriesBindingStartupGate implements ListenerContainerCustomizer<AbstractMessageListenerContainer<?, ?>> {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesBindingStartupGate.class);
+    private static final String BINDING = "timeseriesConsumer-in-0";
+    private final PrometheusWriterProperties props;
+
+    public TimeseriesBindingStartupGate(PrometheusWriterProperties props) { this.props = props; }
+
+    @Override
+    public void configure(AbstractMessageListenerContainer<?, ?> container, String destinationName, String group) {
+        // Match by binding name via destination+group heuristic (SCS passes destination here); real code
+        // uses container.getContainerProperties().getGroupId() for robustness. Keeping it simple:
+        if (!props.startupGate().enabled()) {
+            LOG.info("Startup gate disabled; timeseries binding will start unpaused");
+            return;
+        }
+        LOG.info("Pausing timeseries binding '{}' — will resume on NodeContextCacheReadyEvent", BINDING);
+        container.pause();
+    }
+}
+```
+
+- [ ] **Step 4: Implement `TimeseriesBindingResumer`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.startup;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCacheReadyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.binding.BindingsLifecycleController;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimeseriesBindingResumer {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesBindingResumer.class);
+    private static final String BINDING = "timeseriesConsumer-in-0";
+    private final BindingsLifecycleController lifecycle;
+    private final PrometheusWriterProperties props;
+
+    public TimeseriesBindingResumer(BindingsLifecycleController lifecycle, PrometheusWriterProperties props) {
+        this.lifecycle = lifecycle;
+        this.props = props;
+    }
+
+    @EventListener
+    public void onReady(NodeContextCacheReadyEvent event) {
+        if (!props.startupGate().enabled()) return;
+        LOG.info("NodeContextCache ready (size={}, bootstrap={}ms) — resuming binding {}",
+                event.getCacheSize(), event.getBootstrapDurationMs(), BINDING);
+        lifecycle.resume(BINDING);
+    }
+}
+```
+
+- [ ] **Step 5: Run, expect PASS.**
+
+- [ ] **Step 6: Commit**
+
+```
+git commit -m "feat(prometheus-writer): startup gate pauses timeseries binding until cache ready
+
+TimeseriesBindingStartupGate (ListenerContainerCustomizer) calls
+container.pause() at factory time. TimeseriesBindingResumer
+(@EventListener) calls BindingsLifecycleController.resume() on
+NodeContextCacheReadyEvent. Gated by prometheus-writer.startup-gate.enabled
+(default true).
+
+Ensures any post-startup enrichment_missing counter increment is real
+drift, not warm-up noise."
+```
+
+---
+
+## Task 8: `NameSanitizer` + unit tests
+
+**Goal:** Pure function `String → String`. Lowercase → non-alphanumeric → `_` → collapse consecutive `_` → strip leading digit. Startup-time collision detection with WARN log.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/NameSanitizer.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/NameSanitizerTest.java`
+
+- [ ] **Step 1: Write failing tests.** Cases:
+
+| Input | Expected |
+|---|---|
+| `mib2-interface-errors` | `mib2_interface_errors` |
+| `ifInDiscards` | `ifindiscards` |
+| `mib2-X-interfaces` | `mib2_x_interfaces` |
+| `hrStorage` | `hrstorage` |
+| `1abc` | `_1abc` (leading digit prefixed with `_`) |
+| `foo--bar` | `foo_bar` (consecutive collapsed) |
+| `foo..bar::baz` | `foo_bar_baz` |
+| `foo___bar` | `foo_bar` |
+| `` (empty) | `` |
+| `foo` (already clean) | `foo` |
+
+Test class also asserts `detectCollisions(List.of("foo-bar", "foo_bar"))` returns a map `{"foo_bar" → ["foo-bar", "foo_bar"]}`.
+
+- [ ] **Step 2: Run, expect compile failure.**
+
+- [ ] **Step 3: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Component
+public class NameSanitizer {
+    private static final Logger LOG = LoggerFactory.getLogger(NameSanitizer.class);
+
+    public String sanitize(String input) {
+        if (input == null || input.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(input.length());
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if ((c >= 'A' && c <= 'Z')) sb.append((char)(c + ('a' - 'A')));
+            else if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) sb.append(c);
+            else sb.append('_');
+        }
+        // Collapse consecutive underscores
+        String collapsed = sb.toString().replaceAll("_+", "_");
+        // Strip leading/trailing underscores (label/metric spec edge case) then prefix if starts with digit
+        if (collapsed.isEmpty()) return "";
+        if (Character.isDigit(collapsed.charAt(0))) collapsed = "_" + collapsed;
+        return collapsed;
+    }
+
+    /** Detects collisions in a name set; returns map of sanitized → list of originals where &gt; 1. */
+    public Map<String, List<String>> detectCollisions(List<String> originals) {
+        Map<String, List<String>> buckets = new TreeMap<>();
+        for (String orig : originals) {
+            String clean = sanitize(orig);
+            buckets.computeIfAbsent(clean, k -> new java.util.ArrayList<>()).add(orig);
+        }
+        Map<String, List<String>> collisions = new HashMap<>();
+        for (Map.Entry<String, List<String>> e : buckets.entrySet()) {
+            if (e.getValue().size() > 1) {
+                collisions.put(e.getKey(), e.getValue());
+                LOG.warn("Name sanitization collision: {} → {}", e.getValue(), e.getKey());
+            }
+        }
+        return collisions;
+    }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(prometheus-writer): NameSanitizer — Prometheus-spec-compliant name conversion
+
+Lowercase + non-alphanumeric → underscore + collapse consecutive + prefix
+leading digit with underscore. detectCollisions() WARN-logs any two
+originals that map to the same sanitized form.
+
+10 unit tests cover MIB-hyphen, camelCase, hrStorage, consecutive-sep,
+leading-digit, empty, collision-detection."
+```
+
+---
+
+## Task 9: `LabelBuilder` + unit tests
+
+**Goal:** Pure function: `(TimeseriesBatch, Resource, Optional<NodeContext>, List<String> metadataAllowlist) → Map<String, String>` (label name → label value). Implements spec §3 label set.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/LabelBuilder.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java`
+
+- [ ] **Step 1: Write failing tests.** Cases:
+
+1. `default_labels_always_emitted` — batch + resource + nodeContext, assert exact label set `{node_id, location, node_label, foreign_source, categories, resource_type, resource_instance, collection_package, producer}`.
+2. `categories_sorted_comma_joined` — nodeContext with categories `["production", "critical"]`, expect `categories="critical,production"`.
+3. `categories_empty_when_none` — no categories, expect `categories=""`.
+4. `resource_instance_empty_for_non_tabular` — Resource with empty instance, expect `resource_instance=""`.
+5. `metadata_allowlist_promotes_listed_keys` — allowlist `["requisition:region"]`, nodeContext metadata `{"requisition:region": "us-east-1"}`, expect label `requisition_region="us-east-1"`.
+6. `metadata_allowlist_emits_empty_for_missing_key` — allowlist `["requisition:env"]`, nodeContext has no such key, expect label `requisition_env=""`.
+7. `metadata_not_in_allowlist_not_emitted` — nodeContext has `foo:bar=baz`, allowlist is empty, assert no label `foo_bar`.
+8. `producer_enum_name_stringified` — batch producer `PRODUCER_COLLECTD`, expect `producer="collectd"` (lowercase, without `PRODUCER_` prefix).
+
+- [ ] **Step 2: Run, expect compile failure.**
+
+- [ ] **Step 3: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+public class LabelBuilder {
+    private final NameSanitizer sanitizer;
+    public LabelBuilder(NameSanitizer sanitizer) { this.sanitizer = sanitizer; }
+
+    public Map<String, String> build(TimeseriesBatch batch, Resource resource,
+                                     Optional<NodeContext> nc, List<String> metadataAllowlist) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("node_id", Integer.toString(batch.getNodeId()));
+        labels.put("location", nullToEmpty(batch.getLocation()));
+        labels.put("node_label", nc.map(NodeContext::getNodeLabel).orElse(""));
+        labels.put("foreign_source", nc.map(NodeContext::getForeignSource).orElse(""));
+        labels.put("categories", nc.map(x -> {
+            List<String> sorted = new ArrayList<>(x.getCategoriesList());
+            Collections.sort(sorted);
+            return String.join(",", sorted);
+        }).orElse(""));
+        labels.put("resource_type", nullToEmpty(resource.getType()));
+        labels.put("resource_instance", nullToEmpty(resource.getInstance()));
+        labels.put("collection_package", nullToEmpty(batch.getCollectionPackage()));
+        labels.put("producer", producerLabel(batch.getProducer()));
+
+        for (String metaKey : metadataAllowlist) {
+            String labelName = sanitizer.sanitize(metaKey);
+            String value = nc.map(n -> n.getMetadataMap().getOrDefault(metaKey, "")).orElse("");
+            labels.put(labelName, value);
+        }
+        return labels;
+    }
+
+    private static String producerLabel(ProducerType p) {
+        String name = p.name();
+        return name.startsWith("PRODUCER_") ? name.substring("PRODUCER_".length()).toLowerCase(Locale.ROOT) : name.toLowerCase(Locale.ROOT);
+    }
+
+    private static String nullToEmpty(String s) { return s == null ? "" : s; }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(prometheus-writer): LabelBuilder — default labels + metadata allowlist
+
+9 fixed labels per spec §3 + opt-in metadata labels via
+prometheus-writer.labels.from-metadata. Categories sorted + comma-joined.
+Producer enum stripped of PRODUCER_ prefix, lowercased.
+
+8 unit tests cover every label-shape edge case."
+```
+
+---
+
+## Task 10: `PromSample` + `TimeseriesToPromTranslator`
+
+**Goal:** Pure function `(TimeseriesBatch, Optional<NodeContext>) → List<PromSample>`. Applies every filter and naming rule from spec §4.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/PromSample.java`
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslator.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslatorTest.java`
+
+- [ ] **Step 1: Write `PromSample` record**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import java.util.Map;
+
+public record PromSample(String name, Map<String, String> labels, double value, long timestampMs) {}
+```
+
+- [ ] **Step 2: Write failing test** with cases:
+
+1. `counter_attribute_gets_total_suffix` — batch with one resource, one group `mib2-interface-errors`, one attr `ifInDiscards` type COUNTER. Expect 1 sample, name `opennms_mib2_interface_errors_ifindiscards_total`.
+2. `gauge_attribute_no_total_suffix` — group `mib2-X-interfaces`, attr `ifHighSpeed` type GAUGE. Expect name `opennms_mib2_x_interfaces_ifhighspeed`.
+3. `string_attribute_dropped` — attr type STRING → `samplesDroppedStringAttribute` metric incremented, no sample in returned list.
+4. `unspecified_attribute_dropped` — attr type UNSPECIFIED → `samplesDroppedUnspecifiedType` incremented, no sample.
+5. `missing_node_context_drops_all_samples` — batch for node_id=99 with 3 attributes, `nc=Optional.empty()`, expect 0 samples returned + `enrichmentMissingTotal` incremented by 1 (per batch, not per sample).
+6. `timestamp_from_batch_collection_time` — batch.timestamp_ms=1_700_000_000_000, sample timestamp equals it (NOT `System.currentTimeMillis()`).
+7. `all_labels_populated` — counter sample with full nodeContext, assert label set matches Task 9's default set.
+
+Test uses counter mocks for metrics — inject a `SimpleMeterRegistry` and assert counters by name.
+
+- [ ] **Step 3: Run, expect compile failure.**
+
+- [ ] **Step 4: Implement `TimeseriesToPromTranslator`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.timeseries.proto.*;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+public class TimeseriesToPromTranslator {
+    private final NameSanitizer sanitizer;
+    private final LabelBuilder labelBuilder;
+    private final PrometheusWriterProperties props;
+    private final Counter droppedString;
+    private final Counter droppedUnspecified;
+    private final Counter enrichmentMissing;
+
+    public TimeseriesToPromTranslator(NameSanitizer sanitizer, LabelBuilder labelBuilder,
+                                      PrometheusWriterProperties props, MeterRegistry reg) {
+        this.sanitizer = sanitizer;
+        this.labelBuilder = labelBuilder;
+        this.props = props;
+        this.droppedString = reg.counter("deltav.prometheus.writer.samples.dropped", "reason", "string_attribute");
+        this.droppedUnspecified = reg.counter("deltav.prometheus.writer.samples.dropped", "reason", "type_unspecified");
+        this.enrichmentMissing = reg.counter("deltav.prometheus.writer.enrichment.missing", "reason", "never_seen");
+    }
+
+    public List<PromSample> translate(TimeseriesBatch batch, Optional<NodeContext> nc) {
+        if (nc.isEmpty()) {
+            enrichmentMissing.increment();
+            return List.of();
+        }
+        List<PromSample> out = new ArrayList<>();
+        List<String> allowlist = props.labels().fromMetadata();
+        for (Resource r : batch.getResourcesList()) {
+            Map<String, String> labels = labelBuilder.build(batch, r, nc, allowlist);
+            for (AttributeGroup g : r.getGroupsList()) {
+                for (Attribute a : g.getAttributesList()) {
+                    if (a.getType() == AttributeType.ATTRIBUTE_TYPE_STRING) {
+                        droppedString.increment(); continue;
+                    }
+                    if (a.getType() == AttributeType.ATTRIBUTE_TYPE_UNSPECIFIED) {
+                        droppedUnspecified.increment(); continue;
+                    }
+                    String name = buildMetricName(g.getName(), a.getName(), a.getType());
+                    out.add(new PromSample(name, labels, a.getNumeric(), batch.getTimestampMs()));
+                }
+            }
+        }
+        return out;
+    }
+
+    private String buildMetricName(String groupName, String attrName, AttributeType type) {
+        String base = "opennms_" + sanitizer.sanitize(groupName) + "_" + sanitizer.sanitize(attrName);
+        return type == AttributeType.ATTRIBUTE_TYPE_COUNTER ? base + "_total" : base;
+    }
+}
+```
+
+- [ ] **Step 5: Run, expect PASS.**
+
+- [ ] **Step 6: Commit**
+
+```
+git commit -m "feat(prometheus-writer): TimeseriesToPromTranslator — pure batch→samples function
+
+Iterates resources × groups × attributes. Filters STRING + UNSPECIFIED
+attributes with Micrometer counter-side-effects. Returns empty list and
+increments enrichment_missing when NodeContext absent.
+
+Metric name: opennms_{sanitized(group)}_{sanitized(attr)}[_total if COUNTER].
+Sample timestamp = batch.timestamp_ms (collection time, NOT processing time).
+
+7 unit tests cover counter/_total, gauge/no-suffix, string-drop,
+unspecified-drop, missing-context-drop-all, timestamp fidelity, full label
+set."
+```
+
+---
+
+## Task 11: `WriteRequestBuilder` + `RemoteWriteHttpClient` + MockWebServer tests
+
+**Goal:** Build a Prometheus `WriteRequest` protobuf from `List<PromSample>`. POST Snappy-compressed bytes to the configured RW URL with auth headers.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/WriteRequestBuilder.java`
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/RemoteWriteHttpClient.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/WriteRequestBuilderTest.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RemoteWriteHttpClientTest.java`
+
+- [ ] **Step 1: Write `WriteRequestBuilder`**
+
+Groups `PromSample` list by `(name, labels)` → one `TimeSeries` per group containing all samples. Produces a `WriteRequest.Builder` ready to serialize.
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.springframework.stereotype.Component;
+import prometheus.prompb.Label;
+import prometheus.prompb.Sample;
+import prometheus.prompb.TimeSeries;
+import prometheus.prompb.WriteRequest;
+
+import java.util.*;
+
+@Component
+public class WriteRequestBuilder {
+    public WriteRequest build(List<PromSample> samples) {
+        Map<SeriesKey, List<Sample>> bySeries = new LinkedHashMap<>();
+        Map<SeriesKey, List<Label>> seriesLabels = new HashMap<>();
+        for (PromSample s : samples) {
+            Map<String, String> withName = new LinkedHashMap<>();
+            withName.put("__name__", s.name());
+            withName.putAll(s.labels());
+            SeriesKey key = SeriesKey.from(withName);
+            bySeries.computeIfAbsent(key, k -> new ArrayList<>())
+                    .add(Sample.newBuilder().setValue(s.value()).setTimestamp(s.timestampMs()).build());
+            seriesLabels.computeIfAbsent(key, k -> toLabels(withName));
+        }
+        WriteRequest.Builder req = WriteRequest.newBuilder();
+        for (Map.Entry<SeriesKey, List<Sample>> e : bySeries.entrySet()) {
+            req.addTimeseries(TimeSeries.newBuilder()
+                    .addAllLabels(seriesLabels.get(e.getKey()))
+                    .addAllSamples(e.getValue()));
+        }
+        return req.build();
+    }
+
+    private static List<Label> toLabels(Map<String, String> m) {
+        List<Label> out = new ArrayList<>(m.size());
+        // Prometheus spec: labels sorted lexicographically by name. __name__ sorts last by ASCII but convention
+        // is to sort all alphabetically; prometheus-receivers tolerate either.
+        m.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(e -> out.add(Label.newBuilder().setName(e.getKey()).setValue(e.getValue()).build()));
+        return out;
+    }
+
+    private record SeriesKey(String canonical) {
+        static SeriesKey from(Map<String, String> labels) {
+            StringBuilder sb = new StringBuilder();
+            labels.entrySet().stream().sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> sb.append(e.getKey()).append('=').append(e.getValue()).append('|'));
+            return new SeriesKey(sb.toString());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Unit test `WriteRequestBuilder`**
+
+`WriteRequestBuilderTest`:
+- `builds_one_timeseries_per_unique_label_set`
+- `multiple_samples_same_series_grouped`
+- `metric_name_goes_to___name___label`
+- `labels_sorted_alphabetically_in_output`
+
+- [ ] **Step 3: Implement `RemoteWriteHttpClient`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.WriteRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class RemoteWriteHttpClient {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoteWriteHttpClient.class);
+    private final RestClient client;
+    private final PrometheusWriterProperties props;
+
+    public RemoteWriteHttpClient(RestClient.Builder builder, PrometheusWriterProperties props) {
+        this.props = props;
+        this.client = builder
+                .baseUrl(props.remoteWrite().url())
+                .build();
+    }
+
+    /**
+     * Posts the given WriteRequest to the RW endpoint.
+     * @return HTTP status code on success, or throws RuntimeException wrapping the cause.
+     */
+    public int post(WriteRequest request) throws Exception {
+        byte[] compressed = Snappy.compress(request.toByteArray());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("application/x-protobuf"));
+        headers.set("Content-Encoding", "snappy");
+        headers.set("X-Prometheus-Remote-Write-Version", "0.1.0");
+        headers.set("User-Agent", "deltav-prometheus-writer/" + getClass().getPackage().getImplementationVersion());
+
+        var auth = props.remoteWrite().auth();
+        switch (auth.type()) {
+            case BEARER -> headers.setBearerAuth(auth.bearerToken());
+            case BASIC  -> headers.setBasicAuth(auth.basicUsername(), auth.basicPassword());
+            case NONE   -> {}
+        }
+        for (Map.Entry<String, String> e : props.remoteWrite().headers().entrySet()) {
+            headers.add(e.getKey(), e.getValue());
+        }
+
+        ResponseEntity<Void> resp = client.post()
+                .uri(props.remoteWrite().url())
+                .headers(h -> h.addAll(headers))
+                .body(compressed)
+                .retrieve()
+                .toBodilessEntity();
+        return resp.getStatusCode().value();
+    }
+}
+```
+
+- [ ] **Step 4: MockWebServer test**
+
+`RemoteWriteHttpClientTest`:
+- `post_200_returns_200` — MockWebServer returns 200. Assert Snappy-decompressible body + `Content-Type: application/x-protobuf` + `Content-Encoding: snappy` + `X-Prometheus-Remote-Write-Version: 0.1.0`.
+- `post_with_bearer_adds_authorization_header` — auth type BEARER, token "abc", assert received `Authorization: Bearer abc`.
+- `post_with_basic_adds_basic_auth_header` — auth type BASIC, user/pass "u"/"p", assert received `Authorization: Basic dTpw`.
+- `post_with_extra_headers_adds_them` — `X-Scope-OrgID: tenant-1`, assert received.
+- `post_500_throws_server_error` — MockWebServer returns 500, assert `HttpServerErrorException` thrown.
+- `post_400_throws_client_error` — returns 400, assert `HttpClientErrorException` thrown (so retry policy can distinguish).
+
+- [ ] **Step 5: Run + PASS + Commit**
+
+```
+git commit -m "feat(prometheus-writer): WriteRequestBuilder + RemoteWriteHttpClient
+
+WriteRequestBuilder groups PromSamples into one TimeSeries per unique
+(name, labels) tuple. __name__ label prefixed. Labels sorted
+alphabetically.
+
+RemoteWriteHttpClient: Spring 6 RestClient + Snappy compression + auth
+(bearer/basic/none) + extra headers (X-Scope-OrgID for Mimir tenancy).
+Throws HttpClientErrorException on 4xx and HttpServerErrorException
+on 5xx so RemoteWriteRetryPolicy can classify.
+
+10 unit tests via MockWebServer."
+```
+
+---
+
+## Task 12: `RemoteWriteRetryPolicy` + unit tests
+
+**Goal:** Pure classifier — HTTP status → `RetryAction` (RETRY, POISON_DLQ, CIRCUIT_OPEN).
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/RemoteWriteRetryPolicy.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RemoteWriteRetryPolicyTest.java`
+
+- [ ] **Step 1: Write failing test**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RemoteWriteRetryPolicyTest {
+    private final RemoteWriteRetryPolicy p = new RemoteWriteRetryPolicy();
+
+    @Test void success_200() { assertThat(p.classifyStatus(200)).isEqualTo(RemoteWriteRetryPolicy.Action.SUCCESS); }
+    @Test void success_204() { assertThat(p.classifyStatus(204)).isEqualTo(RemoteWriteRetryPolicy.Action.SUCCESS); }
+    @Test void retry_429() { assertThat(p.classifyStatus(429)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_500() { assertThat(p.classifyStatus(500)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_502() { assertThat(p.classifyStatus(502)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_503() { assertThat(p.classifyStatus(503)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void retry_504() { assertThat(p.classifyStatus(504)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void poison_400() { assertThat(p.classifyStatus(400)).isEqualTo(RemoteWriteRetryPolicy.Action.POISON_DLQ); }
+    @Test void poison_413() { assertThat(p.classifyStatus(413)).isEqualTo(RemoteWriteRetryPolicy.Action.POISON_DLQ); }
+    @Test void circuit_401() { assertThat(p.classifyStatus(401)).isEqualTo(RemoteWriteRetryPolicy.Action.CIRCUIT_OPEN); }
+    @Test void circuit_403() { assertThat(p.classifyStatus(403)).isEqualTo(RemoteWriteRetryPolicy.Action.CIRCUIT_OPEN); }
+    @Test void circuit_404() { assertThat(p.classifyStatus(404)).isEqualTo(RemoteWriteRetryPolicy.Action.CIRCUIT_OPEN); }
+    @Test void unknown_4xx_defaults_to_poison() { assertThat(p.classifyStatus(418)).isEqualTo(RemoteWriteRetryPolicy.Action.POISON_DLQ); }
+    @Test void unknown_5xx_defaults_to_retry() { assertThat(p.classifyStatus(599)).isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF); }
+    @Test void network_exception_retries() {
+        assertThat(p.classifyException(new java.net.ConnectException("refused")))
+                .isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF);
+    }
+    @Test void read_timeout_retries() {
+        assertThat(p.classifyException(new java.net.SocketTimeoutException("timeout")))
+                .isEqualTo(RemoteWriteRetryPolicy.Action.RETRY_WITH_BACKOFF);
+    }
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import org.springframework.stereotype.Component;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+@Component
+public class RemoteWriteRetryPolicy {
+    public enum Action { SUCCESS, RETRY_WITH_BACKOFF, POISON_DLQ, CIRCUIT_OPEN }
+
+    public Action classifyStatus(int status) {
+        if (status == 200 || status == 204) return Action.SUCCESS;
+        if (status == 429) return Action.RETRY_WITH_BACKOFF;
+        if (status >= 500) return Action.RETRY_WITH_BACKOFF;
+        if (status == 400 || status == 413) return Action.POISON_DLQ;
+        if (status == 401 || status == 403 || status == 404) return Action.CIRCUIT_OPEN;
+        if (status >= 400 && status < 500) return Action.POISON_DLQ;  // default other 4xx to poison
+        return Action.POISON_DLQ;
+    }
+
+    public Action classifyException(Throwable t) {
+        if (t instanceof SocketTimeoutException
+                || t instanceof ConnectException
+                || t instanceof UnknownHostException) return Action.RETRY_WITH_BACKOFF;
+        // org.springframework.web.client.ResourceAccessException wraps network errors
+        Throwable cause = t.getCause();
+        if (cause != null && cause != t) return classifyException(cause);
+        return Action.RETRY_WITH_BACKOFF;
+    }
+}
+```
+
+- [ ] **Step 3: Run + PASS + Commit**
+
+```
+git commit -m "feat(prometheus-writer): RemoteWriteRetryPolicy classifier
+
+Tiered by HTTP status per spec §5 retry table:
+  200/204  → SUCCESS
+  429/5xx/network → RETRY_WITH_BACKOFF
+  400/413  → POISON_DLQ
+  401/403/404 → CIRCUIT_OPEN
+  other 4xx → POISON_DLQ (default)
+
+16 unit tests pin every documented code."
+```
+
+---
+
+## Task 13: `BatchingRwWriter` + unit tests
+
+**Goal:** In-memory accumulator. Flush triggers: 1000 samples OR 1 MB uncompressed OR 1 s since first sample. On flush, group by series + build `WriteRequest` + delegate to `RemoteWriteHttpClient` wrapped by circuit breaker.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/BatchingRwWriter.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/BatchingRwWriterTest.java`
+
+- [ ] **Step 1: Write failing tests.** Cases:
+
+1. `flushes_on_max_samples_threshold` — add 1000 samples, assert `flushNow` called once after the 1000th add.
+2. `flushes_on_max_bytes_threshold` — construct samples whose total size exceeds `maxBytes`, assert flush.
+3. `flushes_on_time_interval_via_scheduled_check` — add 500 samples, advance mock clock past 1 s, assert flush triggered by scheduled check.
+4. `flush_calls_http_client_with_grouped_WriteRequest` — mock http client, add 3 samples sharing a name, 2 with different name. Assert client received `WriteRequest` with 2 TimeSeries.
+5. `flush_empty_buffer_is_noop` — no samples added, scheduled flush → no HTTP call.
+
+Inject a `SimpleMeterRegistry` and assert counters `batches_sent_total`, `samples_sent_total` incremented.
+
+- [ ] **Step 2: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import prometheus.prompb.WriteRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+public class BatchingRwWriter {
+    private static final Logger LOG = LoggerFactory.getLogger(BatchingRwWriter.class);
+
+    private final PrometheusWriterProperties props;
+    private final WriteRequestBuilder builder;
+    private final RemoteWriteHttpClient http;
+    private final Counter batchesSent;
+    private final Counter samplesSent;
+    private final DistributionSummary batchBytes;
+    private final DistributionSummary batchSampleCount;
+    private final Timer flushDuration;
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final List<PromSample> buffer = new ArrayList<>();
+    private final AtomicLong approxBytes = new AtomicLong(0);
+    private volatile long firstSampleAtMs = 0L;
+
+    public BatchingRwWriter(PrometheusWriterProperties props, WriteRequestBuilder builder,
+                            RemoteWriteHttpClient http, MeterRegistry reg) {
+        this.props = props; this.builder = builder; this.http = http;
+        String endpoint = props.remoteWrite().url();
+        this.batchesSent = Counter.builder("deltav.prometheus.writer.batches.sent")
+                .tag("endpoint", endpoint).register(reg);
+        this.samplesSent = Counter.builder("deltav.prometheus.writer.samples.sent")
+                .tag("endpoint", endpoint).register(reg);
+        this.batchBytes = DistributionSummary.builder("deltav.prometheus.writer.batch.size.bytes")
+                .tag("endpoint", endpoint).register(reg);
+        this.batchSampleCount = DistributionSummary.builder("deltav.prometheus.writer.batch.sample.count")
+                .tag("endpoint", endpoint).register(reg);
+        this.flushDuration = Timer.builder("deltav.prometheus.writer.flush.duration")
+                .tag("endpoint", endpoint).register(reg);
+    }
+
+    public void add(PromSample sample) {
+        lock.lock();
+        try {
+            if (buffer.isEmpty()) firstSampleAtMs = System.currentTimeMillis();
+            buffer.add(sample);
+            approxBytes.addAndGet(estimateSize(sample));
+            if (shouldFlushNow()) flushNow();
+        } finally { lock.unlock(); }
+    }
+
+    @Scheduled(fixedDelay = 100)
+    public void flushIfStale() {
+        lock.lock();
+        try {
+            if (!buffer.isEmpty()
+                    && System.currentTimeMillis() - firstSampleAtMs >= props.batch().maxIntervalMs()) {
+                flushNow();
+            }
+        } finally { lock.unlock(); }
+    }
+
+    public void flushNow() {
+        if (buffer.isEmpty()) return;
+        List<PromSample> toSend = new ArrayList<>(buffer);
+        buffer.clear();
+        approxBytes.set(0);
+        Timer.Sample sample = Timer.start();
+        try {
+            WriteRequest req = builder.build(toSend);
+            int bytesEstimate = req.getSerializedSize();
+            http.post(req);
+            batchesSent.increment();
+            samplesSent.increment(toSend.size());
+            batchBytes.record(bytesEstimate);
+            batchSampleCount.record(toSend.size());
+        } catch (Exception e) {
+            // Flush failures propagate to caller's retry/DLQ/circuit logic (Task 14/16).
+            // For unit-test purposes here we just rethrow; ConsumerPauseListener decides the reaction.
+            throw new RuntimeException(e);
+        } finally {
+            sample.stop(flushDuration);
+        }
+    }
+
+    private boolean shouldFlushNow() {
+        return buffer.size() >= props.batch().maxSamples()
+                || approxBytes.get() >= props.batch().maxBytes();
+    }
+
+    private long estimateSize(PromSample s) {
+        // Rough heuristic — label-string lengths + 16 bytes per sample overhead.
+        long total = 16;
+        total += s.name().length();
+        for (var e : s.labels().entrySet()) total += e.getKey().length() + e.getValue().length() + 2;
+        return total;
+    }
+}
+```
+
+- [ ] **Step 3: Run + PASS + Commit**
+
+```
+git commit -m "feat(prometheus-writer): BatchingRwWriter — size/bytes/time flush triggers
+
+In-memory buffer + scheduled 100ms staleness check. Flushes on whichever
+trigger hits first: 1000 samples, 1 MB uncompressed (estimated), or 1 s
+since first sample.
+
+Emits deltav_prometheus_writer_{batches_sent,samples_sent,batch_size_bytes,
+batch_sample_count,flush_duration}_ metrics with endpoint tag.
+
+5 unit tests cover every flush trigger + grouping."
+```
+
+---
+
+## Task 14: `PrometheusWriterCircuitBreaker` (Resilience4j)
+
+**Goal:** Resilience4j `CircuitBreaker` bean wrapping the HTTP call. Configurable from `PrometheusWriterProperties.circuitBreaker`.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreaker.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/PrometheusWriterCircuitBreakerTest.java`
+
+- [ ] **Step 1: Write failing tests.** Cases:
+
+1. `starts_closed` — newly-created breaker has state CLOSED.
+2. `opens_at_failure_rate_threshold` — run 20 calls, 11 fail, assert state OPEN after.
+3. `transitions_half_open_after_wait_duration` — trigger OPEN, wait past `waitDurationOpenMs`, assert HALF_OPEN.
+4. `returns_to_closed_after_successful_probes` — from HALF_OPEN, permit 3 successes, assert CLOSED.
+5. `returns_to_open_on_half_open_failure` — from HALF_OPEN, fail once, assert OPEN.
+
+Use Resilience4j's `io.github.resilience4j.core.lang.NonNull` + synthetic `Runnable`s that throw on demand.
+
+- [ ] **Step 2: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Configuration
+public class PrometheusWriterCircuitBreaker {
+
+    public static final String NAME = "prometheus-writer";
+
+    @Bean
+    public CircuitBreakerRegistry circuitBreakerRegistry(PrometheusWriterProperties props) {
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .failureRateThreshold(props.circuitBreaker().failureRateThreshold())
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(props.circuitBreaker().slidingWindowSize())
+                .minimumNumberOfCalls(props.circuitBreaker().minimumNumberOfCalls())
+                .waitDurationInOpenState(Duration.ofMillis(props.circuitBreaker().waitDurationOpenMs()))
+                .permittedNumberOfCallsInHalfOpenState(props.circuitBreaker().halfOpenPermittedCalls())
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .build();
+        return CircuitBreakerRegistry.of(config);
+    }
+
+    @Bean
+    public CircuitBreaker prometheusWriterCircuitBreaker(
+            CircuitBreakerRegistry registry, MeterRegistry metrics, PrometheusWriterProperties props) {
+        CircuitBreaker cb = registry.circuitBreaker(NAME);
+        AtomicInteger stateGauge = new AtomicInteger(0);
+        cb.getEventPublisher().onStateTransition(e -> {
+            stateGauge.set(switch (e.getStateTransition().getToState()) {
+                case CLOSED, METRICS_ONLY, DISABLED, FORCED_OPEN -> 0;
+                case HALF_OPEN -> 1;
+                case OPEN -> 2;
+            });
+        });
+        Gauge.builder("deltav.prometheus.writer.circuit.state", stateGauge::get)
+                .tag("endpoint", props.remoteWrite().url())
+                .register(metrics);
+        return cb;
+    }
+}
+```
+
+- [ ] **Step 3: Run + PASS + Commit**
+
+```
+git commit -m "feat(prometheus-writer): Resilience4j circuit breaker bean
+
+Configured from PrometheusWriterProperties.circuitBreaker (50% failure
+rate, 20-call window, 30s open, 3 half-open probes, auto-transition
+open→half-open).
+
+Gauge 'deltav_prometheus_writer_circuit_state' exposes current state
+(0=closed, 1=half_open, 2=open) for alerting.
+
+5 state-machine unit tests."
+```
+
+---
+
+## Task 15: `TimeseriesConsumer` + SCS test-binder IT
+
+**Goal:** SCS `Function<Message<byte[]>, Void>` bean definition. Deserializes `TimeseriesBatch`, looks up cache, runs translator, forwards samples to `BatchingRwWriter`.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumer.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerBinderIT.java`
+
+- [ ] **Step 1: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.consume;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.rw.BatchingRwWriter;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.deltav.prometheus.writer.translate.TimeseriesToPromTranslator;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+@Configuration
+public class TimeseriesConsumer {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesConsumer.class);
+
+    @Bean
+    public Consumer<Message<byte[]>> timeseriesConsumer(
+            NodeContextCache cache,
+            TimeseriesToPromTranslator translator,
+            BatchingRwWriter writer,
+            MeterRegistry metrics) {
+        Counter consumed = metrics.counter("deltav.prometheus.writer.records.consumed");
+        Counter samplesIn = metrics.counter("deltav.prometheus.writer.samples.in");
+        return message -> {
+            try {
+                TimeseriesBatch batch = TimeseriesBatch.parseFrom(message.getPayload());
+                String key = batch.getLocation() + "@" + batch.getNodeId();
+                Optional<NodeContext> nc = cache.get(key);
+                List<PromSample> samples = translator.translate(batch, nc);
+                consumed.increment();
+                samplesIn.increment(samples.size());
+                samples.forEach(writer::add);
+            } catch (Exception e) {
+                LOG.warn("Failed to process TimeseriesBatch — dropping", e);
+                metrics.counter("deltav.prometheus.writer.records.parse.errors").increment();
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Write SCS test-binder IT**
+
+`TimeseriesConsumerBinderIT` — uses `spring-cloud-stream-test-binder`:
+- Input: publish a `TimeseriesBatch.toByteArray()` to `timeseriesConsumer-in-0`.
+- Assert: `records_consumed_total` incremented, `samples_in_total` incremented by batch-attribute-count, mock `BatchingRwWriter` received `add()` calls for each sample.
+
+- [ ] **Step 3: Run + PASS + Commit**
+
+```
+git commit -m "feat(prometheus-writer): TimeseriesConsumer SCS function
+
+Spring Cloud Stream Consumer<Message<byte[]>> bean bound to
+deltav-timeseries. Parse-error counter increments on malformed records
+(dropped, not rethrown — consumer keeps moving).
+
+SCS test-binder IT asserts full path: binder → deserialize → cache
+lookup → translator → BatchingRwWriter.add()."
+```
+
+---
+
+## Task 16: `ConsumerPauseListener`
+
+**Goal:** Listen to Resilience4j circuit state transitions; pause/resume `timeseriesConsumer-in-0` binding accordingly.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/rw/ConsumerPauseListener.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/ConsumerPauseListenerTest.java`
+
+- [ ] **Step 1: Write failing tests.** Cases:
+
+1. `closed_to_open_pauses_binding` — simulate transition CLOSED → OPEN, assert `lifecycle.pause("timeseriesConsumer-in-0")` called.
+2. `half_open_to_closed_resumes_binding` — transition HALF_OPEN → CLOSED, assert `lifecycle.resume(...)` called.
+3. `half_open_to_open_pauses_again` — transition HALF_OPEN → OPEN, assert pause called.
+4. `open_to_half_open_is_noop` — transition OPEN → HALF_OPEN, assert no pause/resume (probes run on same paused binding).
+
+- [ ] **Step 2: Implement**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.rw;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.binding.BindingsLifecycleController;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class ConsumerPauseListener {
+    private static final Logger LOG = LoggerFactory.getLogger(ConsumerPauseListener.class);
+    private static final String BINDING = "timeseriesConsumer-in-0";
+
+    private final CircuitBreaker cb;
+    private final BindingsLifecycleController lifecycle;
+    private final AtomicInteger pausedGauge = new AtomicInteger(0);
+
+    public ConsumerPauseListener(CircuitBreaker cb, BindingsLifecycleController lifecycle, MeterRegistry metrics) {
+        this.cb = cb;
+        this.lifecycle = lifecycle;
+        Gauge.builder("deltav.prometheus.writer.consumer.paused", pausedGauge::get).register(metrics);
+    }
+
+    @PostConstruct
+    public void wire() {
+        cb.getEventPublisher().onStateTransition(e -> {
+            var from = e.getStateTransition().getFromState();
+            var to = e.getStateTransition().getToState();
+            boolean pauseNow = to == CircuitBreaker.State.OPEN
+                    && (from == CircuitBreaker.State.CLOSED || from == CircuitBreaker.State.HALF_OPEN);
+            boolean resumeNow = from == CircuitBreaker.State.HALF_OPEN && to == CircuitBreaker.State.CLOSED;
+            if (pauseNow) {
+                LOG.warn("Circuit opened — pausing binding {}", BINDING);
+                lifecycle.pause(BINDING);
+                pausedGauge.set(1);
+            } else if (resumeNow) {
+                LOG.info("Circuit closed — resuming binding {}", BINDING);
+                lifecycle.resume(BINDING);
+                pausedGauge.set(0);
+            }
+        });
+    }
+}
+```
+
+- [ ] **Step 3: Run + PASS + Commit**
+
+```
+git commit -m "feat(prometheus-writer): ConsumerPauseListener — circuit state → binding pause/resume
+
+Registers a state-transition listener on the prometheus-writer circuit.
+CLOSED/HALF_OPEN → OPEN pauses the timeseries binding. HALF_OPEN → CLOSED
+resumes it. OPEN → HALF_OPEN is a no-op (probes use the paused binding).
+
+Gauge 'deltav_prometheus_writer_consumer_paused' exposes pause state."
+```
+
+---
+
+## Task 17: `DlqPublisher` + DLQ `NewTopic` bean + binder IT
+
+**Goal:** On 400/413, republish the source `TimeseriesBatch` bytes to `deltav-prometheus-writer-dlq` with diagnostic headers.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/dlq/DlqPublisher.java`
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/KafkaTopicsConfiguration.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/dlq/DlqPublisherBinderIT.java`
+
+- [ ] **Step 1: Implement `KafkaTopicsConfiguration`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+import java.util.Map;
+
+@Configuration
+public class KafkaTopicsConfiguration {
+    @Bean
+    public NewTopic deltavPrometheusWriterDlqTopic() {
+        return TopicBuilder.name("deltav-prometheus-writer-dlq")
+                .partitions(16)
+                .replicas(1)
+                .configs(Map.of(
+                        "cleanup.policy", "delete",
+                        "retention.ms", "604800000",          // 7 days
+                        "compression.type", "lz4"))
+                .build();
+    }
+}
+```
+
+- [ ] **Step 2: Implement `DlqPublisher`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.dlq;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class DlqPublisher {
+    private static final Logger LOG = LoggerFactory.getLogger(DlqPublisher.class);
+    private static final String BINDING = "publishDlq-out-0";
+
+    private final StreamBridge streamBridge;
+    private final MeterRegistry metrics;
+
+    public DlqPublisher(StreamBridge streamBridge, MeterRegistry metrics) {
+        this.streamBridge = streamBridge;
+        this.metrics = metrics;
+    }
+
+    public void publish(byte[] sourcePayload, String key, String reason, int httpStatus,
+                        String endpoint, String errorMessage) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(KafkaHeaders.KEY, key.getBytes());
+        headers.put("x-dlq-reason", reason);
+        headers.put("x-dlq-http-status", Integer.toString(httpStatus));
+        headers.put("x-dlq-endpoint", endpoint);
+        headers.put("x-dlq-timestamp-ms", Long.toString(System.currentTimeMillis()));
+        headers.put("x-dlq-error-message", truncate(errorMessage, 1024));
+        headers.put("x-dlq-writer-version",
+                Optional.ofNullable(getClass().getPackage().getImplementationVersion()).orElse("dev"));
+        Message<byte[]> msg = MessageBuilder.withPayload(sourcePayload).copyHeaders(headers).build();
+        boolean sent = streamBridge.send(BINDING, msg);
+        if (sent) {
+            Counter.builder("deltav.prometheus.writer.dlq.records")
+                    .tag("reason", reason).register(metrics).increment();
+        } else {
+            LOG.error("StreamBridge.send returned false — DLQ record lost: key={} reason={}", key, reason);
+        }
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max);
+    }
+}
+```
+
+(Import `java.util.Optional` in the imports.)
+
+- [ ] **Step 3: SCS binder IT**
+
+`DlqPublisherBinderIT` asserts:
+- Message sent to `deltav-prometheus-writer-dlq`.
+- Byte-array payload preserved byte-for-byte (verifies `use-native-encoding: true`).
+- All 6 diagnostic headers present.
+- `deltav_prometheus_writer_dlq_records_total{reason="bad_request"}` incremented.
+
+- [ ] **Step 4: Run + PASS + Commit**
+
+```
+git commit -m "feat(prometheus-writer): DlqPublisher + deltav-prometheus-writer-dlq NewTopic
+
+DLQ topic: 16 partitions, cleanup.policy=delete, retention 7 days, lz4.
+DlqPublisher uses StreamBridge to send the original TimeseriesBatch
+bytes with 6 diagnostic headers (reason, status, endpoint, timestamp,
+error-message, writer-version).
+
+Binding publishDlq-out-0 uses producer.use-native-encoding: true to
+preserve byte-array payload (Phase 1.5 SCS splitter lesson)."
+```
+
+---
+
+## Task 18: `PrometheusWriterMetrics` central declaration
+
+**Goal:** One bean holds references to every Micrometer meter in the spec §7 table. All other beans request meters from it (or use `MeterRegistry.counter(...)` directly — both are acceptable; this task consolidates the canonical meter names as constants).
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetrics.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetricsTest.java`
+
+- [ ] **Step 1: Implement — just a constants class**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.metrics;
+
+/**
+ * Canonical Micrometer meter names for the prometheus-writer. Every meter
+ * declared here MUST appear at /actuator/prometheus once the service is fully
+ * wired. {@link PrometheusWriterMetricsTest} pins the list.
+ */
+public final class PrometheusWriterMetrics {
+    private PrometheusWriterMetrics() {}
+
+    // ingestion
+    public static final String RECORDS_CONSUMED        = "deltav.prometheus.writer.records.consumed";
+    public static final String SAMPLES_IN              = "deltav.prometheus.writer.samples.in";
+    public static final String RECORDS_PARSE_ERRORS    = "deltav.prometheus.writer.records.parse.errors";
+
+    // enrichment
+    public static final String ENRICHMENT_HIT          = "deltav.prometheus.writer.enrichment.hit";
+    public static final String ENRICHMENT_MISSING      = "deltav.prometheus.writer.enrichment.missing";
+    public static final String NC_CACHE_SIZE           = "deltav.prometheus.writer.node.context.cache.size";
+    public static final String NC_CACHE_READY          = "deltav.prometheus.writer.node.context.cache.ready";
+    public static final String NC_BOOTSTRAP_DURATION   = "deltav.prometheus.writer.node.context.bootstrap.duration";
+
+    // sample dropouts
+    public static final String SAMPLES_DROPPED         = "deltav.prometheus.writer.samples.dropped";
+
+    // rw output
+    public static final String BATCHES_SENT            = "deltav.prometheus.writer.batches.sent";
+    public static final String SAMPLES_SENT            = "deltav.prometheus.writer.samples.sent";
+    public static final String BATCHES_FAILED          = "deltav.prometheus.writer.batches.failed";
+    public static final String BATCH_SIZE_BYTES        = "deltav.prometheus.writer.batch.size.bytes";
+    public static final String BATCH_SAMPLE_COUNT      = "deltav.prometheus.writer.batch.sample.count";
+    public static final String FLUSH_DURATION          = "deltav.prometheus.writer.flush.duration";
+    public static final String RETRY_ATTEMPTS          = "deltav.prometheus.writer.retry.attempts";
+
+    // dlq
+    public static final String DLQ_RECORDS             = "deltav.prometheus.writer.dlq.records";
+
+    // circuit + consumer state
+    public static final String CIRCUIT_STATE           = "deltav.prometheus.writer.circuit.state";
+    public static final String CONSUMER_PAUSED         = "deltav.prometheus.writer.consumer.paused";
+}
+```
+
+- [ ] **Step 2: Unit test pins the field list**
+
+`PrometheusWriterMetricsTest` uses reflection to iterate all `public static final String` fields and asserts a known canonical list (byte-for-byte equal). Fails if someone adds or removes a meter without updating the spec.
+
+- [ ] **Step 3: Update all producer sites** (where counters/gauges/timers are created in Tasks 10–17) to reference `PrometheusWriterMetrics.*` constants instead of string literals. Purely a refactor — tests from those tasks must still pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git commit -m "refactor(prometheus-writer): centralize Micrometer meter names as constants
+
+PrometheusWriterMetrics.java is the canonical source of truth for every
+meter name. All producer sites now reference the constant. Reflection-
+based test pins the full list — adding/removing a meter requires a
+deliberate test change + spec update."
+```
+
+---
+
+## Task 19: Wiring + `PrometheusWriterApplicationScanIT` (real-main-class scar prophylactic)
+
+**Goal:** Create `PrometheusWriterConfiguration`, wire any remaining beans, and add a real-main-class integration test that boots `PrometheusWriterApplication` and asserts every key bean is resolvable. **This is scar prophylactic #1 from the spec** — mandatory before any live E2E.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/PrometheusWriterConfiguration.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/PrometheusWriterApplicationScanIT.java`
+
+- [ ] **Step 1: Implement `PrometheusWriterConfiguration`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer;
+
+import org.deltav.prometheus.writer.config.PrometheusWriterProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Configuration
+@EnableConfigurationProperties(PrometheusWriterProperties.class)
+public class PrometheusWriterConfiguration {
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder()
+                // Connect and read timeouts per spec §5:
+                //   connect 5s, read 30s
+                .requestFactory(new org.springframework.http.client.SimpleClientHttpRequestFactory() {{
+                    setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
+                    setReadTimeout((int) Duration.ofSeconds(30).toMillis());
+                }});
+    }
+}
+```
+
+- [ ] **Step 2: Implement the real-main-class IT**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.deltav.prometheus.writer.consume.TimeseriesConsumer;
+import org.deltav.prometheus.writer.dlq.DlqPublisher;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.nodecontext.NodeContextCacheHealthIndicator;
+import org.deltav.prometheus.writer.nodecontext.NodeContextKafkaBootstrap;
+import org.deltav.prometheus.writer.rw.BatchingRwWriter;
+import org.deltav.prometheus.writer.rw.ConsumerPauseListener;
+import org.deltav.prometheus.writer.rw.RemoteWriteHttpClient;
+import org.deltav.prometheus.writer.rw.RemoteWriteRetryPolicy;
+import org.deltav.prometheus.writer.rw.WriteRequestBuilder;
+import org.deltav.prometheus.writer.startup.TimeseriesBindingResumer;
+import org.deltav.prometheus.writer.startup.TimeseriesBindingStartupGate;
+import org.deltav.prometheus.writer.translate.LabelBuilder;
+import org.deltav.prometheus.writer.translate.NameSanitizer;
+import org.deltav.prometheus.writer.translate.TimeseriesToPromTranslator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-main-class integration test. Boots PrometheusWriterApplication via
+ * SpringApplication.run() against a Testcontainers Kafka broker. Asserts
+ * every key bean from the spec is resolvable.
+ *
+ * <p>Scar prophylactic for the Phase 0 #170 bug: unit tests + @Import-based
+ * ITs bypass the component scan. A mistyped scanBasePackages silently hides
+ * an entire @Configuration class and the problem only surfaces in Docker.
+ * This IT would have caught it in one CI run.
+ */
+@Testcontainers
+@SpringBootTest(classes = PrometheusWriterApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PrometheusWriterApplicationScanIT {
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void kafkaProps(DynamicPropertyRegistry reg) {
+        reg.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        reg.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+        reg.add("prometheus-writer.remote-write.url", () -> "http://localhost:1/unused");
+    }
+
+    @Autowired ApplicationContext ctx;
+
+    @Test
+    void all_key_beans_resolve() {
+        // Node-context subsystem
+        assertThat(ctx.getBean(NodeContextCache.class)).isNotNull();
+        assertThat(ctx.getBean(NodeContextKafkaBootstrap.class)).isNotNull();
+        assertThat(ctx.getBean(NodeContextCacheHealthIndicator.class)).isNotNull();
+        // Translation
+        assertThat(ctx.getBean(NameSanitizer.class)).isNotNull();
+        assertThat(ctx.getBean(LabelBuilder.class)).isNotNull();
+        assertThat(ctx.getBean(TimeseriesToPromTranslator.class)).isNotNull();
+        // RW output
+        assertThat(ctx.getBean(WriteRequestBuilder.class)).isNotNull();
+        assertThat(ctx.getBean(RemoteWriteHttpClient.class)).isNotNull();
+        assertThat(ctx.getBean(RemoteWriteRetryPolicy.class)).isNotNull();
+        assertThat(ctx.getBean(BatchingRwWriter.class)).isNotNull();
+        assertThat(ctx.getBean(CircuitBreaker.class)).isNotNull();
+        assertThat(ctx.getBean(ConsumerPauseListener.class)).isNotNull();
+        // Consumer + startup gate
+        assertThat(ctx.getBean(TimeseriesConsumer.class)).isNotNull();
+        assertThat(ctx.getBean(TimeseriesBindingStartupGate.class)).isNotNull();
+        assertThat(ctx.getBean(TimeseriesBindingResumer.class)).isNotNull();
+        // DLQ
+        assertThat(ctx.getBean(DlqPublisher.class)).isNotNull();
+        assertThat(ctx.getBean("deltavPrometheusWriterDlqTopic", NewTopic.class)).isNotNull();
+    }
+}
+```
+
+- [ ] **Step 3: Run — if any bean missing, FAIL surfaces a scanBasePackages or wiring gap.**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=PrometheusWriterApplicationScanIT
+```
+
+Expected: PASS. If FAIL, the failing assertion tells you exactly which bean isn't resolving; most likely a subpackage missing from `@SpringBootApplication(scanBasePackages=...)` or a typo on a `@Component` / `@Configuration` annotation.
+
+- [ ] **Step 4: Commit**
+
+```
+git commit -m "test(prometheus-writer): PrometheusWriterApplicationScanIT real-main-class IT
+
+Boots PrometheusWriterApplication via SpringApplication.run() against a
+Testcontainers Kafka broker. Asserts every key bean from the spec
+resolves. Catches scanBasePackages gaps in one CI run — Phase 0 #170
+scar prophylactic #1."
+```
+
+---
+
+## Task 20: Full-stack round-trip Testcontainers IT
+
+**Goal:** `RwRoundTripIT` — real Kafka + real MockWebServer as RW target. Produce a `TimeseriesBatch` + `NodeContext` to Kafka, boot the app, assert: cache bootstraps, binding resumes, samples flow, MockWebServer receives a decompressible `WriteRequest` with the expected series name + labels. Also `CircuitBreakerIT` — inject 500s, assert circuit opens + consumer pauses, then recover and assert resume.
+
+**Files:**
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/RwRoundTripIT.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/rw/CircuitBreakerIT.java`
+
+- [ ] **Step 1: `RwRoundTripIT`**
+
+Sketch (~120 lines):
+
+```java
+@Testcontainers
+@SpringBootTest(classes = PrometheusWriterApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+class RwRoundTripIT {
+    @Container static final KafkaContainer KAFKA = new KafkaContainer(...);
+    static MockWebServer mockRw;
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry reg) throws Exception {
+        mockRw = new MockWebServer(); mockRw.start();
+        reg.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        reg.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+        reg.add("prometheus-writer.remote-write.url", () -> mockRw.url("/api/v1/write").toString());
+        reg.add("prometheus-writer.batch.max-interval-ms", () -> "200");
+    }
+
+    @Test
+    void end_to_end_sample_lands_at_rw_target() throws Exception {
+        // 1) Publish NodeContext so cache can bootstrap
+        publishNodeContext(5, "Default", "server-01", List.of("production", "critical"));
+        // 2) Queue success response on mock
+        mockRw.enqueue(new MockResponse().setResponseCode(200));
+        // 3) Publish TimeseriesBatch
+        publishTimeseriesBatch(5, "Default", AttributeType.ATTRIBUTE_TYPE_COUNTER,
+                "mib2-interface-errors", "ifInDiscards", 42.0);
+
+        RecordedRequest req = mockRw.takeRequest(15, TimeUnit.SECONDS);
+        assertThat(req).isNotNull();
+        assertThat(req.getHeader("Content-Type")).isEqualTo("application/x-protobuf");
+        assertThat(req.getHeader("Content-Encoding")).isEqualTo("snappy");
+
+        byte[] uncompressed = Snappy.uncompress(req.getBody().readByteArray());
+        WriteRequest wr = WriteRequest.parseFrom(uncompressed);
+        assertThat(wr.getTimeseriesCount()).isEqualTo(1);
+        TimeSeries ts = wr.getTimeseries(0);
+        Map<String,String> labels = ts.getLabelsList().stream()
+                .collect(Collectors.toMap(Label::getName, Label::getValue));
+        assertThat(labels).containsEntry("__name__", "opennms_mib2_interface_errors_ifindiscards_total");
+        assertThat(labels).containsEntry("node_id", "5");
+        assertThat(labels).containsEntry("node_label", "server-01");
+        assertThat(labels).containsEntry("categories", "critical,production");
+        assertThat(ts.getSamples(0).getValue()).isEqualTo(42.0);
+    }
+}
+```
+
+- [ ] **Step 2: `CircuitBreakerIT`**
+
+- Publish NodeContext + TimeseriesBatches sufficient to trigger `sliding-window-size=20` plus 11 enqueued 500 responses.
+- Assert `circuit_state` gauge flips to OPEN within Awaitility timeout.
+- Assert `consumer_paused` gauge flips to 1.
+- Enqueue 3 success responses; wait past `wait-duration-open-ms` (but cap the test with a low override, e.g. 3000 ms).
+- Assert `circuit_state` returns to CLOSED and `consumer_paused` to 0.
+
+- [ ] **Step 3: Run + PASS + Commit**
+
+```
+git commit -m "test(prometheus-writer): RwRoundTripIT + CircuitBreakerIT
+
+End-to-end Testcontainers coverage: Kafka in → cache bootstrap →
+translator → batching writer → MockWebServer RW target. Asserts Snappy
+decompression + label set + metric name match spec.
+
+CircuitBreakerIT injects 500s to trigger circuit open + binding pause,
+then recovers and asserts resume."
+```
+
+---
+
+## Task 21: `Dockerfile.prometheus-writer`
+
+**Goal:** Containerize the fat jar.
+
+**Files:**
+- Create: `core/prometheus-writer/Dockerfile`
+
+- [ ] **Step 1: Write Dockerfile**
+
+Exactly:
+
+```dockerfile
+# Copyright (C) 2026 BeaconStrategists, Inc.
+# Licensed under the GNU Affero General Public License v3.
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache curl && \
+    addgroup -g 10001 deltav && \
+    adduser -u 10001 -G deltav -D deltav
+
+COPY --chown=deltav:deltav target/prometheus-writer.jar /app/prometheus-writer.jar
+
+USER deltav
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/prometheus-writer.jar"]
+```
+
+- [ ] **Step 2: Build image manually to verify**
+
+```bash
+./mvnw -pl core/prometheus-writer -DskipTests package
+docker build -t opennms/prometheus-writer:dev -f core/prometheus-writer/Dockerfile core/prometheus-writer
+docker run --rm opennms/prometheus-writer:dev --help 2>&1 | head -5
+```
+
+Expected: image builds + container runs. (Container will fail-fast because Kafka is not reachable; we don't care — we're verifying the image.)
+
+- [ ] **Step 3: Commit**
+
+```
+git commit -m "feat(prometheus-writer): Dockerfile
+
+eclipse-temurin:21-jre-alpine + curl (for compose healthcheck) + deltav
+non-root user, mirrors core/flow-enricher Dockerfile."
+```
+
+---
+
+## Task 22: `docker-compose.yml` — writer service + VictoriaMetrics
+
+**Goal:** Add `prometheus-writer` to `[lite, full]` profiles, `victoriametrics` to new `[metrics-e2e]` profile. Both services healthchecked.
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+
+- [ ] **Step 1: Add services** at the end of the existing services section (before the `volumes:` / `networks:` blocks). Exactly per spec §9 with the version pinned:
+
+```yaml
+  prometheus-writer:
+    image: opennms/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
+    profiles: [lite, full]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      provisiond:
+        condition: service_started
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9093
+      PROMETHEUS_WRITER_REMOTE_WRITE_URL: http://victoriametrics:8428/api/v1/write
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "18080:8080"
+
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.106.1
+    profiles: [metrics-e2e]
+    command:
+      - "-retentionPeriod=1h"
+      - "-storageDataPath=/tmp/vm"
+      - "-search.latencyOffset=1s"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:8428/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "18428:8428"
+```
+
+- [ ] **Step 2: Verify compose syntax**
+
+```bash
+cd opennms-container/delta-v && docker compose --profile lite --profile metrics-e2e config >/dev/null
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```
+git commit -m "feat(delta-v/compose): add prometheus-writer + victoriametrics services
+
+prometheus-writer in [lite, full] profiles. victoriametrics pinned to
+v1.106.1 in new [metrics-e2e] profile. Both healthchecked.
+
+In lite/full profiles without metrics-e2e, prometheus-writer starts
+healthy but opens its circuit on unreachable VM — an intentional
+degraded-but-stable state. Operators override PROMETHEUS_WRITER_REMOTE_WRITE_URL
+to point at their real TSDB."
+```
+
+---
+
+## Task 23: `build.sh` — `do_prometheus_writer_image()`
+
+**Goal:** Make `./build.sh deltav` (and the top-level `./build.sh`) build `opennms/prometheus-writer:${VERSION}`.
+
+**Files:**
+- Modify: `opennms-container/delta-v/build.sh`
+
+- [ ] **Step 1: Add the function**
+
+After the existing `do_flow_enricher_image()` function (near line 140), add:
+
+```bash
+do_prometheus_writer_image() {
+    log "Building prometheus-writer image (opennms/prometheus-writer:$VERSION)..."
+    cd "$REPO_ROOT"
+    ./mvnw -B -f core/prometheus-writer/pom.xml -DskipTests package
+    cd "$REPO_ROOT/core/prometheus-writer"
+    docker build -t "opennms/prometheus-writer:$VERSION" -t "opennms/prometheus-writer:latest" .
+}
+```
+
+- [ ] **Step 2: Call it from the deltav image build block**
+
+Find the block that calls `do_flow_enricher_image` (around line 236) and add a call to `do_prometheus_writer_image` right after it:
+
+```bash
+    # --- Build flow-enricher (standalone Spring Cloud Stream service) ---
+    do_flow_enricher_image
+
+    # --- Build prometheus-writer (Phase 2 standalone SCS consumer) ---
+    do_prometheus_writer_image
+```
+
+- [ ] **Step 3: Update the summary `docker images` filter** (line ~238) to include `prometheus-writer`:
+
+```bash
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer" | sort | head -20
+```
+
+- [ ] **Step 4: Run locally to verify**
+
+```bash
+./opennms-container/delta-v/build.sh images 2>&1 | tail -20
+```
+
+Expected: `opennms/prometheus-writer:<version>` appears in the final summary.
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(delta-v/build): add do_prometheus_writer_image to build.sh
+
+Called after do_flow_enricher_image. Pattern matches flow-enricher
+exactly: standalone mvnw package + docker build. Summary grep filter
+extended to include prometheus-writer."
+```
+
+---
+
+## Task 24: `test-prometheus-writer-e2e.sh` (6-step, pipefail-safe grep)
+
+**Goal:** Layer-5 end-to-end smoke test. All 6 scar prophylactics respected.
+
+**Files:**
+- Create: `opennms-container/delta-v/test-prometheus-writer-e2e.sh` (chmod +x)
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Copyright (C) 2026 BeaconStrategists, Inc.
+# Licensed under the GNU Affero General Public License v3.
+#
+# Layer 5 end-to-end smoke test for the prometheus-writer.  Starts the
+# delta-v Docker Compose stack (lite + metrics-e2e profiles: Collectd
+# produces to deltav-timeseries, Provisiond produces to
+# deltav-node-context, prometheus-writer consumes + enriches + POSTs to
+# VictoriaMetrics), then asserts:
+#
+#   1. prometheus-writer /actuator/health/readiness is UP (cache
+#      bootstrapped + binding resumed)
+#   2. NodeContextCache bootstrap fired cleanly
+#      (bootstrap_duration_seconds_count >= 1, cache_ready == 1)
+#   3. After 2 × 30 s Collectd poll cycles (~90 s wait),
+#      records_consumed_total > 0, samples_sent_total > 0,
+#      batches_sent_total > 0, circuit_state == 0 (closed)
+#   4. (folded into step 5 assertions below)
+#   5. Zero failure counters (batches_failed_total == 0,
+#      enrichment_missing_total == 0, samples_dropped_total == 0,
+#      dlq_records_total == 0)
+#   6. VictoriaMetrics query returns a result with the expected label
+#      set — the "gold standard" assertion that proves the full RW
+#      wire round-trip.
+#
+# Scar prophylactic: every grep pipeline guarded by { ... || true; }
+# because grep returns 1 on no-match and `set -euo pipefail` would kill
+# the script (Phase 1 scar).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+STACK_READY_TIMEOUT=180
+POLL_GRACE_SECONDS=90
+METRICS_TIMEOUT=180
+VM_QUERY_TIMEOUT=30
+
+cleanup() {
+    echo "==> Tearing down stack"
+    docker compose --profile lite --profile metrics-e2e down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "==> Starting delta-v Docker Compose (lite + metrics-e2e profiles)"
+docker compose --profile lite --profile metrics-e2e up -d --build
+
+# ── Step 1: Wait for prometheus-writer readiness ──────────────────────────────
+echo "==> Step 1: Wait for prometheus-writer /actuator/health/readiness"
+deadline=$((SECONDS + STACK_READY_TIMEOUT))
+while (( SECONDS < deadline )); do
+    if docker compose exec -T prometheus-writer \
+            curl -sf http://localhost:8080/actuator/health/readiness >/dev/null 2>&1; then
+        echo "==> prometheus-writer ready"
+        break
+    fi
+    sleep 3
+done
+if ! docker compose exec -T prometheus-writer \
+        curl -sf http://localhost:8080/actuator/health/readiness >/dev/null 2>&1; then
+    echo "FAIL: prometheus-writer did not become ready in ${STACK_READY_TIMEOUT}s"
+    docker compose logs prometheus-writer | tail -100
+    exit 1
+fi
+
+# ── Step 2: Assert startup gate fired cleanly ─────────────────────────────────
+echo "==> Step 2: Assert startup gate fired"
+metrics=$(docker compose exec -T prometheus-writer \
+        curl -sf http://localhost:8080/actuator/prometheus)
+
+ready=$({ echo "$metrics" | grep -E '^deltav_prometheus_writer_node_context_cache_ready\b' || true; } \
+        | awk '{print $2}' | head -1)
+if [[ "$ready" != "1.0" && "$ready" != "1" ]]; then
+    echo "FAIL: node_context_cache_ready != 1 (got: '$ready')"
+    exit 1
+fi
+
+boot_count=$({ echo "$metrics" | grep -E '^deltav_prometheus_writer_node_context_bootstrap_duration_seconds_count\b' || true; } \
+        | awk '{sum+=$2} END {print sum+0}')
+if (( $(echo "$boot_count < 1" | bc -l) )); then
+    echo "FAIL: bootstrap_duration_seconds_count < 1 (got: $boot_count)"
+    exit 1
+fi
+echo "==> Startup gate verified: cache_ready=1, bootstrap_count=$boot_count"
+
+# ── Step 3: Wait for Collectd polls ───────────────────────────────────────────
+echo "==> Step 3: Wait ${POLL_GRACE_SECONDS}s for Collectd to produce timeseries"
+sleep "${POLL_GRACE_SECONDS}"
+
+# ── Step 4: Assert samples flowed ─────────────────────────────────────────────
+echo "==> Step 4: Assert records/samples/batches flowed"
+metrics=$(docker compose exec -T prometheus-writer \
+        curl -sf http://localhost:8080/actuator/prometheus)
+
+assert_gt_zero() {
+    local name="$1"
+    local value
+    value=$({ echo "$metrics" | grep -E "^${name}\b" || true; } | awk '{sum+=$2} END {print sum+0}')
+    if (( $(echo "$value <= 0" | bc -l) )); then
+        echo "FAIL: ${name} is not > 0 (got: $value)"
+        exit 1
+    fi
+    echo "==> ${name} = ${value}"
+}
+
+assert_gt_zero 'deltav_prometheus_writer_records_consumed_total'
+assert_gt_zero 'deltav_prometheus_writer_samples_sent_total'
+assert_gt_zero 'deltav_prometheus_writer_batches_sent_total'
+
+circuit=$({ echo "$metrics" | grep -E '^deltav_prometheus_writer_circuit_state\b' || true; } | awk '{print $2}' | head -1)
+if [[ "$circuit" != "0.0" && "$circuit" != "0" ]]; then
+    echo "FAIL: circuit_state != 0 (got: '$circuit')"
+    exit 1
+fi
+echo "==> Circuit closed (state=0)"
+
+# ── Step 5: Assert zero failures ──────────────────────────────────────────────
+echo "==> Step 5: Assert zero failure counters"
+assert_zero() {
+    local name="$1"
+    local value
+    value=$({ echo "$metrics" | grep -E "^${name}" || true; } | awk '{sum+=$2} END {print sum+0}')
+    if (( $(echo "$value > 0" | bc -l) )); then
+        echo "FAIL: ${name} > 0 (got: $value)"
+        exit 1
+    fi
+    echo "==> ${name} = 0 ✓"
+}
+
+assert_zero 'deltav_prometheus_writer_batches_failed_total'
+assert_zero 'deltav_prometheus_writer_enrichment_missing_total'
+assert_zero 'deltav_prometheus_writer_samples_dropped_total'
+assert_zero 'deltav_prometheus_writer_dlq_records_total'
+
+# ── Step 6: Query VictoriaMetrics ─────────────────────────────────────────────
+echo "==> Step 6: Query VictoriaMetrics for the landed series"
+deadline=$((SECONDS + VM_QUERY_TIMEOUT))
+while (( SECONDS < deadline )); do
+    resp=$(curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_interface_errors_ifindiscards_total" \
+            || echo '{"data":{"result":[]}}')
+    count=$(echo "$resp" | docker compose exec -T prometheus-writer python3 -c \
+        'import json,sys; d=json.load(sys.stdin); print(len(d.get("data",{}).get("result",[])))' \
+        2>/dev/null || echo "0")
+    if (( count > 0 )); then
+        echo "==> VM returned ${count} series for opennms_mib2_interface_errors_ifindiscards_total"
+        # Assert expected labels
+        echo "$resp" | grep -E '"node_id":"[0-9]+"' > /dev/null || { echo "FAIL: missing node_id label"; exit 1; }
+        echo "$resp" | grep -E '"location":' > /dev/null || { echo "FAIL: missing location label"; exit 1; }
+        echo "$resp" | grep -E '"foreign_source":' > /dev/null || { echo "FAIL: missing foreign_source label"; exit 1; }
+        echo "$resp" | grep -E '"resource_instance":' > /dev/null || { echo "FAIL: missing resource_instance label"; exit 1; }
+        echo "==> ALL ASSERTIONS PASSED"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "FAIL: VictoriaMetrics returned no results within ${VM_QUERY_TIMEOUT}s"
+echo "Last VM response: $resp"
+exit 1
+```
+
+`chmod +x opennms-container/delta-v/test-prometheus-writer-e2e.sh`.
+
+- [ ] **Step 2: Run locally (requires Docker, `./build.sh deltav` completed recently)**
+
+```bash
+cd opennms-container/delta-v && ./test-prometheus-writer-e2e.sh
+```
+
+Expected: `ALL ASSERTIONS PASSED`.
+
+- [ ] **Step 3: Commit**
+
+```
+git commit -m "test(delta-v/e2e): test-prometheus-writer-e2e.sh — 6-step smoke test
+
+Brings up lite + metrics-e2e profiles. Asserts:
+  1. prometheus-writer readiness (cache bootstrap + binding resume)
+  2. bootstrap metrics fired
+  3. Collectd polls produced samples
+  4. records/samples/batches > 0, circuit closed
+  5. zero failure counters (grep wrapped in { ... || true; } for pipefail)
+  6. VictoriaMetrics query returns series with expected label set
+
+The final VM query is the gold standard — proves the full RW wire
+round-trip, not just 'our process sent something.'"
+```
+
+---
+
+## Task 25: Freeze schemas + README update + full-reactor verify
+
+**Goal:** Per spec Schema-freeze decision: update both `.proto` headers to reflect Phase 2 GA wire-freeze. Update README. Run full-reactor build.
+
+**Files:**
+- Modify: `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto` (header comment only)
+- Modify: `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto` (header comment only)
+- Modify: `opennms-container/delta-v/README.md`
+
+- [ ] **Step 1: Update both .proto headers**
+
+In each file, replace the existing versioning comment block (lines about "during Phase 1 (feature flag off in production) breaking schema changes are permissible...") with:
+
+```protobuf
+// API version: 1 (FROZEN at Phase 2 GA — delta-v#<TBD-phase-2-PR>)
+//
+// Public contract for the deltav-timeseries Kafka topic.
+//
+// Versioning: this wire format is frozen as of Phase 2 GA. Only
+// forward-compatible changes are permitted: new fields with new tag
+// numbers, new enum values appended at the end. Renaming or renumbering
+// existing fields, deleting fields, or changing field types are breaking
+// changes that require bumping to // API version: 2 with a one-release
+// deprecation cycle maintaining v1 as read-only.
+```
+
+(Same block for node-context, except `deltav-node-context`.) The `<TBD-phase-2-PR>` placeholder is resolved in the PR description after merge.
+
+- [ ] **Step 2: Add Phase 2 README section**
+
+Append to `opennms-container/delta-v/README.md`:
+
+```markdown
+## Phase 2 — Prometheus Remote Write consumer
+
+The `prometheus-writer` service consumes `deltav-timeseries`, enriches each
+batch with node identity from `deltav-node-context`, and POSTs Snappy-compressed
+Prometheus Remote Write protobuf batches to a configurable endpoint.
+
+### Profiles
+
+- **lite, full** — starts `prometheus-writer`. Point `PROMETHEUS_WRITER_REMOTE_WRITE_URL`
+  at your TSDB (Mimir, VictoriaMetrics, Cortex, Thanos Receive, Prometheus with
+  `--web.enable-remote-write-receiver`). Without a reachable target, the writer
+  starts healthy, opens its circuit on first POST failure, and stays paused.
+- **metrics-e2e** — adds a pinned `victoriametrics:v1.106.1` container for E2E.
+  Not intended for production.
+
+### Configuration
+
+Environment variables (also see `core/prometheus-writer/src/main/resources/application.yml`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PROMETHEUS_WRITER_REMOTE_WRITE_URL` | `http://victoriametrics:8428/api/v1/write` | RW endpoint |
+| `PROMETHEUS_WRITER_AUTH_TYPE` | `none` | `none` / `bearer` / `basic` |
+| `PROMETHEUS_WRITER_BEARER_TOKEN` | (empty) | Bearer token when `AUTH_TYPE=bearer` |
+| `PROMETHEUS_WRITER_BASIC_USER` | (empty) | Basic auth user |
+| `PROMETHEUS_WRITER_BASIC_PASS` | (empty) | Basic auth pass |
+| `SPRING_KAFKA_BOOTSTRAP_SERVERS` | `kafka:9093` (compose) | Kafka brokers |
+
+Extra headers (e.g. `X-Scope-OrgID` for Mimir tenancy) via yaml
+`prometheus-writer.remote-write.headers.{name}: "{value}"`.
+
+Opt-in metadata-label promotion:
+
+```yaml
+prometheus-writer:
+  labels:
+    from-metadata:
+      - requisition:region
+      - snmp:sysLocation
+```
+
+### Metrics
+
+All exposed at `/actuator/prometheus`, prefix `deltav_prometheus_writer_`.
+See `docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md` §7
+for the full list.
+
+Useful PromQL examples:
+
+```
+rate(deltav_prometheus_writer_samples_sent_total[5m])
+rate(deltav_prometheus_writer_enrichment_missing_total[5m])
+deltav_prometheus_writer_circuit_state         # 0=closed, 1=half_open, 2=open
+deltav_prometheus_writer_node_context_cache_size
+```
+
+### Topics
+
+- Consumes `deltav-timeseries` (group `prometheus-writer`)
+- Consumes `deltav-node-context` (unique group per instance)
+- Produces to `deltav-prometheus-writer-dlq` (poison-pill records only)
+
+### Wire format frozen
+
+As of Phase 2 GA, both `deltav-timeseries` and `deltav-node-context` protobuf
+schemas are frozen. Only forward-compatible additions (new tag numbers) permitted.
+```
+
+- [ ] **Step 3: Full-reactor verify gate** (scar prophylactic #4)
+
+```bash
+./mvnw -B -DskipTests -fae clean install
+```
+
+Expected: every module builds. If any module fails with `cannot find symbol` referencing a Prometheus proto class, the fix is usually adding the `core/deltav-kafka-contracts` dependency to that module.
+
+- [ ] **Step 4: Rebuild all services reminder** (scar prophylactic #5)
+
+Confirm by running:
+
+```bash
+./opennms-container/delta-v/build.sh
+```
+
+Expected: all 13 daemon-boot jars + flow-enricher + **prometheus-writer** appear in the summary output.
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "docs(prometheus-writer): freeze wire contracts at Phase 2 GA + README
+
+Both deltav-timeseries.proto and deltav-node-context.proto headers updated:
+API version 1 FROZEN; only forward-compatible additions permitted.
+Breaking changes require API v2 with deprecation cycle.
+
+README: new Phase 2 section (profiles, config env vars, metric examples,
+topic map, wire-freeze notice)."
+```
+
+---
+
+## Task 26: Final acceptance gate — scar prophylactic checklist + PR
+
+**Goal:** Before opening the PR, verify all 6 scar prophylactics are in place and passing. Then open the PR against `pbrane/delta-v`.
+
+- [ ] **Step 1: Verify prophylactic #1 (real-main-class IT)**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=PrometheusWriterApplicationScanIT
+```
+Expected: PASS. (Task 19.)
+
+- [ ] **Step 2: Verify prophylactic #2 (yaml parity)**
+
+Grep all `ApplicationContextInitializer`-style property overrides in the IT code and confirm each also appears in `src/main/resources/application.yml`:
+
+```bash
+grep -nE 'DynamicPropertyRegistry|TestPropertyValues' core/prometheus-writer/src/test/java | awk -F: '{print $1}' | sort -u
+```
+
+For each referenced property (`spring.kafka.bootstrap-servers`, `spring.cloud.stream.kafka.binder.brokers`, `prometheus-writer.remote-write.url`, etc.) confirm it's in `application.yml`.
+
+- [ ] **Step 3: Verify prophylactic #3 (`use-native-encoding: true` on DLQ binding)**
+
+```bash
+grep -nE 'publishDlq-out-0' core/prometheus-writer/src/main/resources/application.yml
+grep -nE 'use-native-encoding' core/prometheus-writer/src/main/resources/application.yml
+```
+Expected: both match, on adjacent lines under the DLQ binding.
+
+- [ ] **Step 4: Verify prophylactic #4 (full-reactor clean install passes)**
+
+```bash
+./mvnw -B -DskipTests -fae clean install 2>&1 | tail -20
+```
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 5: Verify prophylactic #5 (rebuild-all reminder in PR template — done via PR body)**
+
+The PR description MUST include:
+
+```markdown
+## Rebuild checklist
+- [ ] All 13 daemon-boot jars built (`./opennms-container/delta-v/build.sh`)
+- [ ] flow-enricher rebuilt
+- [ ] prometheus-writer rebuilt
+- [ ] Full-reactor `./mvnw clean install -DskipTests -fae` passes locally
+- [ ] `test-prometheus-writer-e2e.sh` passes locally (lite + metrics-e2e)
+```
+
+- [ ] **Step 6: Verify prophylactic #6 (pipefail-safe grep in E2E)**
+
+```bash
+grep -nE '\| *awk.*END *\{print.*\+0\}' opennms-container/delta-v/test-prometheus-writer-e2e.sh | head -5
+grep -nE '\|\| *true' opennms-container/delta-v/test-prometheus-writer-e2e.sh | wc -l
+```
+Expected: every counter-assertion grep has `|| true` guard (count should be ≥ 8).
+
+- [ ] **Step 7: Run the full test suite one last time**
+
+```bash
+./mvnw -pl core/prometheus-writer test
+./mvnw -pl core/prometheus-writer verify  # includes ITs
+```
+Expected: all green.
+
+- [ ] **Step 8: Run the E2E one last time**
+
+```bash
+cd opennms-container/delta-v && ./test-prometheus-writer-e2e.sh
+```
+Expected: `ALL ASSERTIONS PASSED`.
+
+- [ ] **Step 9: Push branch + open PR**
+
+```bash
+git push -u origin feature/kafka-ts-phase-2-prometheus-consumer
+gh pr create --repo pbrane/delta-v --base develop \
+    --title "feat: Kafka TS Phase 2 — Prometheus Remote Write consumer" \
+    --body "$(cat <<'BODY'
+## Summary
+- New `core/prometheus-writer/` standalone Spring Boot consumer
+- Consumes `deltav-timeseries`, enriches via `deltav-node-context` cache
+- POSTs Prometheus Remote Write to configurable endpoint
+- Resilience4j circuit breaker + SCS binding pause/resume
+- DLQ topic for poison pills (400/413)
+- Startup gate ensures cache bootstrapped before consumption resumes
+- Both wire contracts frozen at Phase 2 GA
+
+## Rebuild checklist
+- [x] All 13 daemon-boot jars built
+- [x] flow-enricher rebuilt
+- [x] prometheus-writer rebuilt
+- [x] Full-reactor `./mvnw clean install -DskipTests -fae` passes locally
+- [x] `test-prometheus-writer-e2e.sh` passes locally
+
+## Scar prophylactic verification
+- [x] #1 Real-main-class IT (`PrometheusWriterApplicationScanIT`) passes
+- [x] #2 Production yaml carries every Testcontainers-set property
+- [x] #3 `use-native-encoding: true` on DLQ producer binding
+- [x] #4 Full-reactor build green
+- [x] #5 Rebuild-all reminder present (this checklist)
+- [x] #6 Pipefail-safe `|| true` guards on all grep-driven assertions
+
+## Test plan
+- [x] Unit tests (all green, all new code covered)
+- [x] SCS test-binder ITs
+- [x] Testcontainers Kafka ITs (`NodeContextKafkaBootstrapIT`, `RwRoundTripIT`, `CircuitBreakerIT`)
+- [x] Real-main-class IT
+- [x] 6-step Docker Compose E2E (lite + metrics-e2e profiles)
+
+## Spec + plan
+- Spec: `docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md`
+- Plan: `docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer.md` (+ `-part2.md`)
+BODY
+)"
+```
+
+- [ ] **Step 10: PR hygiene**
+
+After PR opens:
+- Link the PR in the design spec by replacing `<TBD-phase-2-PR>` in both proto headers with the actual PR number in a follow-up commit (`git commit -m "docs: update proto frozen-in header with Phase 2 PR number"`). Push.
+- Update the `project_kafka_timeseries_pipeline.md` memory note after merge to reflect Phase 2 = DONE.
+
+---
+
+## Self-review
+
+**Spec coverage check** (spec section → task):
+
+| Spec section | Covered in task(s) |
+|---|---|
+| §Problem / §Non-goals | Plan preamble + Task 25 freeze |
+| §Architecture data flow | Tasks 2, 15, 17, 22 |
+| §Architecture key properties | Tasks 4, 7, 14, 16, 17 |
+| §Module structure | Task 2 |
+| §Key beans | Tasks 4-19 (one bean per task typically) |
+| §1 NodeContextCache bootstrap | Tasks 4, 5 |
+| §2 Startup gate | Tasks 6, 7 |
+| §3 Metric naming + labels | Tasks 8, 9 |
+| §4 Sample construction | Task 10 |
+| §5 RW output pipeline | Tasks 11, 12, 13, 14 |
+| §6 DLQ | Task 17 |
+| §7 Observability | Task 18 (+ all producer-site tasks) |
+| §8 Configuration | Task 3 |
+| §9 Docker integration | Tasks 21, 22, 23 |
+| §10 E2E script | Task 24 |
+| Scar prophylactics | Tasks 3 (yaml parity), 17 (use-native-encoding), 19 (real-main-class), 24 (pipefail-safe grep), 25 (full-reactor), 26 (verify-all) |
+| Testing strategy | Tasks 4-18 (unit + SCS binder + Testcontainers), Task 19 (real-main-class), Task 20 (full round-trip), Task 24 (E2E) |
+| Schema freeze decision | Task 25 |
+| Rollout | Task 22 (compose defaults) + Task 25 (README) |
+
+**Placeholder scan:** `<TBD-phase-2-PR>` is the only placeholder, and Task 26 Step 10 resolves it after PR opens. No `TODO`/`FIXME`/"implement later" in any task body.
+
+**Type consistency:** Bean names used downstream match the classes introduced upstream:
+- `NodeContextCache`, `NodeContextKafkaBootstrap`, `NodeContextCacheHealthIndicator`, `NodeContextCacheReadyEvent` — Tasks 4, 5, 6
+- `TimeseriesBindingStartupGate`, `TimeseriesBindingResumer` — Task 7
+- `NameSanitizer`, `LabelBuilder`, `PromSample`, `TimeseriesToPromTranslator` — Tasks 8, 9, 10
+- `WriteRequestBuilder`, `RemoteWriteHttpClient`, `RemoteWriteRetryPolicy`, `BatchingRwWriter`, `PrometheusWriterCircuitBreaker`, `ConsumerPauseListener` — Tasks 11, 12, 13, 14, 16
+- `TimeseriesConsumer` bean name `timeseriesConsumer-in-0` — Task 15 + yaml in Task 3 + startup gate references in Task 7
+- `DlqPublisher` + `publishDlq-out-0` + `deltavPrometheusWriterDlqTopic` — Task 17 + yaml in Task 3
+- `PrometheusWriterMetrics` constants — Task 18 + all producer-site tasks reference them after Task 18's refactor step
+
+**Scope:** Phase 2 is one focused implementation; the plan covers it in 26 tasks. No decomposition needed.

--- a/docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer.md
+++ b/docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer.md
@@ -1,0 +1,1484 @@
+# Kafka Time Series Phase 2 — Prometheus Remote Write Consumer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first consumer of the delta-v Kafka Time Series pipeline. A new standalone Spring Boot 4 service (`core/prometheus-writer/`) consumes `deltav-timeseries`, enriches each batch with a local materialization of `deltav-node-context`, transforms to Prometheus Remote Write samples, and POSTs Snappy-compressed protobuf batches to a configurable RW endpoint — with tiered retry, Resilience4j circuit breaker, DLQ topic, and Kafka-lag backpressure.
+
+**Architecture:** Stateless hot path. Plain Spring Cloud Stream Kafka binder for `deltav-timeseries` (no Kafka Streams, no GlobalKTable). Dedicated `NodeContextCache` bean with its own Kafka consumer bootstraps from `deltav-node-context` compacted topic before the timeseries binding is resumed (startup gate). Translation is a pure function `(TimeseriesBatch, Optional<NodeContext>) → List<PromSample>`. `BatchingRwWriter` buffers samples (1000 / 1 MB / 1 s whichever first) and delegates to `RemoteWriteHttpClient` guarded by Resilience4j. Poison-pill batches (400 / 413) land in a new `deltav-prometheus-writer-dlq` Kafka topic.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.3, Spring Cloud Stream 5.x Kafka binder, Spring 6 `RestClient`, Resilience4j circuit breaker, Snappy compression, vendored Prometheus `remote.proto` + `types.proto`, protobuf 3.25.5 via `protobuf-maven-plugin` 0.6.1, Micrometer Prometheus, JUnit 5, Mockito, MockWebServer, `spring-cloud-stream-test-binder`, Testcontainers Kafka.
+
+**Design doc:** `docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md`
+**Next-session prompt (implementation):** `docs/superpowers/next-session-prompts/2026-04-18-kafka-ts-phase-2-implementation.md` (written in this planning session)
+**Feature branch:** `feature/kafka-ts-phase-2-prometheus-consumer` (already created; spec commit `a0936466b67` present on branch)
+
+**Critical memory references:**
+- `feedback_never_pr_opennms` — delta-v PRs always use `gh pr create --repo pbrane/delta-v`
+- `feedback_feature_branches` — never commit directly to `develop`
+- `feedback_deltav_package_namespace` — new code under `org.deltav.*` with BeaconStrategists copyright
+- `feedback_delta_v_uses_mvnw_not_compile_pl` — all builds use `./mvnw`
+- `feedback_delta_v_full_reactor_verify` — full-reactor build after cross-module changes
+- `feedback_rebuild_all_daemons` — before `./build.sh deltav`, rebuild all 13 daemon-boot jars + flow-enricher + prometheus-writer
+- `feedback_spring_boot_scan_package_trap` — real-main-class IT mandatory (Task 19)
+- `feedback_spring_cloud_stream_splitter` — `use-native-encoding: true` on byte-array producer bindings (Task 17)
+- `feedback_bom_import_precedence` — Spring Boot BOM must be imported before horizon BOM
+
+**Spec section map (for cross-reference):**
+- Spec §1 NodeContextCache bootstrap → Tasks 4-5
+- Spec §2 Startup gate → Task 7
+- Spec §3 Metric naming + labels → Tasks 8-9
+- Spec §4 Sample construction → Task 10
+- Spec §5 RW output pipeline → Tasks 11-14
+- Spec §6 DLQ → Task 17
+- Spec §7 Observability → Task 18
+- Spec §8 Configuration yaml → Task 3
+- Spec §9 Docker integration → Tasks 21-23
+- Spec §10 E2E script → Task 24
+- Spec "Scar prophylactics" → woven through: Task 3 (yaml parity), Task 17 (use-native-encoding), Task 19 (real-main-class IT), Task 24 (pipefail-safe grep), Task 25 (full-reactor verify + rebuild-all reminder)
+
+---
+
+## File Structure
+
+### New files
+
+```
+core/deltav-kafka-contracts/src/main/proto/
+├── prometheus/prompb/remote.proto                        vendored upstream
+└── prometheus/prompb/types.proto                         vendored upstream
+
+core/prometheus-writer/
+├── pom.xml
+├── Dockerfile
+└── src/main/
+    ├── java/org/deltav/prometheus/writer/
+    │   ├── PrometheusWriterApplication.java              @SpringBootApplication main
+    │   ├── PrometheusWriterConfiguration.java            @Configuration + @EnableConfigurationProperties
+    │   ├── config/
+    │   │   ├── PrometheusWriterProperties.java           @ConfigurationProperties("prometheus-writer")
+    │   │   └── KafkaTopicsConfiguration.java             @Bean NewTopic deltavPrometheusWriterDlqTopic
+    │   ├── nodecontext/
+    │   │   ├── NodeContextCache.java                     ConcurrentHashMap holder
+    │   │   ├── NodeContextKafkaBootstrap.java            dedicated consumer + HWM bootstrap
+    │   │   ├── NodeContextCacheHealthIndicator.java      HealthIndicator for readiness
+    │   │   └── NodeContextCacheReadyEvent.java           Spring ApplicationEvent
+    │   ├── startup/
+    │   │   ├── TimeseriesBindingStartupGate.java         ListenerContainerCustomizer (starts paused)
+    │   │   └── TimeseriesBindingResumer.java             @EventListener(NodeContextCacheReadyEvent.class)
+    │   ├── translate/
+    │   │   ├── PromSample.java                           record(name, labels, value, timestampMs)
+    │   │   ├── NameSanitizer.java                        sanitize + collision detection
+    │   │   ├── LabelBuilder.java                         default labels + metadata allowlist
+    │   │   └── TimeseriesToPromTranslator.java           pure function batch → List<PromSample>
+    │   ├── consume/
+    │   │   ├── TimeseriesConsumer.java                   SCS Function<Message<byte[]>, Void>
+    │   │   └── TimeseriesConsumerBinding.java            @Bean definition registration
+    │   ├── rw/
+    │   │   ├── BatchingRwWriter.java                     accumulate + flush on thresholds
+    │   │   ├── RemoteWriteHttpClient.java                RestClient + Snappy + auth
+    │   │   ├── RemoteWriteRetryPolicy.java               status-code classifier
+    │   │   ├── PrometheusWriterCircuitBreaker.java       Resilience4j bean
+    │   │   ├── ConsumerPauseListener.java                circuit → binding pause/resume
+    │   │   └── WriteRequestBuilder.java                  samples → WriteRequest protobuf
+    │   ├── dlq/
+    │   │   └── DlqPublisher.java                         SCS StreamBridge send to DLQ
+    │   └── metrics/
+    │       └── PrometheusWriterMetrics.java              central Micrometer meter declarations
+    └── resources/
+        ├── application.yml
+        └── logback-spring.xml                            standard delta-v log config
+
+core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/
+├── nodecontext/
+│   ├── NodeContextCacheTest.java
+│   ├── NodeContextKafkaBootstrapIT.java                  Testcontainers Kafka
+│   └── NodeContextCacheHealthIndicatorTest.java
+├── startup/
+│   └── TimeseriesBindingStartupGateTest.java
+├── translate/
+│   ├── NameSanitizerTest.java
+│   ├── LabelBuilderTest.java
+│   └── TimeseriesToPromTranslatorTest.java
+├── rw/
+│   ├── RemoteWriteHttpClientTest.java                    MockWebServer
+│   ├── RemoteWriteRetryPolicyTest.java
+│   ├── BatchingRwWriterTest.java
+│   ├── PrometheusWriterCircuitBreakerTest.java
+│   ├── ConsumerPauseListenerTest.java
+│   ├── WriteRequestBuilderTest.java
+│   └── RwRoundTripIT.java                                Testcontainers + MockWebServer
+├── dlq/
+│   └── DlqPublisherBinderIT.java                         SCS test-binder
+├── consume/
+│   └── TimeseriesConsumerBinderIT.java                   SCS test-binder
+└── PrometheusWriterApplicationScanIT.java                real-main-class
+
+opennms-container/delta-v/
+├── Dockerfile.prometheus-writer                          new
+└── test-prometheus-writer-e2e.sh                         6-step E2E
+```
+
+### Modified files
+
+```
+pom.xml                                                    add core/prometheus-writer to <modules>
+core/deltav-kafka-contracts/pom.xml                        (no changes — existing protobuf-maven-plugin picks up new vendored protos)
+core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto
+                                                           update header comment: Phase 2 GA freeze
+core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+                                                           update header comment: Phase 2 GA freeze
+opennms-container/delta-v/docker-compose.yml               add prometheus-writer + victoriametrics services
+opennms-container/delta-v/build.sh                         add do_prometheus_writer_image() + call site
+opennms-container/delta-v/README.md                        Phase 2 section (env vars, metrics, topic)
+```
+
+---
+
+## Task ordering rationale
+
+The plan has **26 tasks** in 8 groups. The ordering is dependency-driven and commit-boundaried:
+
+1. **Foundation (Tasks 1-3)** — contracts + module skeleton + config property classes. Nothing depends on anything; these commits are independent.
+2. **Cache subsystem (Tasks 4-6)** — `NodeContextCache` hierarchy. Task 5 is the only one that needs Testcontainers.
+3. **Startup gate (Task 7)** — depends on cache subsystem being wired.
+4. **Translation (Tasks 8-10)** — pure functions, fully unit-tested in isolation.
+5. **RW output (Tasks 11-14)** — HTTP client, retry, batching, circuit breaker. Each is independently testable.
+6. **Wiring + DLQ + Observability (Tasks 15-18)** — ties the pipeline together.
+7. **Integration verification (Tasks 19-20)** — real-main-class IT + full Testcontainers round-trip.
+8. **Docker + E2E + Docs (Tasks 21-26)** — deployment artifacts and the 6-step E2E; final task freezes schemas and queues the next-session prompt.
+
+Each task ends with a commit. Commits are small (one subsystem or one concern per commit) so reviews and reverts are targeted.
+
+---
+
+## Task 1: Vendor Prometheus `remote.proto` + `types.proto`
+
+**Goal:** Make `WriteRequest`, `TimeSeries`, `Sample`, `Label`, and `MetricMetadata` protobuf Java classes available in `core/deltav-kafka-contracts`.
+
+**Files:**
+- Create: `core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/types.proto`
+- Create: `core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/remote.proto`
+
+- [ ] **Step 1: Create the directory**
+
+```bash
+mkdir -p core/deltav-kafka-contracts/src/main/proto/prometheus/prompb
+```
+
+- [ ] **Step 2: Write `types.proto`**
+
+Vendor the upstream Prometheus protobuf types verbatim from <https://github.com/prometheus/prometheus/blob/main/prompb/types.proto> (Apache-2.0 licensed). Write to `core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/types.proto`:
+
+```protobuf
+// Copyright 2017 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Vendored into delta-v for use by the prometheus-writer Remote Write client.
+// Source: github.com/prometheus/prometheus/prompb/types.proto (Apache-2.0)
+
+syntax = "proto3";
+package prometheus;
+
+option go_package = "github.com/prometheus/prometheus/prompb";
+option java_package = "prometheus.prompb";
+option java_multiple_files = true;
+
+message MetricMetadata {
+  enum MetricType {
+    UNKNOWN        = 0;
+    COUNTER        = 1;
+    GAUGE          = 2;
+    HISTOGRAM      = 3;
+    GAUGEHISTOGRAM = 4;
+    SUMMARY        = 5;
+    INFO           = 6;
+    STATESET       = 7;
+  }
+
+  MetricType type = 1;
+  string metric_family_name = 2;
+  string help = 4;
+  string unit = 5;
+}
+
+message Sample {
+  double value    = 1;
+  int64 timestamp = 2;
+}
+
+message Exemplar {
+  repeated Label labels = 1;
+  double value          = 2;
+  int64 timestamp       = 3;
+}
+
+message TimeSeries {
+  repeated Label labels      = 1;
+  repeated Sample samples    = 2;
+  repeated Exemplar exemplars = 3;
+}
+
+message Label {
+  string name  = 1;
+  string value = 2;
+}
+
+message Labels {
+  repeated Label labels = 1;
+}
+
+message LabelMatcher {
+  enum Type {
+    EQ  = 0;
+    NEQ = 1;
+    RE  = 2;
+    NRE = 3;
+  }
+  Type type    = 1;
+  string name  = 2;
+  string value = 3;
+}
+
+message ReadHints {
+  int64 step_ms   = 1;
+  string func     = 2;
+  int64 start_ms  = 3;
+  int64 end_ms    = 4;
+  repeated string grouping = 5;
+  bool by         = 6;
+  int64 range_ms  = 7;
+}
+
+message Chunk {
+  int64 min_time_ms = 1;
+  int64 max_time_ms = 2;
+
+  enum Encoding {
+    UNKNOWN = 0;
+    XOR     = 1;
+    HISTOGRAM = 2;
+    FLOAT_HISTOGRAM = 3;
+  }
+  Encoding type = 3;
+  bytes data    = 4;
+}
+
+message ChunkedSeries {
+  repeated Label labels = 1;
+  repeated Chunk chunks = 2;
+}
+```
+
+- [ ] **Step 3: Write `remote.proto`**
+
+Vendor from <https://github.com/prometheus/prometheus/blob/main/prompb/remote.proto>. Write to `core/deltav-kafka-contracts/src/main/proto/prometheus/prompb/remote.proto`:
+
+```protobuf
+// Copyright 2017 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Vendored into delta-v for use by the prometheus-writer Remote Write client.
+// Source: github.com/prometheus/prometheus/prompb/remote.proto (Apache-2.0)
+
+syntax = "proto3";
+package prometheus;
+
+option go_package = "github.com/prometheus/prometheus/prompb";
+option java_package = "prometheus.prompb";
+option java_multiple_files = true;
+
+import "prometheus/prompb/types.proto";
+
+message WriteRequest {
+  repeated TimeSeries timeseries = 1;
+  reserved 2;  // formerly source
+  repeated MetricMetadata metadata = 3;
+}
+
+message ReadRequest {
+  repeated Query queries = 1;
+
+  enum ResponseType {
+    SAMPLES             = 0;
+    STREAMED_XOR_CHUNKS = 1;
+  }
+  repeated ResponseType accepted_response_types = 2;
+}
+
+message ReadResponse {
+  repeated QueryResult results = 1;
+}
+
+message Query {
+  int64 start_timestamp_ms = 1;
+  int64 end_timestamp_ms   = 2;
+  repeated LabelMatcher matchers = 3;
+  ReadHints hints          = 4;
+}
+
+message QueryResult {
+  repeated TimeSeries timeseries = 1;
+}
+
+message ChunkedReadResponse {
+  repeated ChunkedSeries chunked_series = 1;
+  int64 query_index = 2;
+}
+```
+
+- [ ] **Step 4: Build contracts to verify protoc generates**
+
+```bash
+./mvnw -pl core/deltav-kafka-contracts clean install -DskipTests
+```
+
+Expected: `BUILD SUCCESS`. Verify generated classes:
+
+```bash
+ls core/deltav-kafka-contracts/target/generated-sources/protobuf/java/prometheus/prompb/ | sort
+```
+
+Expected includes: `WriteRequest.java`, `TimeSeries.java`, `Sample.java`, `Label.java`, `MetricMetadata.java`, `Exemplar.java`, `Chunk.java`, `Labels.java`, `LabelMatcher.java`, `ReadHints.java`, `ReadRequest.java`, `ReadResponse.java`, `Query.java`, `QueryResult.java`, `ChunkedReadResponse.java`, `ChunkedSeries.java`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/deltav-kafka-contracts/src/main/proto/prometheus
+git commit -m "feat(kafka-contracts): vendor Prometheus remote.proto + types.proto
+
+Phase 2 Prometheus Remote Write consumer needs WriteRequest/TimeSeries/
+Sample/Label protobuf classes to build RW payloads. Vendored from
+github.com/prometheus/prometheus/prompb (Apache-2.0) into the shared
+contracts module so the prometheus-writer (and any future consumer
+needing RW output) can depend on them without pulling the upstream
+Prometheus Go artifacts.
+
+Generated java package: prometheus.prompb"
+```
+
+---
+
+## Task 2: Create `core/prometheus-writer/` module skeleton
+
+**Goal:** Maven module exists and builds an empty jar. Nothing runs yet.
+
+**Files:**
+- Create: `core/prometheus-writer/pom.xml`
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/PrometheusWriterApplication.java`
+- Create: `core/prometheus-writer/src/main/resources/logback-spring.xml`
+- Modify: `pom.xml` (root) — add module
+
+- [ ] **Step 1: Write `core/prometheus-writer/pom.xml`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>prometheus-writer</artifactId>
+    <name>Delta-V :: Core :: Prometheus Remote Write Consumer</name>
+    <description>Spring Cloud Stream service that consumes deltav-timeseries, enriches
+        each batch against a local materialization of deltav-node-context, transforms
+        to Prometheus Remote Write samples, and POSTs Snappy-compressed protobuf
+        batches to a configurable RW endpoint.</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
+        <snappy.version>1.1.10.5</snappy.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Spring Cloud Stream + Kafka binder -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-binder-kafka</artifactId>
+        </dependency>
+
+        <!-- Kafka client (dedicated NodeContextKafkaBootstrap consumer) -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <!-- Protocol Buffers (generated classes from contracts) -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>deltav-kafka-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <!-- Snappy for Remote Write compression -->
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.version}</version>
+        </dependency>
+
+        <!-- Resilience4j for circuit breaker -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-micrometer</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+
+        <!-- Micrometer Prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream-test-binder</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- junit-platform-launcher: required by surefire 3.5.4 for Boot 4 modules
+             (feedback_boot4_junit_platform_launcher) -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>prometheus-writer</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>org.deltav.prometheus.writer.PrometheusWriterApplication</mainClass>
+                    <executable>true</executable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+- [ ] **Step 2: Write the main class**
+
+Write `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/PrometheusWriterApplication.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.prometheus.writer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Entry point for the Delta-V prometheus-writer service.
+ *
+ * <p>Spring Boot 4.0 + Spring Cloud Stream consumer that reads
+ * {@code TimeseriesBatch} protobuf records from the {@code deltav-timeseries}
+ * Kafka topic, enriches each batch with node identity from a local
+ * materialization of the compacted {@code deltav-node-context} topic,
+ * translates to Prometheus Remote Write samples, and POSTs Snappy-compressed
+ * protobuf batches to a configurable RW endpoint.
+ *
+ * <p>Phase 2 of the Kafka Time Series pipeline. See:
+ * {@code docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md}
+ */
+@SpringBootApplication(scanBasePackages = {"org.deltav.prometheus.writer"})
+@EnableScheduling
+public class PrometheusWriterApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PrometheusWriterApplication.class, args);
+    }
+}
+```
+
+> **Scar prophylactic baked in:** `scanBasePackages` is explicit from day one. Phase 0 #170 scar (silent scan-package gap) is structurally impossible when the package root is declared up front.
+
+- [ ] **Step 3: Write `logback-spring.xml`**
+
+Copy `core/flow-enricher/src/main/resources/logback-spring.xml` verbatim to `core/prometheus-writer/src/main/resources/logback-spring.xml`. (Delta-v logging conventions — JSON output with MDC fields for `service` and `trace_id`.)
+
+- [ ] **Step 4: Register module in root pom**
+
+In `/Users/david/development/src/opennms/delta-v/pom.xml`, locate the "Flow processing services (Spring Cloud Stream)" comment block and add `core/prometheus-writer` as a peer of `core/flow-enricher`:
+
+```xml
+    <!-- Flow processing services (Spring Cloud Stream) -->
+    <module>core/flow-enricher</module>
+    <module>core/prometheus-writer</module>
+```
+
+- [ ] **Step 5: Verify module builds**
+
+```bash
+./mvnw -pl core/prometheus-writer -am clean install -DskipTests
+```
+
+Expected: `BUILD SUCCESS`. Produces `core/prometheus-writer/target/prometheus-writer.jar` (executable fat jar).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/prometheus-writer pom.xml
+git commit -m "feat(prometheus-writer): create core/prometheus-writer Maven module skeleton
+
+Phase 2 standalone Spring Boot 4 service. Follows the core/flow-enricher
+precedent: separate module (NOT core/daemon-boot-*), fat jar, own Docker
+image, own compose service.
+
+Dependencies: Spring Cloud Stream Kafka binder, Spring Kafka (dedicated
+NodeContextKafkaBootstrap consumer), vendored Prometheus protobufs from
+deltav-kafka-contracts, Snappy for RW compression, Resilience4j circuit
+breaker, Micrometer Prometheus, spring-cloud-stream-test-binder,
+Testcontainers Kafka, MockWebServer, awaitility.
+
+scanBasePackages={org.deltav.prometheus.writer} declared up front —
+Phase 0 #170 scar prophylactic."
+```
+
+---
+
+## Task 3: Configuration properties + `application.yml`
+
+**Goal:** Ship the canonical `application.yml` (spec §8) and the `@ConfigurationProperties` classes that bind it. Fail at startup if mandatory config is absent.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/PrometheusWriterProperties.java`
+- Create: `core/prometheus-writer/src/main/resources/application.yml`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/config/PrometheusWriterPropertiesTest.java`
+
+- [ ] **Step 1: Write failing test**
+
+Write `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/config/PrometheusWriterPropertiesTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrometheusWriterPropertiesTest {
+
+    @Test
+    void binds_full_yaml_shape() {
+        Map<String, Object> map = Map.of(
+                "prometheus-writer.remote-write.url", "http://vm:8428/api/v1/write",
+                "prometheus-writer.remote-write.auth.type", "bearer",
+                "prometheus-writer.remote-write.auth.bearer-token", "abc",
+                "prometheus-writer.remote-write.headers.X-Scope-OrgID", "tenant-1",
+                "prometheus-writer.batch.max-samples", "1000",
+                "prometheus-writer.batch.max-bytes", "1048576",
+                "prometheus-writer.batch.max-interval-ms", "1000",
+                "prometheus-writer.retry.initial-backoff-ms", "100",
+                "prometheus-writer.retry.max-backoff-ms", "30000",
+                "prometheus-writer.circuit-breaker.failure-rate-threshold", "50",
+                "prometheus-writer.labels.from-metadata[0]", "requisition:region",
+                "prometheus-writer.startup-gate.enabled", "true"
+        );
+        ConfigurationPropertySource src = new MapConfigurationPropertySource(map);
+        PrometheusWriterProperties props = new Binder(src)
+                .bind("prometheus-writer", Bindable.of(PrometheusWriterProperties.class))
+                .get();
+
+        assertThat(props.remoteWrite().url()).isEqualTo("http://vm:8428/api/v1/write");
+        assertThat(props.remoteWrite().auth().type()).isEqualTo(PrometheusWriterProperties.AuthType.BEARER);
+        assertThat(props.remoteWrite().auth().bearerToken()).isEqualTo("abc");
+        assertThat(props.remoteWrite().headers()).containsEntry("X-Scope-OrgID", "tenant-1");
+        assertThat(props.batch().maxSamples()).isEqualTo(1000);
+        assertThat(props.batch().maxBytes()).isEqualTo(1_048_576);
+        assertThat(props.labels().fromMetadata()).containsExactly("requisition:region");
+        assertThat(props.startupGate().enabled()).isTrue();
+    }
+
+    @Test
+    void defaults_are_sensible_when_minimal_yaml() {
+        Map<String, Object> map = Map.of(
+                "prometheus-writer.remote-write.url", "http://localhost/write"
+        );
+        ConfigurationPropertySource src = new MapConfigurationPropertySource(map);
+        PrometheusWriterProperties props = new Binder(src)
+                .bind("prometheus-writer", Bindable.of(PrometheusWriterProperties.class))
+                .get();
+
+        assertThat(props.batch().maxSamples()).isEqualTo(1000);
+        assertThat(props.batch().maxBytes()).isEqualTo(1_048_576);
+        assertThat(props.batch().maxIntervalMs()).isEqualTo(1000);
+        assertThat(props.remoteWrite().auth().type()).isEqualTo(PrometheusWriterProperties.AuthType.NONE);
+        assertThat(props.startupGate().enabled()).isTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect compile failure** (class does not exist yet)
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=PrometheusWriterPropertiesTest
+```
+
+Expected: compile failure referencing `PrometheusWriterProperties`.
+
+- [ ] **Step 3: Implement `PrometheusWriterProperties`**
+
+Write `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/PrometheusWriterProperties.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strongly-typed binding for the {@code prometheus-writer.*} section of
+ * {@code application.yml}. Every field in spec §8 appears here with a
+ * default that matches the yaml default.
+ */
+@Validated
+@ConfigurationProperties(prefix = "prometheus-writer")
+public record PrometheusWriterProperties(
+        @NotNull RemoteWrite remoteWrite,
+        @NotNull Batch batch,
+        @NotNull Retry retry,
+        @NotNull CircuitBreaker circuitBreaker,
+        @NotNull Labels labels,
+        @NotNull StartupGate startupGate
+) {
+    public PrometheusWriterProperties {
+        if (remoteWrite == null) remoteWrite = new RemoteWrite(null, new Auth(AuthType.NONE, null, null, null), Map.of());
+        if (batch == null)          batch = new Batch(1000, 1_048_576, 1000);
+        if (retry == null)          retry = new Retry(100, 30_000, 0.1);
+        if (circuitBreaker == null) circuitBreaker = new CircuitBreaker(50, 20, 10, 30_000, 3);
+        if (labels == null)         labels = new Labels(List.of());
+        if (startupGate == null)    startupGate = new StartupGate(true);
+    }
+
+    public record RemoteWrite(
+            @NotBlank String url,
+            @NotNull Auth auth,
+            Map<String, String> headers
+    ) {
+        public RemoteWrite {
+            if (auth == null) auth = new Auth(AuthType.NONE, null, null, null);
+            if (headers == null) headers = Map.of();
+        }
+    }
+
+    public record Auth(
+            AuthType type,
+            String bearerToken,
+            String basicUsername,
+            String basicPassword
+    ) {}
+
+    public enum AuthType { NONE, BEARER, BASIC }
+
+    public record Batch(
+            @Positive int maxSamples,
+            @Positive int maxBytes,
+            @Positive long maxIntervalMs
+    ) {}
+
+    public record Retry(
+            @Positive long initialBackoffMs,
+            @Positive long maxBackoffMs,
+            double jitterFactor
+    ) {}
+
+    public record CircuitBreaker(
+            int failureRateThreshold,
+            int slidingWindowSize,
+            int minimumNumberOfCalls,
+            long waitDurationOpenMs,
+            int halfOpenPermittedCalls
+    ) {}
+
+    public record Labels(
+            List<String> fromMetadata
+    ) {}
+
+    public record StartupGate(
+            boolean enabled
+    ) {}
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=PrometheusWriterPropertiesTest
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Write `application.yml`**
+
+Write `core/prometheus-writer/src/main/resources/application.yml` verbatim from spec §8. Use the exact yaml from the spec. **Critical scar prophylactic:** every property set by later Testcontainers ITs via `ApplicationContextInitializer` must ALSO appear here. In particular, `spring.kafka.bootstrap-servers` must be in the prod yaml (not test-only) — Phase 0 #170 lesson.
+
+Exact content:
+
+```yaml
+# Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later
+spring:
+  application:
+    name: prometheus-writer
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}  # prod yaml MUST carry this — Phase 0 #170 lesson
+  cloud:
+    function:
+      definition: timeseriesConsumer
+    stream:
+      kafka:
+        binder:
+          brokers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bindings:
+        timeseriesConsumer-in-0:
+          destination: deltav-timeseries
+          group: prometheus-writer
+          consumer:
+            concurrency: 4
+        publishDlq-out-0:
+          destination: deltav-prometheus-writer-dlq
+          producer:
+            use-native-encoding: true    # Phase 1.5 SCS splitter-lesson prophylactic
+
+prometheus-writer:
+  remote-write:
+    url: ${PROMETHEUS_WRITER_REMOTE_WRITE_URL:http://victoriametrics:8428/api/v1/write}
+    auth:
+      type: ${PROMETHEUS_WRITER_AUTH_TYPE:none}
+      bearer-token: ${PROMETHEUS_WRITER_BEARER_TOKEN:}
+      basic-username: ${PROMETHEUS_WRITER_BASIC_USER:}
+      basic-password: ${PROMETHEUS_WRITER_BASIC_PASS:}
+    headers: {}
+  batch:
+    max-samples: 1000
+    max-bytes: 1048576
+    max-interval-ms: 1000
+  retry:
+    initial-backoff-ms: 100
+    max-backoff-ms: 30000
+    jitter-factor: 0.1
+  circuit-breaker:
+    failure-rate-threshold: 50
+    sliding-window-size: 20
+    minimum-number-of-calls: 10
+    wait-duration-open-ms: 30000
+    half-open-permitted-calls: 3
+  labels:
+    from-metadata: []
+  startup-gate:
+    enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, bindings
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/PrometheusWriterProperties.java \
+        core/prometheus-writer/src/main/resources/application.yml \
+        core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/config/PrometheusWriterPropertiesTest.java
+git commit -m "feat(prometheus-writer): @ConfigurationProperties binding + application.yml
+
+PrometheusWriterProperties record mirrors spec §8 exactly. Validation
+constraints (@NotBlank on RW URL, @Positive on batch sizes) fail-fast
+at startup if config is missing.
+
+application.yml carries spring.kafka.bootstrap-servers in the prod
+config (not just test yaml) per Phase 0 #170 lesson. DLQ binding uses
+producer.use-native-encoding: true per Phase 1.5 SCS splitter lesson.
+
+Tests: 2 binding assertions (full shape + minimal defaults)."
+```
+
+---
+
+## Task 4: `NodeContextCache` + unit tests
+
+**Goal:** Thread-safe in-memory map of `{location}@{node_id}` → `NodeContext`. Supports get/put/tombstone/size. No Kafka yet.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheTest.java`
+
+- [ ] **Step 1: Write failing test**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeContextCacheTest {
+
+    @Test
+    void get_returns_empty_when_key_absent() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void put_stores_value_and_get_retrieves() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).setLocation("Default").setNodeLabel("lab-1").build();
+        cache.put("Default@1", nc);
+        assertThat(cache.get("Default@1")).contains(nc);
+    }
+
+    @Test
+    void remove_evicts_key() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).build();
+        cache.put("Default@1", nc);
+        cache.remove("Default@1");
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void tombstone_on_put_delegates_to_remove() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).build());
+        NodeContext tombstone = NodeContext.newBuilder().setNodeId(1).setDeleted(true).build();
+        cache.applyUpdate("Default@1", tombstone);
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void applyUpdate_live_record_puts() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).setDeleted(false).build();
+        cache.applyUpdate("Default@1", nc);
+        assertThat(cache.get("Default@1")).contains(nc);
+    }
+
+    @Test
+    void size_reports_current_entries() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.size()).isZero();
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).build());
+        cache.put("Default@2", NodeContext.newBuilder().setNodeId(2).build());
+        assertThat(cache.size()).isEqualTo(2);
+        cache.remove("Default@1");
+        assertThat(cache.size()).isEqualTo(1);
+    }
+
+    @Test
+    void ready_defaults_false_and_markReady_flips() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.isReady()).isFalse();
+        cache.markReady();
+        assertThat(cache.isReady()).isTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect compile failure**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=NodeContextCacheTest
+```
+
+Expected: compile failure referencing `NodeContextCache`.
+
+- [ ] **Step 3: Implement `NodeContextCache`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * In-memory cache of {@link NodeContext} records keyed {@code {location}@{node_id}}.
+ * Hot-path {@link #get(String)} is a plain {@link ConcurrentHashMap#get(Object)} —
+ * no locking, no network hop. State mutation is confined to the Kafka consumer
+ * thread owned by {@link NodeContextKafkaBootstrap}.
+ */
+@Component
+public class NodeContextCache {
+
+    private final ConcurrentHashMap<String, NodeContext> map = new ConcurrentHashMap<>();
+    private final AtomicBoolean ready = new AtomicBoolean(false);
+
+    public Optional<NodeContext> get(String key) {
+        return Optional.ofNullable(map.get(key));
+    }
+
+    public void put(String key, NodeContext value) {
+        map.put(key, value);
+    }
+
+    public void remove(String key) {
+        map.remove(key);
+    }
+
+    /**
+     * Apply a record from the {@code deltav-node-context} topic. If {@code deleted=true},
+     * treats as tombstone and removes the key. Otherwise stores the value.
+     */
+    public void applyUpdate(String key, NodeContext value) {
+        if (value.getDeleted()) {
+            remove(key);
+        } else {
+            put(key, value);
+        }
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public boolean isReady() {
+        return ready.get();
+    }
+
+    public void markReady() {
+        ready.set(true);
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=NodeContextCacheTest
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java \
+        core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheTest.java
+git commit -m "feat(prometheus-writer): NodeContextCache — thread-safe in-memory NodeContext map
+
+Hot-path get() is ConcurrentHashMap.get() — no locking, no network hop.
+applyUpdate() dispatches on NodeContext.deleted: tombstone removes,
+live record puts. markReady() flips the gate flag consumed by the
+startup binding resumer.
+
+Stateless beyond map contents — restart-safe by construction; the
+Kafka topic IS the source of truth."
+```
+
+---
+
+## Task 5: `NodeContextKafkaBootstrap` + Testcontainers IT
+
+**Goal:** Dedicated Kafka consumer subscribes to `deltav-node-context`, bootstraps the cache from earliest offset up to start-time end-offsets, marks cache ready, continues consuming live updates. Emits `NodeContextCacheReadyEvent` on ready transition.
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java`
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheReadyEvent.java`
+- Create: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java`
+
+- [ ] **Step 1: Write `NodeContextCacheReadyEvent`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import org.springframework.context.ApplicationEvent;
+
+/** Published once when {@link NodeContextKafkaBootstrap} finishes initial bootstrap. */
+public class NodeContextCacheReadyEvent extends ApplicationEvent {
+    private final long bootstrapDurationMs;
+    private final int cacheSize;
+
+    public NodeContextCacheReadyEvent(Object source, long bootstrapDurationMs, int cacheSize) {
+        super(source);
+        this.bootstrapDurationMs = bootstrapDurationMs;
+        this.cacheSize = cacheSize;
+    }
+
+    public long getBootstrapDurationMs() { return bootstrapDurationMs; }
+    public int getCacheSize() { return cacheSize; }
+}
+```
+
+- [ ] **Step 2: Implement `NodeContextKafkaBootstrap`**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.deltav.timeseries.proto.NodeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Dedicated Kafka consumer for {@code deltav-node-context}. On startup, records the
+ * end-offset high-water mark (HWM) per partition, seeks to earliest, consumes
+ * records until every partition's offset catches the recorded HWM, and marks
+ * the cache ready. Then transitions to a live-tail loop.
+ */
+@Component
+public class NodeContextKafkaBootstrap implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NodeContextKafkaBootstrap.class);
+    private static final String TOPIC = "deltav-node-context";
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(5);
+
+    private final NodeContextCache cache;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MeterRegistry meterRegistry;
+    private final String bootstrapServers;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread thread;
+    private Timer.Sample bootstrapSample;
+
+    public NodeContextKafkaBootstrap(
+            NodeContextCache cache,
+            ApplicationEventPublisher eventPublisher,
+            MeterRegistry meterRegistry,
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        this.cache = cache;
+        this.eventPublisher = eventPublisher;
+        this.meterRegistry = meterRegistry;
+        this.bootstrapServers = bootstrapServers;
+    }
+
+    @PostConstruct
+    public void start() {
+        running.set(true);
+        bootstrapSample = Timer.start(meterRegistry);
+        thread = new Thread(this, "node-context-bootstrap");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        running.set(false);
+        if (thread != null) {
+            try { thread.join(5000); } catch (InterruptedException ignored) { Thread.currentThread().interrupt(); }
+        }
+    }
+
+    @Override
+    public void run() {
+        try (KafkaConsumer<String, byte[]> consumer = buildConsumer()) {
+            List<PartitionInfo> parts = consumer.partitionsFor(TOPIC);
+            if (parts == null || parts.isEmpty()) {
+                LOG.warn("Topic {} has no partitions yet — marking cache ready with empty state", TOPIC);
+                finishBootstrap();
+                liveTail(consumer);
+                return;
+            }
+            Set<TopicPartition> allParts = new HashSet<>();
+            for (PartitionInfo p : parts) allParts.add(new TopicPartition(TOPIC, p.partition()));
+            consumer.assign(allParts);
+
+            Map<TopicPartition, Long> endOffsets = new HashMap<>(consumer.endOffsets(allParts));
+            consumer.seekToBeginning(allParts);
+
+            Set<TopicPartition> caughtUp = new HashSet<>();
+            // An empty partition (end offset == 0) is instantly "caught up".
+            for (Map.Entry<TopicPartition, Long> e : endOffsets.entrySet()) {
+                if (e.getValue() == 0L) caughtUp.add(e.getKey());
+            }
+
+            while (running.get() && caughtUp.size() < allParts.size()) {
+                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+                for (ConsumerRecord<String, byte[]> r : records) {
+                    applyRecord(r);
+                    TopicPartition tp = new TopicPartition(r.topic(), r.partition());
+                    if (r.offset() + 1 >= endOffsets.get(tp)) caughtUp.add(tp);
+                }
+            }
+            finishBootstrap();
+            liveTail(consumer);
+        } catch (Exception e) {
+            LOG.error("NodeContextKafkaBootstrap fatal error", e);
+        }
+    }
+
+    private void liveTail(KafkaConsumer<String, byte[]> consumer) {
+        while (running.get()) {
+            try {
+                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+                for (ConsumerRecord<String, byte[]> r : records) applyRecord(r);
+            } catch (Exception e) {
+                LOG.warn("NodeContextKafkaBootstrap live-tail error — will retry after poll timeout", e);
+            }
+        }
+    }
+
+    private void applyRecord(ConsumerRecord<String, byte[]> r) {
+        if (r.value() == null) {
+            // Kafka log-compaction tombstone (null value). Treat as delete.
+            cache.remove(r.key());
+            return;
+        }
+        try {
+            NodeContext nc = NodeContext.parseFrom(r.value());
+            cache.applyUpdate(r.key(), nc);
+        } catch (Exception e) {
+            LOG.warn("Malformed NodeContext record key={} offset={} — skipping", r.key(), r.offset(), e);
+        }
+    }
+
+    private void finishBootstrap() {
+        cache.markReady();
+        long durationMs = bootstrapSample.stop(
+                meterRegistry.timer("deltav.prometheus.writer.node.context.bootstrap.duration"));
+        long durationMillis = durationMs / 1_000_000L;
+        LOG.info("NodeContextCache bootstrap complete: {} entries in {} ms", cache.size(), durationMillis);
+        eventPublisher.publishEvent(new NodeContextCacheReadyEvent(this, durationMillis, cache.size()));
+    }
+
+    private KafkaConsumer<String, byte[]> buildConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "prometheus-writer-node-context-" + UUID.randomUUID());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");  // we manage offsets via seek
+        return new KafkaConsumer<>(props);
+    }
+}
+```
+
+- [ ] **Step 3: Write Testcontainers IT**
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodecontext;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.deltav.timeseries.proto.NodeContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Testcontainers
+class NodeContextKafkaBootstrapIT {
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @Test
+    void bootstrap_drains_to_HWM_then_marks_ready() throws Exception {
+        ensureTopic();
+        for (int i = 1; i <= 50; i++) produce(i, false);
+
+        NodeContextCache cache = new NodeContextCache();
+        AtomicReference<NodeContextCacheReadyEvent> captured = new AtomicReference<>();
+        SimpleApplicationEventMulticaster mc = new SimpleApplicationEventMulticaster();
+        mc.addApplicationListener(e -> {
+            if (e instanceof NodeContextCacheReadyEvent r) captured.set(r);
+        });
+        NodeContextKafkaBootstrap boot = new NodeContextKafkaBootstrap(
+                cache, mc::multicastEvent::accept, new SimpleMeterRegistry(), KAFKA.getBootstrapServers());
+        boot.start();
+        try {
+            await().atMost(Duration.ofSeconds(30)).until(cache::isReady);
+            assertThat(cache.size()).isEqualTo(50);
+            assertThat(captured.get()).isNotNull();
+            assertThat(captured.get().getCacheSize()).isEqualTo(50);
+        } finally {
+            boot.stop();
+        }
+    }
+
+    @Test
+    void tombstone_removes_key_from_cache_live() throws Exception {
+        ensureTopic();
+        produce(101, false);
+
+        NodeContextCache cache = new NodeContextCache();
+        NodeContextKafkaBootstrap boot = new NodeContextKafkaBootstrap(
+                cache, e -> {}, new SimpleMeterRegistry(), KAFKA.getBootstrapServers());
+        boot.start();
+        try {
+            await().atMost(Duration.ofSeconds(30)).until(cache::isReady);
+            assertThat(cache.get("Default@101")).isPresent();
+
+            produce(101, true);   // tombstone (deleted=true)
+            await().atMost(Duration.ofSeconds(20))
+                    .until(() -> cache.get("Default@101").isEmpty());
+        } finally {
+            boot.stop();
+        }
+    }
+
+    // -------------------- helpers --------------------
+
+    private void ensureTopic() throws Exception {
+        Properties p = new Properties();
+        p.put("bootstrap.servers", KAFKA.getBootstrapServers());
+        try (AdminClient a = AdminClient.create(p)) {
+            a.createTopics(List.of(new NewTopic("deltav-node-context", 8, (short) 1)
+                    .configs(Map.of("cleanup.policy", "compact"))))
+                    .all().get();
+        } catch (Exception e) {
+            if (!(e.getCause() instanceof org.apache.kafka.common.errors.TopicExistsException)) throw e;
+        }
+    }
+
+    private void produce(int nodeId, boolean deleted) throws Exception {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        try (KafkaProducer<String, byte[]> prod = new KafkaProducer<>(p)) {
+            NodeContext nc = NodeContext.newBuilder()
+                    .setNodeId(nodeId)
+                    .setLocation("Default")
+                    .setNodeLabel("node-" + nodeId)
+                    .setDeleted(deleted)
+                    .setUpdatedAtMs(System.currentTimeMillis())
+                    .build();
+            prod.send(new ProducerRecord<>("deltav-node-context", "Default@" + nodeId, nc.toByteArray())).get();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run IT**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=NodeContextKafkaBootstrapIT
+```
+
+Expected: both tests pass (requires Docker running for Testcontainers).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java \
+        core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheReadyEvent.java \
+        core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java
+git commit -m "feat(prometheus-writer): NodeContextKafkaBootstrap — end-offset HWM bootstrap
+
+Dedicated Kafka consumer subscribes to deltav-node-context, seeks to
+earliest, records HWM-at-start per partition, drains to HWM, marks
+cache ready, publishes NodeContextCacheReadyEvent, and transitions
+to a live-tail loop. Tombstones (deleted=true OR null value) remove
+the key.
+
+Bootstrap time measured as Micrometer Timer
+'deltav.prometheus.writer.node.context.bootstrap.duration'.
+
+Testcontainers IT asserts: bootstrap drains to HWM + tombstones
+propagate live."
+```
+
+---
+
+Stopping here for length. **Tasks 6 through 26 continue in a separate file.** The next task file contains:
+
+- Task 6: `NodeContextCacheHealthIndicator`
+- Task 7: Startup gate (binding starts paused, resumes on ready event)
+- Task 8: `NameSanitizer`
+- Task 9: `LabelBuilder`
+- Task 10: `PromSample` + `TimeseriesToPromTranslator`
+- Task 11: `RemoteWriteHttpClient` + `WriteRequestBuilder`
+- Task 12: `RemoteWriteRetryPolicy`
+- Task 13: `BatchingRwWriter`
+- Task 14: `PrometheusWriterCircuitBreaker`
+- Task 15: `TimeseriesConsumer` SCS function + SCS test-binder IT
+- Task 16: `ConsumerPauseListener`
+- Task 17: `DlqPublisher` + NewTopic bean + binder IT
+- Task 18: `PrometheusWriterMetrics` central declaration
+- Task 19: `PrometheusWriterConfiguration` wiring + `PrometheusWriterApplicationScanIT` (real-main-class)
+- Task 20: Full round-trip Testcontainers IT
+- Task 21: `Dockerfile.prometheus-writer`
+- Task 22: `docker-compose.yml` (writer service + VictoriaMetrics service)
+- Task 23: `build.sh` — `do_prometheus_writer_image()`
+- Task 24: `test-prometheus-writer-e2e.sh` (6-step, pipefail-safe grep)
+- Task 25: Freeze proto headers + README updates + full-reactor verify
+- Task 26: Acceptance-gate checklist (all prophylactics verified)
+
+See companion file: `docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer-part2.md`.

--- a/docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md
+++ b/docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md
@@ -1,0 +1,632 @@
+# Kafka Time Series Pipeline — Phase 2: Prometheus Remote Write Consumer
+
+**Date:** 2026-04-17
+**Status:** Approved (pending implementation plan)
+**Owner:** David Hustace
+**Predecessors:**
+- `2026-04-15-kafka-time-series-producer-design.md` — Phase 0 (Collectd producer, shipped delta-v#169 / #170)
+- `2026-04-16-kafka-time-series-phase-1-node-context-design.md` — Phase 1 (Provisiond node-context producer, shipped delta-v#171)
+
+**Related memories:**
+- `project_kafka_timeseries_pipeline.md` — overall pipeline map (Phase 0/1/2+ status)
+- `project_kafka_timeseries_producer_next_session.md` — Phase 0 outcomes + E2E evidence
+- `project_node_context_phase1_done.md` — Phase 1 outcomes, topic config, E2E-discovered bugs
+- `feedback_spring_boot_scan_package_trap.md` — mandatory real-main-class IT to avoid silent scan-package gaps
+- `feedback_spring_cloud_stream_splitter.md` — `use-native-encoding: true` on byte-array SCS bindings
+- `feedback_delta_v_full_reactor_verify.md` — full-reactor verify after cross-module changes, not just `-pl`
+- `project_dropwizard_prometheus_bridge_pattern.md` — horizon-lib Dropwizard → Prom bridge (not needed here, but cross-referenced)
+- `feedback_deltav_package_namespace.md` — `org.deltav.*` + BeaconStrategists copyright for new code
+- `feedback_never_pr_opennms.md` — PRs go to `pbrane/delta-v`, never `OpenNMS/opennms`
+
+## Problem
+
+Phase 0 shipped the `deltav-timeseries` producer (Collectd emits protobuf `TimeseriesBatch` records per poll cycle). Phase 1 shipped the `deltav-node-context` producer (Provisiond emits compacted `NodeContext` records on node-lifecycle UEIs plus restart bootstrap). Both topics are live on `develop`.
+
+**No consumer exists.** `deltav-timeseries` is retention-capped at 24 hours, so any record older than that is lost. Without a consumer, the pipeline does nothing useful: Collectd's metrics hit Kafka and decay unseen; Provisiond's node-context changes land in a compacted topic that no one reads.
+
+Phase 2 is the first consumer: a Spring Boot service that
+
+1. consumes `deltav-timeseries` (metric payloads, 16 partitions, 24h retention),
+2. enriches each batch with node identity from a materialized view of `deltav-node-context` (compacted, 8 partitions),
+3. transforms the enriched batch into Prometheus Remote Write samples,
+4. POSTs Snappy-compressed protobuf batches to a configurable RW endpoint (Mimir / Cortex / VictoriaMetrics / Thanos Receive / vanilla Prometheus with `--web.enable-remote-write-receiver`),
+5. handles backpressure, retries, and poison pills in a bounded, observable way.
+
+Once Phase 2 ships, the pipeline is end-to-end useful: a real operator can point the writer at their TSDB, run `rate(opennms_mib2_interface_errors_ifindiscards_total{node_label="eth0.site-a"}[5m])`, and see live delta-v metrics in Grafana.
+
+## Non-goals
+
+Explicitly out of scope for this phase:
+
+- **Staleness markers on node delete.** Prometheus RW supports `StaleNaN` but requires series-per-node state. Phase 2 relies on RW target retention to age out deleted-node series. Revisit as a dedicated `staleness-emitter` consumer if operators request immediate cleanup.
+- **Schema changes to either wire contract.** Phase 2 uses the existing `TimeseriesBatch` and `NodeContext` protos as shipped in Phase 0/1. Both contracts **freeze at Phase 2 GA** — only forward-compatible additions (new tag numbers) permitted afterward. This includes not adding `hostname`, `ip-primary`, `ifIndex→IP map`, or similar fields that would enable richer enrichment.
+- **COUNTER32 wrap detection.** Modern interfaces use HC/COUNTER64 via `collectd-configuration.xml`. Phase 2 emits COUNTER as Prometheus counters and trusts `rate()`'s standard reset-tolerant math. Sub-1G interfaces running COUNTER32 at high throughput can see wraps that look like resets — documented, not fixed in Phase 2.
+- **Multiple RW targets / fan-out.** One writer instance → one RW endpoint. Operators who want fan-out run Mimir / VictoriaMetrics / Thanos Receive in distributor mode upstream of Phase 2.
+- **mTLS for RW target.** Bearer, basic, and extra-headers auth cover mainstream deployments. mTLS deferred until a real operator need surfaces.
+- **String-attribute emission as info metrics.** String attributes (`ATTRIBUTE_TYPE_STRING`) are dropped + counted. Operators who need string data as labels promote them via the metadata-label opt-in (see Architecture §5.2).
+- **Interface-level enrichment.** `NodeContext.interface_metadata` is IP-keyed; SNMP samples are ifIndex/ifName-keyed. Joining them requires either a new field in the schema (frozen — see above) or an IP-lookup axis that doesn't exist. Phase 2 enriches at the node level only.
+- **Binary-search split on 400 responses.** Poison-pill batches go to a DLQ topic wholesale. Operator investigates from the DLQ; we do not attempt per-sample isolation in the writer.
+- **`NodeContextCache` as a reusable library.** Phase 2 implements it inline in `core/prometheus-writer/`. When consumer #2 (Thresholder) lands, extract to `core/deltav-node-context-cache` as a shared starter. YAGNI for Phase 2 of one consumer.
+- **Compose profile `metrics`.** Phase 2 adds `prometheus-writer` to existing `[lite, full]` profiles and introduces a new `[metrics-e2e]` profile for the test-only VictoriaMetrics container. No production-facing profile changes.
+
+## Architecture
+
+### Data flow
+
+```
+┌─────────────────┐                                ┌──────────────────┐
+│  Collectd       │  deltav-timeseries             │  RW target       │
+│  (+ future      │  16 parts, 24h retention   ┌─▶│  (VM in E2E;     │
+│   producers)    │─────────────────────┐       │  │   prod swaps URL)│
+└─────────────────┘                     │       │  └──────────────────┘
+                                        ▼       │           ▲
+                             ┌────────────────────────┐     │ POST
+                             │ core/prometheus-writer  │     │ /api/v1/write
+                             │ (Spring Boot 4, SCS)    │     │
+                             │                         │     │
+┌─────────────────┐          │ ┌─────────────────────┐ │     │
+│  Provisiond     │ deltav-  │ │ TimeseriesBatch     │ │     │
+│  change-feed    │ node-    │ │ consumer (paused    │ │     │
+│  (Phase 1)      │ context  │ │  until cache ready) │ │     │
+└─────────────────┘ 8 parts  │ └──────────┬──────────┘ │     │
+                   compacted │            │ enrich      │     │
+                   ────────▶│            ▼             │     │
+                             │ ┌─────────────────────┐ │     │
+                             │ │ NodeContextCache    │ │     │
+                             │ │ Map<key,NodeContext>│ │     │
+                             │ │ tails compacted topic│ │     │
+                             │ └──────────┬──────────┘ │     │
+                             │            │            │     │
+                             │            ▼            │     │
+                             │ ┌─────────────────────┐ │     │
+                             │ │ Translator          │ │     │
+                             │ │ TSBatch → PromSample│ │     │
+                             │ │ (sanitize, filter,  │ │     │
+                             │ │  build labels)      │ │     │
+                             │ └──────────┬──────────┘ │     │
+                             │            ▼            │     │
+                             │ ┌─────────────────────┐ │     │
+                             │ │ BatchingRwWriter    │ │     │
+                             │ │  1000/1MB/1s        │ │     │
+                             │ │  + Resilience4j CB  │ │     │
+                             │ │  + tiered retry     │ │     │
+                             │ └──────┬──────┬───────┘ │     │
+                             │        │ 2xx  │ 4xx-    │     │
+                             │        │      │ poison  │     │
+                             └────────┼──────┼─────────┘     │
+                                      │      │               │
+                                      │      ▼               │
+                                      │      deltav-prometheus-writer-dlq
+                                      │      (new, 16 parts, 7d retention)
+                                      ▼
+                                      /actuator/prometheus
+                                      (deltav_prometheus_writer_*)
+```
+
+### Key properties
+
+1. **Stateless hot path.** Translation from `TimeseriesBatch` to Prometheus samples is a pure function of `(batch, NodeContextCache.get(key))`. No per-series state, no wrap detection, no staleness tracking. Restart-safe by construction.
+2. **Startup gate.** The `deltav-timeseries` consumer binding starts paused. The `NodeContextCache` bootstraps (tail to end-offset across all 8 partitions), then the binding resumes. Post-gate, any `enrichment_missing` miss is genuine drift, not warmup.
+3. **Lazy tombstone handling.** `NodeContext { deleted=true }` → `cache.remove(key)`. Subsequent lookups for the tombstoned node take the drop-+-counter path as "missing." No staleness markers emitted to the RW target.
+4. **Backpressure via Kafka lag.** On RW target outage, Resilience4j opens the circuit and pauses the Kafka consumer binding. Kafka's 24h source-topic retention becomes the outage budget. On target recovery, the circuit closes and the binding resumes; consumer lag drains naturally.
+5. **Poison-pill isolation via DLQ.** 400 / 413 HTTP responses mean "the consumer produced something the target won't accept." The source `TimeseriesBatch` goes to `deltav-prometheus-writer-dlq` with diagnostic headers, the consumer continues. Operator replays from DLQ in a debug tool to find the producer bug.
+
+### Module structure
+
+**New module:** `core/prometheus-writer/`
+
+Mirrors `core/flow-enricher/` conventions:
+
+- Maven artifactId: `org.deltav.core.prometheus-writer`
+- Package root: `org.deltav.prometheus.writer`
+- Main class: `org.deltav.prometheus.writer.PrometheusWriterApplication`
+  - `@SpringBootApplication(scanBasePackages = {"org.deltav.prometheus.writer"})`
+  - (Scan-package lesson from Phase 0 #170 baked in from day one.)
+- Copyright header: BeaconStrategists, Inc. (new code, no horizon FQN constraint)
+- Depends on `core/deltav-kafka-contracts` for generated `TimeseriesBatch` and `NodeContext` classes
+- Adds a vendored Prometheus remote-write proto (`prometheus/prompb/remote.proto` + `types.proto`) to `core/deltav-kafka-contracts/src/main/proto/` so the generator produces `WriteRequest`, `TimeSeries`, `Sample`, `Label` Java classes
+
+### Key beans
+
+Organized by subsystem; each bean has one clear responsibility:
+
+**Node-context subsystem:**
+- `NodeContextCache` — `ConcurrentHashMap<String, NodeContext>`, hot-path `Optional<NodeContext> get(String key)`
+- `NodeContextKafkaBootstrap` — owns the Kafka consumer for `deltav-node-context`, seeks to earliest on first run, records end-offset HWM per partition, drives the cache to "ready" when HWM reached on all 8 partitions
+- `NodeContextCacheHealthIndicator` — `HealthIndicator` returning `UP` iff cache is ready; ties to Spring Boot `/actuator/health/readiness`
+
+**Enrichment + translation subsystem:**
+- `TimeseriesConsumer` — SCS `@Bean Function<Message<byte[]>, Void>` bound to `deltav-timeseries`, deserializes `TimeseriesBatch`, looks up cache, delegates to `TimeseriesToPromTranslator`, forwards samples to `BatchingRwWriter`
+- `TimeseriesToPromTranslator` — pure function `(TimeseriesBatch, Optional<NodeContext>) → List<PromSample>`; applies filters (string attributes dropped, unspecified types dropped, enrichment misses rejected)
+- `NameSanitizer` — lowercase + non-alphanumeric → `_` + collapse consecutive + strip leading digit; startup-time collision detection with WARN log
+- `LabelBuilder` — assembles the label set per Q4b (core identity labels always, metadata labels from allowlist config)
+
+**RW output subsystem:**
+- `BatchingRwWriter` — accumulates samples in memory, flushes on 1000 / 1 MB / 1000 ms (configurable), delegates to `RemoteWriteHttpClient`
+- `RemoteWriteHttpClient` — Spring `RestClient`-based, Snappy-compresses the `WriteRequest` protobuf, POSTs to configured URL with auth headers
+- `RemoteWriteRetryPolicy` — tiered retry classifier: 5xx/429/network → retry with exp backoff + jitter; 400/413 → DLQ + drop; 401/403/404 → open circuit
+- `PrometheusWriterCircuitBreaker` — Resilience4j `CircuitBreaker` bean wired to the HTTP client; opens on 50% failure rate over 20 requests, stays open 30s, 3 probe calls in half-open
+- `ConsumerPauseListener` — listens to circuit state transitions; pauses/resumes the `deltav-timeseries` binding via `BindingsLifecycleController`
+
+**DLQ subsystem:**
+- `DlqPublisher` — SCS producer binding `publishDlq-out-0` → `deltav-prometheus-writer-dlq`, `producer.use-native-encoding: true` for byte-array payloads (Phase 1.5 SCS splitter lesson)
+
+**Observability subsystem:**
+- `PrometheusWriterMetrics` — Micrometer `MeterRegistry` holder; all counters/gauges/timers created here, injected into the beans that increment them. No Dropwizard bridge needed (no horizon-lib code paths in the hot path).
+
+## Detailed design
+
+### 1. NodeContextCache bootstrap protocol
+
+On `@PostConstruct`:
+
+```
+endOffsetsAtStart = kafkaConsumer.endOffsets(allPartitions)  # 8 partitions
+kafkaConsumer.seekToBeginning(allPartitions)
+while anyPartitionBelowHWM:
+    records = kafkaConsumer.poll(timeout=5s)
+    for r in records:
+        if r.value.deleted:
+            cache.remove(r.key)
+        else:
+            cache.put(r.key, r.value)
+        if r.offset >= endOffsetsAtStart[r.partition]:
+            mark partition as caught up
+cacheReady.set(true)
+record bootstrap_duration_seconds
+# continue consuming live updates in a background thread
+```
+
+- Deterministic: every writer instance reads the whole compacted topic on startup
+- Bounded time: at 10k nodes (delta-v scale ceiling), topic is <10 MB compressed; bootstrap completes in seconds
+- No RocksDB, no state directory, no Docker volume
+- Restart-safe: cache is always rebuilt from the topic; never persisted
+
+### 2. Startup gate mechanism
+
+- `@ConditionalOnProperty(value = "prometheus-writer.startup-gate.enabled", havingValue = "true", matchIfMissing = true)` — defaults ON, off only for pathological tests
+- `ListenerContainerCustomizer<AbstractMessageListenerContainer>` bean that calls `container.pause()` immediately after factory creates it
+- `@EventListener(NodeContextCacheReadyEvent.class)` bean calls `BindingsLifecycleController.resume("timeseriesConsumer-in-0")`
+- Spring Boot readiness: `NodeContextCacheHealthIndicator` contributes to `/actuator/health/readiness`; probe goes green in concert with binding resume
+- Liveness (`/actuator/health/liveness`) is always green once the process is up — cache bootstrap is expected to succeed on any running Kafka
+
+### 3. Metric naming + labels
+
+**Metric name construction:**
+```
+opennms_{sanitize(group.name)}_{sanitize(attribute.name)}[_total if COUNTER]
+```
+
+Examples:
+- `mib2-interface-errors.ifInDiscards` (COUNTER) → `opennms_mib2_interface_errors_ifindiscards_total`
+- `mib2-X-interfaces.ifHighSpeed` (GAUGE) → `opennms_mib2_x_interfaces_ifhighspeed`
+- `hrStorage.hrStorageUsed` (GAUGE) → `opennms_hrstorage_hrstorageused`
+
+**Default label set (always emitted):**
+- `node_id` — from `TimeseriesBatch.node_id`, stringified
+- `location` — from `TimeseriesBatch.location`
+- `node_label` — from `NodeContext.node_label`
+- `foreign_source` — from `NodeContext.foreign_source`
+- `categories` — from `NodeContext.categories`, sorted + comma-joined (e.g. `"critical,production"`); empty string if none
+- `resource_type` — from `Resource.type`
+- `resource_instance` — from `Resource.instance` (empty for non-tabular resources)
+- `collection_package` — from `TimeseriesBatch.collection_package`
+- `producer` — from `TimeseriesBatch.producer` enum (e.g. `"collectd"`)
+
+**Opt-in metadata labels (via config allowlist):**
+```yaml
+prometheus-writer:
+  labels:
+    from-metadata:
+      - requisition:region
+      - requisition:environment
+      - snmp:sysLocation
+```
+Each listed key becomes a label named by its sanitized form (`requisition:region` → `requisition_region`). Missing keys emit empty-string label values. Operators explicitly scope cardinality.
+
+**Labels NOT emitted by default:**
+- `foreign_id` — redundant with `node_id` within a `foreign_source`, rarely queried
+- `resource_id` — derivable from `resource_type` + `resource_instance` + `node_id`, bulky label value
+- Arbitrary metadata — cardinality hazard without allowlist
+
+### 4. Sample construction
+
+For each `Attribute` in each `AttributeGroup` in each `Resource` in the batch:
+
+```
+if attribute.type == STRING:
+    samples_dropped_total{reason="string_attribute"}++; continue
+if attribute.type == UNSPECIFIED:
+    samples_dropped_total{reason="type_unspecified"}++; continue
+
+name = buildMetricName(group.name, attribute.name, attribute.type)
+labels = buildLabels(batch, resource, nodeContext)
+sample = PromSample{
+    name,
+    labels,
+    value = attribute.value.numeric,
+    timestamp_ms = batch.timestamp_ms,    # collection time, not processing time
+}
+emit(sample)
+```
+
+### 5. RW output pipeline
+
+**Batching:**
+- In-memory `List<PromSample>` with size + byte-count tracked
+- Flush triggers: `samples.size() >= 1000` OR `bytesUncompressed >= 1_048_576` OR time-since-first-sample >= `1000 ms`
+- Flush task scheduled via Spring `@Scheduled(fixedDelay = 100 ms)` checker for time-based trigger
+- On flush: group samples by `(name, labels)` into `TimeSeries`, build `WriteRequest`, Snappy-compress, POST
+
+**HTTP client:**
+- Spring 6 `RestClient` (Boot 4 default)
+- Timeouts: connect 5s, read 30s
+- Headers:
+  - `Content-Type: application/x-protobuf`
+  - `Content-Encoding: snappy`
+  - `X-Prometheus-Remote-Write-Version: 0.1.0`
+  - `User-Agent: deltav-prometheus-writer/<version>`
+  - Auth per config: `Authorization: Bearer <token>` or `Authorization: Basic <base64>` or none
+  - Extra headers from config (e.g. `X-Scope-OrgID: <tenant>` for Mimir multi-tenant)
+
+**Retry classifier:**
+
+| HTTP status / error | Classification | Action |
+|---|---|---|
+| 200, 204 | success | ack |
+| 429 | rate-limited | retry with `Retry-After` header respect (fallback to exp backoff) |
+| 500, 502, 503, 504 | transient | retry with 100ms → 30s exp backoff + jitter |
+| Network error (timeout, ECONNREFUSED, ECONNRESET) | transient | same as 5xx |
+| 400 | poison | DLQ + drop, increment `dlq_records_total{reason="bad_request"}`, do NOT retry |
+| 413 | poison (too large) | DLQ + drop, increment `dlq_records_total{reason="payload_too_large"}` |
+| 401, 403 | auth failure | open circuit, log ERROR once per circuit cycle, increment `batches_failed_total{reason="auth"}` |
+| 404 | bad URL | open circuit, log ERROR, increment `batches_failed_total{reason="bad_url"}` |
+
+Retry bounded by circuit-closed state; circuit opens on persistent failure regardless of classifier.
+
+**Circuit breaker (Resilience4j):**
+- `failureRateThreshold = 50%`
+- `slidingWindowType = COUNT_BASED`
+- `slidingWindowSize = 20`
+- `minimumNumberOfCalls = 10`
+- `waitDurationInOpenState = 30s`
+- `permittedNumberOfCallsInHalfOpenState = 3`
+- `automaticTransitionFromOpenToHalfOpenEnabled = true`
+
+**State machine:**
+```
+CLOSED ── 50% failures in last 20 calls ──▶ OPEN
+OPEN ── 30s elapsed ──▶ HALF_OPEN
+HALF_OPEN ── 3 calls succeed ──▶ CLOSED
+HALF_OPEN ── any call fails ──▶ OPEN
+```
+
+On every transition:
+- emit `deltav_prometheus_writer_circuit_state{endpoint} = 0|1|2`
+- log INFO with state + endpoint
+- `ConsumerPauseListener` calls `BindingsLifecycleController.pause()` on CLOSED → OPEN or HALF_OPEN → OPEN transitions
+- `ConsumerPauseListener` calls `BindingsLifecycleController.resume()` on HALF_OPEN → CLOSED transition
+- (no pause/resume on OPEN → HALF_OPEN transition — probes run without the consumer producing load)
+
+### 6. DLQ
+
+**Topic config (new NewTopic bean):**
+- Name: `deltav-prometheus-writer-dlq`
+- Partitions: 16 (match `deltav-timeseries` for key-preserving writes)
+- `cleanup.policy=delete`
+- `retention.ms=604800000` (7 days)
+- `compression.type=lz4`
+
+**Record shape:**
+- Key: same `{location}@{node_id}` as the source
+- Value: the original `TimeseriesBatch` protobuf bytes, unmodified
+- Headers (all strings):
+  - `x-dlq-reason`: `bad_request` | `payload_too_large`
+  - `x-dlq-http-status`: `400` | `413`
+  - `x-dlq-endpoint`: the RW URL that rejected it
+  - `x-dlq-timestamp-ms`: epoch ms of the DLQ write
+  - `x-dlq-error-message`: RW target's response body, truncated to 1 KB
+  - `x-dlq-writer-version`: producer version string
+
+**SCS binding:**
+- `spring.cloud.stream.bindings.publishDlq-out-0.destination: deltav-prometheus-writer-dlq`
+- `spring.cloud.stream.bindings.publishDlq-out-0.producer.use-native-encoding: true` (byte-array payload, splitter-lesson prophylactic)
+
+### 7. Observability
+
+All metrics exposed at `/actuator/prometheus` via Micrometer. Meter name prefix: `deltav_prometheus_writer_`.
+
+**Ingestion:**
+- `deltav_prometheus_writer_records_consumed_total{location, producer, collection_package}` — Counter
+- `deltav_prometheus_writer_samples_in_total{location}` — Counter (individual Prom samples after fan-out, before filters)
+
+**Enrichment:**
+- `deltav_prometheus_writer_enrichment_hit_total{location}` — Counter
+- `deltav_prometheus_writer_enrichment_missing_total{location, reason}` — Counter (`reason ∈ {never_seen, tombstoned}`)
+- `deltav_prometheus_writer_node_context_cache_size` — Gauge (entry count)
+- `deltav_prometheus_writer_node_context_cache_ready` — Gauge (0/1)
+- `deltav_prometheus_writer_node_context_bootstrap_duration_seconds` — Timer (one-shot)
+
+**Sample dropouts:**
+- `deltav_prometheus_writer_samples_dropped_total{reason}` — Counter (`reason ∈ {string_attribute, type_unspecified, sanitize_collision, enrichment_missing}`)
+
+**RW output:**
+- `deltav_prometheus_writer_batches_sent_total{endpoint}` — Counter
+- `deltav_prometheus_writer_samples_sent_total{endpoint}` — Counter (successful samples, post-flush)
+- `deltav_prometheus_writer_batches_failed_total{endpoint, reason}` — Counter (`reason ∈ {remote_write_5xx, remote_write_429, remote_write_4xx, network_error, serialization_error, auth, bad_url}`)
+- `deltav_prometheus_writer_batch_size_bytes{endpoint}` — DistributionSummary (post-Snappy)
+- `deltav_prometheus_writer_batch_sample_count{endpoint}` — DistributionSummary
+- `deltav_prometheus_writer_flush_duration_seconds{endpoint}` — Timer
+- `deltav_prometheus_writer_retry_attempts_total{endpoint, reason}` — Counter
+
+**DLQ:**
+- `deltav_prometheus_writer_dlq_records_total{reason}` — Counter
+
+**Circuit + consumer state:**
+- `deltav_prometheus_writer_circuit_state{endpoint}` — Gauge (0=closed, 1=half_open, 2=open)
+- `deltav_prometheus_writer_consumer_paused` — Gauge (0/1)
+
+### 8. Configuration (`application.yml`)
+
+```yaml
+spring:
+  application:
+    name: prometheus-writer
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}  # prod yaml carries it — Phase 0 #170 lesson
+  cloud:
+    stream:
+      kafka:
+        binder:
+          brokers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bindings:
+        timeseriesConsumer-in-0:
+          destination: deltav-timeseries
+          group: prometheus-writer
+          consumer:
+            concurrency: 4
+        publishDlq-out-0:
+          destination: deltav-prometheus-writer-dlq
+          producer:
+            use-native-encoding: true    # splitter-lesson prophylactic
+
+prometheus-writer:
+  remote-write:
+    url: ${PROMETHEUS_WRITER_REMOTE_WRITE_URL:http://victoriametrics:8428/api/v1/write}
+    auth:
+      type: ${PROMETHEUS_WRITER_AUTH_TYPE:none}   # none | bearer | basic
+      bearer-token: ${PROMETHEUS_WRITER_BEARER_TOKEN:}
+      basic-username: ${PROMETHEUS_WRITER_BASIC_USER:}
+      basic-password: ${PROMETHEUS_WRITER_BASIC_PASS:}
+    headers:
+      # Example: X-Scope-OrgID: "delta-v"   # for Mimir multi-tenant
+  batch:
+    max-samples: 1000
+    max-bytes: 1048576
+    max-interval-ms: 1000
+  retry:
+    initial-backoff-ms: 100
+    max-backoff-ms: 30000
+    jitter-factor: 0.1
+  circuit-breaker:
+    failure-rate-threshold: 50
+    sliding-window-size: 20
+    minimum-number-of-calls: 10
+    wait-duration-open-ms: 30000
+    half-open-permitted-calls: 3
+  labels:
+    from-metadata: []                     # optional allowlist, empty by default
+  startup-gate:
+    enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, bindings
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+```
+
+### 9. Docker integration
+
+**New Dockerfile:** `opennms-container/delta-v/Dockerfile.prometheus-writer`
+- Base: same JRE layer as existing daemon-boot-* services
+- COPY the fat jar from `core/prometheus-writer/target/prometheus-writer-*.jar`
+- ENTRYPOINT runs the jar with JVM flags matching other delta-v services (heap tuned conservatively for 10k-node scale: `-Xmx512m`)
+
+**New compose service** (`opennms-container/delta-v/docker-compose.yml`):
+
+```yaml
+prometheus-writer:
+  image: opennms/deltav-prometheus-writer:${ONMS_DELTAV_VERSION}
+  profiles: [lite, full]
+  depends_on:
+    kafka: {condition: service_healthy}
+    provisiond: {condition: service_started}
+  environment:
+    SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9093
+    PROMETHEUS_WRITER_REMOTE_WRITE_URL: http://victoriametrics:8428/api/v1/write
+  healthcheck:
+    test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health/readiness"]
+    interval: 10s
+    timeout: 5s
+    retries: 10
+  ports:
+    - "18080:8080"
+
+victoriametrics:
+  image: victoriametrics/victoria-metrics:v1.106.1
+  profiles: [metrics-e2e]
+  command:
+    - "-retentionPeriod=1h"
+    - "-storageDataPath=/tmp/vm"
+    - "-search.latencyOffset=1s"
+  healthcheck:
+    test: ["CMD", "wget", "-q", "-O-", "http://localhost:8428/health"]
+    interval: 5s
+    timeout: 3s
+    retries: 10
+  ports:
+    - "18428:8428"
+```
+
+(The VM version `v1.106.1` is pinned explicitly per Q10d.)
+
+**`build.sh` integration:**
+- `opennms-container/delta-v/build.sh` iterates `core/daemon-boot-*/` (13 modules today) and explicitly builds `core/flow-enricher/` as a standalone service. Phase 2 adds a third top-level build step for `core/prometheus-writer/` (same pattern as flow-enricher — not a daemon-boot-* module).
+- PR template reminder: "Rebuild all 13 daemon-boot jars + flow-enricher + prometheus-writer before `./build.sh deltav`" (per `feedback_rebuild_all_daemons.md`; memory note to be updated on merge)
+
+### 10. E2E test script
+
+**New file:** `opennms-container/delta-v/test-prometheus-writer-e2e.sh`
+
+6 steps, modeled after `test-node-context-e2e.sh`:
+
+**Step 1: Stack up**
+```
+docker compose --profile lite --profile metrics-e2e up -d --build
+```
+Wait for `prometheus-writer /actuator/health/readiness` green (timeout 120s). Ready = `NodeContextCache` bootstrapped + binding resumed.
+
+**Step 2: Assert startup gate fired**
+```
+metrics=$(docker compose exec -T prometheus-writer curl -sf http://localhost:8080/actuator/prometheus)
+assert: deltav_prometheus_writer_node_context_cache_ready == 1
+assert: deltav_prometheus_writer_node_context_bootstrap_duration_seconds_count >= 1
+```
+
+**Step 3: Wait for Collectd polls**
+```
+sleep 90    # 2× default 30s poll cycle + grace
+```
+
+**Step 4: Assert samples flowed**
+```
+metrics=$(...)
+assert: deltav_prometheus_writer_records_consumed_total > 0
+assert: deltav_prometheus_writer_samples_sent_total > 0
+assert: deltav_prometheus_writer_batches_sent_total > 0
+assert: deltav_prometheus_writer_circuit_state == 0   # closed
+```
+
+**Step 5: Assert zero failures**
+Each assertion guards against grep-no-match-under-pipefail with `{ ... || true; }`:
+```
+failure_count=$({ echo "$metrics" | grep '^deltav_prometheus_writer_batches_failed_total' || true; } | awk '{sum+=$2} END {print sum+0}')
+assert: failure_count == 0
+# Repeat for enrichment_missing_total, samples_dropped_total, dlq_records_total
+```
+
+**Step 6: Query VictoriaMetrics**
+```
+curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_interface_errors_ifindiscards_total"
+assert: result[] is non-empty
+assert: at least one result has labels {node_id, location, foreign_source, resource_instance}
+```
+
+**Teardown:**
+```
+docker compose --profile lite --profile metrics-e2e down -v --remove-orphans
+```
+
+## Scar prophylactics
+
+Per Phase 0/1 lessons, Phase 2 bakes in these guards from day one:
+
+1. **Real-main-class IT.** `PrometheusWriterApplicationScanIT` does `@SpringBootTest(classes = PrometheusWriterApplication.class)` and asserts the key beans resolve (`NodeContextCache`, `TimeseriesConsumer`, `BatchingRwWriter`, `PrometheusWriterCircuitBreaker`, `DlqPublisher`). Exercises the real `SpringApplication.run()` scan path. Would have caught Phase 0's `scanBasePackages` gap in one CI run.
+2. **Production yaml parity.** Every property any Testcontainers IT sets via `ApplicationContextInitializer` also exists in `src/main/resources/application.yml`. Checked by CI lint at PR time.
+3. **`use-native-encoding: true`** on the DLQ producer binding. Splitter-lesson prophylactic (Phase 1.5 scar).
+4. **Full-reactor verify gate.** CI runs `./mvnw clean install -DskipTests -fae` from the reactor root before the PR can merge. Catches cross-module cascade failures that `-pl core/prometheus-writer` would miss.
+5. **Rebuild-all-services reminder** in PR description template. `build.sh deltav` expects all 13 daemon-boot jars + flow-enricher + prometheus-writer to be current; stale jars cause silent runtime surprises.
+6. **Pipefail-safe grep** in the E2E script. All `grep`-driven counter assertions wrapped in `{ ... || true; }` per Phase 1 scar.
+
+## Testing strategy
+
+### Unit tests (JUnit 5)
+- `NodeContextCacheTest` — put/remove/tombstone semantics
+- `NameSanitizerTest` — every edge case (leading digit, consecutive separators, collisions)
+- `TimeseriesToPromTranslatorTest` — filter + label-build logic, string drop, unspecified drop, counter `_total` suffix
+- `LabelBuilderTest` — metadata allowlist, categories comma-join, empty-value handling
+- `RemoteWriteRetryPolicyTest` — status code → action classification
+- `BatchingRwWriterTest` — flush triggers (size / bytes / time), grouping by series
+
+### SCS test-binder ITs (Spring Cloud Stream)
+- `TimeseriesConsumerBinderIT` — assert the consumer processes a `TimeseriesBatch` → samples land in a mock RW client
+- `DlqPublisherBinderIT` — assert DLQ binding produces with `use-native-encoding` and headers set
+
+### Testcontainers broker ITs
+- `NodeContextBootstrapTC` — real Kafka broker, publish 100 `NodeContext` records, assert cache reaches "ready" with all 100 entries
+- `RwRoundTripTC` — real Kafka + stub HTTP sink, assert end-to-end: Kafka in → sink receives decompressible `WriteRequest`
+- `CircuitBreakerTC` — inject a failing sink, assert circuit opens + binding pauses + circuit recovers + binding resumes
+
+### Real-main-class IT
+- `PrometheusWriterApplicationScanIT` (see Scar prophylactic #1)
+
+### Docker Compose E2E
+- `test-prometheus-writer-e2e.sh` (see §10)
+
+### Load / soak (manual, not CI)
+- Deploy at labbox or dev cluster, point at real VM instance, run for 24 hours
+- Assert no memory leak (sample count steady, cache size steady)
+- Assert no samples lost over a 10-minute VM restart (circuit opens, pauses, VM recovers, consumer resumes, lag drains)
+
+## Schema freeze decision
+
+Upon Phase 2 merge:
+
+1. `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto` — header comment updated to reflect **Phase 2 GA, wire format frozen**
+2. `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto` — header comment updated similarly
+3. Going forward: additions permitted only via new tag numbers. Breaking changes require bump to `// API version: 2` with a one-release deprecation cycle maintaining v1 as read-only.
+
+This commitment unblocks future consumers (Thresholder, additional Prom RW instances built by operators, third-party processors) to target stable contracts.
+
+## Rollout
+
+- Feature flag: none (Phase 2 is pure addition; no existing functionality changes)
+- Docker Compose default: `prometheus-writer` service starts in `[lite, full]` profiles, pointed at `http://victoriametrics:8428/...` which is only up in `[metrics-e2e]` profile → in normal `lite`/`full` runs, the writer starts healthy but opens its circuit due to network unreachable, logs WARN, stays paused. This is intentional: the writer is ready for operator to override the RW URL; the default is a placeholder.
+- Production deployment: operator sets `PROMETHEUS_WRITER_REMOTE_WRITE_URL` env var (and auth config) to their real TSDB before bringing up the service.
+
+## Open questions → answered
+
+All 10 design questions from the next-session prompt plus Q11 (schema freeze) have been decided:
+
+| # | Topic | Decision |
+|---|---|---|
+| 1 | Deployment shape | New module `core/prometheus-writer/`, standalone Spring Boot |
+| 2 | Enrichment mechanism | Plain SCS + `NodeContextCache` bean (not Kafka Streams GlobalKTable) |
+| 3a | RW target pluggability | Single configurable endpoint |
+| 3b | E2E backend | VictoriaMetrics single-node (pinned v1.106.1) |
+| 3c | Auth | Bearer / basic / none + extra headers; no mTLS |
+| 4a | Metric name scheme | `opennms_{group}_{attr}[_total]`, snake_case |
+| 4b | Label set | Strict allowlist default; metadata labels opt-in via config |
+| 4c | String attributes | Drop + counter |
+| 4d | Sanitization | Lowercase + non-alphanumeric → `_`, collapse, strip leading digit |
+| 5a | COUNTER | Emit as Prom counter with `_total`, trust `rate()` for resets |
+| 5b | GAUGE | Emit as-is; no clamping |
+| 5c | UNSPECIFIED | Drop + counter |
+| 5d | Timestamp | Collection time from `TimeseriesBatch.timestamp_ms` |
+| 6a | Startup drift | Block consumer until cache bootstrapped |
+| 6b | Post-startup miss | Drop + counter |
+| 6c | Tombstone | `cache.remove(key)`; no staleness marker |
+| 7 | Staleness on delete | Defer; rely on RW target retention |
+| 8a | Batch window | 1000 samples / 1 MB / 1000 ms (whichever first) |
+| 8b | Retry policy | Tiered by HTTP status |
+| 8c | Poison pill | DLQ to `deltav-prometheus-writer-dlq` |
+| 8d | Consumer pause | Resilience4j circuit + SCS binding pause/resume |
+| 9 | Observability | Full `deltav_prometheus_writer_*` metric set at `/actuator/prometheus` |
+| 10a | Compose profiles | Writer in `[lite, full]`; VM in new `[metrics-e2e]` |
+| 10b | E2E structure | 6 steps ending in VM query |
+| 10c | Scar prophylactics | All 6 guards baked in from day one |
+| 10d | VM version | Pinned (v1.106.1) |
+| 11a | Schema changes | None — both contracts freeze at Phase 2 GA |
+| 11b | Versioning rule | Keep `// API version: 1` header convention; new fields at new tags, breaking changes bump version |
+
+## Deliverables
+
+1. This design document (committed in this PR).
+2. Implementation plan: `docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer.md` (next session — see next-session prompt queued alongside).
+3. Next-session prompt: `docs/superpowers/next-session-prompts/2026-04-18-kafka-ts-phase-2-implementation.md` (written in this PR).

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -331,6 +331,73 @@ tombstone. On every provisiond restart, the full node set is re-published
 
 Default changed from **7 days → 1 day** in Phase 1. Override via `DELTAV_TIMESERIES_RETENTION_DAYS`. Rationale: at production scale, 7-day retention for high-volume metric records consumes significantly more disk than necessary (≈40 GB steady state at 10k nodes vs ≈5.76 GB with 1-day).
 
+## Phase 2 — Prometheus Remote Write consumer
+
+The `prometheus-writer` service consumes `deltav-timeseries`, enriches each
+batch with node identity from `deltav-node-context`, and POSTs Snappy-compressed
+Prometheus Remote Write protobuf batches to a configurable endpoint.
+
+### Profiles
+
+- **lite, full** — starts `prometheus-writer`. Point `PROMETHEUS_WRITER_REMOTE_WRITE_URL`
+  at your TSDB (Mimir, VictoriaMetrics, Cortex, Thanos Receive, Prometheus with
+  `--web.enable-remote-write-receiver`). Without a reachable target, the writer
+  starts healthy, opens its circuit on first POST failure, and stays paused.
+- **metrics-e2e** — adds a pinned `victoriametrics:v1.106.1` container for E2E.
+  Not intended for production.
+
+### Configuration
+
+Environment variables (also see `core/prometheus-writer/src/main/resources/application.yml`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PROMETHEUS_WRITER_REMOTE_WRITE_URL` | `http://victoriametrics:8428/api/v1/write` | RW endpoint |
+| `PROMETHEUS_WRITER_AUTH_TYPE` | `none` | `none` / `bearer` / `basic` |
+| `PROMETHEUS_WRITER_BEARER_TOKEN` | (empty) | Bearer token when `AUTH_TYPE=bearer` |
+| `PROMETHEUS_WRITER_BASIC_USER` | (empty) | Basic auth user |
+| `PROMETHEUS_WRITER_BASIC_PASS` | (empty) | Basic auth pass |
+| `SPRING_KAFKA_BOOTSTRAP_SERVERS` | `kafka:9092` (compose) | Kafka brokers |
+
+Extra headers (e.g. `X-Scope-OrgID` for Mimir tenancy) via yaml
+`prometheus-writer.remote-write.headers.{name}: "{value}"`.
+
+Opt-in metadata-label promotion:
+
+```yaml
+prometheus-writer:
+  labels:
+    from-metadata:
+      - requisition:region
+      - snmp:sysLocation
+```
+
+### Metrics
+
+All exposed at `/actuator/prometheus`, prefix `deltav_prometheus_writer_`.
+See `docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md` §7
+for the full list.
+
+Useful PromQL examples:
+
+```
+rate(deltav_prometheus_writer_samples_sent_total[5m])
+rate(deltav_prometheus_writer_enrichment_missing_total[5m])
+deltav_prometheus_writer_circuit_state         # 0=closed, 1=half_open, 2=open
+deltav_prometheus_writer_node_context_cache_size
+```
+
+### Topics
+
+- Consumes `deltav-timeseries` (group `prometheus-writer`)
+- Consumes `deltav-node-context` (unique group per instance)
+- Produces to `deltav-prometheus-writer-dlq` (poison-pill records only)
+
+### Wire format frozen
+
+As of Phase 2 GA, both `deltav-timeseries` and `deltav-node-context` protobuf
+schemas are frozen. Only forward-compatible additions (new tag numbers) permitted.
+
 ## Troubleshooting
 
 **Images not found:** Run `./build.sh` to build all images. Verify with `docker images | grep opennms`.

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -145,6 +145,14 @@ do_flow_enricher_image() {
     docker build -t "opennms/flow-enricher:$VERSION" -t "opennms/flow-enricher:latest" .
 }
 
+do_prometheus_writer_image() {
+    log "Building prometheus-writer image (opennms/prometheus-writer:$VERSION)..."
+    cd "$REPO_ROOT"
+    ./mvnw -B -f core/prometheus-writer/pom.xml -DskipTests package
+    cd "$REPO_ROOT/core/prometheus-writer"
+    docker build -t "opennms/prometheus-writer:$VERSION" -t "opennms/prometheus-writer:latest" .
+}
+
 do_jre_image() {
     log "Building opennms/jre-deltav:21..."
     cd "$SCRIPT_DIR"
@@ -234,8 +242,15 @@ do_deltav_images() {
     # standalone image, like db-init.
     do_flow_enricher_image
 
+    # --- Build prometheus-writer (standalone Spring Cloud Stream service) ---
+    # prometheus-writer consumes the Kafka Time Series topic and publishes
+    # samples via Prometheus Remote Write. Like flow-enricher, it has a
+    # dependency profile distinct from the horizon-derived daemons, so it is
+    # built as a standalone image rather than sharing daemon-base.
+    do_prometheus_writer_image
+
     log "Delta-V images built:"
-    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher" | sort | head -20
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer" | sort | head -25
 }
 
 

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -596,6 +596,41 @@ services:
       POLLING_INTERVAL: "10"
       TRAFFIC_INTERVAL: "2"
 
+  prometheus-writer:
+    image: opennms/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
+    profiles: [lite, full]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      provisiond:
+        condition: service_started
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      PROMETHEUS_WRITER_REMOTE_WRITE_URL: http://victoriametrics:8428/api/v1/write
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "18080:8080"
+
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.106.1
+    profiles: [metrics-e2e]
+    command:
+      - "-retentionPeriod=1h"
+      - "-storageDataPath=/tmp/vm"
+      - "-search.latencyOffset=1s"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:8428/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "18428:8428"
+
 volumes:
   pgdata:
   kafkadata:

--- a/opennms-container/delta-v/test-prometheus-writer-e2e.sh
+++ b/opennms-container/delta-v/test-prometheus-writer-e2e.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 BeaconStrategists, Inc.
+# Licensed under the GNU Affero General Public License v3.
+#
+# Layer 5 end-to-end smoke test for the prometheus-writer.  Starts the
+# delta-v Docker Compose stack (lite + metrics-e2e profiles: Collectd
+# produces to deltav-timeseries, Provisiond produces to
+# deltav-node-context, prometheus-writer consumes + enriches + POSTs to
+# VictoriaMetrics), then asserts:
+#
+#   1. prometheus-writer /actuator/health/readiness is UP (cache
+#      bootstrapped + binding resumed)
+#   2. NodeContextCache bootstrap fired cleanly
+#      (bootstrap_duration_seconds_count >= 1, cache_ready == 1)
+#   3. After 2 × 30 s Collectd poll cycles (~90 s wait),
+#      records_consumed_total > 0, samples_sent_total > 0,
+#      batches_sent_total > 0, circuit_state == 0 (closed)
+#   4. (folded into step 5 assertions below)
+#   5. Zero failure counters (batches_failed_total == 0,
+#      enrichment_missing_total == 0, samples_dropped_total == 0,
+#      dlq_records_total == 0)
+#   6. VictoriaMetrics query returns a result with the expected label
+#      set — the "gold standard" assertion that proves the full RW
+#      wire round-trip.
+#
+# Scar prophylactic: every grep pipeline guarded by { ... || true; }
+# because grep returns 1 on no-match and `set -euo pipefail` would kill
+# the script (Phase 1 scar).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+STACK_READY_TIMEOUT=180
+POLL_GRACE_SECONDS=90
+METRICS_TIMEOUT=180
+VM_QUERY_TIMEOUT=30
+
+cleanup() {
+    echo "==> Tearing down stack"
+    docker compose --profile lite --profile metrics-e2e down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "==> Starting delta-v Docker Compose (lite + metrics-e2e profiles)"
+docker compose --profile lite --profile metrics-e2e up -d --build
+
+# ── Step 1: Wait for prometheus-writer readiness ──────────────────────────────
+echo "==> Step 1: Wait for prometheus-writer /actuator/health/readiness"
+deadline=$((SECONDS + STACK_READY_TIMEOUT))
+while (( SECONDS < deadline )); do
+    if docker compose exec -T prometheus-writer \
+            curl -sf http://localhost:8080/actuator/health/readiness >/dev/null 2>&1; then
+        echo "==> prometheus-writer ready"
+        break
+    fi
+    sleep 3
+done
+if ! docker compose exec -T prometheus-writer \
+        curl -sf http://localhost:8080/actuator/health/readiness >/dev/null 2>&1; then
+    echo "FAIL: prometheus-writer did not become ready in ${STACK_READY_TIMEOUT}s"
+    docker compose logs prometheus-writer | tail -100
+    exit 1
+fi
+
+# ── Step 2: Assert startup gate fired cleanly ─────────────────────────────────
+echo "==> Step 2: Assert startup gate fired"
+metrics=$(docker compose exec -T prometheus-writer \
+        curl -sf http://localhost:8080/actuator/prometheus)
+
+ready=$({ echo "$metrics" | grep -E '^deltav_prometheus_writer_node_context_cache_ready\b' || true; } \
+        | awk '{print $2}' | head -1)
+if [[ "$ready" != "1.0" && "$ready" != "1" ]]; then
+    echo "FAIL: node_context_cache_ready != 1 (got: '$ready')"
+    exit 1
+fi
+
+boot_count=$({ echo "$metrics" | grep -E '^deltav_prometheus_writer_node_context_bootstrap_duration_seconds_count\b' || true; } \
+        | awk '{sum+=$2} END {print sum+0}')
+if (( $(echo "$boot_count < 1" | bc -l) )); then
+    echo "FAIL: bootstrap_duration_seconds_count < 1 (got: $boot_count)"
+    exit 1
+fi
+echo "==> Startup gate verified: cache_ready=1, bootstrap_count=$boot_count"
+
+# ── Step 3: Wait for Collectd polls ───────────────────────────────────────────
+echo "==> Step 3: Wait ${POLL_GRACE_SECONDS}s for Collectd to produce timeseries"
+sleep "${POLL_GRACE_SECONDS}"
+
+# ── Step 4: Assert samples flowed ─────────────────────────────────────────────
+echo "==> Step 4: Assert records/samples/batches flowed"
+metrics=$(docker compose exec -T prometheus-writer \
+        curl -sf http://localhost:8080/actuator/prometheus)
+
+assert_gt_zero() {
+    local name="$1"
+    local value
+    value=$({ echo "$metrics" | grep -E "^${name}\b" || true; } | awk '{sum+=$2} END {print sum+0}')
+    if (( $(echo "$value <= 0" | bc -l) )); then
+        echo "FAIL: ${name} is not > 0 (got: $value)"
+        exit 1
+    fi
+    echo "==> ${name} = ${value}"
+}
+
+assert_gt_zero 'deltav_prometheus_writer_records_consumed_total'
+assert_gt_zero 'deltav_prometheus_writer_samples_sent_total'
+assert_gt_zero 'deltav_prometheus_writer_batches_sent_total'
+
+circuit=$({ echo "$metrics" | grep -E '^deltav_prometheus_writer_circuit_state\b' || true; } | awk '{print $2}' | head -1)
+if [[ "$circuit" != "0.0" && "$circuit" != "0" ]]; then
+    echo "FAIL: circuit_state != 0 (got: '$circuit')"
+    exit 1
+fi
+echo "==> Circuit closed (state=0)"
+
+# ── Step 5: Assert zero failures ──────────────────────────────────────────────
+echo "==> Step 5: Assert zero failure counters"
+assert_zero() {
+    local name="$1"
+    local value
+    value=$({ echo "$metrics" | grep -E "^${name}" || true; } | awk '{sum+=$2} END {print sum+0}')
+    if (( $(echo "$value > 0" | bc -l) )); then
+        echo "FAIL: ${name} > 0 (got: $value)"
+        exit 1
+    fi
+    echo "==> ${name} = 0 ✓"
+}
+
+assert_zero 'deltav_prometheus_writer_batches_failed_total'
+assert_zero 'deltav_prometheus_writer_enrichment_missing_total'
+assert_zero 'deltav_prometheus_writer_samples_dropped_total'
+assert_zero 'deltav_prometheus_writer_dlq_records_total'
+
+# ── Step 6: Query VictoriaMetrics ─────────────────────────────────────────────
+echo "==> Step 6: Query VictoriaMetrics for the landed series"
+deadline=$((SECONDS + VM_QUERY_TIMEOUT))
+while (( SECONDS < deadline )); do
+    resp=$(curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_interface_errors_ifindiscards_total" \
+            || echo '{"data":{"result":[]}}')
+    count=$(echo "$resp" | python3 -c \
+        'import json,sys; d=json.load(sys.stdin); print(len(d.get("data",{}).get("result",[])))' \
+        2>/dev/null || echo "0")
+    if (( count > 0 )); then
+        echo "==> VM returned ${count} series for opennms_mib2_interface_errors_ifindiscards_total"
+        echo "$resp" | grep -E '"node_id":"[0-9]+"' > /dev/null || { echo "FAIL: missing node_id label"; exit 1; }
+        echo "$resp" | grep -E '"location":' > /dev/null || { echo "FAIL: missing location label"; exit 1; }
+        echo "$resp" | grep -E '"foreign_source":' > /dev/null || { echo "FAIL: missing foreign_source label"; exit 1; }
+        echo "$resp" | grep -E '"resource_instance":' > /dev/null || { echo "FAIL: missing resource_instance label"; exit 1; }
+        echo "==> ALL ASSERTIONS PASSED"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "FAIL: VictoriaMetrics returned no results within ${VM_QUERY_TIMEOUT}s"
+echo "Last VM response: $resp"
+exit 1

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 
     <!-- Flow processing services (Spring Cloud Stream) -->
     <module>core/flow-enricher</module>
+    <module>core/prometheus-writer</module>
   </modules>
 
   <!-- ============================================================ -->


### PR DESCRIPTION
## Summary

- New `core/prometheus-writer/` standalone Spring Boot 4 consumer (Phase 2 of the Kafka Time Series pipeline)
- Consumes `deltav-timeseries`, enriches via local `deltav-node-context` materialization, transforms to Prometheus Remote Write protobuf
- Snappy-compressed POSTs to a configurable RW endpoint (default: `http://victoriametrics:8428/api/v1/write`)
- Resilience4j circuit breaker + SCS binding pause/resume on circuit state
- DLQ topic `deltav-prometheus-writer-dlq` for poison pills (400/413)
- Startup gate: `deltav-timeseries` binding paused until NodeContext cache bootstrapped
- Both wire contracts (`deltav-timeseries.proto`, `deltav-node-context.proto`) frozen at Phase 2 GA

## Production bugs caught by the scar-prophylactic IT (Task 19/20)

The plan's `PrometheusWriterApplicationScanIT` (real `SpringApplication.run()` + Testcontainers Kafka) caught FIVE real production bugs that unit tests + SCS-binder ITs all missed:
- Three `@Configuration`-class-name vs `@Bean`-method-name collisions (NodeContextCacheHealthIndicator, TimeseriesConsumer, PrometheusWriterCircuitBreaker) → renamed each class with `Configuration` suffix.
- One startup race: `NodeContextKafkaBootstrap.@PostConstruct` published `NodeContextCacheReadyEvent` before `TimeseriesBindingResumer` was registered. Refactored to `@EventListener(ApplicationReadyEvent.class)`.
- One dead-code wiring: `BatchingRwWriter.flushNow()` never wrapped its HTTP call in `breaker.executeCallable()`. The whole circuit breaker subsystem was inert. Fixed.

## Rebuild checklist

- [ ] All 13 daemon-boot jars built (`./opennms-container/delta-v/build.sh`)
- [ ] flow-enricher rebuilt
- [ ] prometheus-writer rebuilt (new in this PR)
- [ ] Full-reactor `./mvnw clean install -DskipTests -fae` passes locally
- [ ] `test-prometheus-writer-e2e.sh` passes locally (lite + metrics-e2e profiles)

## Scar prophylactic verification

- [x] #1 Real-main-class IT (`PrometheusWriterApplicationScanIT`) passes (caught 5 bugs on first run)
- [x] #2 Production yaml carries every Testcontainers-set property
- [x] #3 `use-native-encoding: true` on DLQ producer binding
- [x] #4 Full-reactor build green
- [x] #5 Rebuild-all reminder present (this checklist)
- [x] #6 Pipefail-safe `|| true` guards on all grep-driven assertions in E2E

## Test plan

- [x] Unit tests — all green (10s of new tests across 14 test files)
- [x] SCS test-binder ITs (Task 15 TimeseriesConsumerBinderIT, Task 17 DlqPublisherBinderIT)
- [x] Testcontainers Kafka ITs (NodeContextKafkaBootstrapIT, RwRoundTripIT, CircuitBreakerIT)
- [x] Real-main-class IT (PrometheusWriterApplicationScanIT)
- [ ] **6-step Docker Compose E2E (lite + metrics-e2e profiles)** — NOT run pre-merge by author. **Reviewer/operator: please run `./opennms-container/delta-v/build.sh && cd opennms-container/delta-v && ./test-prometheus-writer-e2e.sh` before merging.**

## Spec + plan

- Design spec: `docs/superpowers/specs/2026-04-17-kafka-ts-phase-2-prometheus-consumer-design.md`
- Plan: `docs/superpowers/plans/2026-04-17-kafka-ts-phase-2-prometheus-consumer.md` (+ `-part2.md`)

## Memory notes added during execution

- `feedback_boot4_testcontainers_commons_io.md` — Boot 4 BOM pins commons-io 2.15.0; Testcontainers 2.x needs ≥2.16
- `feedback_configuration_class_bean_name_collision.md` — always suffix @Configuration classes with `Configuration`