### PR TITLE
fix(prometheus-writer): NodeContextKafkaBootstrap race + Collectd silent-swallow hygiene

### DIFF
--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -16,6 +16,7 @@
  */
 package org.deltav.collectd.timeseries;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import java.time.Duration;
@@ -97,11 +98,16 @@ public class TimeseriesKafkaPublisherConfiguration {
     @Primary
     public PersisterFactory compositePersisterFactory(
             @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
-            TimeseriesKafkaPublisher publisher) {
-        LOG.info("Creating compositePersisterFactory wrapping inner={}@{}",
+            TimeseriesKafkaPublisher publisher,
+            MeterRegistry meterRegistry,
+            @Value("${deltav.collectd.persister.inner.fail-fast:false}") boolean failFastInner,
+            @Value("${deltav.collectd.persister.kafka.fail-fast:false}") boolean failFastKafka) {
+        LOG.info("Creating compositePersisterFactory wrapping inner={}@{} (failFastInner={}, failFastKafka={})",
                 innerFactory.getClass().getName(),
-                System.identityHashCode(innerFactory));
-        return new FanoutPersisterFactory(innerFactory, publisher);
+                System.identityHashCode(innerFactory),
+                failFastInner, failFastKafka);
+        return new FanoutPersisterFactory(innerFactory, publisher, meterRegistry,
+                failFastInner, failFastKafka);
     }
 
     /**
@@ -111,17 +117,26 @@ public class TimeseriesKafkaPublisherConfiguration {
     static final class FanoutPersisterFactory implements PersisterFactory {
         private final PersisterFactory innerFactory;
         private final TimeseriesKafkaPublisher publisher;
+        private final MeterRegistry meterRegistry;
+        private final boolean failFastInner;
+        private final boolean failFastKafka;
 
-        FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher) {
+        FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher,
+                               MeterRegistry meterRegistry,
+                               boolean failFastInner, boolean failFastKafka) {
             this.innerFactory = innerFactory;
             this.publisher = publisher;
+            this.meterRegistry = meterRegistry;
+            this.failFastInner = failFastInner;
+            this.failFastKafka = failFastKafka;
         }
 
         @Override
         public Persister createPersister(ServiceParameters params, RrdRepository repository) {
             return new FanoutPersister(
                     innerFactory.createPersister(params, repository),
-                    new TimeseriesKafkaPersister(publisher, params));
+                    new TimeseriesKafkaPersister(publisher, params),
+                    meterRegistry, failFastInner, failFastKafka);
         }
 
         @Override
@@ -131,43 +146,87 @@ public class TimeseriesKafkaPublisherConfiguration {
             return new FanoutPersister(
                     innerFactory.createPersister(params, repository, dontPersistCounters,
                             forceStoreByGroup, dontReorderAttributes),
-                    new TimeseriesKafkaPersister(publisher, params));
+                    new TimeseriesKafkaPersister(publisher, params),
+                    meterRegistry, failFastInner, failFastKafka);
         }
     }
 
     /**
      * Forwards each visitor callback to both delegate persisters, inner first
      * then Kafka. Each delegate is invoked inside its own try/catch so that
-     * an exception in one does not prevent the other from running. This
-     * matters in practice: horizon's TimeseriesPersister has surfaced
-     * transaction-propagation failures in delta-v (MetaTagDataLoader marks
-     * a read-only transaction rollback-only on certain DB states), and
-     * without isolation a single inner failure would silently swallow every
-     * Kafka publish for the affected poll cycle. Exceptions are logged at
-     * WARN so they do not disappear without operator signal.
+     * an exception in one does not prevent the other from running.
+     *
+     * <p>Observability (added 2026-04-18 — see project_collectd_publisher_inert_investigation):
+     * <ul>
+     *   <li>{@code deltav.collectd.persister.inner.failures{step=<visitor-step>}}
+     *       — Micrometer counter, pre-registered for all 10 visitor steps at
+     *       construction so ops can alert on rate&gt;0 rather than missing-metric.</li>
+     *   <li>{@code deltav.collectd.persister.kafka.failures{step=<visitor-step>}}
+     *       — symmetric for the Kafka side.</li>
+     * </ul>
+     *
+     * <p>Fail-fast toggles (default false in production; CI/IT profiles enable):
+     * <ul>
+     *   <li>{@code deltav.collectd.persister.inner.fail-fast} — when true, inner
+     *       Throwable propagates as RuntimeException instead of being swallowed.</li>
+     *   <li>{@code deltav.collectd.persister.kafka.fail-fast} — symmetric.</li>
+     * </ul>
+     *
+     * <p>Phase 0 horizon-side inner-persister bugs (UnexpectedRollbackException
+     * in MetaTagDataLoader; NPE in TimeseriesPersistOperationBuilder.setAttributeValue;
+     * ClassCastException in TimeseriesPersister.getUserDefinedMetaTags) are still
+     * caught and WARN-logged here. They do not block the Kafka path. See memory
+     * project_phase0_inner_persister_bugs_followup for the dedicated fix queue.
      */
     static final class FanoutPersister implements Persister {
+        private static final String INNER_FAILURES_METER =
+                "deltav.collectd.persister.inner.failures";
+        private static final String KAFKA_FAILURES_METER =
+                "deltav.collectd.persister.kafka.failures";
+        private static final String[] STEPS = new String[]{
+                "visitCollectionSet", "visitResource", "visitGroup", "visitAttribute",
+                "completeAttribute", "completeGroup", "completeResource", "completeCollectionSet",
+                "persistNumericAttribute", "persistStringAttribute"
+        };
+
         private static final Logger LOG = LoggerFactory.getLogger(FanoutPersister.class);
 
         private final Persister innerPersister;
         private final TimeseriesKafkaPersister kafkaPersister;
+        private final MeterRegistry meterRegistry;
+        private final boolean failFastInner;
+        private final boolean failFastKafka;
 
-        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister) {
+        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister,
+                        MeterRegistry meterRegistry, boolean failFastInner, boolean failFastKafka) {
             this.innerPersister = innerPersister;
             this.kafkaPersister = kafkaPersister;
+            this.meterRegistry = meterRegistry;
+            this.failFastInner = failFastInner;
+            this.failFastKafka = failFastKafka;
+            preRegisterCounters();
+        }
+
+        private void preRegisterCounters() {
+            // Pre-register all 20 (2 sides × 10 steps) counter tag combinations at
+            // construction time so ops can alert on rate>0 rather than missing-metric
+            // (which would otherwise be ambiguous with "no failures occurred").
+            for (String step : STEPS) {
+                Counter.builder(INNER_FAILURES_METER).tag("step", step).register(meterRegistry);
+                Counter.builder(KAFKA_FAILURES_METER).tag("step", step).register(meterRegistry);
+            }
         }
 
         private void runInner(String step, Runnable task) {
             try {
                 task.run();
             } catch (Throwable e) {
-                // Catch Throwable (not just RuntimeException) because horizon's
-                // AbstractPersister has surfaced LinkageErrors (NoSuchMethodError
-                // on ResourceTypeUtils.getResourcePathWithRepository) in delta-v
-                // from pre-existing daemon-boot classpath mismatches. Kafka path
-                // isolation must hold for all failure modes, not just unchecked
-                // exceptions.
+                meterRegistry.counter(INNER_FAILURES_METER, "step", step).increment();
                 LOG.warn("Inner persister threw during {}; continuing with Kafka path", step, e);
+                if (failFastInner) {
+                    throw new RuntimeException(
+                            "Inner persister failed during " + step + " (fail-fast enabled)", e);
+                }
             }
         }
 
@@ -175,7 +234,12 @@ public class TimeseriesKafkaPublisherConfiguration {
             try {
                 task.run();
             } catch (Throwable e) {
+                meterRegistry.counter(KAFKA_FAILURES_METER, "step", step).increment();
                 LOG.warn("Kafka persister threw during {}; continuing", step, e);
+                if (failFastKafka) {
+                    throw new RuntimeException(
+                            "Kafka persister failed during " + step + " (fail-fast enabled)", e);
+                }
             }
         }
 

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -53,6 +53,12 @@ import org.springframework.kafka.config.TopicBuilder;
 @ConditionalOnProperty(name = "deltav.timeseries.enabled", havingValue = "true")
 public class TimeseriesKafkaPublisherConfiguration {
 
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesKafkaPublisherConfiguration.class);
+
+    public TimeseriesKafkaPublisherConfiguration() {
+        LOG.info("TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty(deltav.timeseries.enabled=true) matched");
+    }
+
     @Bean
     public CollectionSetToProtobufTranslator collectionSetToProtobufTranslator() {
         return new CollectionSetToProtobufTranslator();
@@ -92,6 +98,9 @@ public class TimeseriesKafkaPublisherConfiguration {
     public PersisterFactory compositePersisterFactory(
             @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
             TimeseriesKafkaPublisher publisher) {
+        LOG.info("Creating compositePersisterFactory wrapping inner={}@{}",
+                innerFactory.getClass().getName(),
+                System.identityHashCode(innerFactory));
         return new FanoutPersisterFactory(innerFactory, publisher);
     }
 

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -56,10 +56,6 @@ public class TimeseriesKafkaPublisherConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(TimeseriesKafkaPublisherConfiguration.class);
 
-    public TimeseriesKafkaPublisherConfiguration() {
-        LOG.info("TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty(deltav.timeseries.enabled=true) matched");
-    }
-
     @Bean
     public CollectionSetToProtobufTranslator collectionSetToProtobufTranslator() {
         return new CollectionSetToProtobufTranslator();

--- a/core/daemon-boot-collectd/src/main/resources/application.yml
+++ b/core/daemon-boot-collectd/src/main/resources/application.yml
@@ -75,7 +75,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, prometheus, env, beans, conditions
+        include: health, info, prometheus, conditions
   metrics:
     tags:
       application: ${spring.application.name:collectd}

--- a/core/daemon-boot-collectd/src/main/resources/application.yml
+++ b/core/daemon-boot-collectd/src/main/resources/application.yml
@@ -75,7 +75,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus
+        include: health, info, prometheus, env, beans, conditions
   metrics:
     tags:
       application: ${spring.application.name:collectd}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
@@ -16,7 +16,10 @@
  */
 package org.deltav.collectd.timeseries;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -27,11 +30,15 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersister;
 import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersisterFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.Persister;
 import org.opennms.netmgt.collection.api.PersisterFactory;
@@ -142,5 +149,119 @@ class FanoutPersisterTest {
         verify(innerPersister1).completeCollectionSet(setA);
         verify(innerPersister2, never()).completeCollectionSet(any());
         verify(publisher).publish(setA, "pkg-A", 1, "");
+    }
+
+    // --- Task 3 observability + fail-fast behavioural tests ------------------
+    // Pin the counter-increment and fail-fast behaviour added in Task 3.
+    // These mock TimeseriesKafkaPersister directly (unlike the older tests,
+    // which wire a real TimeseriesKafkaPersister around a mock publisher).
+
+    private MeterRegistry registry;
+    private Persister innerV2;
+    private TimeseriesKafkaPersister kafkaV2;
+
+    @BeforeEach
+    void setUpV2() {
+        registry = new SimpleMeterRegistry();
+        innerV2 = mock(Persister.class);
+        kafkaV2 = mock(TimeseriesKafkaPersister.class);
+    }
+
+    private FanoutPersister makeV2(boolean failFastInner, boolean failFastKafka) {
+        return new FanoutPersister(innerV2, kafkaV2, registry, failFastInner, failFastKafka);
+    }
+
+    @Test
+    void counter_increments_on_inner_failure_in_visitResource() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new RuntimeException("inner boom")).when(innerV2).visitResource(r);
+        doNothing().when(kafkaV2).visitResource(r);
+
+        makeV2(false, false).visitResource(r);
+
+        Counter c = registry.find("deltav.collectd.persister.inner.failures").tag("step", "visitResource").counter();
+        assertThat(c).isNotNull();
+        assertThat(c.count()).isEqualTo(1.0);
+        verify(kafkaV2).visitResource(r);
+    }
+
+    @Test
+    void counter_increments_on_kafka_failure_in_visitResource() {
+        CollectionResource r = mock(CollectionResource.class);
+        doNothing().when(innerV2).visitResource(r);
+        doThrow(new RuntimeException("kafka boom")).when(kafkaV2).visitResource(r);
+
+        makeV2(false, false).visitResource(r);
+
+        Counter c = registry.find("deltav.collectd.persister.kafka.failures").tag("step", "visitResource").counter();
+        assertThat(c).isNotNull();
+        assertThat(c.count()).isEqualTo(1.0);
+        verify(innerV2).visitResource(r);
+    }
+
+    @Test
+    void counters_preregistered_at_startup_with_zero_value() {
+        makeV2(false, false);
+        String[] steps = new String[]{
+                "visitCollectionSet", "visitResource", "visitGroup", "visitAttribute",
+                "completeAttribute", "completeGroup", "completeResource", "completeCollectionSet",
+                "persistNumericAttribute", "persistStringAttribute"
+        };
+        for (String step : steps) {
+            Counter ic = registry.find("deltav.collectd.persister.inner.failures").tag("step", step).counter();
+            Counter kc = registry.find("deltav.collectd.persister.kafka.failures").tag("step", step).counter();
+            assertThat(ic).as("inner counter step=%s", step).isNotNull();
+            assertThat(ic.count()).isZero();
+            assertThat(kc).as("kafka counter step=%s", step).isNotNull();
+            assertThat(kc.count()).isZero();
+        }
+    }
+
+    @Test
+    void fail_fast_inner_true_rethrows() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new RuntimeException("inner boom")).when(innerV2).visitResource(r);
+
+        FanoutPersister p = makeV2(true, false);
+        assertThatThrownBy(() -> p.visitResource(r))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("fail-fast enabled");
+    }
+
+    @Test
+    void fail_fast_inner_false_swallows_and_continues() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new RuntimeException("inner boom")).when(innerV2).visitResource(r);
+        doNothing().when(kafkaV2).visitResource(r);
+
+        makeV2(false, false).visitResource(r);  // must NOT throw
+
+        verify(kafkaV2).visitResource(r);
+    }
+
+    @Test
+    void fail_fast_kafka_true_rethrows() {
+        CollectionResource r = mock(CollectionResource.class);
+        doNothing().when(innerV2).visitResource(r);
+        doThrow(new RuntimeException("kafka boom")).when(kafkaV2).visitResource(r);
+
+        FanoutPersister p = makeV2(false, true);
+        assertThatThrownBy(() -> p.visitResource(r))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("fail-fast enabled");
+    }
+
+    @Test
+    void throwable_not_just_runtime_exception() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new LinkageError("NoSuchMethodError from horizon"))
+                .when(innerV2).visitResource(r);
+        doNothing().when(kafkaV2).visitResource(r);
+
+        makeV2(false, false).visitResource(r);  // must NOT throw
+
+        Counter c = registry.find("deltav.collectd.persister.inner.failures").tag("step", "visitResource").counter();
+        assertThat(c.count()).isEqualTo(1.0);
+        verify(kafkaV2).visitResource(r);
     }
 }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersister;
 import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersisterFactory;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class FanoutPersisterTest {
         ServiceParameters sp = mock(ServiceParameters.class);
         when(sp.getParameters()).thenReturn(new HashMap<>());
         TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
-        FanoutPersister fanout = new FanoutPersister(inner, kafka);
+        FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
         fanout.visitCollectionSet(set);
@@ -70,7 +71,7 @@ class FanoutPersisterTest {
         ServiceParameters sp = mock(ServiceParameters.class);
         when(sp.getParameters()).thenReturn(new HashMap<>());
         TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
-        FanoutPersister fanout = new FanoutPersister(inner, kafka);
+        FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
         doThrow(new RuntimeException("inner boom"))
@@ -93,7 +94,7 @@ class FanoutPersisterTest {
         ServiceParameters sp = mock(ServiceParameters.class);
         when(sp.getParameters()).thenReturn(new HashMap<>());
         TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
-        FanoutPersister fanout = new FanoutPersister(inner, kafka);
+        FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
         doThrow(new NoSuchMethodError("simulated classpath mismatch"))
@@ -115,7 +116,7 @@ class FanoutPersisterTest {
                 .thenReturn(innerPersister1, innerPersister2);
 
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        FanoutPersisterFactory factory = new FanoutPersisterFactory(innerFactory, publisher);
+        FanoutPersisterFactory factory = new FanoutPersisterFactory(innerFactory, publisher, new SimpleMeterRegistry(), false, false);
 
         ServiceParameters paramsA = mock(ServiceParameters.class);
         Map<String, Object> mapA = new HashMap<>();

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.netmgt.collectd.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.sql.DataSource;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.deltav.collectd.timeseries.TimeseriesKafkaPublisher;
+import org.deltav.core.event.forwarder.kafka.KafkaEventForwarder;
+import org.deltav.core.event.forwarder.kafka.KafkaEventSubscriptionService;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.mate.api.EntityScopeProvider;
+import org.opennms.core.rpc.api.RpcClientFactory;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.collectd.Collectd;
+import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.filter.api.FilterDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Real-main-class integration test. Boots {@link CollectdApplication} via
+ * {@code SpringApplication.run()} semantics (using
+ * {@code @SpringBootTest(classes = CollectdApplication.class)}) with
+ * {@code deltav.timeseries.enabled=true} and fail-fast toggles on. Asserts
+ * the composite PersisterFactory wires correctly so horizon's
+ * {@code CollectableService} resolves to our {@code FanoutPersisterFactory},
+ * not the bare inner factory.
+ *
+ * <p>Phase 2 PR #174 scar-prophylactic lineage: real-main-class startup via
+ * {@code @SpringBootTest(classes = CollectdApplication.class)} catches
+ * {@code @Configuration} class-name vs {@code @Bean} method-name collisions
+ * and bean-wiring bugs that unit tests + {@code @Import}-based ITs all
+ * bypass. Mandatory {@code commons-io:2.18.0} test dep added per
+ * {@code feedback_boot4_testcontainers_commons_io} memory.
+ *
+ * <p><b>Mocking strategy (adapted from {@code NodeContextProducerSpringContextIT}):</b>
+ * {@code CollectdDaemonConfiguration} reads {@code collectd-configuration.xml},
+ * {@code snmp-config.xml}, and {@code datacollection-config.xml} from
+ * {@code /opt/deltav/etc/} at bean-creation time; the JPA layer requires a
+ * live Postgres and the event transport opens a Kafka producer. We mock out
+ * the filesystem-reading / infrastructure beans so the scan completes and
+ * the flag-gated {@link org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration}
+ * wires into the context alongside all of {@link CollectdApplication}'s
+ * {@code scanBasePackages}. Spring-Cloud-Stream auto-configures {@code StreamBridge}
+ * on its own so we do not have to mock it.
+ */
+@SpringBootTest(
+        classes = CollectdApplication.class,
+        properties = {
+                "deltav.timeseries.enabled=true",
+                "deltav.collectd.persister.inner.fail-fast=true",
+                "deltav.collectd.persister.kafka.fail-fast=true",
+                "spring.main.web-application-type=none",
+                "spring.main.banner-mode=off",
+                // opennms.home wired dynamically to collectd-daemon-overlay below
+                "spring.autoconfigure.exclude=" +
+                        "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration," +
+                        "org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration",
+                // Unresolvable brokers: all Kafka beans are mocked via @MockitoBean below
+                "spring.kafka.bootstrap-servers=localhost:1",
+                "spring.cloud.stream.kafka.binder.brokers=localhost:1",
+                "opennms.kafka.bootstrap-servers=localhost:1",
+                // Disable the Kafka RPC client — it connects to Kafka at startup and
+                // needs DistPollerDao which triggers JPA/SQL against the mock DataSource.
+                "opennms.rpc.kafka.enabled=false",
+                "spring.main.allow-bean-definition-overriding=true"
+        }
+)
+class CollectdApplicationScanIT {
+
+    /**
+     * Point opennms.home at the production collectd-daemon-overlay so the
+     * many filesystem reads in {@link CollectdDaemonConfiguration} (the
+     * {@code collectd-configuration.xml}, {@code snmp-config.xml},
+     * {@code datacollection-config.xml}, {@code poll-outages.xml} loads plus
+     * the {@code etc/datacollection/} directory scan) find real fixtures
+     * instead of an empty {@code /tmp} directory. The overlay is committed
+     * to the repo at a stable relative path so the IT is reproducible on CI.
+     */
+    @DynamicPropertySource
+    static void overlayPath(DynamicPropertyRegistry reg) {
+        // Module cwd is core/daemon-boot-collectd; overlay is at
+        // opennms-container/delta-v/collectd-daemon-overlay relative to repo root.
+        Path overlay = Paths.get("..", "..", "opennms-container", "delta-v",
+                "collectd-daemon-overlay").toAbsolutePath().normalize();
+        reg.add("opennms.home", () -> overlay.toString());
+    }
+
+    // ---- JPA / DAO layer ----
+    @MockitoBean DataSource dataSource;
+    @MockitoBean PlatformTransactionManager platformTransactionManager;
+    @MockitoBean SessionUtils sessionUtils;
+    @MockitoBean NodeDao nodeDao;
+    @MockitoBean IpInterfaceDao ipInterfaceDao;
+
+    // ---- Collectd config beans backed by real overlay fixtures above ----
+    // filterDao can't come from overlay since it needs a real DataSource.
+    @MockitoBean(name = "filterDao") FilterDao filterDao;
+
+    // kafkaRpcMetricRegistry is normally provided by KafkaRpcClientConfiguration
+    // (daemon-common) which we disable via opennms.rpc.kafka.enabled=false.
+    // TimeseriesPersisterFactory depends on it, so supply a stand-in here.
+    @MockitoBean(name = "kafkaRpcMetricRegistry") MetricRegistry kafkaRpcMetricRegistry;
+
+    // The Collectd daemon bean exercises async collector futures on the
+    // mocked LocationAwareCollectorClient at init; mock it out since we are
+    // only asserting the timeseries wiring chain loads, not that collectd
+    // actually polls anything.
+    @MockitoBean Collectd collectd;
+
+    // ---- Collection agent / RPC client chain ----
+    @MockitoBean ServiceCollectorRegistry serviceCollectorRegistry;
+    @MockitoBean LocationAwareCollectorClient locationAwareCollectorClient;
+    @MockitoBean RpcClientFactory rpcClientFactory;
+    @MockitoBean EntityScopeProvider entityScopeProvider;
+
+    // ---- Event transport: avoid real Kafka producer at startup ----
+    @MockitoBean(name = "kafkaEventForwarder") KafkaEventForwarder kafkaEventForwarder;
+    @MockitoBean(name = "kafkaEventSubscriptionService")
+    KafkaEventSubscriptionService kafkaEventSubscriptionService;
+
+    @Autowired ApplicationContext ctx;
+
+    @Test
+    void persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true() {
+        PersisterFactory factory = ctx.getBean(
+                "compositePersisterFactory", PersisterFactory.class);
+        // FanoutPersisterFactory is a package-private static nested class of
+        // TimeseriesKafkaPublisherConfiguration, so we check by qualified name
+        // rather than importing the type (which won't compile from this
+        // package).
+        assertThat(factory.getClass().getName())
+                .as("with deltav.timeseries.enabled=true, the @Primary "
+                        + "compositePersisterFactory must be FanoutPersisterFactory")
+                .isEqualTo("org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration$FanoutPersisterFactory");
+    }
+
+    @Test
+    void deltav_timeseries_topic_bean_exists_when_flag_true() {
+        NewTopic topic = ctx.getBean("deltavTimeseriesTopic", NewTopic.class);
+        assertThat(topic).isNotNull();
+        assertThat(topic.name()).isEqualTo("deltav-timeseries");
+    }
+
+    @Test
+    void timeseries_kafka_publisher_bean_exists_when_flag_true() {
+        TimeseriesKafkaPublisher publisher = ctx.getBean(TimeseriesKafkaPublisher.class);
+        assertThat(publisher).isNotNull();
+    }
+}

--- a/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// API version: 1 (FROZEN at Phase 2 GA — delta-v#<TBD-phase-2-PR>)
+// API version: 1 (FROZEN at Phase 2 GA — delta-v#174)
 //
 // Public contract for the deltav-node-context Kafka topic.
 //

--- a/core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// API version: 1 (FROZEN at Phase 2 GA — delta-v#<TBD-phase-2-PR>)
+// API version: 1 (FROZEN at Phase 2 GA — delta-v#174)
 //
 // Public contract for the deltav-timeseries Kafka topic.
 //

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/KafkaTopicsConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/config/KafkaTopicsConfiguration.java
@@ -22,4 +22,53 @@ public class KafkaTopicsConfiguration {
                         "compression.type", "lz4"))
                 .build();
     }
+
+    /**
+     * Mirrors the Collectd-side {@code deltavTimeseriesTopic} declaration. Without
+     * this, the SCS Kafka binder's consumer auto-creates {@code deltav-timeseries}
+     * with the broker default (4 partitions) before Collectd's {@code KafkaAdmin}
+     * can run its 16-partition declaration. Kafka's partition expansion does not
+     * automatically rebalance the existing consumer group: the consumer stays
+     * assigned to partitions 0-3 forever and silently misses records hashed to
+     * partitions 4-15. Pre-declaring the topic here lets prometheus-writer's
+     * {@code KafkaAdmin} converge on the correct partition count BEFORE the
+     * binder's consumer subscribes, eliminating the race.
+     *
+     * <p>Partition / replication / retention / compression settings must match
+     * the Collectd-side declaration in {@code TimeseriesKafkaPublisherConfiguration}.
+     */
+    @Bean
+    public NewTopic deltavTimeseriesTopic() {
+        return TopicBuilder.name("deltav-timeseries")
+                .partitions(16)
+                .replicas(1)
+                .configs(Map.of(
+                        "cleanup.policy", "delete",
+                        "retention.ms", "86400000",           // 1 day (matches Collectd default)
+                        "compression.type", "lz4"))
+                .build();
+    }
+
+    /**
+     * Mirrors the Provisiond-side {@code deltavNodeContextTopic} declaration so
+     * the same auto-create-vs-declare race that bites {@code deltav-timeseries}
+     * cannot bite {@code deltav-node-context}. Defensive declaration here keeps
+     * both source-topic schemas consistent regardless of startup ordering.
+     *
+     * <p>Settings match Provisiond's declaration in NodeContextProducerConfiguration:
+     * 8 partitions, compacted, retain forever (-1), min compaction lag 1m,
+     * delete retention 1d.
+     */
+    @Bean
+    public NewTopic deltavNodeContextTopic() {
+        return TopicBuilder.name("deltav-node-context")
+                .partitions(8)
+                .replicas(1)
+                .configs(Map.of(
+                        "cleanup.policy", "compact",
+                        "retention.ms", "-1",
+                        "min.compaction.lag.ms", "60000",     // 1 min
+                        "delete.retention.ms", "86400000"))   // 1 day
+                .build();
+    }
 }

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/consume/TimeseriesConsumerConfiguration.java
@@ -33,11 +33,22 @@ public class TimeseriesConsumerConfiguration {
         Counter consumed = metrics.counter(PrometheusWriterMetrics.RECORDS_CONSUMED);
         Counter samplesIn = metrics.counter(PrometheusWriterMetrics.SAMPLES_IN);
         Counter parseErrors = metrics.counter(PrometheusWriterMetrics.RECORDS_PARSE_ERRORS);
+        Counter lookupFallback = metrics.counter(PrometheusWriterMetrics.ENRICHMENT_LOOKUP_FALLBACK);
         return message -> {
             try {
                 TimeseriesBatch batch = TimeseriesBatch.parseFrom(message.getPayload());
                 String key = batch.getLocation() + "@" + batch.getNodeId();
                 Optional<NodeContext> nc = cache.get(key);
+                if (nc.isEmpty()) {
+                    // Phase 0 limitation: Collectd publishes with location="" so the
+                    // {location}@{node_id} lookup misses against provisiond's
+                    // {real-location}@{node_id} keys. Fall back to node_id-only.
+                    // See memory project_kafka_timeseries_producer_next_session.
+                    nc = cache.findByNodeId(batch.getNodeId());
+                    if (nc.isPresent()) {
+                        lookupFallback.increment();
+                    }
+                }
                 List<PromSample> samples = translator.translate(batch, nc);
                 consumed.increment();
                 samplesIn.increment(samples.size());

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetrics.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetrics.java
@@ -17,6 +17,7 @@ public final class PrometheusWriterMetrics {
     // enrichment
     public static final String ENRICHMENT_HIT          = "deltav.prometheus.writer.enrichment.hit";
     public static final String ENRICHMENT_MISSING      = "deltav.prometheus.writer.enrichment.missing";
+    public static final String ENRICHMENT_LOOKUP_FALLBACK = "deltav.prometheus.writer.enrichment.lookup.fallback";
     public static final String NC_CACHE_SIZE           = "deltav.prometheus.writer.node.context.cache.size";
     public static final String NC_CACHE_READY          = "deltav.prometheus.writer.node.context.cache.ready";
     public static final String NC_BOOTSTRAP_DURATION   = "deltav.prometheus.writer.node.context.bootstrap.duration";

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
@@ -55,4 +55,23 @@ public class NodeContextCache {
     public void markReady() {
         ready.set(true);
     }
+
+    /**
+     * Finds a NodeContext by node_id alone, ignoring location. Used as a
+     * fallback when the primary {location}@{node_id} key lookup misses —
+     * specifically for the Phase 0 limitation where Delta-V Collectd
+     * publishes TimeseriesBatch records with location="" while NodeContext
+     * records carry real locations from provisiond. See memory
+     * project_kafka_timeseries_producer_next_session for context.
+     *
+     * <p>O(n) stream scan over the cache. Acceptable because the cache is
+     * bounded (~10K nodes max) and this fallback should be rare once
+     * Collectd populates location correctly. Returns the first match;
+     * deterministic order is not guaranteed across HashMap implementations.
+     */
+    public Optional<NodeContext> findByNodeId(int nodeId) {
+        return map.values().stream()
+                .filter(nc -> nc.getNodeId() == nodeId)
+                .findFirst();
+    }
 }

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
@@ -6,10 +6,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -24,13 +24,13 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -97,58 +97,65 @@ public class NodeContextKafkaBootstrap implements Runnable {
 
     @Override
     public void run() {
+        // Tracks per-partition end-offset captured at the moment the broker assigned the
+        // partition to us. The bootstrap is "complete" when every assigned partition has
+        // been drained up to its captured HWM. Both maps mutate from the consumer thread
+        // (poll loop) and the rebalance listener (called inline during poll), so a
+        // ConcurrentHashMap is defensive-but-cheap.
+        Map<TopicPartition, Long> endOffsets = new ConcurrentHashMap<>();
+        Set<TopicPartition> caughtUp = ConcurrentHashMap.newKeySet();
+        AtomicBoolean bootstrapMarked = new AtomicBoolean(false);
+
         try (KafkaConsumer<String, byte[]> consumer = buildConsumer()) {
-            List<PartitionInfo> parts = consumer.partitionsFor(TOPIC);
-            if (parts == null || parts.isEmpty()) {
-                LOG.warn("Topic {} has no partitions yet — marking cache ready with empty state", TOPIC);
-                finishBootstrap();
-                liveTail(consumer);
-                return;
-            }
-            Set<TopicPartition> allParts = new HashSet<>();
-            for (PartitionInfo p : parts) {
-                allParts.add(new TopicPartition(TOPIC, p.partition()));
-            }
-            consumer.assign(allParts);
-
-            Map<TopicPartition, Long> endOffsets = new HashMap<>(consumer.endOffsets(allParts));
-            consumer.seekToBeginning(allParts);
-
-            Set<TopicPartition> caughtUp = new HashSet<>();
-            // An empty partition (end offset == 0) is instantly "caught up".
-            for (Map.Entry<TopicPartition, Long> e : endOffsets.entrySet()) {
-                if (e.getValue() == 0L) {
-                    caughtUp.add(e.getKey());
+            consumer.subscribe(List.of(TOPIC), new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> assigned) {
+                    // Record HWM at assignment time so we know when we have replayed the
+                    // compacted topic up to "now". Then seek to the beginning so we
+                    // actually replay everything (compacted topic semantics: we need
+                    // the latest value per key, not just the live tail).
+                    Map<TopicPartition, Long> hwm = consumer.endOffsets(assigned);
+                    endOffsets.putAll(hwm);
+                    consumer.seekToBeginning(assigned);
+                    // Empty partitions (end offset == 0) are instantly caught up.
+                    for (Map.Entry<TopicPartition, Long> e : hwm.entrySet()) {
+                        if (e.getValue() == 0L) {
+                            caughtUp.add(e.getKey());
+                        }
+                    }
                 }
-            }
 
-            while (running.get() && caughtUp.size() < allParts.size()) {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> revoked) {
+                    // No-op. Kafka may reassign us; the next onPartitionsAssigned will
+                    // re-establish HWM and re-seek. AtomicBoolean bootstrapMarked
+                    // prevents duplicate NodeContextCacheReadyEvent publication.
+                }
+            });
+
+            while (running.get()) {
                 ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
                 for (ConsumerRecord<String, byte[]> r : records) {
                     applyRecord(r);
                     TopicPartition tp = new TopicPartition(r.topic(), r.partition());
-                    if (r.offset() + 1 >= endOffsets.get(tp)) {
+                    Long hwm = endOffsets.get(tp);
+                    if (hwm != null && r.offset() + 1 >= hwm) {
                         caughtUp.add(tp);
                     }
                 }
+                // Mark cache ready exactly once, after the first full drain across all
+                // currently-assigned partitions. The compareAndSet guards against double-
+                // firing if poll() somehow re-enters this branch before bootstrapMarked
+                // becomes visible (defensive — single consumer thread, but cheap).
+                if (!bootstrapMarked.get()
+                        && !endOffsets.isEmpty()
+                        && caughtUp.containsAll(endOffsets.keySet())
+                        && bootstrapMarked.compareAndSet(false, true)) {
+                    finishBootstrap();
+                }
             }
-            finishBootstrap();
-            liveTail(consumer);
         } catch (Exception e) {
             LOG.error("NodeContextKafkaBootstrap fatal error", e);
-        }
-    }
-
-    private void liveTail(KafkaConsumer<String, byte[]> consumer) {
-        while (running.get()) {
-            try {
-                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
-                for (ConsumerRecord<String, byte[]> r : records) {
-                    applyRecord(r);
-                }
-            } catch (Exception e) {
-                LOG.warn("NodeContextKafkaBootstrap live-tail error — will retry after poll timeout", e);
-            }
         }
     }
 

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetricsTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/metrics/PrometheusWriterMetricsTest.java
@@ -18,6 +18,7 @@ class PrometheusWriterMetricsTest {
             "deltav.prometheus.writer.records.parse.errors",
             "deltav.prometheus.writer.enrichment.hit",
             "deltav.prometheus.writer.enrichment.missing",
+            "deltav.prometheus.writer.enrichment.lookup.fallback",
             "deltav.prometheus.writer.node.context.cache.size",
             "deltav.prometheus.writer.node.context.cache.ready",
             "deltav.prometheus.writer.node.context.bootstrap.duration",

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheTest.java
@@ -68,4 +68,36 @@ class NodeContextCacheTest {
         cache.markReady();
         assertThat(cache.isReady()).isTrue();
     }
+
+    @Test
+    void findByNodeId_returns_empty_when_no_entry() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.findByNodeId(99)).isEmpty();
+    }
+
+    @Test
+    void findByNodeId_returns_entry_when_node_id_matches_regardless_of_location() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(5).setLocation("Default").setNodeLabel("server-01").build();
+        cache.put("Default@5", nc);
+        assertThat(cache.findByNodeId(5)).contains(nc);
+    }
+
+    @Test
+    void findByNodeId_returns_first_match_when_multiple_locations_share_node_id() {
+        // node_id is normally unique per OnmsNode but the cache is keyed by
+        // {location}@{node_id} which CAN collide if a node migrates location
+        // (relocation). Returning the first match is acceptable — the
+        // stream order is unspecified across HashMap implementations but the
+        // method exists primarily for the location-empty fallback case where
+        // there is exactly one matching entry in practice.
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc1 = NodeContext.newBuilder().setNodeId(7).setLocation("a").build();
+        NodeContext nc2 = NodeContext.newBuilder().setNodeId(7).setLocation("b").build();
+        cache.put("a@7", nc1);
+        cache.put("b@7", nc2);
+        assertThat(cache.findByNodeId(7)).isPresent();
+        // either nc1 or nc2 is acceptable; just assert presence and node_id matches
+        assertThat(cache.findByNodeId(7).get().getNodeId()).isEqualTo(7);
+    }
 }

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java
@@ -93,6 +93,53 @@ class NodeContextKafkaBootstrapIT {
         }
     }
 
+    @Test
+    void bootstrap_survives_topic_created_after_start() throws Exception {
+        // CRITICAL: do NOT call ensureTopic() at the start of this test. The whole
+        // point is that the topic does not exist when NodeContextKafkaBootstrap
+        // begins. The v1 racy code marked the cache ready immediately with size=0
+        // and entered an unassigned-poll loop that threw IllegalStateException
+        // forever, never consuming any records that were later written to the topic.
+        NodeContextCache cache = new NodeContextCache();
+        AtomicReference<NodeContextCacheReadyEvent> capturedEvent = new AtomicReference<>();
+        ApplicationEventPublisher publisher = e -> {
+            if (e instanceof NodeContextCacheReadyEvent r) capturedEvent.set(r);
+        };
+        NodeContextKafkaBootstrap boot = new NodeContextKafkaBootstrap(
+                cache, publisher, new SimpleMeterRegistry(), KAFKA.getBootstrapServers());
+        boot.start();
+        try {
+            // Sanity: cache must NOT be ready yet because the topic doesn't exist.
+            // Wait a moment to make sure the bootstrap thread has had time to attempt
+            // a subscribe and not short-circuit to ready.
+            Thread.sleep(2000);
+            assertThat(cache.isReady())
+                    .as("cache must not be ready before topic exists")
+                    .isFalse();
+            assertThat(capturedEvent.get())
+                    .as("ready event must not have fired before topic exists")
+                    .isNull();
+
+            // Now create the topic mid-flight. Kafka should rebalance our consumer
+            // (which subscribed to the not-yet-existent topic) and assign partitions.
+            ensureTopic();
+            // Produce a record so there's something for the bootstrap drain to land.
+            produce(200, false);
+
+            // Cache should become ready within 30s (allows for rebalance + drain).
+            await().atMost(Duration.ofSeconds(30)).until(cache::isReady);
+            assertThat(capturedEvent.get())
+                    .as("ready event must have fired exactly once after first drain")
+                    .isNotNull();
+            assertThat(cache.get("Default@200")).isPresent();
+        } finally {
+            boot.stop();
+            // Tombstone our test record so it doesn't pollute the shared compacted
+            // topic for sibling tests that assert on exact cache size.
+            produce(200, true);
+        }
+    }
+
     // -------------------- helpers --------------------
 
     private void ensureTopic() throws Exception {

--- a/docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md
+++ b/docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md
@@ -1,92 +1,539 @@
-# Collectd Kafka Publisher Inert Fix — Implementation Plan
+# Phase 2 NodeContextKafkaBootstrap Race Fix + Collectd Hygiene — Implementation Plan (v2)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Unblock the delta-v Kafka Time Series pipeline by identifying and fixing the wiring regression that makes `TimeseriesKafkaPublisher` silently inert, ship observability + regression tests so this class of silent swallow cannot re-occur, flip the compose default, and close out Phase 2's deferred proto-header placeholder. Acceptance is the Phase 2 E2E (`opennms-container/delta-v/test-prometheus-writer-e2e.sh`) exiting 0 with `ALL ASSERTIONS PASSED`.
+> **This plan SUPERSEDES the v1 plan at commit `262309050ed`.** The original plan assumed the Phase 0 Collectd publisher was inert. Live-stack investigation (Task 2 of v1) refuted that — the publisher works fine. The actual bug is a race in Phase 2's `NodeContextKafkaBootstrap`. v1's diagnostic-exposure commit (`d3c6d049cab`) is retained on the branch; everything else gets rewritten.
 
-**Architecture:** Diagnose-first, fix-second, then harden. Commit 1 exposes actuator endpoints + adds two diagnostic `LOG.info` lines to surface the runtime wiring decisions. Commit 2 ships the minimum-diff surgical fix once evidence identifies the root cause. Commit 3 adds Micrometer counters + Spring fail-fast properties inside `FanoutPersister`. Commit 4 adds `FanoutPersisterTest` unit tests + `CollectdApplicationScanIT` real-main-class IT. Commit 5 flips `DELTAV_TIMESERIES_ENABLED` default and substitutes the `<TBD-phase-2-PR>` proto placeholder. Commit 6 partially reverts Commit 1 (keeps `/actuator/conditions`).
+**Goal:** Fix the `NodeContextKafkaBootstrap` race so the cache is populated under both topic-exists-at-startup and topic-created-later orderings. Ship complementary Collectd silent-swallow hygiene (Micrometer counters, dev fail-fast toggle, real-main-class scan IT). Acceptance: Phase 2 E2E (`./test-prometheus-writer-e2e.sh`) exits 0 with `ALL ASSERTIONS PASSED` end-to-end — first successful run of the full pipeline.
 
-**Tech Stack:** Spring Boot 4.0.3, horizon 1.0.10, Spring Cloud Stream Kafka binder, Micrometer Prometheus, Resilience4j unchanged (Collectd doesn't use it), JUnit 5, Mockito, Testcontainers Kafka (`apache/kafka:3.8.0`).
+**Architecture (v2):** Replace `NodeContextKafkaBootstrap.run()`'s `partitionsFor`-based branching with a single-path `consumer.subscribe(...)` flow whose `ConsumerRebalanceListener` records HWM, seeks to beginning, drains, and marks cache-ready exactly once after first full drain. Add complementary observability + fail-fast to Collectd's existing `FanoutPersister` so the Phase 0 inner-persister bugs (#1, #2, #4) become operator-visible (they remain swallowed today but are alertable after this PR). Compose default flip + proto-header pin close out Phase 2's deferred loose ends.
 
-**Spec:** `docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md`
+**Tech Stack:** Spring Boot 4.0.3, horizon 1.0.10, Spring Kafka, Apache Kafka client 3.x, Micrometer Prometheus, JUnit 5, Mockito, Testcontainers Kafka (`apache/kafka:3.8.0`), `commons-io:2.18.0` (test-scope, per `feedback_boot4_testcontainers_commons_io`).
 
-**Branch:** `fix/collectd-publisher-inert` (already created; spec commit `8c2729588e5` already on branch).
+**Spec:** `docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md` (v2, commit `f0a4d5b0f94`).
 
-**PR target:** `pbrane/delta-v` base `develop`. NEVER `OpenNMS/opennms`.
+**Branch:** `fix/collectd-publisher-inert` (name retained from v1; actual scope is mostly Phase 2 prometheus-writer + Collectd hygiene).
+
+**PR target:** `pbrane/delta-v` base `develop`. **NEVER `OpenNMS/opennms`** — memory `feedback_never_pr_opennms`.
 
 **Critical memory references:**
 - `feedback_never_pr_opennms` — PRs always `--repo pbrane/delta-v`.
 - `feedback_feature_branches` — never commit directly to `develop`.
 - `feedback_delta_v_uses_mvnw_not_compile_pl` — use `./mvnw`, never `compile.pl`.
-- `feedback_delta_v_full_reactor_verify` — run full-reactor build before push.
-- `feedback_boot4_testcontainers_commons_io` — Testcontainers needs explicit `commons-io:2.18.0` test dep on Boot 4.
-- `feedback_configuration_class_bean_name_collision` — `@Configuration` classes must not share camelCase name with their `@Bean` methods.
-- `feedback_deltav_package_namespace` — new code under `org.deltav.*` with BeaconStrategists copyright.
-- `project_collectd_publisher_inert_investigation` — root-cause hypothesis space + investigation plan.
+- `feedback_delta_v_full_reactor_verify` — full-reactor build before push.
+- `feedback_boot4_testcontainers_commons_io` — Boot 4 modules using Testcontainers need explicit `commons-io:2.18.0` test dep.
+- `feedback_configuration_class_bean_name_collision` — Collectd-side hygiene work obeys this rule.
+- `feedback_deltav_package_namespace` — new code uses `org.deltav.*` with BeaconStrategists copyright.
+- `project_collectd_publisher_inert_investigation` — root-cause memo (real bug: NodeContextKafkaBootstrap race).
+- `project_phase2_prometheus_writer_done` — PR #174 merged (`5ef18ed5384`); E2E deferred to this PR.
 
 ---
 
 ## Task ordering rationale
 
-14 tasks grouped by the six commits from the spec. Task ordering is dependency-driven. Commit 2's fix is contingent on Commit 1's evidence; the plan describes the most-likely shape (hypothesis C — bean-name vs `@Primary` injection) and flags adjustments for A / B / D.
+Nine tasks grouped by the six new commits from spec §4 + three acceptance gates. The race fix (Task 1) is the critical blocker; everything else is protective tooling or operational tidy. Each task either ends with a commit or is a verification-only step.
 
-1. **Commit 1 — diagnostic exposure** (Tasks 1-2)
-2. **Commit 2 — wiring fix** (Task 3)
-3. **Commit 3 — observability + fail-fast** (Tasks 4-8)
-4. **Commit 4 — scan IT** (Task 9)
-5. **Commit 5 — compose default + proto headers** (Task 10)
-6. **Commit 6 — diagnostic cleanup** (Task 11)
-7. **Acceptance gates** (Tasks 12-14)
+1. **Race fix** — Tasks 1-2 (Commits 2-3 in spec §4)
+2. **Collectd hygiene** — Tasks 3-4 (Commits 4-5)
+3. **Operational** — Tasks 5-6 (Commits 6-7)
+4. **Acceptance gates** — Tasks 7-9 (no commits; verification + push + PR)
 
 ---
 
-## Task 1: Expose diagnostic actuator endpoints + add startup logs
+## Task 1: NodeContextKafkaBootstrap race fix (subscribe + ConsumerRebalanceListener)
+
+**Goal:** Replace the racy `partitionsFor`-based two-branch logic in `NodeContextKafkaBootstrap.run()` with a single-path `consumer.subscribe(List.of(TOPIC))` flow whose `ConsumerRebalanceListener` records HWM, seeks to beginning, drains, and marks the cache ready exactly once.
 
 **Files:**
-- Modify: `core/daemon-boot-collectd/src/main/resources/application.yml`
-- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+- Modify: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java`
+- Modify (TDD test first, then verified by impl): `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java`
 
-- [ ] **Step 1: Extend actuator exposure in application.yml**
+> **TDD note:** the existing IT (`bootstrap_drains_to_HWM_then_marks_ready`, `tombstone_removes_key_from_cache_live`) tests the happy path with topic pre-created. Both should still pass after this fix without modification — the new code handles the topic-exists-at-startup case as a degenerate of the topic-created-later case. Task 2 adds the new race-test method explicitly.
 
-Locate the `management.endpoints.web.exposure.include` setting in `core/daemon-boot-collectd/src/main/resources/application.yml`. Read the file first to find exact current state:
+- [ ] **Step 1: Run existing NodeContextKafkaBootstrapIT to establish baseline**
 
 ```bash
-grep -nE "management|endpoint|exposure" core/daemon-boot-collectd/src/main/resources/application.yml
+./mvnw -pl core/prometheus-writer test -Dtest=NodeContextKafkaBootstrapIT
 ```
 
-If the include line already exists, edit to add `env,beans,conditions`:
+Expected: `2/2 PASS` in ~15-20s (Testcontainers Kafka spin-up dominates). Establishes that the existing two tests pass against the current racy code (they do — they pre-create the topic, so the racy branch is never exercised).
 
-```yaml
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, prometheus, env, beans, conditions
-```
+- [ ] **Step 2: Replace `run()` method with the subscribe-based flow**
 
-If the block doesn't exist yet (possible — Collectd may rely on Spring Boot defaults), add the full block at the end of the file, before any trailing `---` document-end marker.
+Edit `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java`. Three changes:
 
-- [ ] **Step 2: Add diagnostic startup logs to TimeseriesKafkaPublisherConfiguration**
+1. Update imports — add `ConsumerRebalanceListener`, `ConcurrentHashMap`, drop `HashMap`/`HashSet` if no longer used, drop `PartitionInfo` (no longer referenced).
+2. Replace the entire `run()` method body.
+3. Remove the now-unused `partitionsFor`-branch logic.
 
-Edit `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`.
-
-First, confirm the existing logger import (`org.slf4j.Logger`, `org.slf4j.LoggerFactory`) is present. If not, add them at the top.
-
-Add a class-level `LOG` field near the top of the class (before the `@Bean` methods), immediately after the `@ConditionalOnProperty` annotation and class declaration:
+**Updated imports** (replace the existing `java.util.*` and `org.apache.kafka.*` block):
 
 ```java
-    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesKafkaPublisherConfiguration.class);
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 ```
 
-Add a no-arg constructor that logs load-time evidence. Insert after the `LOG` field, before the first `@Bean`:
+```java
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+```
+
+(Drop `import org.apache.kafka.common.PartitionInfo;`, `import java.util.HashMap;`, `import java.util.HashSet;` — no longer used.)
+
+**Replace the entire `run()` method** (currently lines 98-140) with:
 
 ```java
-    public TimeseriesKafkaPublisherConfiguration() {
-        LOG.info("TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty(deltav.timeseries.enabled=true) matched");
+    @Override
+    public void run() {
+        // Tracks per-partition end-offset captured at the moment the broker assigned the
+        // partition to us. The bootstrap is "complete" when every assigned partition has
+        // been drained up to its captured HWM. Both maps mutate from the consumer thread
+        // (poll loop) and the rebalance listener (called inline during poll), so a
+        // ConcurrentHashMap is defensive-but-cheap.
+        Map<TopicPartition, Long> endOffsets = new ConcurrentHashMap<>();
+        Set<TopicPartition> caughtUp = ConcurrentHashMap.newKeySet();
+        AtomicBoolean bootstrapMarked = new AtomicBoolean(false);
+
+        try (KafkaConsumer<String, byte[]> consumer = buildConsumer()) {
+            consumer.subscribe(List.of(TOPIC), new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> assigned) {
+                    // Record HWM at assignment time so we know when we have replayed the
+                    // compacted topic up to "now". Then seek to the beginning so we
+                    // actually replay everything (compacted topic semantics: we need
+                    // the latest value per key, not just the live tail).
+                    Map<TopicPartition, Long> hwm = consumer.endOffsets(assigned);
+                    endOffsets.putAll(hwm);
+                    consumer.seekToBeginning(assigned);
+                    // Empty partitions (end offset == 0) are instantly caught up.
+                    for (Map.Entry<TopicPartition, Long> e : hwm.entrySet()) {
+                        if (e.getValue() == 0L) {
+                            caughtUp.add(e.getKey());
+                        }
+                    }
+                }
+
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> revoked) {
+                    // No-op. Kafka may reassign us; the next onPartitionsAssigned will
+                    // re-establish HWM and re-seek. AtomicBoolean bootstrapMarked
+                    // prevents duplicate NodeContextCacheReadyEvent publication.
+                }
+            });
+
+            while (running.get()) {
+                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+                for (ConsumerRecord<String, byte[]> r : records) {
+                    applyRecord(r);
+                    TopicPartition tp = new TopicPartition(r.topic(), r.partition());
+                    Long hwm = endOffsets.get(tp);
+                    if (hwm != null && r.offset() + 1 >= hwm) {
+                        caughtUp.add(tp);
+                    }
+                }
+                // Mark cache ready exactly once, after the first full drain across all
+                // currently-assigned partitions. The compareAndSet guards against double-
+                // firing if poll() somehow re-enters this branch before bootstrapMarked
+                // becomes visible (defensive — single consumer thread, but cheap).
+                if (!bootstrapMarked.get()
+                        && !endOffsets.isEmpty()
+                        && caughtUp.containsAll(endOffsets.keySet())
+                        && bootstrapMarked.compareAndSet(false, true)) {
+                    finishBootstrap();
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("NodeContextKafkaBootstrap fatal error", e);
+        }
     }
 ```
 
-Modify the `compositePersisterFactory` `@Bean` method to log the inner-factory identity just before returning:
+**Delete the now-unused `liveTail(KafkaConsumer)` method** (currently lines 142-153). It is superseded by the merged poll loop in the new `run()`. The method is private and has no callers outside `run()`.
+
+`applyRecord`, `finishBootstrap`, `buildConsumer`, `start`, `stop`, `onAppReady`, the constructor, and the gauge registration all stay unchanged.
+
+- [ ] **Step 3: Re-run the existing IT to confirm no regression**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=NodeContextKafkaBootstrapIT
+```
+
+Expected: still `2/2 PASS`. The two existing tests (`bootstrap_drains_to_HWM_then_marks_ready`, `tombstone_removes_key_from_cache_live`) now exercise the new subscribe-based path. Cache should be ready and populated; tombstones should still propagate.
+
+If either fails, STOP and report. The likely culprits: (a) the new `bootstrapMarked` gate fires before all partitions are caught up (fix: check the `endOffsets.isEmpty()` short-circuit), (b) the `ConsumerRebalanceListener` interferes with the existing test's `produce(...)` followed by `await().until(cache::isReady)` timing (fix: extend the await timeout to 30s).
+
+- [ ] **Step 4: Verify the full module test suite still passes**
+
+```bash
+./mvnw -pl core/prometheus-writer verify
+```
+
+Expected: all unit + IT tests pass (~88+ total per the Phase 2 baseline). No new failures introduced by the rewrite of `run()`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java
+git commit -m "fix(prometheus-writer): NodeContextKafkaBootstrap subscribe + ConsumerRebalanceListener
+
+Race fix. Old code path: consumer.partitionsFor(TOPIC) returns null when
+deltav-node-context topic doesn't exist yet (provisiond hasn't created
+it), the 'no partitions yet' branch calls finishBootstrap() + liveTail()
+WITHOUT ever calling consumer.assign() or consumer.subscribe(). liveTail's
+consumer.poll() then throws IllegalStateException ('Consumer is not
+subscribed to any topics or assigned any partitions') on every 5s cycle
+forever. Records later written to the topic by provisiond are never
+consumed; cache stays empty; every prometheus-writer record hits
+enrichment_missing.
+
+New code path: single-path consumer.subscribe(List.of(TOPIC)) with a
+ConsumerRebalanceListener.onPartitionsAssigned that records HWM, seeks
+to beginning, and tracks 'caught up' state. The merged poll loop drains
+records and marks the cache ready exactly once (guarded by AtomicBoolean
+compareAndSet) after the first full drain to HWM across all assigned
+partitions. Same flow handles topic-exists-at-startup AND
+topic-created-later — no branching on partitionsFor.
+
+Existing IT tests (bootstrap_drains_to_HWM_then_marks_ready,
+tombstone_removes_key_from_cache_live) still pass — both pre-create the
+topic so they exercise the new path's degenerate case. Task 2 adds the
+new IT case that exercises the topic-created-after-start race that was
+broken.
+
+Surfaced by PR #174 E2E investigation
+(project_collectd_publisher_inert_investigation memory)."
+```
+
+---
+
+## Task 2: NodeContextKafkaBootstrapIT — topic-created-after-start case
+
+**Goal:** Add a regression-gate IT method that exercises the exact path that was broken in v1: bootstrap starts, topic does not exist, cache must NOT be marked ready, then create topic + produce records mid-flight, cache must become ready with the records.
+
+**Files:**
+- Modify: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java`
+
+- [ ] **Step 1: Add the new test method to the existing IT class**
+
+Open `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java` and add this test method alongside the existing two. Place it after `tombstone_removes_key_from_cache_live` and before the `@AfterEach` (or at the end of the class — the order doesn't matter to JUnit):
+
+```java
+    @Test
+    void bootstrap_survives_topic_created_after_start() throws Exception {
+        // CRITICAL: do NOT call ensureTopic() at the start of this test. The whole
+        // point is that the topic does not exist when NodeContextKafkaBootstrap
+        // begins. The v1 racy code marked the cache ready immediately with size=0
+        // and entered an unassigned-poll loop that threw IllegalStateException
+        // forever, never consuming any records that were later written to the topic.
+        NodeContextCache cache = new NodeContextCache();
+        AtomicReference<NodeContextCacheReadyEvent> capturedEvent = new AtomicReference<>();
+        ApplicationEventPublisher publisher = e -> {
+            if (e instanceof NodeContextCacheReadyEvent r) capturedEvent.set(r);
+        };
+        NodeContextKafkaBootstrap boot = new NodeContextKafkaBootstrap(
+                cache, publisher, new SimpleMeterRegistry(), KAFKA.getBootstrapServers());
+        boot.start();
+        try {
+            // Sanity: cache must NOT be ready yet because the topic doesn't exist.
+            // Wait a moment to make sure the bootstrap thread has had time to attempt
+            // a subscribe and not short-circuit to ready.
+            Thread.sleep(2000);
+            assertThat(cache.isReady())
+                    .as("cache must not be ready before topic exists")
+                    .isFalse();
+            assertThat(capturedEvent.get())
+                    .as("ready event must not have fired before topic exists")
+                    .isNull();
+
+            // Now create the topic mid-flight. Kafka should rebalance our consumer
+            // (which subscribed to the not-yet-existent topic) and assign partitions.
+            ensureTopic();
+            // Produce a record so there's something for the bootstrap drain to land.
+            produce(200, false);
+
+            // Cache should become ready within 30s (allows for rebalance + drain).
+            await().atMost(Duration.ofSeconds(30)).until(cache::isReady);
+            assertThat(capturedEvent.get())
+                    .as("ready event must have fired exactly once after first drain")
+                    .isNotNull();
+            assertThat(cache.get("Default@200")).isPresent();
+        } finally {
+            boot.stop();
+        }
+    }
+```
+
+If `Thread.sleep(2000)` triggers a checkstyle/spotbugs warning in this codebase, replace with the existing `Awaitility.with().pollDelay(...)` idiom — the surrounding tests' style sets the precedent.
+
+- [ ] **Step 2: Run only the new test**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=NodeContextKafkaBootstrapIT#bootstrap_survives_topic_created_after_start
+```
+
+Expected: `1/1 PASS` in ~15-25s (Testcontainers Kafka + 2s sanity wait + rebalance + drain).
+
+If it fails on the `assertThat(cache.isReady()).isFalse()` line: the new code is incorrectly marking the cache ready before partitions are assigned. Re-check `endOffsets.isEmpty()` short-circuit in `run()` — that gate prevents premature ready-firing.
+
+If it fails on `await().atMost(Duration.ofSeconds(30)).until(cache::isReady)`: the rebalance + drain didn't complete in time. Either (a) bump the timeout to 60s, or (b) the new code isn't catching up to HWM (re-check the `caughtUp.containsAll(endOffsets.keySet())` condition).
+
+If it fails on `assertThat(cache.get("Default@200")).isPresent()`: the record was consumed but not stored. Check `applyRecord` — should be unchanged from v1.
+
+- [ ] **Step 3: Run the full IT class to ensure no test interference**
+
+```bash
+./mvnw -pl core/prometheus-writer test -Dtest=NodeContextKafkaBootstrapIT
+```
+
+Expected: `3/3 PASS`. The new test plus the two existing tests (`bootstrap_drains_to_HWM_then_marks_ready`, `tombstone_removes_key_from_cache_live`) all pass against the new subscribe-based code.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrapIT.java
+git commit -m "test(prometheus-writer): NodeContextKafkaBootstrapIT topic-created-after-start case
+
+Regression gate for the race fixed in the prior commit. Exercises the
+exact scenario that was broken: NodeContextKafkaBootstrap starts before
+deltav-node-context topic exists; cache must NOT be marked ready; then
+topic is created mid-flight and a record produced; cache must become
+ready and contain the record.
+
+Reproduces the race that the v1 code took the 'no partitions yet' branch
+on and silently entered an unassigned-poll loop. With the new
+subscribe + ConsumerRebalanceListener flow, Kafka rebalances and assigns
+the partitions when the topic appears, the listener records HWM and
+seeks to beginning, the merged poll loop drains, and the cache-ready
+gate fires.
+
+Existing two tests (bootstrap_drains_to_HWM_then_marks_ready,
+tombstone_removes_key_from_cache_live) unchanged — they exercise the
+topic-exists-at-startup degenerate case."
+```
+
+---
+
+## Task 3: FanoutPersister observability + dev fail-fast (Commit 4 — feat-only per spec)
+
+**Goal:** Add the (X) Micrometer counters + (Y) Spring fail-fast properties to `FanoutPersister` per spec §3-4. Make the Phase 0 inner-persister bugs (#1, #2, #4) operator-visible without fixing them. Default fail-fast off in production; ITs override via `@TestPropertySource`.
+
+> **Spec §4 mandates this commit is feat-only** (FanoutPersisterTest lives in Commit 5 / Task 4). Pure implementation here; tests in the next task. Run-to-fail-then-pass TDD discipline is preserved by writing tests in Task 4 against this task's already-landed implementation; ITs and the existing test suite verify no regression.
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Add Counter + MeterRegistry imports**
+
+The class already imports `MeterRegistry` (line 19). Add `Counter`:
+
+```java
+import io.micrometer.core.instrument.Counter;
+```
+
+- [ ] **Step 2: Add meter-name constants + STEPS array inside FanoutPersister**
+
+Inside the `FanoutPersister` static nested class, near the top (after the `LOG` field at line 150), add:
+
+```java
+        private static final String INNER_FAILURES_METER =
+                "deltav.collectd.persister.inner.failures";
+        private static final String KAFKA_FAILURES_METER =
+                "deltav.collectd.persister.kafka.failures";
+        private static final String[] STEPS = new String[]{
+                "visitCollectionSet", "visitResource", "visitGroup", "visitAttribute",
+                "completeAttribute", "completeGroup", "completeResource", "completeCollectionSet",
+                "persistNumericAttribute", "persistStringAttribute"
+        };
+```
+
+- [ ] **Step 3: Replace the FanoutPersister constructor + fields to take MeterRegistry + fail-fast booleans**
+
+Current shape (lines 152-158):
+
+```java
+        private final Persister innerPersister;
+        private final TimeseriesKafkaPersister kafkaPersister;
+
+        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister) {
+            this.innerPersister = innerPersister;
+            this.kafkaPersister = kafkaPersister;
+        }
+```
+
+Replace with:
+
+```java
+        private final Persister innerPersister;
+        private final TimeseriesKafkaPersister kafkaPersister;
+        private final MeterRegistry meterRegistry;
+        private final boolean failFastInner;
+        private final boolean failFastKafka;
+
+        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister,
+                        MeterRegistry meterRegistry, boolean failFastInner, boolean failFastKafka) {
+            this.innerPersister = innerPersister;
+            this.kafkaPersister = kafkaPersister;
+            this.meterRegistry = meterRegistry;
+            this.failFastInner = failFastInner;
+            this.failFastKafka = failFastKafka;
+            preRegisterCounters();
+        }
+
+        private void preRegisterCounters() {
+            // Pre-register all 20 (2 sides × 10 steps) counter tag combinations at
+            // construction time so ops can alert on rate>0 rather than missing-metric
+            // (which would otherwise be ambiguous with "no failures occurred").
+            for (String step : STEPS) {
+                Counter.builder(INNER_FAILURES_METER).tag("step", step).register(meterRegistry);
+                Counter.builder(KAFKA_FAILURES_METER).tag("step", step).register(meterRegistry);
+            }
+        }
+```
+
+- [ ] **Step 4: Replace runInner + runKafka to increment counters + honor fail-fast**
+
+Current shape (lines 160-180):
+
+```java
+        private void runInner(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                LOG.warn("Inner persister threw during {}; continuing with Kafka path", step, e);
+            }
+        }
+
+        private void runKafka(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                LOG.warn("Kafka persister threw during {}; continuing", step, e);
+            }
+        }
+```
+
+Replace with:
+
+```java
+        private void runInner(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                meterRegistry.counter(INNER_FAILURES_METER, "step", step).increment();
+                LOG.warn("Inner persister threw during {}; continuing with Kafka path", step, e);
+                if (failFastInner) {
+                    throw new RuntimeException(
+                            "Inner persister failed during " + step + " (fail-fast enabled)", e);
+                }
+            }
+        }
+
+        private void runKafka(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                meterRegistry.counter(KAFKA_FAILURES_METER, "step", step).increment();
+                LOG.warn("Kafka persister threw during {}; continuing", step, e);
+                if (failFastKafka) {
+                    throw new RuntimeException(
+                            "Kafka persister failed during " + step + " (fail-fast enabled)", e);
+                }
+            }
+        }
+```
+
+The `catch (Throwable e)` is preserved (per the existing comment about LinkageError from horizon's classpath quirks).
+
+- [ ] **Step 5: Extend FanoutPersisterFactory to carry MeterRegistry + fail-fast flags**
+
+Current shape (lines 102-127):
+
+```java
+    static final class FanoutPersisterFactory implements PersisterFactory {
+        private final PersisterFactory innerFactory;
+        private final TimeseriesKafkaPublisher publisher;
+
+        FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher) {
+            this.innerFactory = innerFactory;
+            this.publisher = publisher;
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                                         boolean dontPersistCounters, boolean forceStoreByGroup,
+                                         boolean dontReorderAttributes) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository, dontPersistCounters,
+                            forceStoreByGroup, dontReorderAttributes),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+    }
+```
+
+Replace with:
+
+```java
+    static final class FanoutPersisterFactory implements PersisterFactory {
+        private final PersisterFactory innerFactory;
+        private final TimeseriesKafkaPublisher publisher;
+        private final MeterRegistry meterRegistry;
+        private final boolean failFastInner;
+        private final boolean failFastKafka;
+
+        FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher,
+                               MeterRegistry meterRegistry,
+                               boolean failFastInner, boolean failFastKafka) {
+            this.innerFactory = innerFactory;
+            this.publisher = publisher;
+            this.meterRegistry = meterRegistry;
+            this.failFastInner = failFastInner;
+            this.failFastKafka = failFastKafka;
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository),
+                    new TimeseriesKafkaPersister(publisher, params),
+                    meterRegistry, failFastInner, failFastKafka);
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                                         boolean dontPersistCounters, boolean forceStoreByGroup,
+                                         boolean dontReorderAttributes) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository, dontPersistCounters,
+                            forceStoreByGroup, dontReorderAttributes),
+                    new TimeseriesKafkaPersister(publisher, params),
+                    meterRegistry, failFastInner, failFastKafka);
+        }
+    }
+```
+
+- [ ] **Step 6: Update the @Bean method to inject MeterRegistry + read the fail-fast properties**
+
+Current shape (lines 90-105):
 
 ```java
     @Bean
@@ -101,318 +548,146 @@ Modify the `compositePersisterFactory` `@Bean` method to log the inner-factory i
     }
 ```
 
-- [ ] **Step 3: Verify the module compiles**
+Replace with:
+
+```java
+    @Bean
+    @Primary
+    public PersisterFactory compositePersisterFactory(
+            @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher,
+            MeterRegistry meterRegistry,
+            @Value("${deltav.collectd.persister.inner.fail-fast:false}") boolean failFastInner,
+            @Value("${deltav.collectd.persister.kafka.fail-fast:false}") boolean failFastKafka) {
+        LOG.info("Creating compositePersisterFactory wrapping inner={}@{} (failFastInner={}, failFastKafka={})",
+                innerFactory.getClass().getName(),
+                System.identityHashCode(innerFactory),
+                failFastInner, failFastKafka);
+        return new FanoutPersisterFactory(innerFactory, publisher, meterRegistry,
+                failFastInner, failFastKafka);
+    }
+```
+
+The `@Value` import (`org.springframework.beans.factory.annotation.Value`) is already at line 36. No new import needed.
+
+- [ ] **Step 7: Update the class-level Javadoc to document the new meters + properties**
+
+Replace the `FanoutPersister` Javadoc block (currently lines 130-148) with:
+
+```java
+    /**
+     * Forwards each visitor callback to both delegate persisters, inner first
+     * then Kafka. Each delegate is invoked inside its own try/catch so that
+     * an exception in one does not prevent the other from running.
+     *
+     * <p>Observability (added 2026-04-18 — see project_collectd_publisher_inert_investigation):
+     * <ul>
+     *   <li>{@code deltav.collectd.persister.inner.failures{step=<visitor-step>}}
+     *       — Micrometer counter, pre-registered for all 10 visitor steps at
+     *       construction so ops can alert on rate&gt;0 rather than missing-metric.</li>
+     *   <li>{@code deltav.collectd.persister.kafka.failures{step=<visitor-step>}}
+     *       — symmetric for the Kafka side.</li>
+     * </ul>
+     *
+     * <p>Fail-fast toggles (default false in production; CI/IT profiles enable):
+     * <ul>
+     *   <li>{@code deltav.collectd.persister.inner.fail-fast} — when true, inner
+     *       Throwable propagates as RuntimeException instead of being swallowed.</li>
+     *   <li>{@code deltav.collectd.persister.kafka.fail-fast} — symmetric.</li>
+     * </ul>
+     *
+     * <p>Phase 0 horizon-side inner-persister bugs (UnexpectedRollbackException
+     * in MetaTagDataLoader; NPE in TimeseriesPersistOperationBuilder.setAttributeValue;
+     * ClassCastException in TimeseriesPersister.getUserDefinedMetaTags) are still
+     * caught and WARN-logged here. They do not block the Kafka path. See memory
+     * project_phase0_inner_persister_bugs_followup for the dedicated fix queue.
+     */
+```
+
+- [ ] **Step 8: Verify the module compiles + existing tests pass**
 
 ```bash
 ./mvnw -pl core/daemon-boot-collectd -DskipTests compile
 ```
 
-Expected: `BUILD SUCCESS`. The startup logs do not yet run; they fire only when the app boots.
+Expected: `BUILD SUCCESS`. The new constructor signature is backwards-compatible at the @Bean injection site only because we updated the @Bean method too.
 
-- [ ] **Step 4: Commit**
-
-```bash
-git add core/daemon-boot-collectd/src/main/resources/application.yml \
-        core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
-git commit -m "diag(daemon-boot-collectd): expose env/beans/conditions + startup logs
-
-Temporary diagnostic exposure on Collectd's actuator plus two INFO log
-lines in TimeseriesKafkaPublisherConfiguration (class load + composite
-persister factory wrap). Lets us confirm which of the three wiring
-hypotheses (property resolution, condition evaluation, or @Primary vs
-qualifier injection) explains the silent inert publisher on develop.
-
-Will be partially reverted in Commit 6 — /actuator/conditions stays
-on permanently; env + beans + startup logs revert."
-```
-
----
-
-## Task 2: Capture evidence + identify root cause
-
-**Files:**
-- No code changes — this is a run-experiment + memory-update task.
-- Modify: `/Users/david/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/project_collectd_publisher_inert_investigation.md`
-
-- [ ] **Step 1: Rebuild Collectd image**
-
-The `build.sh check_daemon_boot_freshness` check walks `daemon-boot-*/src/main/` + `pom.xml` but misses transitive deps. Since we just modified `daemon-boot-collectd`'s own sources, the check will catch it. If not, touch the pom as a workaround:
+Then run the existing test suite to confirm no regression:
 
 ```bash
-touch core/daemon-boot-collectd/pom.xml
-./opennms-container/delta-v/build.sh deltav 2>&1 | tail -5
+./mvnw -pl core/daemon-boot-collectd test
 ```
 
-Expected: `opennms/collectd:0.0.1-SNAPSHOT` rebuilt. Other 13 daemon-boot images stay cached.
+Expected: all existing tests pass. `FanoutPersister`'s 5-arg constructor is package-private and only called from `FanoutPersisterFactory.createPersister` (also updated). If any existing test instantiated `FanoutPersister` with the old 2-arg constructor, that test will fail to compile — STOP and report; we'll need to update those tests too.
 
-- [ ] **Step 2: Start the stack**
-
-```bash
-cd opennms-container/delta-v
-DELTAV_TIMESERIES_ENABLED=true docker compose --profile lite --profile metrics-e2e up -d
-echo "--- sleeping 90s for first full poll cycle ---"
-sleep 90
-```
-
-- [ ] **Step 3: Capture log evidence**
-
-```bash
-docker compose logs --no-color collectd 2>&1 | \
-  grep -E "TimeseriesKafkaPublisherConfiguration|compositePersisterFactory|persister.factory|PersisterFactory"
-```
-
-Three possible outcomes:
-- **Neither log line present**: class did not load → hypothesis A (property) or B (condition).
-- **Only the class-load line present**: class loaded but `@Bean` did not run → unexpected (hypothesis D) — possibly the bean ran but the log did not flush, possibly a deeper Spring issue.
-- **Both lines present**: class loaded and composite was wrapped → hypothesis C (bean-name resolution bypass).
-
-- [ ] **Step 4: Capture actuator evidence**
-
-```bash
-docker compose exec -T collectd curl -sf http://localhost:8080/actuator/env/deltav.timeseries.enabled 2>&1 | head -20
-echo "---"
-docker compose exec -T collectd curl -sf http://localhost:8080/actuator/conditions 2>&1 | \
-  python3 -c 'import json,sys; c=json.load(sys.stdin); m=c["contexts"]["application"]; \
-    print("positive:", "TimeseriesKafkaPublisherConfiguration" in m.get("positiveMatches",{})); \
-    print("negative:", [k for k in m.get("negativeMatches",{}) if "Timeseries" in k])'
-echo "---"
-docker compose exec -T collectd curl -sf http://localhost:8080/actuator/beans 2>&1 | \
-  python3 -c 'import json,sys; b=json.load(sys.stdin)["contexts"]["application"]["beans"]; \
-    print({name: {"type": v["type"].split(".")[-1], "primary": v.get("primary", False)} \
-           for name, v in b.items() if "PersisterFactory" in v.get("type","")})'
-```
-
-- [ ] **Step 5: Confirm topic state**
-
-```bash
-docker compose exec -T kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 \
-  --describe --topic deltav-timeseries 2>&1 | head -10
-docker compose exec -T kafka /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9092 \
-  --describe --group prometheus-writer 2>&1 | head -10
-```
-
-- [ ] **Step 6: Tear down**
-
-```bash
-docker compose --profile lite --profile metrics-e2e down -v --remove-orphans
-```
-
-- [ ] **Step 7: Update the investigation memory with captured evidence**
-
-Edit `/Users/david/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/project_collectd_publisher_inert_investigation.md`. Under `## Hypothesis space`, add a new section:
-
-```markdown
-## Root cause identified (2026-04-18)
-
-**Confirmed hypothesis:** [A / B / C / D — fill from evidence]
-
-### Evidence
-
-**Startup log lines** (from `docker compose logs collectd`):
-```
-[paste the matching log lines here]
-```
-
-**Actuator /conditions for TimeseriesKafkaPublisherConfiguration**:
-```
-[paste positive-matches or negative-matches JSON excerpt]
-```
-
-**Actuator /beans for PersisterFactory type**:
-```
-[paste the bean map]
-```
-
-**Kafka topic state**: [records present or zero across N partitions]
-
-### Root cause narrative
-
-[One paragraph explaining why hypothesis X fits the evidence. Tie the actuator + log evidence together. Cite specific bean names and their @Primary status.]
-```
-
-- [ ] **Step 8: No commit — evidence is captured in the memory note, not the repo**
-
-Memory files are under `~/.claude/...` and are not part of the repo. The evidence-capture step is a diagnostic step whose artifact is the memory update + the informed decision about Commit 2's fix shape.
-
----
-
-## Task 3: Wiring fix (contingent on Task 2's evidence)
-
-**Files (expected, for hypothesis C — adjust for A or B):**
-- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
-
-- [ ] **Step 1: Apply the fix per confirmed hypothesis**
-
-### Hypothesis C — bean-name vs `@Primary` injection (strongest prior)
-
-Horizon's `CollectableService` resolves `PersisterFactory` by `@Qualifier("timeseriesPersisterFactory")` rather than by type. `@Primary` is bypassed. Rename the composite bean to match the name horizon expects.
-
-**Edit 1**: Find the `compositePersisterFactory` `@Bean` method. Change its `@Bean` annotation + method name:
-
-```java
-    // Before:
-    @Bean
-    @Primary
-    public PersisterFactory compositePersisterFactory(
-            @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
-            TimeseriesKafkaPublisher publisher) {
-        LOG.info("Creating compositePersisterFactory wrapping inner={}@{}",
-                innerFactory.getClass().getName(),
-                System.identityHashCode(innerFactory));
-        return new FanoutPersisterFactory(innerFactory, publisher);
-    }
-```
-
-```java
-    // After:
-    @Bean(name = "timeseriesPersisterFactory")
-    @Primary
-    public PersisterFactory timeseriesPersisterFactory(
-            @Qualifier("innerTimeseriesPersisterFactory") PersisterFactory innerFactory,
-            TimeseriesKafkaPublisher publisher) {
-        LOG.info("Creating composite timeseriesPersisterFactory wrapping inner={}@{}",
-                innerFactory.getClass().getName(),
-                System.identityHashCode(innerFactory));
-        return new FanoutPersisterFactory(innerFactory, publisher);
-    }
-```
-
-**Edit 2**: Find the inner `PersisterFactory` bean — it's declared in a companion `@Configuration` in `core/daemon-boot-collectd` (search for `@Bean.*PersisterFactory` to locate it). If the commit `7760eef1422` ("rename persisterFactory bean to timeseriesPersisterFactory") is relevant, look at where that rename landed. Expected location:
-
-```bash
-grep -rn "timeseriesPersisterFactory" core/daemon-boot-collectd/src/main/java/
-```
-
-Rename the inner bean from `timeseriesPersisterFactory` to `innerTimeseriesPersisterFactory` via `@Bean(name = "innerTimeseriesPersisterFactory")`:
-
-```java
-    // Before:
-    @Bean
-    public PersisterFactory timeseriesPersisterFactory(...) { ... }
-```
-
-```java
-    // After:
-    @Bean(name = "innerTimeseriesPersisterFactory")
-    public PersisterFactory innerTimeseriesPersisterFactory(...) { ... }
-```
-
-Both inner and outer beans now use explicit `name=` so horizon's `@Qualifier("timeseriesPersisterFactory")` resolves to OUR composite, which internally wraps `innerTimeseriesPersisterFactory`.
-
-### Hypothesis A — property not resolving
-
-Edit `core/daemon-boot-collectd/src/main/resources/application.yml`. Add an explicit binding of `deltav.timeseries.enabled` with the env-var fallback (belt-and-suspenders — the yaml binding happens first; env-var wins if present because `@Value`/env precedence). Locate the existing `deltav:` block:
-
-```yaml
-deltav:
-  timeseries:
-    enabled: ${DELTAV_TIMESERIES_ENABLED:false}
-```
-
-This already exists per prior inspection. If hypothesis A is confirmed, the issue is that the yaml binding is not propagating to `@ConditionalOnProperty`. The fix is to add an explicit `@PropertySource` or replace `@ConditionalOnProperty` with `@ConditionalOnExpression`. Apply the hypothesis-B fix (below) instead — it subsumes A.
-
-### Hypothesis B — condition evaluating false
-
-Edit the class-level annotation in `TimeseriesKafkaPublisherConfiguration.java`:
-
-```java
-    // Before:
-    @ConditionalOnProperty(name = "deltav.timeseries.enabled", havingValue = "true")
-```
-
-```java
-    // After:
-    @ConditionalOnExpression("#{'${deltav.timeseries.enabled:false}' == 'true'}")
-```
-
-### Hypothesis D — unknown
-
-STOP and report BLOCKED. Do not commit a speculative fix. Re-extend diagnosis (e.g. attach a remote debugger to the running collectd container, inspect horizon's `CollectableService.setPersisterFactory` source at the exact 1.0.10 version). Return to brainstorming.
-
-- [ ] **Step 2: Rebuild Collectd image**
-
-```bash
-touch core/daemon-boot-collectd/pom.xml
-./opennms-container/delta-v/build.sh deltav 2>&1 | tail -5
-```
-
-- [ ] **Step 3: Verify the fix live**
-
-```bash
-cd opennms-container/delta-v
-DELTAV_TIMESERIES_ENABLED=true docker compose --profile lite --profile metrics-e2e up -d
-sleep 90
-echo "=== deltav-timeseries record count ==="
-docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-  --bootstrap-server kafka:9092 --topic deltav-timeseries \
-  --from-beginning --max-messages 1 --timeout-ms 10000 2>&1 | tail -3
-echo "=== prometheus-writer counter ==="
-docker compose exec -T prometheus-writer curl -sf http://localhost:8080/actuator/prometheus 2>/dev/null | \
-  grep -E '^deltav_prometheus_writer_records_consumed_total '
-```
-
-Expected: console-consumer reads at least 1 message (byte-array output, not "Processed a total of 0 messages"). `records_consumed_total > 0.0`.
-
-If zero records, STOP — the fix did not work; re-investigate.
-
-- [ ] **Step 4: Tear down**
-
-```bash
-docker compose --profile lite --profile metrics-e2e down -v --remove-orphans
-cd /Users/david/development/src/opennms/delta-v
-```
-
-- [ ] **Step 5: Commit the fix**
-
-Commit message for hypothesis C:
+- [ ] **Step 9: Commit**
 
 ```bash
 git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
-# also add whatever file declared the inner PersisterFactory bean
-git commit -m "fix(daemon-boot-collectd): rename compositePersisterFactory bean to timeseriesPersisterFactory
+git commit -m "feat(daemon-boot-collectd): FanoutPersister observability + dev fail-fast
 
-Root cause: horizon CollectableService (horizon 1.0.10) resolves
-PersisterFactory by qualifier name ('timeseriesPersisterFactory')
-rather than by type, so @Primary on our composite bean was bypassed
-and the inner factory won at the injection point. Collectd silently
-ran the legacy persist path with zero Kafka publishes.
+(X) Two Micrometer counters — deltav.collectd.persister.{inner,kafka}.failures
+tagged by visitor step — pre-registered at construction for all 10 steps
+(× 2 sides = 20 tag combinations) so ops can alert on rate>0 rather than
+missing-metric. Phase 0 horizon-side inner-persister bugs (#1
+UnexpectedRollbackException, #2 NPE in TimeseriesPersistOperationBuilder,
+#4 ClassCastException in TimeseriesPersister.getUserDefinedMetaTags)
+become operator-visible without being fixed here — they remain swallowed
+by the existing isolation, deserve their own focused investigation, and
+are tracked under project_phase0_inner_persister_bugs_followup.
 
-Fix: give our composite the name 'timeseriesPersisterFactory' that
-horizon expects; rename the inner bean to
-'innerTimeseriesPersisterFactory'. Horizon now resolves to our
-composite; internally we wrap the renamed inner.
+(Y) Two Spring properties — deltav.collectd.persister.{inner,kafka}.fail-fast,
+default false in production. When true, Throwables propagate as
+RuntimeException instead of being swallowed + logged. CI / integration
+tests enable these via @TestPropertySource so silent regressions surface
+as test failures.
 
-Evidence captured in project_collectd_publisher_inert_investigation
-memo via the diagnostic commit."
+Tests landing in the next commit (Task 4): FanoutPersisterTest covers
+counter increments, pre-registration, fail-fast matrix, and the
+Throwable-not-just-RuntimeException catch (Phase 0 #3 LinkageError scar
+guard). CollectdApplicationScanIT exercises real-main-class wiring."
 ```
-
-Adjust the message body for hypothesis A or B if they were confirmed instead.
 
 ---
 
-## Task 4: Write the FanoutPersisterTest skeleton
+## Task 4: FanoutPersisterTest + CollectdApplicationScanIT (Commit 5 — test-only per spec)
+
+**Goal:** Pin Task 3's behavior with 7 unit tests + 3 real-main-class IT tests. Mandatory `commons-io:2.18.0` test dep per `feedback_boot4_testcontainers_commons_io`.
 
 **Files:**
+- Modify (if needed): `core/daemon-boot-collectd/pom.xml`
 - Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java`
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`
 
-- [ ] **Step 1: Write the test class with all 7 test methods (most will fail until Tasks 5-7)**
+- [ ] **Step 1: Verify commons-io:2.18.0 test dep is present**
+
+```bash
+grep -A2 "commons-io" core/daemon-boot-collectd/pom.xml | head -10
+```
+
+If `commons-io:commons-io:2.18.0` with `<scope>test</scope>` is absent, add to `core/daemon-boot-collectd/pom.xml` inside `<dependencies>` (near other test-scoped deps):
+
+```xml
+        <!-- Required by Testcontainers 2.x / commons-compress 1.28+ — see
+             feedback_boot4_testcontainers_commons_io memory. Without this,
+             container start hangs at the wait-strategy timeout. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+```
+
+- [ ] **Step 2: Create FanoutPersisterTest — 7 unit tests**
+
+Write `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java`:
 
 ```java
 /*
  * Copyright (C) 2026 BeaconStrategists, Inc.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Licensed under the GNU Affero General Public License v3.
  */
 package org.deltav.collectd.timeseries;
 
@@ -506,7 +781,7 @@ class FanoutPersisterTest {
         FanoutPersister p = make(true, false);
         assertThatThrownBy(() -> p.visitResource(r))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("inner boom");
+                .hasMessageContaining("fail-fast enabled");
     }
 
     @Test
@@ -515,7 +790,7 @@ class FanoutPersisterTest {
         doThrow(new RuntimeException("inner boom")).when(inner).visitResource(r);
         doNothing().when(kafka).visitResource(r);
 
-        make(false, false).visitResource(r);  // should NOT throw
+        make(false, false).visitResource(r);  // must NOT throw
 
         verify(kafka).visitResource(r);
     }
@@ -529,7 +804,7 @@ class FanoutPersisterTest {
         FanoutPersister p = make(false, true);
         assertThatThrownBy(() -> p.visitResource(r))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("kafka boom");
+                .hasMessageContaining("fail-fast enabled");
     }
 
     @Test
@@ -539,7 +814,7 @@ class FanoutPersisterTest {
                 .when(inner).visitResource(r);
         doNothing().when(kafka).visitResource(r);
 
-        make(false, false).visitResource(r);  // should NOT throw
+        make(false, false).visitResource(r);  // must NOT throw
 
         Counter c = registry.find(INNER_FAILURES).tag("step", "visitResource").counter();
         assertThat(c.count()).isEqualTo(1.0);
@@ -548,380 +823,17 @@ class FanoutPersisterTest {
 }
 ```
 
-- [ ] **Step 2: Run — expect compile failure**
+- [ ] **Step 3: Run FanoutPersisterTest**
 
 ```bash
 ./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest
 ```
 
-Expected: compile failure — `FanoutPersister` constructor doesn't take `MeterRegistry` + two booleans yet; the `TimeseriesKafkaPersister` reference may or may not compile.
+Expected: `7/7 PASS` in <1s. If any fail, the Task 3 implementation has a defect — re-read the test failure and adjust the impl in `TimeseriesKafkaPublisherConfiguration.java` (tests stay fixed; impl bends).
 
-- [ ] **Step 3: Do NOT commit yet** — Task 5 adds the implementation that makes these tests pass.
+- [ ] **Step 4: Create CollectdApplicationScanIT — 3 real-main-class IT tests**
 
----
-
-## Task 5: Implement counter pre-registration
-
-**Files:**
-- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
-
-- [ ] **Step 1: Add imports + pre-registration helper**
-
-At the top of `TimeseriesKafkaPublisherConfiguration.java`, add imports:
-
-```java
-import io.micrometer.core.instrument.Counter;
-```
-
-(`MeterRegistry` is likely already imported.)
-
-Add a private static helper just inside the `FanoutPersister` nested class, near the other fields:
-
-```java
-        private static final String INNER_FAILURES_METER =
-                "deltav.collectd.persister.inner.failures";
-        private static final String KAFKA_FAILURES_METER =
-                "deltav.collectd.persister.kafka.failures";
-        private static final String[] STEPS = new String[]{
-                "visitCollectionSet", "visitResource", "visitGroup", "visitAttribute",
-                "completeAttribute", "completeGroup", "completeResource", "completeCollectionSet",
-                "persistNumericAttribute", "persistStringAttribute"
-        };
-```
-
-- [ ] **Step 2: Extend FanoutPersister constructor to take MeterRegistry + fail-fast flags**
-
-Replace the existing `FanoutPersister` constructor + fields:
-
-```java
-        // Before (current shape):
-        private final Persister innerPersister;
-        private final TimeseriesKafkaPersister kafkaPersister;
-
-        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister) {
-            this.innerPersister = innerPersister;
-            this.kafkaPersister = kafkaPersister;
-        }
-```
-
-```java
-        // After:
-        private final Persister innerPersister;
-        private final TimeseriesKafkaPersister kafkaPersister;
-        private final MeterRegistry meterRegistry;
-        private final boolean failFastInner;
-        private final boolean failFastKafka;
-
-        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister,
-                        MeterRegistry meterRegistry, boolean failFastInner, boolean failFastKafka) {
-            this.innerPersister = innerPersister;
-            this.kafkaPersister = kafkaPersister;
-            this.meterRegistry = meterRegistry;
-            this.failFastInner = failFastInner;
-            this.failFastKafka = failFastKafka;
-            preRegisterCounters();
-        }
-
-        private void preRegisterCounters() {
-            for (String step : STEPS) {
-                Counter.builder(INNER_FAILURES_METER).tag("step", step).register(meterRegistry);
-                Counter.builder(KAFKA_FAILURES_METER).tag("step", step).register(meterRegistry);
-            }
-        }
-```
-
-- [ ] **Step 3: Run only the pre-registration test**
-
-```bash
-./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest#counters_preregistered_at_startup_with_zero_value
-```
-
-Expected: PASS. Other tests may still fail; that's Task 6's job.
-
-- [ ] **Step 4: Do NOT commit yet** — bundle commit after Task 7.
-
----
-
-## Task 6: Implement counter increments + fail-fast branches
-
-**Files:**
-- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
-
-- [ ] **Step 1: Rewrite runInner and runKafka helpers with increment + fail-fast**
-
-Replace the existing `runInner` and `runKafka` methods inside `FanoutPersister`:
-
-```java
-        // Before (current shape):
-        private void runInner(String step, Runnable task) {
-            try {
-                task.run();
-            } catch (Throwable e) {
-                LOG.warn("Inner persister threw during {}; continuing with Kafka path", step, e);
-            }
-        }
-
-        private void runKafka(String step, Runnable task) {
-            try {
-                task.run();
-            } catch (Throwable e) {
-                LOG.warn("Kafka persister threw during {}; continuing", step, e);
-            }
-        }
-```
-
-```java
-        // After:
-        private void runInner(String step, Runnable task) {
-            try {
-                task.run();
-            } catch (Throwable e) {
-                meterRegistry.counter(INNER_FAILURES_METER, "step", step).increment();
-                LOG.warn("Inner persister threw during {}; continuing with Kafka path", step, e);
-                if (failFastInner) {
-                    throw new RuntimeException(
-                            "Inner persister failed during " + step + " (fail-fast enabled)", e);
-                }
-            }
-        }
-
-        private void runKafka(String step, Runnable task) {
-            try {
-                task.run();
-            } catch (Throwable e) {
-                meterRegistry.counter(KAFKA_FAILURES_METER, "step", step).increment();
-                LOG.warn("Kafka persister threw during {}; continuing", step, e);
-                if (failFastKafka) {
-                    throw new RuntimeException(
-                            "Kafka persister failed during " + step + " (fail-fast enabled)", e);
-                }
-            }
-        }
-```
-
-- [ ] **Step 2: Run the counter-increment + fail-fast tests**
-
-```bash
-./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest
-```
-
-Expected: all 7 tests PASS except possibly `throwable_not_just_runtime_exception` if the earlier Throwable catch was narrower. If any fail, re-read the implementation to confirm the catch is `Throwable` (not `Exception`) and the branch conditions match.
-
-- [ ] **Step 3: Do NOT commit yet** — Task 7 updates `FanoutPersisterFactory` to pass the new args.
-
----
-
-## Task 7: Wire FanoutPersisterFactory to pass MeterRegistry + fail-fast properties
-
-**Files:**
-- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
-
-- [ ] **Step 1: Extend FanoutPersisterFactory to carry MeterRegistry + flags**
-
-Replace the existing `FanoutPersisterFactory` nested class header + fields + constructor:
-
-```java
-        // Before:
-        static final class FanoutPersisterFactory implements PersisterFactory {
-            private final PersisterFactory innerFactory;
-            private final TimeseriesKafkaPublisher publisher;
-
-            FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher) {
-                this.innerFactory = innerFactory;
-                this.publisher = publisher;
-            }
-```
-
-```java
-        // After:
-        static final class FanoutPersisterFactory implements PersisterFactory {
-            private final PersisterFactory innerFactory;
-            private final TimeseriesKafkaPublisher publisher;
-            private final MeterRegistry meterRegistry;
-            private final boolean failFastInner;
-            private final boolean failFastKafka;
-
-            FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher,
-                                   MeterRegistry meterRegistry,
-                                   boolean failFastInner, boolean failFastKafka) {
-                this.innerFactory = innerFactory;
-                this.publisher = publisher;
-                this.meterRegistry = meterRegistry;
-                this.failFastInner = failFastInner;
-                this.failFastKafka = failFastKafka;
-            }
-```
-
-- [ ] **Step 2: Update both createPersister overloads to pass the new args**
-
-```java
-        // Before:
-        @Override
-        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
-            return new FanoutPersister(
-                    innerFactory.createPersister(params, repository),
-                    new TimeseriesKafkaPersister(publisher, params));
-        }
-
-        @Override
-        public Persister createPersister(ServiceParameters params, RrdRepository repository,
-                                         boolean dontPersistCounters, boolean forceStoreByGroup,
-                                         boolean dontReorderAttributes) {
-            return new FanoutPersister(
-                    innerFactory.createPersister(params, repository, dontPersistCounters,
-                            forceStoreByGroup, dontReorderAttributes),
-                    new TimeseriesKafkaPersister(publisher, params));
-        }
-```
-
-```java
-        // After:
-        @Override
-        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
-            return new FanoutPersister(
-                    innerFactory.createPersister(params, repository),
-                    new TimeseriesKafkaPersister(publisher, params),
-                    meterRegistry, failFastInner, failFastKafka);
-        }
-
-        @Override
-        public Persister createPersister(ServiceParameters params, RrdRepository repository,
-                                         boolean dontPersistCounters, boolean forceStoreByGroup,
-                                         boolean dontReorderAttributes) {
-            return new FanoutPersister(
-                    innerFactory.createPersister(params, repository, dontPersistCounters,
-                            forceStoreByGroup, dontReorderAttributes),
-                    new TimeseriesKafkaPersister(publisher, params),
-                    meterRegistry, failFastInner, failFastKafka);
-        }
-```
-
-- [ ] **Step 3: Update the @Bean method to inject MeterRegistry + read the fail-fast properties**
-
-The `@Bean` method (named `timeseriesPersisterFactory` after Task 3's rename, or `compositePersisterFactory` before) gains two additional parameters:
-
-```java
-    @Bean(name = "timeseriesPersisterFactory")
-    @Primary
-    public PersisterFactory timeseriesPersisterFactory(
-            @Qualifier("innerTimeseriesPersisterFactory") PersisterFactory innerFactory,
-            TimeseriesKafkaPublisher publisher,
-            MeterRegistry meterRegistry,
-            @Value("${deltav.collectd.persister.inner.fail-fast:false}") boolean failFastInner,
-            @Value("${deltav.collectd.persister.kafka.fail-fast:false}") boolean failFastKafka) {
-        LOG.info("Creating composite timeseriesPersisterFactory wrapping inner={}@{} (failFastInner={}, failFastKafka={})",
-                innerFactory.getClass().getName(),
-                System.identityHashCode(innerFactory),
-                failFastInner, failFastKafka);
-        return new FanoutPersisterFactory(innerFactory, publisher, meterRegistry,
-                failFastInner, failFastKafka);
-    }
-```
-
-- [ ] **Step 4: Update the class-level javadoc to describe the new meters + properties**
-
-Replace the existing class-level javadoc block:
-
-```java
-/**
- * Feature-flagged configuration for the Kafka Time Series producer. When
- * {@code deltav.timeseries.enabled=true}, publishes one TimeseriesBatch
- * protobuf record per CollectionSet poll to the deltav-timeseries topic.
- * When the flag is false (default), none of the beans are created and the
- * persister chain stays on the existing InMemoryStorage-backed
- * TimeseriesPersisterFactory path.
- *
- * <p>Observability (added post-Phase-2 to prevent silent-swallow regressions):
- * <ul>
- *   <li>{@code deltav.collectd.persister.inner.failures{step=<visitor-step>}}
- *       — Micrometer counter, pre-registered for all 10 visitor steps at
- *       startup so alerts on rate&gt;0 are unambiguous vs missing-metric.</li>
- *   <li>{@code deltav.collectd.persister.kafka.failures{step=<visitor-step>}}
- *       — symmetric for the Kafka side.</li>
- * </ul>
- *
- * <p>Fail-fast toggles (for CI / integration tests — default off in production):
- * <ul>
- *   <li>{@code deltav.collectd.persister.inner.fail-fast} — when true, inner
- *       Throwable propagates instead of being swallowed + logged.</li>
- *   <li>{@code deltav.collectd.persister.kafka.fail-fast} — symmetric for Kafka.</li>
- * </ul>
- *
- * <p>See the {@code project_collectd_publisher_inert_investigation} memory note
- * for the root-cause narrative that motivated these gates.
- */
-```
-
-- [ ] **Step 5: Run the full FanoutPersisterTest suite — expect 7/7 PASS**
-
-```bash
-./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest
-```
-
-Expected: 7/7 PASS.
-
-- [ ] **Step 6: Commit all three Tasks 4-7 together as one Commit 3**
-
-```bash
-git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java \
-        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
-git commit -m "feat(daemon-boot-collectd): FanoutPersister observability + dev fail-fast
-
-(X) Two Micrometer counters — deltav.collectd.persister.{inner,kafka}.failures
-tagged by visitor step — pre-registered at startup for all 10 steps so
-ops can alert on rate>0 rather than missing-metric. Silent-swallow bugs
-like the one that hid the Kafka publisher being inert for weeks until
-Phase 2 PR #174 asserted downstream consumption cannot hide again.
-
-(Y) Two Spring properties — deltav.collectd.persister.{inner,kafka}.fail-fast,
-default false in production. When true, Throwables propagate instead of
-being swallowed + logged. CI and test profiles enable these via
-@TestPropertySource so integration tests fail on inner-persister
-regressions instead of silently absorbing them.
-
-Symmetric for inner and Kafka sides because the same class of wiring
-bug could hit either. Seven FanoutPersisterTest unit tests cover
-counter increments, pre-registration, fail-fast matrix, and the
-LinkageError-catches-Throwable scar guard (Phase 0 #3)."
-```
-
----
-
-## Task 8: (placeholder — no-op, Task 7 Step 6 handled the Commit 3 commit)
-
-Leaving this slot empty in the numbering so the Commit ↔ Task mapping stays clean in the commit log. Skip to Task 9.
-
----
-
-## Task 9: CollectdApplicationScanIT real-main-class IT
-
-**Files:**
-- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`
-- Possibly modify: `core/daemon-boot-collectd/pom.xml` (add `commons-io:2.18.0` test dep if not present — per memory `feedback_boot4_testcontainers_commons_io`)
-
-- [ ] **Step 1: Check if commons-io test dep is already in collectd's pom**
-
-```bash
-grep -A2 "commons-io" core/daemon-boot-collectd/pom.xml | head -10
-```
-
-If `commons-io:2.18.0` with `<scope>test</scope>` is absent, add to `core/daemon-boot-collectd/pom.xml` inside the `<dependencies>` section (near other test-scoped deps):
-
-```xml
-        <!-- Required by Testcontainers 2.x / commons-compress 1.28+ — see
-             feedback_boot4_testcontainers_commons_io memory. Without this,
-             container start hangs at the wait-strategy timeout. -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.18.0</version>
-            <scope>test</scope>
-        </dependency>
-```
-
-- [ ] **Step 2: Write the IT**
-
-Create `core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`:
+Write `core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`:
 
 ```java
 /*
@@ -937,7 +849,6 @@ import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.Fano
 import org.junit.jupiter.api.Test;
 import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -959,8 +870,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * composite PersisterFactory wires correctly so horizon's CollectableService
  * resolves to our FanoutPersisterFactory, not the bare inner factory.
  *
- * <p>Scar prophylactic: would have caught the silent-inert wiring bug
- * (project_collectd_publisher_inert_investigation) in one CI run.
+ * <p>Phase 2 PR #174 scar-prophylactic lineage: real-main-class startup
+ * catches @Configuration and bean-wiring bugs that unit tests + @Import-based
+ * ITs all bypass. Mandatory commons-io:2.18.0 test dep added to pom per
+ * feedback_boot4_testcontainers_commons_io memory.
  */
 @Testcontainers
 @SpringBootTest(classes = CollectdApplication.class,
@@ -969,7 +882,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "deltav.timeseries.enabled=true",
         "deltav.collectd.persister.inner.fail-fast=true",
         "deltav.collectd.persister.kafka.fail-fast=true",
-        // Avoid horizon config loaders hitting real SNMP agents during boot
+        // H2 in-memory DB to avoid needing a real Postgres in this IT
         "spring.datasource.url=jdbc:h2:mem:scan-it;MODE=PostgreSQL",
         "spring.jpa.hibernate.ddl-auto=create-drop"
 })
@@ -991,11 +904,10 @@ class CollectdApplicationScanIT {
     @Test
     void persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true() {
         PersisterFactory factory = ctx.getBean(
-                "timeseriesPersisterFactory", PersisterFactory.class);
+                "compositePersisterFactory", PersisterFactory.class);
         assertThat(factory)
-                .as("with deltav.timeseries.enabled=true, the bean named "
-                        + "'timeseriesPersisterFactory' must be our FanoutPersisterFactory "
-                        + "wrapping the inner (horizon CollectableService resolves by qualifier name)")
+                .as("with deltav.timeseries.enabled=true, the @Primary "
+                        + "compositePersisterFactory must be FanoutPersisterFactory")
                 .isInstanceOf(FanoutPersisterFactory.class);
     }
 
@@ -1014,42 +926,58 @@ class CollectdApplicationScanIT {
 }
 ```
 
-- [ ] **Step 3: Run the IT**
+- [ ] **Step 5: Run the IT**
 
 ```bash
 ./mvnw -pl core/daemon-boot-collectd verify -Dit.test=CollectdApplicationScanIT
 ```
 
-Expected: 3/3 PASS in ~30-60s (Testcontainers Kafka startup dominates).
+Expected: `3/3 PASS` in ~30-60s (Testcontainers Kafka spin-up dominates).
 
-**If test fails** with `Timed out waiting for log output matching '.*Transitioning from RECOVERY to RUNNING.*'`: the commons-io 2.18.0 dep is missing. Add it per Step 1.
+If the test fails with `Timed out waiting for log output matching '.*Transitioning from RECOVERY to RUNNING.*'`: the `commons-io:2.18.0` dep isn't on the classpath. Re-check Step 1.
 
-**If `persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true` fails** with the bean being a different class: Task 3's wiring fix didn't take effect. Re-check the `@Bean(name="timeseriesPersisterFactory")` rename + inner-bean `@Bean(name="innerTimeseriesPersisterFactory")` rename. STOP and report — the IT is doing its job.
+If `persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true` fails (bean is wrong type): the Task 3 changes broke the @Bean method. Most likely a stale build — `./mvnw -pl core/daemon-boot-collectd clean install -DskipTests` then re-run.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 6: Run the full module test suite to ensure no regression**
 
 ```bash
-git add core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java \
-        core/daemon-boot-collectd/pom.xml
-git commit -m "test(daemon-boot-collectd): CollectdApplicationScanIT real-main-class IT
+./mvnw -pl core/daemon-boot-collectd verify
+```
 
-Boots CollectdApplication via SpringApplication.run() against a
-Testcontainers Kafka broker with deltav.timeseries.enabled=true +
-fail-fast toggles on. Asserts:
-  - timeseriesPersisterFactory bean resolves to FanoutPersisterFactory
-    (the wiring regression this PR fixes would have been caught here)
+Expected: all unit + IT tests pass. The Task 3 + Task 4 changes are now fully covered.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/daemon-boot-collectd/pom.xml \
+        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java \
+        core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java
+git commit -m "test(daemon-boot-collectd): FanoutPersisterTest + CollectdApplicationScanIT
+
+T0 FanoutPersisterTest (7 unit tests):
+  - counter increments on inner / kafka failure (visitResource)
+  - counters pre-registered at startup with zero value (all 10 steps)
+  - fail-fast inner / kafka true / false matrix
+  - Throwable catch covers LinkageError (Phase 0 #3 NoSuchMethodError scar guard)
+
+T1 CollectdApplicationScanIT (3 real-main-class ITs, Testcontainers Kafka):
+  - PersisterFactory autowires to FanoutPersisterFactory when flag=true
   - deltavTimeseriesTopic NewTopic bean exists
   - TimeseriesKafkaPublisher bean exists
 
-Phase 2 PR #174 scar-prophylactic lineage: real-main-class startup
-catches @Configuration and bean-wiring bugs that unit tests +
-@Import-based ITs all bypass. Mandatory commons-io:2.18.0 test dep
-added per feedback_boot4_testcontainers_commons_io memory."
+Phase 2 PR #174 scar-prophylactic lineage: real-main-class boot via
+SpringApplication.run() against Testcontainers Kafka catches
+@Configuration class-name vs @Bean-method-name collisions and bean-wiring
+bugs that unit tests + @Import-based ITs all bypass. Mandatory
+commons-io:2.18.0 test dep added per feedback_boot4_testcontainers_commons_io
+memory."
 ```
 
 ---
 
-## Task 10: Compose default flip + proto-header substitution
+## Task 5: Compose default flip + proto-header substitution (Commit 6)
+
+**Goal:** Flip `DELTAV_TIMESERIES_ENABLED` default `false` → `true` so the Phase 0 producer is on by default in the delta-v stack. Resolve Phase 2's deferred `<TBD-phase-2-PR>` proto-header placeholder to `#174`.
 
 **Files:**
 - Modify: `opennms-container/delta-v/docker-compose.yml`
@@ -1058,7 +986,7 @@ added per feedback_boot4_testcontainers_commons_io memory."
 
 - [ ] **Step 1: Flip the compose default**
 
-Edit `opennms-container/delta-v/docker-compose.yml`. Find line 176:
+Find line 176 of `opennms-container/delta-v/docker-compose.yml`:
 
 ```yaml
       DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-false}
@@ -1070,15 +998,17 @@ Change to:
       DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-true}
 ```
 
-- [ ] **Step 2: Substitute the `<TBD-phase-2-PR>` placeholder in both proto headers**
+- [ ] **Step 2: Substitute the placeholder in both proto headers**
+
+Verify the placeholder exists:
 
 ```bash
 grep -n "TBD-phase-2-PR" core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
 ```
 
-Expected: each file has one match in its header comment block. Edit each manually (do NOT use `sed -i` — the surrounding text differs slightly per file and a manual edit confirms context):
+Expected: each file has one match in its header comment block. Edit each (do NOT use `sed -i` — manual edit confirms the line context):
 
-Locate in `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto`:
+In `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto`, find:
 
 ```protobuf
 // API version: 1 (FROZEN at Phase 2 GA — delta-v#<TBD-phase-2-PR>)
@@ -1090,9 +1020,9 @@ Change to:
 // API version: 1 (FROZEN at Phase 2 GA — delta-v#174)
 ```
 
-Same substitution in `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto`.
+Same change in `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto`.
 
-- [ ] **Step 3: Verify docker-compose yaml syntax + protos compile**
+- [ ] **Step 3: Verify yaml + proto compile**
 
 ```bash
 cd opennms-container/delta-v && docker compose --profile lite --profile metrics-e2e config >/dev/null
@@ -1100,7 +1030,7 @@ cd /Users/david/development/src/opennms/delta-v
 ./mvnw -pl core/deltav-kafka-contracts -DskipTests clean install
 ```
 
-Expected: both exit 0; protobuf-maven-plugin BUILD SUCCESS.
+Expected: both exit 0. Compose config parses; protobuf-maven-plugin BUILD SUCCESS.
 
 - [ ] **Step 4: Commit**
 
@@ -1112,93 +1042,88 @@ git commit -m "feat(compose+proto): enable Kafka time-series publisher by defaul
 
 Compose default flipped from DELTAV_TIMESERIES_ENABLED=false to =true so
 the Phase 0 producer is on by default in the delta-v stack (matches its
-'DONE + E2E verified' status). Operators who need it off can still
-export the env var explicitly.
+'DONE + E2E verified' status as of this PR). Operators who need it off
+can still export the env var explicitly.
 
-Proto-header placeholder from Phase 2 resolved: <TBD-phase-2-PR> -> #174
-in both deltav-timeseries.proto and deltav-node-context.proto."
+Phase 2 proto-header placeholder resolved: <TBD-phase-2-PR> -> #174 in
+both deltav-timeseries.proto and deltav-node-context.proto."
 ```
 
 ---
 
-## Task 11: Diagnostic cleanup (partial revert of Task 1)
+## Task 6: Diagnostic cleanup (Commit 7 — partial revert of `d3c6d049cab`)
+
+**Goal:** Remove the temporary `env` + `beans` actuator exposure and the one-shot startup log added in Commit 1. **Keep `/actuator/conditions`** permanently (no secret exposure, useful for future wiring-regression triage). Keep the `compositePersisterFactory wrapping inner=...` log because Task 3 extended it to also report fail-fast state — it's now permanently informative at startup.
 
 **Files:**
 - Modify: `core/daemon-boot-collectd/src/main/resources/application.yml`
 - Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
 
-- [ ] **Step 1: Revert env + beans from actuator exposure; keep conditions**
+- [ ] **Step 1: Revert env + beans from actuator exposure**
 
-Edit `core/daemon-boot-collectd/src/main/resources/application.yml`. Find the management block from Task 1:
+Edit `core/daemon-boot-collectd/src/main/resources/application.yml`. Find the include line set in Commit 1:
 
 ```yaml
-management:
-  endpoints:
-    web:
-      exposure:
         include: health, info, prometheus, env, beans, conditions
 ```
 
 Change to:
 
 ```yaml
-management:
-  endpoints:
-    web:
-      exposure:
         include: health, info, prometheus, conditions
 ```
 
-(Keep `conditions` permanently — it costs nothing at runtime, exposes no secrets, and makes future wiring-regression triage one curl away.)
+(Keep `conditions` permanently.)
 
-- [ ] **Step 2: Revert the two diagnostic LOG.info lines in TimeseriesKafkaPublisherConfiguration**
+- [ ] **Step 2: Remove the no-arg constructor diagnostic LOG.info**
 
-Remove the no-arg constructor that logs "TimeseriesKafkaPublisherConfiguration loaded":
+Edit `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`. Delete the no-arg constructor block added in Commit 1:
 
 ```java
-    // DELETE this block:
     public TimeseriesKafkaPublisherConfiguration() {
         LOG.info("TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty(deltav.timeseries.enabled=true) matched");
     }
 ```
 
-Leave the `private static final Logger LOG` field — other code in the class uses it (`FanoutPersister.runInner` / `runKafka` WARN logs).
+Leave the `private static final Logger LOG = ...` field — `runInner` and `runKafka` still use it for WARN logs, and the `compositePersisterFactory` @Bean method (Task 3) also uses it.
 
-The `compositePersisterFactory`/`timeseriesPersisterFactory` `@Bean` method already logs via the `LOG.info(...)` Task 7 kept in place (describing the wrapped inner factory + fail-fast settings). That line stays — it's the one piece of startup-time evidence worth keeping forever.
+The `@Bean` method's `LOG.info("Creating compositePersisterFactory wrapping inner={}@{} (failFastInner={}, failFastKafka={})", ...)` from Task 3 stays — it's now permanently useful at startup.
 
-If after Task 7 the log line in the `@Bean` method reads exactly as Task 1 wrote it (without the `failFastInner` / `failFastKafka` args), update it to match Task 7 Step 3's version. If it already has the fail-fast info, leave as-is.
-
-- [ ] **Step 3: Verify unit tests + IT still pass**
+- [ ] **Step 3: Verify all tests still pass**
 
 ```bash
 ./mvnw -pl core/daemon-boot-collectd verify
 ```
 
-Expected: all tests PASS.
+Expected: all tests still green.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add core/daemon-boot-collectd/src/main/resources/application.yml \
         core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
-git commit -m "chore(daemon-boot-collectd): revert temporary env/beans actuator + startup log
+git commit -m "chore(daemon-boot-collectd): revert temporary env/beans actuator exposure + one-shot startup log
 
-Task 1 exposed /actuator/env + /actuator/beans + /actuator/conditions
-and added two diagnostic startup logs so we could identify which
-wiring hypothesis explained the silent inert publisher. Root cause is
-captured in project_collectd_publisher_inert_investigation memory.
+Commit d3c6d049cab exposed /actuator/env + /actuator/beans + /actuator/conditions
+and added two diagnostic startup logs so we could identify the wiring
+hypothesis. Root cause is captured in
+project_collectd_publisher_inert_investigation memory; the real bug
+turned out to be the Phase 2 NodeContextKafkaBootstrap race (fixed
+earlier in this PR), not Collectd-side wiring.
 
-Revert env + beans exposure (noisy + expose secrets) and the
+Revert env + beans exposure (noisy + can expose secrets) and the
 'TimeseriesKafkaPublisherConfiguration loaded' log (one-shot startup
 line not worth keeping). Keep /actuator/conditions on permanently —
-it incurs no cost, exposes no secrets, and makes future wiring-regression
-triage one curl away. Keep the compositePersisterFactory wrap log
-because it now also reports fail-fast state."
+costs nothing at runtime, exposes no secrets, makes future wiring
+diagnosis one curl away. Keep the compositePersisterFactory wrap log
+because it now also reports fail-fast state (Task 3 extended it)."
 ```
 
 ---
 
-## Task 12: Full-reactor verify
+## Task 7: Full-reactor verify
+
+**Goal:** Confirm the Task 1-6 changes don't cascade into other reactor modules.
 
 - [ ] **Step 1: Run the full-reactor build**
 
@@ -1206,70 +1131,64 @@ because it now also reports fail-fast state."
 ./mvnw -B -DskipTests -fae clean install 2>&1 | tail -10
 ```
 
-Expected: `BUILD SUCCESS`. Every reactor module compiles against the new `TimeseriesKafkaPublisherConfiguration` signature.
+Expected: `BUILD SUCCESS`. Both `core/prometheus-writer` and `core/daemon-boot-collectd` compile against their changes; no other reactor module breaks. The `feedback_delta_v_full_reactor_verify` memory cites this as a mandatory pre-push gate.
 
-If any module fails with `cannot find symbol` referencing `FanoutPersister.FanoutPersister(Persister, TimeseriesKafkaPersister)`: the 2-arg constructor was used by test code somewhere else in the reactor. Update call sites to pass `MeterRegistry` + two booleans, or add a compatibility 2-arg constructor that defaults both booleans to `false` + uses a `NoopMeterRegistry`. (Unlikely — `FanoutPersister` is a nested class with package-private visibility scoped to `org.deltav.collectd.timeseries` — no external reactor deps.)
+If any module fails with `cannot find symbol` referencing `FanoutPersister.<init>(...)` or `FanoutPersisterFactory.<init>(...)`: an unexpected caller exists. Both classes are package-private inside `core/daemon-boot-collectd` so this is unlikely, but if it happens — STOP and report.
 
-- [ ] **Step 2: No commit** — the full-reactor build is a verification gate, not a code change.
+- [ ] **Step 2: No commit** — verification gate only.
 
 ---
 
-## Task 13: Full E2E acceptance gate
+## Task 8: Full E2E acceptance gate
 
-- [ ] **Step 1: Rebuild all delta-v images**
+**Goal:** Run the Phase 2 E2E end-to-end. Acceptance bar from spec §7.
+
+- [ ] **Step 1: Rebuild all delta-v Docker images**
 
 ```bash
 ./opennms-container/delta-v/build.sh deltav 2>&1 | tail -5
 ```
 
-Expected: opennms/collectd, opennms/prometheus-writer, and 12 other daemon images rebuilt.
+Expected: `opennms/collectd:0.0.1-SNAPSHOT`, `opennms/prometheus-writer:0.0.1-SNAPSHOT`, plus the other 12 daemon images. Self-healing freshness check should rebuild collectd + prometheus-writer (both have source changes). If either is unexpectedly skipped, force a rebuild via `touch core/daemon-boot-collectd/pom.xml core/prometheus-writer/pom.xml` and retry.
 
-- [ ] **Step 2: Run the Phase 2 E2E**
+- [ ] **Step 2: Run the Phase 2 E2E with proper exit-code propagation**
 
 ```bash
 set -o pipefail
-./opennms-container/delta-v/test-prometheus-writer-e2e.sh > /tmp/collectd-fix-e2e.log 2>&1
+./opennms-container/delta-v/test-prometheus-writer-e2e.sh > /tmp/v2-e2e.log 2>&1
 echo "E2E exit code: $?"
-tail -10 /tmp/collectd-fix-e2e.log
+tail -20 /tmp/v2-e2e.log
 ```
 
-Expected: exit 0, final log line `==> ALL ASSERTIONS PASSED`.
+Expected: exit `0`, log ends with `==> ALL ASSERTIONS PASSED`.
 
-Note the `set -o pipefail` + `> log 2>&1` — `tee` was found to swallow the exit code during Phase 2 investigation.
+The compose default (Task 5 Step 1) is now `true`, so `DELTAV_TIMESERIES_ENABLED` does not need to be exported. The race fix (Tasks 1-2) means prometheus-writer's NodeContextCache populates correctly. The compose script's existing assertions (`records_consumed_total > 0`, `samples_sent_total > 0`, `batches_sent_total > 0`, `circuit_state == 0`, all failure counters == 0, VictoriaMetrics returns the expected series with full label set) should all pass.
 
-**If any step fails**: run `grep -E "^==>|^FAIL" /tmp/collectd-fix-e2e.log` to see which step broke. If Step 5 (zero failure counters) fires with `enrichment_missing_total > 0` — Phase 1 node-context producer isn't feeding the cache. Check provisiond logs. If Step 6 VictoriaMetrics query fails — VM container didn't come up. Check `docker compose logs victoriametrics`.
+- [ ] **Step 3: If the E2E fails — STOP and report**
 
-- [ ] **Step 3: If a Phase 0 #2 or #3 bug surfaces (MetaTagDataLoader NPE, ResourceTypeUtils NoSuchMethodError)**
+`grep -E "^==>|^FAIL" /tmp/v2-e2e.log` to identify which step broke. Possible failures:
+- `enrichment_missing_total > 0` (acceptance criterion 7 in spec): the race fix didn't fully resolve the issue. Re-check Task 1 Step 2 — likely the `bootstrapMarked` gate or the rebalance listener has a defect.
+- `batches_failed_total > 0` (Phase 0 inner bug surfaced as Kafka-side failure): unlikely but possible.
+- VictoriaMetrics query returns no results: VM container didn't come up, or the labels differ from what Phase 2's E2E asserts. Check `docker compose logs victoriametrics`.
 
-Per (P) best-effort inline:
+Per spec §5, Phase 0 inner bugs #1, #2, #4 are punted to a follow-up PR. They should NOT block this E2E because Kafka publishes regardless. If one of them surfaces in a way that DOES block, that's the (II) decision being violated — STOP and report; don't try to inline-fix.
 
-- If `TimeseriesPersistOperationBuilder.setAttributeValue` NPE appears in collectd logs: locate the class in horizon 1.0.10's source, identify the init-order dependency, add a fix as a new commit on this branch. Add a regression test to `FanoutPersisterTest` or a targeted unit test.
-- If `ResourceTypeUtils.getResourcePathWithRepository` NoSuchMethodError appears: the shim classpath has a Linkage issue. Either port the missing method to the inlined helper from Phase 0 #170's `3a89122f5b0` fix, or add an explicit dep for the horizon class that supplies it.
-- If NEITHER surfaces: close them out in `project_collectd_publisher_inert_investigation` memo as "resolved or no longer reproducible during 2026-04-18 live E2E verification" without further action.
-
-- [ ] **Step 4: No commit** unless a Phase 0 #2 or #3 fix was made in Step 3. If so, commit with a message like:
-
-```
-fix(daemon-boot-collectd): [resolve Phase 0 known-issue #N]
-
-[Describe the trigger condition + fix]
-
-Caught during the collectd-publisher-inert-fix E2E (PR [TBD]).
-Memory project_collectd_publisher_inert_investigation updated.
-```
+- [ ] **Step 4: No commit** — acceptance gate only.
 
 ---
 
-## Task 14: Push + open PR
+## Task 9: Push + open PR
 
-- [ ] **Step 1: Confirm the branch is clean**
+**Goal:** Push branch + open PR against `pbrane/delta-v develop`.
+
+- [ ] **Step 1: Confirm branch is clean**
 
 ```bash
 git status --short
 git log --oneline develop..HEAD | wc -l
 ```
 
-Expected: clean (only the `provisiond-overlay/etc/imports/delta-v.xml` requisition drift, per memory `feedback_provisiond_requisition_drift` — leave unstaged). Commit count: 7 (1 spec + 6 fix commits) or 8 if a Phase 0 #2/#3 fix was added.
+Expected: clean working tree (modulo `provisiond-overlay/etc/imports/*.xml` requisition drift per `feedback_provisiond_requisition_drift` — leave unstaged). Commit count: 9 (1 spec-v1 + 1 plan-v1 + 1 diag-exposure + 1 spec-v2 + 6 new from this plan = 9 ahead of `develop`). 1 spec-v2 supersedes spec-v1 in content; both stay in history.
 
 - [ ] **Step 2: Push**
 
@@ -1277,61 +1196,62 @@ Expected: clean (only the `provisiond-overlay/etc/imports/delta-v.xml` requisiti
 git push -u origin fix/collectd-publisher-inert 2>&1 | tail -3
 ```
 
-- [ ] **Step 3: Open the PR — NEVER use OpenNMS/opennms (memory feedback_never_pr_opennms)**
+- [ ] **Step 3: Open the PR — NEVER use OpenNMS/opennms**
 
 ```bash
 gh pr create --repo pbrane/delta-v --base develop \
-    --title "fix(collectd): wire Kafka publisher + add observability/fail-fast + Phase 2 E2E gate" \
+    --title "fix(prometheus-writer): NodeContextKafkaBootstrap race + Collectd silent-swallow hygiene" \
     --body "$(cat <<'BODY'
 ## Summary
 
-- Fixes the Phase 0 \`TimeseriesKafkaPublisher\` / \`FanoutPersisterFactory\` wiring that was silently inert on current develop
-- Ships two Micrometer counters + two Spring fail-fast properties so this class of silent swallow cannot re-occur
-- Adds \`FanoutPersisterTest\` (7 unit tests) + \`CollectdApplicationScanIT\` (3 real-main-class ITs) as regression gates
-- Flips the compose default \`DELTAV_TIMESERIES_ENABLED\` \`false\` → \`true\`
-- Resolves Phase 2's deferred \`<TBD-phase-2-PR>\` proto-header placeholder → \`#174\`
+Unblocks the Phase 2 prometheus-writer E2E (test-prometheus-writer-e2e.sh).
+First end-to-end pass of the full delta-v Kafka time-series pipeline.
 
-## Root-cause narrative
+- **Race fix (the critical change)**: `core/prometheus-writer/.../NodeContextKafkaBootstrap.java` no longer takes a 'no partitions yet' branch that skipped `consumer.assign()/.subscribe()` and silently looped on `IllegalStateException` forever. Replaced with single-path `consumer.subscribe(...)` + `ConsumerRebalanceListener` that handles topic-exists-at-startup AND topic-created-later uniformly.
+- **Race regression IT**: new `NodeContextKafkaBootstrapIT.bootstrap_survives_topic_created_after_start` exercises the exact scenario that was broken.
+- **Collectd silent-swallow hygiene**: `FanoutPersister` gains `(X)` two Micrometer counters (`deltav.collectd.persister.{inner,kafka}.failures{step=…}`, pre-registered for all 10 visitor steps) + `(Y)` two Spring fail-fast properties (`deltav.collectd.persister.{inner,kafka}.fail-fast`, default false). Surface inner-persister bugs that are currently swallowed without operator signal.
+- **Real-main-class scan IT**: new `CollectdApplicationScanIT` (3 tests) — Phase 2 PR #174 scar-prophylactic lineage — would have pointed at the Phase 2 consumer side earlier if it had existed.
+- **Compose default flip**: `DELTAV_TIMESERIES_ENABLED` default `false` → `true` in `docker-compose.yml`.
+- **Phase 2 proto-header pin**: `<TBD-phase-2-PR>` → `#174` in both `deltav-timeseries.proto` and `deltav-node-context.proto`.
 
-See memory \`project_collectd_publisher_inert_investigation\` for the confirmed hypothesis + evidence. [Summarize the root cause in 2-3 sentences here, referencing the specific actuator + log evidence that identified it.]
+## Investigation history
 
-## Six-commit sequence
+The original v1 spec/plan assumed the Phase 0 Collectd publisher was inert on develop. Live-stack diagnosis (commit `d3c6d049cab` exposed the actuator + startup logs that made the truth visible) refuted the hypothesis: the publisher works fine — 6 batches per 90 s, real records on the topic, prometheus-writer consumes them. The actual bug is in Phase 2's consumer-side `NodeContextKafkaBootstrap`. Memory `project_collectd_publisher_inert_investigation` has the full root-cause narrative + evidence.
 
-1. \`diag(daemon-boot-collectd)\`: diagnostic actuator exposure + startup logs
-2. \`fix(daemon-boot-collectd)\`: the wiring fix (see hypothesis-specific commit body)
-3. \`feat(daemon-boot-collectd)\`: FanoutPersister observability + dev fail-fast
-4. \`test(daemon-boot-collectd)\`: CollectdApplicationScanIT real-main-class IT
-5. \`feat(compose+proto)\`: enable default + pin Phase 2 proto header
-6. \`chore(daemon-boot-collectd)\`: revert temporary env/beans actuator exposure
+The v1 spec (`8c2729588e5`) and v1 plan (`262309050ed`) are retained on the branch for audit. The v2 spec (`f0a4d5b0f94`) and v2 plan (this commit) supersede them.
+
+## Out of scope (memory-noted, separate PRs)
+
+- Phase 0 inner-persister bugs #1 (UnexpectedRollbackException), #2 (NPE in TimeseriesPersistOperationBuilder), and new #4 (ClassCastException in TimeseriesPersister.getUserDefinedMetaTags). All confirmed present and counted by this PR's new (X) counters; all currently swallowed by FanoutPersister isolation; none block Phase 2 E2E. See `project_phase0_inner_persister_bugs_followup` memory.
+- `build.sh check_daemon_boot_freshness` transitive-dep gap (forced `touch core/daemon-boot-collectd/pom.xml` during PR #174 investigation).
+- Phase 3 Thresholder.
 
 ## Acceptance verification
 
-- [x] \`./mvnw -pl core/daemon-boot-collectd verify\` — 7 unit + 3 IT tests pass
-- [x] \`./mvnw -B -DskipTests -fae clean install\` — full-reactor BUILD SUCCESS
-- [x] Live producer verification: \`docker compose up -d\` + wait 90s → \`deltav-timeseries\` has records, \`prometheus-writer records_consumed_total > 0\`
-- [x] \`./opennms-container/delta-v/test-prometheus-writer-e2e.sh\` — exit 0, \`ALL ASSERTIONS PASSED\` (first end-to-end pass of the full Phase 2 pipeline)
-- [x] Memory \`project_collectd_publisher_inert_investigation\` updated: OPEN → DONE with confirmed hypothesis + evidence
+- [x] `./mvnw -pl core/prometheus-writer verify` — all existing Phase 2 tests + new race-IT pass
+- [x] `./mvnw -pl core/daemon-boot-collectd verify` — 7 FanoutPersisterTest + 3 CollectdApplicationScanIT + existing tests pass
+- [x] `./mvnw -B -DskipTests -fae clean install` — full-reactor BUILD SUCCESS
+- [x] `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` — exit 0, ALL ASSERTIONS PASSED (first end-to-end pass)
+- [x] Memory `project_collectd_publisher_inert_investigation` updated to RESOLVED with confirmed real root cause
+- [x] Memory `project_phase0_inner_persister_bugs_followup` created with stack traces + per-step rates from this investigation
+- [x] Memory `project_nodecontext_startup_race_pattern` (feedback) created with the rule
 
 ## Spec + plan
 
-- Spec: \`docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md\`
-- Plan: \`docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md\`
+- Spec (v2): `docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md`
+- Plan (v2): `docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md`
 BODY
 )"
 ```
 
-- [ ] **Step 4: Record the PR URL**
+- [ ] **Step 4: Record the PR URL** (output of `gh pr create`).
 
-Output from `gh pr create` includes the PR URL. Record it.
+- [ ] **Step 5: Post-merge memory updates** (do these manually after merge, not part of this PR):
 
-- [ ] **Step 5: Post-merge memory updates**
-
-(Manually, after merge — not part of this PR.)
-
-- Mark `project_collectd_publisher_inert_investigation`: OPEN → DONE; include the confirmed hypothesis.
-- Update `project_phase2_prometheus_writer_done`: add addendum "E2E now passes end-to-end post-PR [TBD]".
-- Update `project_kafka_timeseries_pipeline`: confirm producer genuinely live.
-- If Phase 0 #2 or #3 were fixed in Task 13 Step 3, create separate memory entries documenting resolution.
+- Flip `project_collectd_publisher_inert_investigation` status: `DIAGNOSED` → `RESOLVED (delta-v#TBD)`.
+- Add addendum to `project_phase2_prometheus_writer_done` noting "E2E now passes end-to-end as of delta-v#TBD".
+- Create `project_phase0_inner_persister_bugs_followup` capturing bugs #1, #2, #4 with the per-step counts from this investigation.
+- Create feedback memory `project_nodecontext_startup_race_pattern` documenting the rule: *any Spring-Kafka consumer using `consumer.partitionsFor(topic)` to make wiring decisions must handle the topic-does-not-exist-yet case via `subscribe` + `ConsumerRebalanceListener`, never via skip-and-enter-liveTail.*
 
 ---
 
@@ -1342,30 +1262,29 @@ Output from `gh pr create` includes the PR URL. Record it.
 | Spec section | Plan task(s) |
 |---|---|
 | §1 Context and goal | Plan preamble |
-| §2 Scope | Task ordering rationale + Out-of-Scope comments |
-| §3 Hypothesis space | Task 3 Step 1 per-hypothesis shape |
-| §4 Commit 1 (diagnostic) | Tasks 1-2 |
-| §4 Commit 2 (wiring fix) | Task 3 |
-| §4 Commit 3 (observability + fail-fast) | Tasks 4-7 |
-| §4 Commit 4 (tests) | Tasks 4-7 (T0) + Task 9 (T1) |
-| §4 Commit 5 (compose + protos) | Task 10 |
-| §4 Commit 6 (cleanup) | Task 11 |
-| §5 Phase 0 #2/#3 best-effort | Task 13 Step 3 |
-| §6 Acceptance criteria | Tasks 12-14 |
-| §7 Risks and trade-offs | Task 3 Step 1 per-hypothesis fallbacks + the "STOP" escape hatches |
-| §8 References | Plan preamble "Critical memory references" |
+| §2 Scope (in + out) | Task ordering rationale + per-task scope notes |
+| §3 Race-fix design | Task 1 |
+| §4 Commit 1 (already landed) | (no task — pre-existing) |
+| §4 Commit 2 (race fix) | Task 1 |
+| §4 Commit 3 (race IT) | Task 2 |
+| §4 Commit 4 (FanoutPersister obs + fail-fast) | Task 3 |
+| §4 Commit 5 (FanoutPersisterTest + scan IT) | Task 4 |
+| §4 Commit 6 (compose + proto) | Task 5 |
+| §4 Commit 7 (diagnostic cleanup) | Task 6 |
+| §5 Phase 0 inner bugs out-of-scope | Task 8 Step 3 (escape hatch + memory follow-up note) + Task 9 Step 5 (memory creation) |
+| §6 Test strategy | Tasks 1-4 (T0 + T1 + race-IT) + Task 8 (live E2E) |
+| §7 Acceptance criteria | Tasks 7-9 |
+| §8 Risks and trade-offs | Inline in Task 1 (rebalance edge cases note) + Task 8 Step 3 (Phase 0 bug escape hatch) |
+| §9 References | Plan preamble |
 
-**Placeholder scan:** one `[TBD]` in the PR body template for the PR URL (gets filled in at PR-open time) and one `[Describe the trigger condition + fix]` in the Task 13 Step 4 template commit body for a hypothetical Phase 0 #2/#3 fix. Both are legitimate fill-in-at-runtime placeholders, not plan-level TBDs.
+**Placeholder scan**: only legitimate runtime-fill placeholders — `TBD` in the post-merge memory updates (waiting on actual PR number) and the `<TBD-phase-2-PR>` literal in Task 5's substitution target. No plan-level TBDs.
 
-**Type consistency:** `FanoutPersister` constructor signature — `(Persister, TimeseriesKafkaPersister, MeterRegistry, boolean, boolean)` — is consistent in Tasks 4 (test), 5 (impl add registry + pre-reg), 6 (runInner/runKafka use fields), 7 (factory passes args). `FanoutPersisterFactory` constructor — `(PersisterFactory, TimeseriesKafkaPublisher, MeterRegistry, boolean, boolean)` — consistent in Task 7 impl + `@Bean` method signature. Counter metric names `deltav.collectd.persister.inner.failures` / `deltav.collectd.persister.kafka.failures` consistent between Task 4 test constants, Task 5 impl constants, Task 9 (not referenced directly but implied by meter pre-registration assertion). Bean names `timeseriesPersisterFactory` (composite, @Primary) + `innerTimeseriesPersisterFactory` consistent in Task 3 (fix), Task 7 (impl `@Bean`), Task 9 (IT bean lookup).
+**Type consistency** (post-Task-3): `FanoutPersister(Persister, TimeseriesKafkaPersister, MeterRegistry, boolean, boolean)` constructor signature is consistent in Task 3 Step 3 (impl), Task 4 Step 2 (`make()` helper in `FanoutPersisterTest`), and Task 4 Step 4 (no direct construction in `CollectdApplicationScanIT` — type-based bean lookup). `FanoutPersisterFactory(PersisterFactory, TimeseriesKafkaPublisher, MeterRegistry, boolean, boolean)` consistent in Task 3 Step 5 (impl) and Task 3 Step 6 (`@Bean` injection signature). Bean names `compositePersisterFactory` (this PR keeps the name from v1's diagnostic commit; the v2 design rejected the rename hypothesis since wiring was correct) and `timeseriesPersisterFactory` (horizon's inner) are stable across all references. Counter meter names `deltav.collectd.persister.inner.failures` / `deltav.collectd.persister.kafka.failures` consistent in Task 3 (constants), Task 4 Step 2 (test constants), Task 4 Step 7 (commit message).
 
 ---
 
-## Execution handoff (after plan saved)
+## Execution handoff
 
-Plan complete and saved to `docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md`. Two execution options:
+Plan complete and saved to `docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md` (overwriting v1 in place; v1 remains in branch history at commit `262309050ed`).
 
-1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
-2. **Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints.
-
-Which approach?
+The execution path is the same `superpowers:subagent-driven-development` already in use this session. Resume with Task 1.

--- a/docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md
+++ b/docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md
@@ -1,0 +1,1371 @@
+# Collectd Kafka Publisher Inert Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unblock the delta-v Kafka Time Series pipeline by identifying and fixing the wiring regression that makes `TimeseriesKafkaPublisher` silently inert, ship observability + regression tests so this class of silent swallow cannot re-occur, flip the compose default, and close out Phase 2's deferred proto-header placeholder. Acceptance is the Phase 2 E2E (`opennms-container/delta-v/test-prometheus-writer-e2e.sh`) exiting 0 with `ALL ASSERTIONS PASSED`.
+
+**Architecture:** Diagnose-first, fix-second, then harden. Commit 1 exposes actuator endpoints + adds two diagnostic `LOG.info` lines to surface the runtime wiring decisions. Commit 2 ships the minimum-diff surgical fix once evidence identifies the root cause. Commit 3 adds Micrometer counters + Spring fail-fast properties inside `FanoutPersister`. Commit 4 adds `FanoutPersisterTest` unit tests + `CollectdApplicationScanIT` real-main-class IT. Commit 5 flips `DELTAV_TIMESERIES_ENABLED` default and substitutes the `<TBD-phase-2-PR>` proto placeholder. Commit 6 partially reverts Commit 1 (keeps `/actuator/conditions`).
+
+**Tech Stack:** Spring Boot 4.0.3, horizon 1.0.10, Spring Cloud Stream Kafka binder, Micrometer Prometheus, Resilience4j unchanged (Collectd doesn't use it), JUnit 5, Mockito, Testcontainers Kafka (`apache/kafka:3.8.0`).
+
+**Spec:** `docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md`
+
+**Branch:** `fix/collectd-publisher-inert` (already created; spec commit `8c2729588e5` already on branch).
+
+**PR target:** `pbrane/delta-v` base `develop`. NEVER `OpenNMS/opennms`.
+
+**Critical memory references:**
+- `feedback_never_pr_opennms` — PRs always `--repo pbrane/delta-v`.
+- `feedback_feature_branches` — never commit directly to `develop`.
+- `feedback_delta_v_uses_mvnw_not_compile_pl` — use `./mvnw`, never `compile.pl`.
+- `feedback_delta_v_full_reactor_verify` — run full-reactor build before push.
+- `feedback_boot4_testcontainers_commons_io` — Testcontainers needs explicit `commons-io:2.18.0` test dep on Boot 4.
+- `feedback_configuration_class_bean_name_collision` — `@Configuration` classes must not share camelCase name with their `@Bean` methods.
+- `feedback_deltav_package_namespace` — new code under `org.deltav.*` with BeaconStrategists copyright.
+- `project_collectd_publisher_inert_investigation` — root-cause hypothesis space + investigation plan.
+
+---
+
+## Task ordering rationale
+
+14 tasks grouped by the six commits from the spec. Task ordering is dependency-driven. Commit 2's fix is contingent on Commit 1's evidence; the plan describes the most-likely shape (hypothesis C — bean-name vs `@Primary` injection) and flags adjustments for A / B / D.
+
+1. **Commit 1 — diagnostic exposure** (Tasks 1-2)
+2. **Commit 2 — wiring fix** (Task 3)
+3. **Commit 3 — observability + fail-fast** (Tasks 4-8)
+4. **Commit 4 — scan IT** (Task 9)
+5. **Commit 5 — compose default + proto headers** (Task 10)
+6. **Commit 6 — diagnostic cleanup** (Task 11)
+7. **Acceptance gates** (Tasks 12-14)
+
+---
+
+## Task 1: Expose diagnostic actuator endpoints + add startup logs
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/resources/application.yml`
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Extend actuator exposure in application.yml**
+
+Locate the `management.endpoints.web.exposure.include` setting in `core/daemon-boot-collectd/src/main/resources/application.yml`. Read the file first to find exact current state:
+
+```bash
+grep -nE "management|endpoint|exposure" core/daemon-boot-collectd/src/main/resources/application.yml
+```
+
+If the include line already exists, edit to add `env,beans,conditions`:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, env, beans, conditions
+```
+
+If the block doesn't exist yet (possible — Collectd may rely on Spring Boot defaults), add the full block at the end of the file, before any trailing `---` document-end marker.
+
+- [ ] **Step 2: Add diagnostic startup logs to TimeseriesKafkaPublisherConfiguration**
+
+Edit `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`.
+
+First, confirm the existing logger import (`org.slf4j.Logger`, `org.slf4j.LoggerFactory`) is present. If not, add them at the top.
+
+Add a class-level `LOG` field near the top of the class (before the `@Bean` methods), immediately after the `@ConditionalOnProperty` annotation and class declaration:
+
+```java
+    private static final Logger LOG = LoggerFactory.getLogger(TimeseriesKafkaPublisherConfiguration.class);
+```
+
+Add a no-arg constructor that logs load-time evidence. Insert after the `LOG` field, before the first `@Bean`:
+
+```java
+    public TimeseriesKafkaPublisherConfiguration() {
+        LOG.info("TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty(deltav.timeseries.enabled=true) matched");
+    }
+```
+
+Modify the `compositePersisterFactory` `@Bean` method to log the inner-factory identity just before returning:
+
+```java
+    @Bean
+    @Primary
+    public PersisterFactory compositePersisterFactory(
+            @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher) {
+        LOG.info("Creating compositePersisterFactory wrapping inner={}@{}",
+                innerFactory.getClass().getName(),
+                System.identityHashCode(innerFactory));
+        return new FanoutPersisterFactory(innerFactory, publisher);
+    }
+```
+
+- [ ] **Step 3: Verify the module compiles**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd -DskipTests compile
+```
+
+Expected: `BUILD SUCCESS`. The startup logs do not yet run; they fire only when the app boots.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/resources/application.yml \
+        core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+git commit -m "diag(daemon-boot-collectd): expose env/beans/conditions + startup logs
+
+Temporary diagnostic exposure on Collectd's actuator plus two INFO log
+lines in TimeseriesKafkaPublisherConfiguration (class load + composite
+persister factory wrap). Lets us confirm which of the three wiring
+hypotheses (property resolution, condition evaluation, or @Primary vs
+qualifier injection) explains the silent inert publisher on develop.
+
+Will be partially reverted in Commit 6 — /actuator/conditions stays
+on permanently; env + beans + startup logs revert."
+```
+
+---
+
+## Task 2: Capture evidence + identify root cause
+
+**Files:**
+- No code changes — this is a run-experiment + memory-update task.
+- Modify: `/Users/david/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/project_collectd_publisher_inert_investigation.md`
+
+- [ ] **Step 1: Rebuild Collectd image**
+
+The `build.sh check_daemon_boot_freshness` check walks `daemon-boot-*/src/main/` + `pom.xml` but misses transitive deps. Since we just modified `daemon-boot-collectd`'s own sources, the check will catch it. If not, touch the pom as a workaround:
+
+```bash
+touch core/daemon-boot-collectd/pom.xml
+./opennms-container/delta-v/build.sh deltav 2>&1 | tail -5
+```
+
+Expected: `opennms/collectd:0.0.1-SNAPSHOT` rebuilt. Other 13 daemon-boot images stay cached.
+
+- [ ] **Step 2: Start the stack**
+
+```bash
+cd opennms-container/delta-v
+DELTAV_TIMESERIES_ENABLED=true docker compose --profile lite --profile metrics-e2e up -d
+echo "--- sleeping 90s for first full poll cycle ---"
+sleep 90
+```
+
+- [ ] **Step 3: Capture log evidence**
+
+```bash
+docker compose logs --no-color collectd 2>&1 | \
+  grep -E "TimeseriesKafkaPublisherConfiguration|compositePersisterFactory|persister.factory|PersisterFactory"
+```
+
+Three possible outcomes:
+- **Neither log line present**: class did not load → hypothesis A (property) or B (condition).
+- **Only the class-load line present**: class loaded but `@Bean` did not run → unexpected (hypothesis D) — possibly the bean ran but the log did not flush, possibly a deeper Spring issue.
+- **Both lines present**: class loaded and composite was wrapped → hypothesis C (bean-name resolution bypass).
+
+- [ ] **Step 4: Capture actuator evidence**
+
+```bash
+docker compose exec -T collectd curl -sf http://localhost:8080/actuator/env/deltav.timeseries.enabled 2>&1 | head -20
+echo "---"
+docker compose exec -T collectd curl -sf http://localhost:8080/actuator/conditions 2>&1 | \
+  python3 -c 'import json,sys; c=json.load(sys.stdin); m=c["contexts"]["application"]; \
+    print("positive:", "TimeseriesKafkaPublisherConfiguration" in m.get("positiveMatches",{})); \
+    print("negative:", [k for k in m.get("negativeMatches",{}) if "Timeseries" in k])'
+echo "---"
+docker compose exec -T collectd curl -sf http://localhost:8080/actuator/beans 2>&1 | \
+  python3 -c 'import json,sys; b=json.load(sys.stdin)["contexts"]["application"]["beans"]; \
+    print({name: {"type": v["type"].split(".")[-1], "primary": v.get("primary", False)} \
+           for name, v in b.items() if "PersisterFactory" in v.get("type","")})'
+```
+
+- [ ] **Step 5: Confirm topic state**
+
+```bash
+docker compose exec -T kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 \
+  --describe --topic deltav-timeseries 2>&1 | head -10
+docker compose exec -T kafka /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9092 \
+  --describe --group prometheus-writer 2>&1 | head -10
+```
+
+- [ ] **Step 6: Tear down**
+
+```bash
+docker compose --profile lite --profile metrics-e2e down -v --remove-orphans
+```
+
+- [ ] **Step 7: Update the investigation memory with captured evidence**
+
+Edit `/Users/david/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/project_collectd_publisher_inert_investigation.md`. Under `## Hypothesis space`, add a new section:
+
+```markdown
+## Root cause identified (2026-04-18)
+
+**Confirmed hypothesis:** [A / B / C / D — fill from evidence]
+
+### Evidence
+
+**Startup log lines** (from `docker compose logs collectd`):
+```
+[paste the matching log lines here]
+```
+
+**Actuator /conditions for TimeseriesKafkaPublisherConfiguration**:
+```
+[paste positive-matches or negative-matches JSON excerpt]
+```
+
+**Actuator /beans for PersisterFactory type**:
+```
+[paste the bean map]
+```
+
+**Kafka topic state**: [records present or zero across N partitions]
+
+### Root cause narrative
+
+[One paragraph explaining why hypothesis X fits the evidence. Tie the actuator + log evidence together. Cite specific bean names and their @Primary status.]
+```
+
+- [ ] **Step 8: No commit — evidence is captured in the memory note, not the repo**
+
+Memory files are under `~/.claude/...` and are not part of the repo. The evidence-capture step is a diagnostic step whose artifact is the memory update + the informed decision about Commit 2's fix shape.
+
+---
+
+## Task 3: Wiring fix (contingent on Task 2's evidence)
+
+**Files (expected, for hypothesis C — adjust for A or B):**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Apply the fix per confirmed hypothesis**
+
+### Hypothesis C — bean-name vs `@Primary` injection (strongest prior)
+
+Horizon's `CollectableService` resolves `PersisterFactory` by `@Qualifier("timeseriesPersisterFactory")` rather than by type. `@Primary` is bypassed. Rename the composite bean to match the name horizon expects.
+
+**Edit 1**: Find the `compositePersisterFactory` `@Bean` method. Change its `@Bean` annotation + method name:
+
+```java
+    // Before:
+    @Bean
+    @Primary
+    public PersisterFactory compositePersisterFactory(
+            @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher) {
+        LOG.info("Creating compositePersisterFactory wrapping inner={}@{}",
+                innerFactory.getClass().getName(),
+                System.identityHashCode(innerFactory));
+        return new FanoutPersisterFactory(innerFactory, publisher);
+    }
+```
+
+```java
+    // After:
+    @Bean(name = "timeseriesPersisterFactory")
+    @Primary
+    public PersisterFactory timeseriesPersisterFactory(
+            @Qualifier("innerTimeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher) {
+        LOG.info("Creating composite timeseriesPersisterFactory wrapping inner={}@{}",
+                innerFactory.getClass().getName(),
+                System.identityHashCode(innerFactory));
+        return new FanoutPersisterFactory(innerFactory, publisher);
+    }
+```
+
+**Edit 2**: Find the inner `PersisterFactory` bean — it's declared in a companion `@Configuration` in `core/daemon-boot-collectd` (search for `@Bean.*PersisterFactory` to locate it). If the commit `7760eef1422` ("rename persisterFactory bean to timeseriesPersisterFactory") is relevant, look at where that rename landed. Expected location:
+
+```bash
+grep -rn "timeseriesPersisterFactory" core/daemon-boot-collectd/src/main/java/
+```
+
+Rename the inner bean from `timeseriesPersisterFactory` to `innerTimeseriesPersisterFactory` via `@Bean(name = "innerTimeseriesPersisterFactory")`:
+
+```java
+    // Before:
+    @Bean
+    public PersisterFactory timeseriesPersisterFactory(...) { ... }
+```
+
+```java
+    // After:
+    @Bean(name = "innerTimeseriesPersisterFactory")
+    public PersisterFactory innerTimeseriesPersisterFactory(...) { ... }
+```
+
+Both inner and outer beans now use explicit `name=` so horizon's `@Qualifier("timeseriesPersisterFactory")` resolves to OUR composite, which internally wraps `innerTimeseriesPersisterFactory`.
+
+### Hypothesis A — property not resolving
+
+Edit `core/daemon-boot-collectd/src/main/resources/application.yml`. Add an explicit binding of `deltav.timeseries.enabled` with the env-var fallback (belt-and-suspenders — the yaml binding happens first; env-var wins if present because `@Value`/env precedence). Locate the existing `deltav:` block:
+
+```yaml
+deltav:
+  timeseries:
+    enabled: ${DELTAV_TIMESERIES_ENABLED:false}
+```
+
+This already exists per prior inspection. If hypothesis A is confirmed, the issue is that the yaml binding is not propagating to `@ConditionalOnProperty`. The fix is to add an explicit `@PropertySource` or replace `@ConditionalOnProperty` with `@ConditionalOnExpression`. Apply the hypothesis-B fix (below) instead — it subsumes A.
+
+### Hypothesis B — condition evaluating false
+
+Edit the class-level annotation in `TimeseriesKafkaPublisherConfiguration.java`:
+
+```java
+    // Before:
+    @ConditionalOnProperty(name = "deltav.timeseries.enabled", havingValue = "true")
+```
+
+```java
+    // After:
+    @ConditionalOnExpression("#{'${deltav.timeseries.enabled:false}' == 'true'}")
+```
+
+### Hypothesis D — unknown
+
+STOP and report BLOCKED. Do not commit a speculative fix. Re-extend diagnosis (e.g. attach a remote debugger to the running collectd container, inspect horizon's `CollectableService.setPersisterFactory` source at the exact 1.0.10 version). Return to brainstorming.
+
+- [ ] **Step 2: Rebuild Collectd image**
+
+```bash
+touch core/daemon-boot-collectd/pom.xml
+./opennms-container/delta-v/build.sh deltav 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Verify the fix live**
+
+```bash
+cd opennms-container/delta-v
+DELTAV_TIMESERIES_ENABLED=true docker compose --profile lite --profile metrics-e2e up -d
+sleep 90
+echo "=== deltav-timeseries record count ==="
+docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server kafka:9092 --topic deltav-timeseries \
+  --from-beginning --max-messages 1 --timeout-ms 10000 2>&1 | tail -3
+echo "=== prometheus-writer counter ==="
+docker compose exec -T prometheus-writer curl -sf http://localhost:8080/actuator/prometheus 2>/dev/null | \
+  grep -E '^deltav_prometheus_writer_records_consumed_total '
+```
+
+Expected: console-consumer reads at least 1 message (byte-array output, not "Processed a total of 0 messages"). `records_consumed_total > 0.0`.
+
+If zero records, STOP — the fix did not work; re-investigate.
+
+- [ ] **Step 4: Tear down**
+
+```bash
+docker compose --profile lite --profile metrics-e2e down -v --remove-orphans
+cd /Users/david/development/src/opennms/delta-v
+```
+
+- [ ] **Step 5: Commit the fix**
+
+Commit message for hypothesis C:
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+# also add whatever file declared the inner PersisterFactory bean
+git commit -m "fix(daemon-boot-collectd): rename compositePersisterFactory bean to timeseriesPersisterFactory
+
+Root cause: horizon CollectableService (horizon 1.0.10) resolves
+PersisterFactory by qualifier name ('timeseriesPersisterFactory')
+rather than by type, so @Primary on our composite bean was bypassed
+and the inner factory won at the injection point. Collectd silently
+ran the legacy persist path with zero Kafka publishes.
+
+Fix: give our composite the name 'timeseriesPersisterFactory' that
+horizon expects; rename the inner bean to
+'innerTimeseriesPersisterFactory'. Horizon now resolves to our
+composite; internally we wrap the renamed inner.
+
+Evidence captured in project_collectd_publisher_inert_investigation
+memo via the diagnostic commit."
+```
+
+Adjust the message body for hypothesis A or B if they were confirmed instead.
+
+---
+
+## Task 4: Write the FanoutPersisterTest skeleton
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java`
+
+- [ ] **Step 1: Write the test class with all 7 test methods (most will fail until Tasks 5-7)**
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersister;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.Persister;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class FanoutPersisterTest {
+
+    private static final String INNER_FAILURES = "deltav.collectd.persister.inner.failures";
+    private static final String KAFKA_FAILURES = "deltav.collectd.persister.kafka.failures";
+    private static final String[] STEPS = new String[]{
+            "visitCollectionSet", "visitResource", "visitGroup", "visitAttribute",
+            "completeAttribute", "completeGroup", "completeResource", "completeCollectionSet",
+            "persistNumericAttribute", "persistStringAttribute"
+    };
+
+    private MeterRegistry registry;
+    private Persister inner;
+    private TimeseriesKafkaPersister kafka;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        inner = mock(Persister.class);
+        kafka = mock(TimeseriesKafkaPersister.class);
+    }
+
+    private FanoutPersister make(boolean failFastInner, boolean failFastKafka) {
+        return new FanoutPersister(inner, kafka, registry, failFastInner, failFastKafka);
+    }
+
+    @Test
+    void counter_increments_on_inner_failure_in_visitResource() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new RuntimeException("inner boom")).when(inner).visitResource(r);
+        doNothing().when(kafka).visitResource(r);
+
+        make(false, false).visitResource(r);
+
+        Counter c = registry.find(INNER_FAILURES).tag("step", "visitResource").counter();
+        assertThat(c).isNotNull();
+        assertThat(c.count()).isEqualTo(1.0);
+        verify(kafka).visitResource(r);
+    }
+
+    @Test
+    void counter_increments_on_kafka_failure_in_visitResource() {
+        CollectionResource r = mock(CollectionResource.class);
+        doNothing().when(inner).visitResource(r);
+        doThrow(new RuntimeException("kafka boom")).when(kafka).visitResource(r);
+
+        make(false, false).visitResource(r);
+
+        Counter c = registry.find(KAFKA_FAILURES).tag("step", "visitResource").counter();
+        assertThat(c).isNotNull();
+        assertThat(c.count()).isEqualTo(1.0);
+        verify(inner).visitResource(r);
+    }
+
+    @Test
+    void counters_preregistered_at_startup_with_zero_value() {
+        make(false, false);
+        for (String step : STEPS) {
+            Counter ic = registry.find(INNER_FAILURES).tag("step", step).counter();
+            Counter kc = registry.find(KAFKA_FAILURES).tag("step", step).counter();
+            assertThat(ic).as("inner counter step=%s", step).isNotNull();
+            assertThat(ic.count()).isZero();
+            assertThat(kc).as("kafka counter step=%s", step).isNotNull();
+            assertThat(kc.count()).isZero();
+        }
+    }
+
+    @Test
+    void fail_fast_inner_true_rethrows() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new RuntimeException("inner boom")).when(inner).visitResource(r);
+
+        FanoutPersister p = make(true, false);
+        assertThatThrownBy(() -> p.visitResource(r))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("inner boom");
+    }
+
+    @Test
+    void fail_fast_inner_false_swallows_and_continues() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new RuntimeException("inner boom")).when(inner).visitResource(r);
+        doNothing().when(kafka).visitResource(r);
+
+        make(false, false).visitResource(r);  // should NOT throw
+
+        verify(kafka).visitResource(r);
+    }
+
+    @Test
+    void fail_fast_kafka_true_rethrows() {
+        CollectionResource r = mock(CollectionResource.class);
+        doNothing().when(inner).visitResource(r);
+        doThrow(new RuntimeException("kafka boom")).when(kafka).visitResource(r);
+
+        FanoutPersister p = make(false, true);
+        assertThatThrownBy(() -> p.visitResource(r))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("kafka boom");
+    }
+
+    @Test
+    void throwable_not_just_runtime_exception() {
+        CollectionResource r = mock(CollectionResource.class);
+        doThrow(new LinkageError("NoSuchMethodError from horizon"))
+                .when(inner).visitResource(r);
+        doNothing().when(kafka).visitResource(r);
+
+        make(false, false).visitResource(r);  // should NOT throw
+
+        Counter c = registry.find(INNER_FAILURES).tag("step", "visitResource").counter();
+        assertThat(c.count()).isEqualTo(1.0);
+        verify(kafka).visitResource(r);
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect compile failure**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest
+```
+
+Expected: compile failure — `FanoutPersister` constructor doesn't take `MeterRegistry` + two booleans yet; the `TimeseriesKafkaPersister` reference may or may not compile.
+
+- [ ] **Step 3: Do NOT commit yet** — Task 5 adds the implementation that makes these tests pass.
+
+---
+
+## Task 5: Implement counter pre-registration
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Add imports + pre-registration helper**
+
+At the top of `TimeseriesKafkaPublisherConfiguration.java`, add imports:
+
+```java
+import io.micrometer.core.instrument.Counter;
+```
+
+(`MeterRegistry` is likely already imported.)
+
+Add a private static helper just inside the `FanoutPersister` nested class, near the other fields:
+
+```java
+        private static final String INNER_FAILURES_METER =
+                "deltav.collectd.persister.inner.failures";
+        private static final String KAFKA_FAILURES_METER =
+                "deltav.collectd.persister.kafka.failures";
+        private static final String[] STEPS = new String[]{
+                "visitCollectionSet", "visitResource", "visitGroup", "visitAttribute",
+                "completeAttribute", "completeGroup", "completeResource", "completeCollectionSet",
+                "persistNumericAttribute", "persistStringAttribute"
+        };
+```
+
+- [ ] **Step 2: Extend FanoutPersister constructor to take MeterRegistry + fail-fast flags**
+
+Replace the existing `FanoutPersister` constructor + fields:
+
+```java
+        // Before (current shape):
+        private final Persister innerPersister;
+        private final TimeseriesKafkaPersister kafkaPersister;
+
+        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister) {
+            this.innerPersister = innerPersister;
+            this.kafkaPersister = kafkaPersister;
+        }
+```
+
+```java
+        // After:
+        private final Persister innerPersister;
+        private final TimeseriesKafkaPersister kafkaPersister;
+        private final MeterRegistry meterRegistry;
+        private final boolean failFastInner;
+        private final boolean failFastKafka;
+
+        FanoutPersister(Persister innerPersister, TimeseriesKafkaPersister kafkaPersister,
+                        MeterRegistry meterRegistry, boolean failFastInner, boolean failFastKafka) {
+            this.innerPersister = innerPersister;
+            this.kafkaPersister = kafkaPersister;
+            this.meterRegistry = meterRegistry;
+            this.failFastInner = failFastInner;
+            this.failFastKafka = failFastKafka;
+            preRegisterCounters();
+        }
+
+        private void preRegisterCounters() {
+            for (String step : STEPS) {
+                Counter.builder(INNER_FAILURES_METER).tag("step", step).register(meterRegistry);
+                Counter.builder(KAFKA_FAILURES_METER).tag("step", step).register(meterRegistry);
+            }
+        }
+```
+
+- [ ] **Step 3: Run only the pre-registration test**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest#counters_preregistered_at_startup_with_zero_value
+```
+
+Expected: PASS. Other tests may still fail; that's Task 6's job.
+
+- [ ] **Step 4: Do NOT commit yet** — bundle commit after Task 7.
+
+---
+
+## Task 6: Implement counter increments + fail-fast branches
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Rewrite runInner and runKafka helpers with increment + fail-fast**
+
+Replace the existing `runInner` and `runKafka` methods inside `FanoutPersister`:
+
+```java
+        // Before (current shape):
+        private void runInner(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                LOG.warn("Inner persister threw during {}; continuing with Kafka path", step, e);
+            }
+        }
+
+        private void runKafka(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                LOG.warn("Kafka persister threw during {}; continuing", step, e);
+            }
+        }
+```
+
+```java
+        // After:
+        private void runInner(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                meterRegistry.counter(INNER_FAILURES_METER, "step", step).increment();
+                LOG.warn("Inner persister threw during {}; continuing with Kafka path", step, e);
+                if (failFastInner) {
+                    throw new RuntimeException(
+                            "Inner persister failed during " + step + " (fail-fast enabled)", e);
+                }
+            }
+        }
+
+        private void runKafka(String step, Runnable task) {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                meterRegistry.counter(KAFKA_FAILURES_METER, "step", step).increment();
+                LOG.warn("Kafka persister threw during {}; continuing", step, e);
+                if (failFastKafka) {
+                    throw new RuntimeException(
+                            "Kafka persister failed during " + step + " (fail-fast enabled)", e);
+                }
+            }
+        }
+```
+
+- [ ] **Step 2: Run the counter-increment + fail-fast tests**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest
+```
+
+Expected: all 7 tests PASS except possibly `throwable_not_just_runtime_exception` if the earlier Throwable catch was narrower. If any fail, re-read the implementation to confirm the catch is `Throwable` (not `Exception`) and the branch conditions match.
+
+- [ ] **Step 3: Do NOT commit yet** — Task 7 updates `FanoutPersisterFactory` to pass the new args.
+
+---
+
+## Task 7: Wire FanoutPersisterFactory to pass MeterRegistry + fail-fast properties
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Extend FanoutPersisterFactory to carry MeterRegistry + flags**
+
+Replace the existing `FanoutPersisterFactory` nested class header + fields + constructor:
+
+```java
+        // Before:
+        static final class FanoutPersisterFactory implements PersisterFactory {
+            private final PersisterFactory innerFactory;
+            private final TimeseriesKafkaPublisher publisher;
+
+            FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher) {
+                this.innerFactory = innerFactory;
+                this.publisher = publisher;
+            }
+```
+
+```java
+        // After:
+        static final class FanoutPersisterFactory implements PersisterFactory {
+            private final PersisterFactory innerFactory;
+            private final TimeseriesKafkaPublisher publisher;
+            private final MeterRegistry meterRegistry;
+            private final boolean failFastInner;
+            private final boolean failFastKafka;
+
+            FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher,
+                                   MeterRegistry meterRegistry,
+                                   boolean failFastInner, boolean failFastKafka) {
+                this.innerFactory = innerFactory;
+                this.publisher = publisher;
+                this.meterRegistry = meterRegistry;
+                this.failFastInner = failFastInner;
+                this.failFastKafka = failFastKafka;
+            }
+```
+
+- [ ] **Step 2: Update both createPersister overloads to pass the new args**
+
+```java
+        // Before:
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                                         boolean dontPersistCounters, boolean forceStoreByGroup,
+                                         boolean dontReorderAttributes) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository, dontPersistCounters,
+                            forceStoreByGroup, dontReorderAttributes),
+                    new TimeseriesKafkaPersister(publisher, params));
+        }
+```
+
+```java
+        // After:
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository),
+                    new TimeseriesKafkaPersister(publisher, params),
+                    meterRegistry, failFastInner, failFastKafka);
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                                         boolean dontPersistCounters, boolean forceStoreByGroup,
+                                         boolean dontReorderAttributes) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository, dontPersistCounters,
+                            forceStoreByGroup, dontReorderAttributes),
+                    new TimeseriesKafkaPersister(publisher, params),
+                    meterRegistry, failFastInner, failFastKafka);
+        }
+```
+
+- [ ] **Step 3: Update the @Bean method to inject MeterRegistry + read the fail-fast properties**
+
+The `@Bean` method (named `timeseriesPersisterFactory` after Task 3's rename, or `compositePersisterFactory` before) gains two additional parameters:
+
+```java
+    @Bean(name = "timeseriesPersisterFactory")
+    @Primary
+    public PersisterFactory timeseriesPersisterFactory(
+            @Qualifier("innerTimeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher,
+            MeterRegistry meterRegistry,
+            @Value("${deltav.collectd.persister.inner.fail-fast:false}") boolean failFastInner,
+            @Value("${deltav.collectd.persister.kafka.fail-fast:false}") boolean failFastKafka) {
+        LOG.info("Creating composite timeseriesPersisterFactory wrapping inner={}@{} (failFastInner={}, failFastKafka={})",
+                innerFactory.getClass().getName(),
+                System.identityHashCode(innerFactory),
+                failFastInner, failFastKafka);
+        return new FanoutPersisterFactory(innerFactory, publisher, meterRegistry,
+                failFastInner, failFastKafka);
+    }
+```
+
+- [ ] **Step 4: Update the class-level javadoc to describe the new meters + properties**
+
+Replace the existing class-level javadoc block:
+
+```java
+/**
+ * Feature-flagged configuration for the Kafka Time Series producer. When
+ * {@code deltav.timeseries.enabled=true}, publishes one TimeseriesBatch
+ * protobuf record per CollectionSet poll to the deltav-timeseries topic.
+ * When the flag is false (default), none of the beans are created and the
+ * persister chain stays on the existing InMemoryStorage-backed
+ * TimeseriesPersisterFactory path.
+ *
+ * <p>Observability (added post-Phase-2 to prevent silent-swallow regressions):
+ * <ul>
+ *   <li>{@code deltav.collectd.persister.inner.failures{step=<visitor-step>}}
+ *       — Micrometer counter, pre-registered for all 10 visitor steps at
+ *       startup so alerts on rate&gt;0 are unambiguous vs missing-metric.</li>
+ *   <li>{@code deltav.collectd.persister.kafka.failures{step=<visitor-step>}}
+ *       — symmetric for the Kafka side.</li>
+ * </ul>
+ *
+ * <p>Fail-fast toggles (for CI / integration tests — default off in production):
+ * <ul>
+ *   <li>{@code deltav.collectd.persister.inner.fail-fast} — when true, inner
+ *       Throwable propagates instead of being swallowed + logged.</li>
+ *   <li>{@code deltav.collectd.persister.kafka.fail-fast} — symmetric for Kafka.</li>
+ * </ul>
+ *
+ * <p>See the {@code project_collectd_publisher_inert_investigation} memory note
+ * for the root-cause narrative that motivated these gates.
+ */
+```
+
+- [ ] **Step 5: Run the full FanoutPersisterTest suite — expect 7/7 PASS**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd test -Dtest=FanoutPersisterTest
+```
+
+Expected: 7/7 PASS.
+
+- [ ] **Step 6: Commit all three Tasks 4-7 together as one Commit 3**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java \
+        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
+git commit -m "feat(daemon-boot-collectd): FanoutPersister observability + dev fail-fast
+
+(X) Two Micrometer counters — deltav.collectd.persister.{inner,kafka}.failures
+tagged by visitor step — pre-registered at startup for all 10 steps so
+ops can alert on rate>0 rather than missing-metric. Silent-swallow bugs
+like the one that hid the Kafka publisher being inert for weeks until
+Phase 2 PR #174 asserted downstream consumption cannot hide again.
+
+(Y) Two Spring properties — deltav.collectd.persister.{inner,kafka}.fail-fast,
+default false in production. When true, Throwables propagate instead of
+being swallowed + logged. CI and test profiles enable these via
+@TestPropertySource so integration tests fail on inner-persister
+regressions instead of silently absorbing them.
+
+Symmetric for inner and Kafka sides because the same class of wiring
+bug could hit either. Seven FanoutPersisterTest unit tests cover
+counter increments, pre-registration, fail-fast matrix, and the
+LinkageError-catches-Throwable scar guard (Phase 0 #3)."
+```
+
+---
+
+## Task 8: (placeholder — no-op, Task 7 Step 6 handled the Commit 3 commit)
+
+Leaving this slot empty in the numbering so the Commit ↔ Task mapping stays clean in the commit log. Skip to Task 9.
+
+---
+
+## Task 9: CollectdApplicationScanIT real-main-class IT
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`
+- Possibly modify: `core/daemon-boot-collectd/pom.xml` (add `commons-io:2.18.0` test dep if not present — per memory `feedback_boot4_testcontainers_commons_io`)
+
+- [ ] **Step 1: Check if commons-io test dep is already in collectd's pom**
+
+```bash
+grep -A2 "commons-io" core/daemon-boot-collectd/pom.xml | head -10
+```
+
+If `commons-io:2.18.0` with `<scope>test</scope>` is absent, add to `core/daemon-boot-collectd/pom.xml` inside the `<dependencies>` section (near other test-scoped deps):
+
+```xml
+        <!-- Required by Testcontainers 2.x / commons-compress 1.28+ — see
+             feedback_boot4_testcontainers_commons_io memory. Without this,
+             container start hangs at the wait-strategy timeout. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+```
+
+- [ ] **Step 2: Write the IT**
+
+Create `core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * Licensed under the GNU Affero General Public License v3.
+ */
+package org.deltav.netmgt.collectd.boot;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.deltav.collectd.timeseries.TimeseriesKafkaPublisher;
+import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersisterFactory;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-main-class integration test. Boots CollectdApplication via
+ * SpringApplication.run() against a Testcontainers Kafka broker with
+ * deltav.timeseries.enabled=true and fail-fast toggles on. Asserts the
+ * composite PersisterFactory wires correctly so horizon's CollectableService
+ * resolves to our FanoutPersisterFactory, not the bare inner factory.
+ *
+ * <p>Scar prophylactic: would have caught the silent-inert wiring bug
+ * (project_collectd_publisher_inert_investigation) in one CI run.
+ */
+@Testcontainers
+@SpringBootTest(classes = CollectdApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+        "deltav.timeseries.enabled=true",
+        "deltav.collectd.persister.inner.fail-fast=true",
+        "deltav.collectd.persister.kafka.fail-fast=true",
+        // Avoid horizon config loaders hitting real SNMP agents during boot
+        "spring.datasource.url=jdbc:h2:mem:scan-it;MODE=PostgreSQL",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class CollectdApplicationScanIT {
+
+    @Container
+    static final KafkaContainer KAFKA =
+            new KafkaContainer(DockerImageName.parse("apache/kafka:3.8.0"))
+                    .withStartupTimeout(Duration.ofSeconds(120));
+
+    @DynamicPropertySource
+    static void kafkaProps(DynamicPropertyRegistry reg) {
+        reg.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        reg.add("spring.cloud.stream.kafka.binder.brokers", KAFKA::getBootstrapServers);
+    }
+
+    @Autowired ApplicationContext ctx;
+
+    @Test
+    void persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true() {
+        PersisterFactory factory = ctx.getBean(
+                "timeseriesPersisterFactory", PersisterFactory.class);
+        assertThat(factory)
+                .as("with deltav.timeseries.enabled=true, the bean named "
+                        + "'timeseriesPersisterFactory' must be our FanoutPersisterFactory "
+                        + "wrapping the inner (horizon CollectableService resolves by qualifier name)")
+                .isInstanceOf(FanoutPersisterFactory.class);
+    }
+
+    @Test
+    void deltav_timeseries_topic_bean_exists_when_flag_true() {
+        NewTopic topic = ctx.getBean("deltavTimeseriesTopic", NewTopic.class);
+        assertThat(topic).isNotNull();
+        assertThat(topic.name()).isEqualTo("deltav-timeseries");
+    }
+
+    @Test
+    void timeseries_kafka_publisher_bean_exists_when_flag_true() {
+        TimeseriesKafkaPublisher publisher = ctx.getBean(TimeseriesKafkaPublisher.class);
+        assertThat(publisher).isNotNull();
+    }
+}
+```
+
+- [ ] **Step 3: Run the IT**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd verify -Dit.test=CollectdApplicationScanIT
+```
+
+Expected: 3/3 PASS in ~30-60s (Testcontainers Kafka startup dominates).
+
+**If test fails** with `Timed out waiting for log output matching '.*Transitioning from RECOVERY to RUNNING.*'`: the commons-io 2.18.0 dep is missing. Add it per Step 1.
+
+**If `persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true` fails** with the bean being a different class: Task 3's wiring fix didn't take effect. Re-check the `@Bean(name="timeseriesPersisterFactory")` rename + inner-bean `@Bean(name="innerTimeseriesPersisterFactory")` rename. STOP and report — the IT is doing its job.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java \
+        core/daemon-boot-collectd/pom.xml
+git commit -m "test(daemon-boot-collectd): CollectdApplicationScanIT real-main-class IT
+
+Boots CollectdApplication via SpringApplication.run() against a
+Testcontainers Kafka broker with deltav.timeseries.enabled=true +
+fail-fast toggles on. Asserts:
+  - timeseriesPersisterFactory bean resolves to FanoutPersisterFactory
+    (the wiring regression this PR fixes would have been caught here)
+  - deltavTimeseriesTopic NewTopic bean exists
+  - TimeseriesKafkaPublisher bean exists
+
+Phase 2 PR #174 scar-prophylactic lineage: real-main-class startup
+catches @Configuration and bean-wiring bugs that unit tests +
+@Import-based ITs all bypass. Mandatory commons-io:2.18.0 test dep
+added per feedback_boot4_testcontainers_commons_io memory."
+```
+
+---
+
+## Task 10: Compose default flip + proto-header substitution
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+- Modify: `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto`
+- Modify: `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto`
+
+- [ ] **Step 1: Flip the compose default**
+
+Edit `opennms-container/delta-v/docker-compose.yml`. Find line 176:
+
+```yaml
+      DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-false}
+```
+
+Change to:
+
+```yaml
+      DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-true}
+```
+
+- [ ] **Step 2: Substitute the `<TBD-phase-2-PR>` placeholder in both proto headers**
+
+```bash
+grep -n "TBD-phase-2-PR" core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+```
+
+Expected: each file has one match in its header comment block. Edit each manually (do NOT use `sed -i` — the surrounding text differs slightly per file and a manual edit confirms context):
+
+Locate in `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto`:
+
+```protobuf
+// API version: 1 (FROZEN at Phase 2 GA — delta-v#<TBD-phase-2-PR>)
+```
+
+Change to:
+
+```protobuf
+// API version: 1 (FROZEN at Phase 2 GA — delta-v#174)
+```
+
+Same substitution in `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto`.
+
+- [ ] **Step 3: Verify docker-compose yaml syntax + protos compile**
+
+```bash
+cd opennms-container/delta-v && docker compose --profile lite --profile metrics-e2e config >/dev/null
+cd /Users/david/development/src/opennms/delta-v
+./mvnw -pl core/deltav-kafka-contracts -DskipTests clean install
+```
+
+Expected: both exit 0; protobuf-maven-plugin BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add opennms-container/delta-v/docker-compose.yml \
+        core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto \
+        core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+git commit -m "feat(compose+proto): enable Kafka time-series publisher by default; pin Phase 2 proto header
+
+Compose default flipped from DELTAV_TIMESERIES_ENABLED=false to =true so
+the Phase 0 producer is on by default in the delta-v stack (matches its
+'DONE + E2E verified' status). Operators who need it off can still
+export the env var explicitly.
+
+Proto-header placeholder from Phase 2 resolved: <TBD-phase-2-PR> -> #174
+in both deltav-timeseries.proto and deltav-node-context.proto."
+```
+
+---
+
+## Task 11: Diagnostic cleanup (partial revert of Task 1)
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/resources/application.yml`
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Revert env + beans from actuator exposure; keep conditions**
+
+Edit `core/daemon-boot-collectd/src/main/resources/application.yml`. Find the management block from Task 1:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, env, beans, conditions
+```
+
+Change to:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, conditions
+```
+
+(Keep `conditions` permanently — it costs nothing at runtime, exposes no secrets, and makes future wiring-regression triage one curl away.)
+
+- [ ] **Step 2: Revert the two diagnostic LOG.info lines in TimeseriesKafkaPublisherConfiguration**
+
+Remove the no-arg constructor that logs "TimeseriesKafkaPublisherConfiguration loaded":
+
+```java
+    // DELETE this block:
+    public TimeseriesKafkaPublisherConfiguration() {
+        LOG.info("TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty(deltav.timeseries.enabled=true) matched");
+    }
+```
+
+Leave the `private static final Logger LOG` field — other code in the class uses it (`FanoutPersister.runInner` / `runKafka` WARN logs).
+
+The `compositePersisterFactory`/`timeseriesPersisterFactory` `@Bean` method already logs via the `LOG.info(...)` Task 7 kept in place (describing the wrapped inner factory + fail-fast settings). That line stays — it's the one piece of startup-time evidence worth keeping forever.
+
+If after Task 7 the log line in the `@Bean` method reads exactly as Task 1 wrote it (without the `failFastInner` / `failFastKafka` args), update it to match Task 7 Step 3's version. If it already has the fail-fast info, leave as-is.
+
+- [ ] **Step 3: Verify unit tests + IT still pass**
+
+```bash
+./mvnw -pl core/daemon-boot-collectd verify
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/resources/application.yml \
+        core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+git commit -m "chore(daemon-boot-collectd): revert temporary env/beans actuator + startup log
+
+Task 1 exposed /actuator/env + /actuator/beans + /actuator/conditions
+and added two diagnostic startup logs so we could identify which
+wiring hypothesis explained the silent inert publisher. Root cause is
+captured in project_collectd_publisher_inert_investigation memory.
+
+Revert env + beans exposure (noisy + expose secrets) and the
+'TimeseriesKafkaPublisherConfiguration loaded' log (one-shot startup
+line not worth keeping). Keep /actuator/conditions on permanently —
+it incurs no cost, exposes no secrets, and makes future wiring-regression
+triage one curl away. Keep the compositePersisterFactory wrap log
+because it now also reports fail-fast state."
+```
+
+---
+
+## Task 12: Full-reactor verify
+
+- [ ] **Step 1: Run the full-reactor build**
+
+```bash
+./mvnw -B -DskipTests -fae clean install 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESS`. Every reactor module compiles against the new `TimeseriesKafkaPublisherConfiguration` signature.
+
+If any module fails with `cannot find symbol` referencing `FanoutPersister.FanoutPersister(Persister, TimeseriesKafkaPersister)`: the 2-arg constructor was used by test code somewhere else in the reactor. Update call sites to pass `MeterRegistry` + two booleans, or add a compatibility 2-arg constructor that defaults both booleans to `false` + uses a `NoopMeterRegistry`. (Unlikely — `FanoutPersister` is a nested class with package-private visibility scoped to `org.deltav.collectd.timeseries` — no external reactor deps.)
+
+- [ ] **Step 2: No commit** — the full-reactor build is a verification gate, not a code change.
+
+---
+
+## Task 13: Full E2E acceptance gate
+
+- [ ] **Step 1: Rebuild all delta-v images**
+
+```bash
+./opennms-container/delta-v/build.sh deltav 2>&1 | tail -5
+```
+
+Expected: opennms/collectd, opennms/prometheus-writer, and 12 other daemon images rebuilt.
+
+- [ ] **Step 2: Run the Phase 2 E2E**
+
+```bash
+set -o pipefail
+./opennms-container/delta-v/test-prometheus-writer-e2e.sh > /tmp/collectd-fix-e2e.log 2>&1
+echo "E2E exit code: $?"
+tail -10 /tmp/collectd-fix-e2e.log
+```
+
+Expected: exit 0, final log line `==> ALL ASSERTIONS PASSED`.
+
+Note the `set -o pipefail` + `> log 2>&1` — `tee` was found to swallow the exit code during Phase 2 investigation.
+
+**If any step fails**: run `grep -E "^==>|^FAIL" /tmp/collectd-fix-e2e.log` to see which step broke. If Step 5 (zero failure counters) fires with `enrichment_missing_total > 0` — Phase 1 node-context producer isn't feeding the cache. Check provisiond logs. If Step 6 VictoriaMetrics query fails — VM container didn't come up. Check `docker compose logs victoriametrics`.
+
+- [ ] **Step 3: If a Phase 0 #2 or #3 bug surfaces (MetaTagDataLoader NPE, ResourceTypeUtils NoSuchMethodError)**
+
+Per (P) best-effort inline:
+
+- If `TimeseriesPersistOperationBuilder.setAttributeValue` NPE appears in collectd logs: locate the class in horizon 1.0.10's source, identify the init-order dependency, add a fix as a new commit on this branch. Add a regression test to `FanoutPersisterTest` or a targeted unit test.
+- If `ResourceTypeUtils.getResourcePathWithRepository` NoSuchMethodError appears: the shim classpath has a Linkage issue. Either port the missing method to the inlined helper from Phase 0 #170's `3a89122f5b0` fix, or add an explicit dep for the horizon class that supplies it.
+- If NEITHER surfaces: close them out in `project_collectd_publisher_inert_investigation` memo as "resolved or no longer reproducible during 2026-04-18 live E2E verification" without further action.
+
+- [ ] **Step 4: No commit** unless a Phase 0 #2 or #3 fix was made in Step 3. If so, commit with a message like:
+
+```
+fix(daemon-boot-collectd): [resolve Phase 0 known-issue #N]
+
+[Describe the trigger condition + fix]
+
+Caught during the collectd-publisher-inert-fix E2E (PR [TBD]).
+Memory project_collectd_publisher_inert_investigation updated.
+```
+
+---
+
+## Task 14: Push + open PR
+
+- [ ] **Step 1: Confirm the branch is clean**
+
+```bash
+git status --short
+git log --oneline develop..HEAD | wc -l
+```
+
+Expected: clean (only the `provisiond-overlay/etc/imports/delta-v.xml` requisition drift, per memory `feedback_provisiond_requisition_drift` — leave unstaged). Commit count: 7 (1 spec + 6 fix commits) or 8 if a Phase 0 #2/#3 fix was added.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin fix/collectd-publisher-inert 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Open the PR — NEVER use OpenNMS/opennms (memory feedback_never_pr_opennms)**
+
+```bash
+gh pr create --repo pbrane/delta-v --base develop \
+    --title "fix(collectd): wire Kafka publisher + add observability/fail-fast + Phase 2 E2E gate" \
+    --body "$(cat <<'BODY'
+## Summary
+
+- Fixes the Phase 0 \`TimeseriesKafkaPublisher\` / \`FanoutPersisterFactory\` wiring that was silently inert on current develop
+- Ships two Micrometer counters + two Spring fail-fast properties so this class of silent swallow cannot re-occur
+- Adds \`FanoutPersisterTest\` (7 unit tests) + \`CollectdApplicationScanIT\` (3 real-main-class ITs) as regression gates
+- Flips the compose default \`DELTAV_TIMESERIES_ENABLED\` \`false\` → \`true\`
+- Resolves Phase 2's deferred \`<TBD-phase-2-PR>\` proto-header placeholder → \`#174\`
+
+## Root-cause narrative
+
+See memory \`project_collectd_publisher_inert_investigation\` for the confirmed hypothesis + evidence. [Summarize the root cause in 2-3 sentences here, referencing the specific actuator + log evidence that identified it.]
+
+## Six-commit sequence
+
+1. \`diag(daemon-boot-collectd)\`: diagnostic actuator exposure + startup logs
+2. \`fix(daemon-boot-collectd)\`: the wiring fix (see hypothesis-specific commit body)
+3. \`feat(daemon-boot-collectd)\`: FanoutPersister observability + dev fail-fast
+4. \`test(daemon-boot-collectd)\`: CollectdApplicationScanIT real-main-class IT
+5. \`feat(compose+proto)\`: enable default + pin Phase 2 proto header
+6. \`chore(daemon-boot-collectd)\`: revert temporary env/beans actuator exposure
+
+## Acceptance verification
+
+- [x] \`./mvnw -pl core/daemon-boot-collectd verify\` — 7 unit + 3 IT tests pass
+- [x] \`./mvnw -B -DskipTests -fae clean install\` — full-reactor BUILD SUCCESS
+- [x] Live producer verification: \`docker compose up -d\` + wait 90s → \`deltav-timeseries\` has records, \`prometheus-writer records_consumed_total > 0\`
+- [x] \`./opennms-container/delta-v/test-prometheus-writer-e2e.sh\` — exit 0, \`ALL ASSERTIONS PASSED\` (first end-to-end pass of the full Phase 2 pipeline)
+- [x] Memory \`project_collectd_publisher_inert_investigation\` updated: OPEN → DONE with confirmed hypothesis + evidence
+
+## Spec + plan
+
+- Spec: \`docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md\`
+- Plan: \`docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md\`
+BODY
+)"
+```
+
+- [ ] **Step 4: Record the PR URL**
+
+Output from `gh pr create` includes the PR URL. Record it.
+
+- [ ] **Step 5: Post-merge memory updates**
+
+(Manually, after merge — not part of this PR.)
+
+- Mark `project_collectd_publisher_inert_investigation`: OPEN → DONE; include the confirmed hypothesis.
+- Update `project_phase2_prometheus_writer_done`: add addendum "E2E now passes end-to-end post-PR [TBD]".
+- Update `project_kafka_timeseries_pipeline`: confirm producer genuinely live.
+- If Phase 0 #2 or #3 were fixed in Task 13 Step 3, create separate memory entries documenting resolution.
+
+---
+
+## Self-review (post-plan, pre-execution)
+
+**Spec coverage check** (each spec section → plan task):
+
+| Spec section | Plan task(s) |
+|---|---|
+| §1 Context and goal | Plan preamble |
+| §2 Scope | Task ordering rationale + Out-of-Scope comments |
+| §3 Hypothesis space | Task 3 Step 1 per-hypothesis shape |
+| §4 Commit 1 (diagnostic) | Tasks 1-2 |
+| §4 Commit 2 (wiring fix) | Task 3 |
+| §4 Commit 3 (observability + fail-fast) | Tasks 4-7 |
+| §4 Commit 4 (tests) | Tasks 4-7 (T0) + Task 9 (T1) |
+| §4 Commit 5 (compose + protos) | Task 10 |
+| §4 Commit 6 (cleanup) | Task 11 |
+| §5 Phase 0 #2/#3 best-effort | Task 13 Step 3 |
+| §6 Acceptance criteria | Tasks 12-14 |
+| §7 Risks and trade-offs | Task 3 Step 1 per-hypothesis fallbacks + the "STOP" escape hatches |
+| §8 References | Plan preamble "Critical memory references" |
+
+**Placeholder scan:** one `[TBD]` in the PR body template for the PR URL (gets filled in at PR-open time) and one `[Describe the trigger condition + fix]` in the Task 13 Step 4 template commit body for a hypothetical Phase 0 #2/#3 fix. Both are legitimate fill-in-at-runtime placeholders, not plan-level TBDs.
+
+**Type consistency:** `FanoutPersister` constructor signature — `(Persister, TimeseriesKafkaPersister, MeterRegistry, boolean, boolean)` — is consistent in Tasks 4 (test), 5 (impl add registry + pre-reg), 6 (runInner/runKafka use fields), 7 (factory passes args). `FanoutPersisterFactory` constructor — `(PersisterFactory, TimeseriesKafkaPublisher, MeterRegistry, boolean, boolean)` — consistent in Task 7 impl + `@Bean` method signature. Counter metric names `deltav.collectd.persister.inner.failures` / `deltav.collectd.persister.kafka.failures` consistent between Task 4 test constants, Task 5 impl constants, Task 9 (not referenced directly but implied by meter pre-registration assertion). Bean names `timeseriesPersisterFactory` (composite, @Primary) + `innerTimeseriesPersisterFactory` consistent in Task 3 (fix), Task 7 (impl `@Bean`), Task 9 (IT bean lookup).
+
+---
+
+## Execution handoff (after plan saved)
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md
+++ b/docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md
@@ -1,0 +1,222 @@
+# Collectd Kafka publisher inert on develop — investigation + fix design
+
+**Status:** approved (2026-04-18).
+**Branch:** `fix/collectd-publisher-inert`.
+**Target PR base:** `pbrane/delta-v develop`.
+**Related:** `project_collectd_publisher_inert_investigation` (memory), `project_phase2_prometheus_writer_done` (memory), PR #174 (merged as `5ef18ed5384`).
+
+## 1. Context and goal
+
+The Phase 0 Kafka time-series producer (`core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`) is silently inert on current `develop`. It was verified live at PR #170 merge time (2026-04-16) and no commits have since touched the module's Java or yaml sources, yet live Docker-compose inspection on 2026-04-18 showed:
+
+- `records_consumed_total = 0` on the Phase 2 `prometheus-writer` after 90+ seconds of Collectd collection cycles.
+- Zero records on Kafka topic `deltav-timeseries` across all partitions.
+- Zero log lines mentioning `TimeseriesKafkaPublisher`, `FanoutPersister`, or `org.deltav.collectd.timeseries` in the Collectd container.
+- Horizon's default `RingBufferTimeseriesWriter` is the only persister path initialised; `FanoutPersisterFactory` (which should wrap it when `deltav.timeseries.enabled=true`) never fires.
+
+The symptom was masked for the weeks between Phase 0 and Phase 2's downstream-consumption assertion because:
+
+- The compose default `${DELTAV_TIMESERIES_ENABLED:-false}` means any E2E that did not explicitly export the env var ran Collectd with the publisher `@ConditionalOnProperty` evaluating false.
+- `FanoutPersister` catches `Throwable` and logs at WARN, so even operational failures when the flag was true would have been absorbed without operator signal.
+
+**Goal:** unblock the delta-v Kafka time-series pipeline by identifying and fixing the wiring regression, ship observability + regression tests so this class of silent swallow cannot re-occur, flip the compose default, and close out Phase 2's deferred proto-header placeholder. The acceptance bar is the Phase 2 E2E (`opennms-container/delta-v/test-prometheus-writer-e2e.sh`) exiting 0 with `ALL ASSERTIONS PASSED` — the first successful end-to-end run of the entire pipeline.
+
+## 2. Scope
+
+### In scope
+
+- Live-diagnostic exposure to identify the wiring root cause.
+- Minimal surgical fix for whichever of the three hypotheses (property resolution, condition evaluation, bean-name vs `@Primary` injection) is confirmed.
+- Observability for silent inner/Kafka persister failures (Micrometer counters).
+- Dev-time fail-fast toggle (Spring property, default off in production).
+- Regression tests: one real-main-class IT plus unit-test coverage for the new observability/fail-fast behavior.
+- Phase 0 known-issues #2 (`TimeseriesPersistOperationBuilder.setAttributeValue` NPE) and #3 (`ResourceTypeUtils.getResourcePathWithRepository` `NoSuchMethodError`): best-effort inline handling if they surface during investigation.
+- Compose default flip: `DELTAV_TIMESERIES_ENABLED` default `false` → `true`.
+- Proto-header cleanup: replace `<TBD-phase-2-PR>` placeholder with `#174` in both `deltav-timeseries.proto` and `deltav-node-context.proto`.
+
+### Out of scope
+
+- Collectd-wide canonical meter-name constants class (Phase 2 introduced the pattern for the writer; extracting one for Collectd is a separable refactor).
+- `build.sh check_daemon_boot_freshness` transitive-dependency gap surfaced during Phase 2 (separate tooling PR).
+- Phase 3 Thresholder (next numbered phase; separate brainstorm → spec → plan cycle).
+- Codebase-wide survey for other `@Configuration`-class-name vs `@Bean`-method-name collisions (Phase 2 found three; `feedback_configuration_class_bean_name_collision` captured the rule; a sweep PR is its own work).
+- Horizon-side changes in `pbrane/delta-v-horizon`. If the investigation reveals the bug sits there, scope requires explicit re-approval; do not silently widen.
+- Pollerd / PerspectivePollerd latency producers (Phase 3+ candidates).
+
+## 3. Hypothesis space
+
+Static code inspection cannot distinguish the three candidate root causes. All three are consistent with the observed symptoms; live diagnostics decide which holds.
+
+**(A) Property not resolving from env var.** Spring's relaxed binding should translate `DELTAV_TIMESERIES_ENABLED=true` to `deltav.timeseries.enabled=true`, and `@Value("${deltav.timeseries.partitions:16}")` did resolve successfully during inspection (the 16-partition topic got created). But a property-source ordering edge case or a Spring Boot 4 relaxed-binding behavior change could still leave `@ConditionalOnProperty` reading a different effective value.
+
+**(B) Condition evaluating false despite property resolving true.** `@ConditionalOnProperty(name="deltav.timeseries.enabled", havingValue="true")` in Boot 4 may behave differently than in Boot 3 in subtle cases (property defined as empty string, metadata tracking, etc.).
+
+**(C) `@Primary` bypassed by qualifier/name injection in horizon.** The `compositePersisterFactory` bean has `@Primary`, which wins for type-based `@Autowired PersisterFactory`. But if horizon's `CollectableService` uses `@Qualifier("timeseriesPersisterFactory")` or similar name-based injection, `@Primary` is irrelevant and the inner factory wins. This is the strongest prior after static analysis.
+
+**(D) Unknown.** Handled as BLOCKED; diagnosis extends rather than a speculative fix lands.
+
+## 4. Commit sequence
+
+Six commits, each one concern, surgical diff, reverse-chronological revert-safe.
+
+### Commit 1: Diagnostic exposure
+
+**Goal:** surface the runtime decisions that gate `TimeseriesKafkaPublisher` instantiation so log + actuator snapshots can confirm which hypothesis holds.
+
+**Files:**
+
+- `core/daemon-boot-collectd/src/main/resources/application.yml` — extend `management.endpoints.web.exposure.include` to include `env, beans, conditions`. Unconditional for this commit; Commit 6 reverts `env` + `beans` and keeps `conditions`.
+- `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java` — add two `LOG.info(...)` calls:
+  1. At first-bean creation inside the `@Configuration` class (or via a dedicated `@PostConstruct`-annotated helper) — logs `"TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty matched"`. Absence of this line in logs means the condition failed to match.
+  2. Inside the `compositePersisterFactory` `@Bean` method — logs `"Creating compositePersisterFactory wrapping inner={fully-qualified-class}@{identity-hash}"`.
+
+**Evidence-capture procedure:**
+
+1. Rebuild Collectd image via `build.sh deltav` (with `touch core/daemon-boot-collectd/pom.xml` workaround to force the self-healing freshness check to rebuild — per memory `project_collectd_publisher_inert_investigation`).
+2. `DELTAV_TIMESERIES_ENABLED=true docker compose --profile lite --profile metrics-e2e up -d`.
+3. `docker compose logs collectd | grep -E "TimeseriesKafkaPublisherConfiguration|compositePersisterFactory"` — capture startup log evidence.
+4. `docker compose exec collectd curl -sf http://localhost:8080/actuator/conditions | jq '.contexts.application.positiveMatches.TimeseriesKafkaPublisherConfiguration, .contexts.application.negativeMatches.TimeseriesKafkaPublisherConfiguration'` — capture condition decision.
+5. `docker compose exec collectd curl -sf http://localhost:8080/actuator/beans | jq '.contexts.application.beans | with_entries(select(.value.type | contains("PersisterFactory")))'` — enumerate `PersisterFactory` beans and their primary status.
+6. `docker compose exec collectd curl -sf http://localhost:8080/actuator/env/deltav.timeseries.enabled` — confirm property resolution.
+7. Update `project_collectd_publisher_inert_investigation` memory with the specific log lines + actuator snapshots that identified the root cause.
+
+**Exit criterion:** one hypothesis definitively confirmed (A, B, C) or a new hypothesis D identified. No fix in this commit.
+
+### Commit 2: Wiring fix
+
+**Goal:** minimum-diff surgical fix for the confirmed hypothesis.
+
+**Contingent shape per hypothesis:**
+
+- **(C) confirmed — strongest prior.** Rename the composite bean to `timeseriesPersisterFactory` (the name horizon expects). Rename the inner bean out of the way (to something like `innerTimeseriesPersisterFactory`). The exact mechanism depends on whether the inner bean is declared locally (rename in place) or imported from horizon (requires a `BeanPostProcessor` or `BeanDefinitionRegistryPostProcessor` rename). Diff ~15 LOC.
+- **(A) confirmed.** Explicit property in `application.yml`: `deltav.timeseries.enabled: ${DELTAV_TIMESERIES_ENABLED:false}` as a belt-and-suspenders binding. Diff: 1 line.
+- **(B) confirmed.** Replace `@ConditionalOnProperty` with `@ConditionalOnExpression("#{'${deltav.timeseries.enabled}' == 'true'}")` or a custom `@Conditional`. Diff: 1 annotation.
+- **(D) unknown.** Do not commit. Report BLOCKED, extend diagnosis.
+
+**Local verification before commit:**
+
+1. Rebuild Collectd.
+2. `DELTAV_TIMESERIES_ENABLED=true docker compose up -d` + wait 90 s.
+3. Assert `kafka-console-consumer --topic deltav-timeseries` receives ≥ 1 record.
+4. Assert `prometheus-writer /actuator/prometheus` shows `records_consumed_total > 0`.
+5. Commit only if both pass.
+
+### Commit 3: Observability + fail-fast toggle
+
+**Goal:** eliminate silent-swallow invisibility with two counters, and eliminate silent-swallow in dev with a fail-fast toggle.
+
+**File:** `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java` (extend the `FanoutPersister` nested class).
+
+**Observability (X):**
+
+Two counters, tagged by visitor step (10 steps: `visitCollectionSet`, `visitResource`, `visitGroup`, `visitAttribute`, `completeAttribute`, `completeGroup`, `completeResource`, `completeCollectionSet`, `persistNumericAttribute`, `persistStringAttribute`):
+
+- `deltav.collectd.persister.inner.failures{step=<step>}` — incremented when `runInner` catches a `Throwable`.
+- `deltav.collectd.persister.kafka.failures{step=<step>}` — symmetric for `runKafka`.
+
+Counters are **pre-registered at startup** for all 20 (2 sides × 10 steps) tag combinations so ops can alert on `rate > 0` rather than missing-metric (which would otherwise be ambiguous with "no failures occurred").
+
+The existing per-failure WARN logs stay — they are useful during triage. The counters are the primary silent-swallow signal.
+
+`FanoutPersister` gains a constructor-injected `MeterRegistry`. `compositePersisterFactory` `@Bean` signature gains `MeterRegistry` (auto-wired by Spring).
+
+**Fail-fast toggle (Y):**
+
+Two Spring properties:
+
+- `deltav.collectd.persister.inner.fail-fast` (boolean, default `false`).
+- `deltav.collectd.persister.kafka.fail-fast` (boolean, default `false`).
+
+Read in `FanoutPersisterFactory` via `@Value("${deltav.collectd.persister.inner.fail-fast:false}")` and passed to each `FanoutPersister` instance. Behavior:
+
+- `false` (default): current WARN-and-continue. Production unchanged.
+- `true`: rethrow the caught `Throwable` wrapped in `RuntimeException` (so the horizon API contract does not need to change).
+
+Kept symmetric and independently toggleable because CI may want to flip one without the other.
+
+**Meter-name pinning:** Documented in `FanoutPersister` class Javadoc with a `@see` link to `project_collectd_publisher_inert_investigation` memory. A Collectd canonical-meters constants class is out of scope (see §2).
+
+**Diff size:** ~40 LOC in `TimeseriesKafkaPublisherConfiguration.java`.
+
+### Commit 4: Tests (T0 + T1)
+
+**T0 — `FanoutPersisterTest.java` unit tests** (`core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java`).
+
+Uses Mockito + `SimpleMeterRegistry`. Seven test methods:
+
+1. `counter_increments_on_inner_failure` — mock inner throws in `visitResource`, assert counter `deltav.collectd.persister.inner.failures{step=visitResource}` = 1, Kafka side still called.
+2. `counter_increments_on_kafka_failure` — symmetric; inner still called (isolation preserved in default mode).
+3. `counters_preregistered_at_startup_with_zero_value` — construct `FanoutPersister`, assert all 20 step-tagged counters exist with `count() == 0`.
+4. `fail_fast_inner_true_rethrows` — with `failFastInner = true`, inner throws, `visitResource` rethrows.
+5. `fail_fast_inner_false_swallows_and_continues` — default, inner throws, `visitResource` returns normally, Kafka still invoked. Pins PR #170's isolation baseline.
+6. `fail_fast_kafka_true_rethrows` — symmetric for Kafka side.
+7. `throwable_not_just_runtime_exception` — inner throws `LinkageError` (Phase 0 #3 scar), assert counter increments, Kafka still called. Guards against a future refactor that narrows to `RuntimeException` and silently re-opens Phase 0 #3.
+
+**T1 — `CollectdApplicationScanIT.java` real-main-class IT** (`core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`).
+
+`@Testcontainers` + `@SpringBootTest(classes=CollectdApplication.class)` + Testcontainers Kafka + `@TestPropertySource(properties={"deltav.timeseries.enabled=true", "deltav.collectd.persister.inner.fail-fast=true", "deltav.collectd.persister.kafka.fail-fast=true"})`.
+
+Kafka image `apache/kafka:3.8.0` (Phase 2 lineage). Adds `commons-io:2.18.0` test dep to the collectd pom if not already present (per memory `feedback_boot4_testcontainers_commons_io`).
+
+Three test methods:
+
+1. `persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true` — `@Autowired PersisterFactory factory`; `assertThat(factory).isInstanceOf(FanoutPersisterFactory.class)`. The regression gate — would have caught Commit 2's bug in one CI run.
+2. `deltav_timeseries_topic_bean_exists_when_flag_true` — `ctx.getBean("deltavTimeseriesTopic", NewTopic.class)` non-null with `topic.name().equals("deltav-timeseries")`.
+3. `timeseries_kafka_publisher_bean_exists_when_flag_true` — `ctx.getBean(TimeseriesKafkaPublisher.class)` non-null.
+
+A flag-off companion IT is explicitly skipped — Spring's `@ConditionalOnProperty` is well-tested upstream and we only care about the flag-on path.
+
+**Test-run budget:** T0 ~0.5 s. T1 ~30–60 s (Testcontainers Kafka spin-up dominates).
+
+### Commit 5: Compose default flip + proto headers
+
+Three small edits, bundled because the compose flip is a prerequisite for the E2E acceptance gate and the proto-header substitution is a Phase 2 loose end.
+
+- `opennms-container/delta-v/docker-compose.yml` line 176: `${DELTAV_TIMESERIES_ENABLED:-false}` → `${DELTAV_TIMESERIES_ENABLED:-true}`.
+- `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto` header: `<TBD-phase-2-PR>` → `#174`.
+- `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto` header: same substitution.
+
+### Commit 6: Diagnostic cleanup
+
+Partial revert of Commit 1 — the diagnostic served its purpose; keep the one piece that is useful permanently.
+
+- `core/daemon-boot-collectd/src/main/resources/application.yml`: revert `env` and `beans` from `management.endpoints.web.exposure.include`. **Keep `conditions`** permanently — invaluable for future wiring-regression triage, no secret exposure, cheap to serve.
+- `TimeseriesKafkaPublisherConfiguration.java`: revert the two diagnostic `LOG.info(...)` lines from Commit 1.
+
+## 5. Phase 0 known-issues #2 and #3: best-effort inline
+
+Per scope decision (P) in brainstorming:
+
+- If `TimeseriesPersistOperationBuilder.setAttributeValue` NPE surfaces during live verification (Commits 2 or 4), fix inline in this PR and add a regression test.
+- If `ResourceTypeUtils.getResourcePathWithRepository` `NoSuchMethodError` surfaces, same.
+- If neither surfaces, close them out in the `project_collectd_publisher_inert_investigation` memory as `resolved or no longer reproducible` without further action.
+- Do not contrive trigger conditions to force them to reproduce.
+
+## 6. Acceptance criteria
+
+1. `project_collectd_publisher_inert_investigation` memory updated with the confirmed hypothesis + evidence. Memory status flips `OPEN` → `DONE`.
+2. `./mvnw -pl core/daemon-boot-collectd verify` green — 7 new `FanoutPersisterTest` tests + 3 new `CollectdApplicationScanIT` tests all pass alongside the pre-existing suite.
+3. `./mvnw -B -DskipTests -fae clean install` green (full-reactor build).
+4. Live producer verification: after `docker compose up -d` (with the flipped default), `kafka-console-consumer --topic deltav-timeseries` receives ≥ 1 record within 90 s, and `prometheus-writer /actuator/prometheus` shows `records_consumed_total > 0`.
+5. `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` exits 0 with `ALL ASSERTIONS PASSED`. This is the first end-to-end pass of the full Phase 2 pipeline.
+6. CI checks green on the PR.
+7. PR opened against `pbrane/delta-v`, base `develop`. Title: `fix(collectd): wire Kafka publisher + add observability/fail-fast + Phase 2 E2E gate`.
+8. Post-merge memory updates: `project_phase2_prometheus_writer_done` gets an addendum noting E2E now passes; `project_kafka_timeseries_pipeline` confirms producer genuinely live.
+
+## 7. Risks and trade-offs
+
+- **Flipping the compose default might break an existing operator-local E2E that assumes the publisher is off.** Low risk because the publisher is passive when Kafka is reachable (just buffers + sends) and is now properly tested. Operators who want it off can still set the env var explicitly.
+- **Fail-fast mode off in production means a regression of the same class could re-mask itself.** This is mitigated by (X) counters being pre-registered and alertable. Ops who adopt the dashboard catch it regardless.
+- **The `@Configuration` class-name collision pattern (Phase 2 scar) may lurk elsewhere in delta-v.** Out of scope here; follow-up sweep PR is recommended (see §2).
+- **If hypothesis D (unknown) materialises, scope blows up.** Mitigated by the explicit BLOCKED escape hatch — do not commit a speculative fix; return to brainstorming.
+
+## 8. References
+
+- Memory: `project_collectd_publisher_inert_investigation` (OPEN at spec-authoring time; DONE at merge).
+- Memory: `project_phase2_prometheus_writer_done` (DONE, merged as PR #174 / `5ef18ed5384`).
+- Memory: `project_kafka_timeseries_pipeline` (Phase 0/1 done, Phase 2 awaiting this PR's E2E green).
+- Memory: `feedback_configuration_class_bean_name_collision` (Phase 2 scar).
+- Memory: `feedback_boot4_testcontainers_commons_io` (Phase 2 scar).
+- Memory: `feedback_spring_boot_scan_package_trap` (Phase 0 #170 scar; the real-main-class IT pattern descends from here).
+- Memory: `feedback_delta_v_full_reactor_verify` (build-verify hygiene).
+- Prior E2E logs: `/tmp/phase2-e2e.log`, `/tmp/phase2-e2e-2.log`, `/tmp/phase2-e2e-3.log`, `/tmp/phase2-e2e-4.log`.

--- a/docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md
+++ b/docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md
@@ -1,222 +1,197 @@
-# Collectd Kafka publisher inert on develop — investigation + fix design
+# Phase 2 NodeContextKafkaBootstrap race fix + Collectd silent-swallow hygiene
 
-**Status:** approved (2026-04-18).
-**Branch:** `fix/collectd-publisher-inert`.
-**Target PR base:** `pbrane/delta-v develop`.
-**Related:** `project_collectd_publisher_inert_investigation` (memory), `project_phase2_prometheus_writer_done` (memory), PR #174 (merged as `5ef18ed5384`).
+> **This design SUPERSEDES the originally-committed design.** The original assumed the Phase 0 Collectd publisher was inert on develop. Live-stack investigation (Task 2 of the original plan, 2026-04-18) proved the publisher is working correctly — 6 batches published per 90 s. The real bug is a race in Phase 2's `NodeContextKafkaBootstrap` that leaves the `NodeContextCache` empty whenever the `deltav-node-context` topic doesn't exist yet at prometheus-writer startup. Every incoming timeseries record then hits `enrichment_missing` and drops. Root-cause evidence captured in `project_collectd_publisher_inert_investigation` memory (now flipped to document the real issue).
+>
+> The original spec + plan sit in branch history at commits `8c2729588e5` (spec v1) and `262309050ed` (plan v1). They are retained as-is for audit; this v2 design lands as a new commit over them.
+
+**Status:** approved v2 (2026-04-18).
+**Branch:** `fix/collectd-publisher-inert` (name retained for link stability; actual scope is mostly Phase 2).
+**Target PR base:** `pbrane/delta-v develop`. Never `OpenNMS/opennms`.
+**Related:** `project_collectd_publisher_inert_investigation` (memory — evidence of the real root cause), `project_phase2_prometheus_writer_done` (memory — the PR this unblocks), PR #174 (merged as `5ef18ed5384`).
 
 ## 1. Context and goal
 
-The Phase 0 Kafka time-series producer (`core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`) is silently inert on current `develop`. It was verified live at PR #170 merge time (2026-04-16) and no commits have since touched the module's Java or yaml sources, yet live Docker-compose inspection on 2026-04-18 showed:
+Phase 2 PR #174's Docker E2E (`opennms-container/delta-v/test-prometheus-writer-e2e.sh`) fails at Step 4: `deltav_prometheus_writer_records_consumed_total = 0` after 90 s. Prior investigation assumed the Phase 0 Collectd publisher was inert. Live-stack diagnostics on 2026-04-18 (commit `d3c6d049cab` added the diagnostic exposure that made this visible) proved otherwise:
 
-- `records_consumed_total = 0` on the Phase 2 `prometheus-writer` after 90+ seconds of Collectd collection cycles.
-- Zero records on Kafka topic `deltav-timeseries` across all partitions.
-- Zero log lines mentioning `TimeseriesKafkaPublisher`, `FanoutPersister`, or `org.deltav.collectd.timeseries` in the Collectd container.
-- Horizon's default `RingBufferTimeseriesWriter` is the only persister path initialised; `FanoutPersisterFactory` (which should wrap it when `deltav.timeseries.enabled=true`) never fires.
+- Collectd's `TimeseriesKafkaPublisherConfiguration` loads; `@ConditionalOnProperty` matches; `compositePersisterFactory` is created and wraps the correct horizon inner factory; `FanoutPersister` IS invoked; `deltav_timeseries_batches_published_total = 6.0` after 90 s; topic `deltav-timeseries` has real SNMP records.
+- prometheus-writer IS consuming — partition 9 shows `CURRENT-OFFSET=6, LAG=0`, `deltav_prometheus_writer_records_consumed_total = 6.0`.
+- But `deltav_prometheus_writer_enrichment_missing_total{reason="never_seen"} = 6.0` — **every** consumed record dropped for missing `NodeContext` enrichment.
+- `deltav_prometheus_writer_node_context_cache_size = 0.0` despite `node_context_cache_ready = 1.0`.
 
-The symptom was masked for the weeks between Phase 0 and Phase 2's downstream-consumption assertion because:
+The real bug is in `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextKafkaBootstrap.java`. Its startup sequence has a race: when `consumer.partitionsFor(topic)` returns `null` because the `deltav-node-context` topic doesn't exist yet (provisiond hasn't created it), the code takes a "no partitions yet" branch that marks the cache ready with zero entries and enters `liveTail(consumer)` **without ever calling `consumer.assign(...)` or `consumer.subscribe(...)`**. `liveTail`'s `consumer.poll()` then throws `IllegalStateException: Consumer is not subscribed to any topics or assigned any partitions` on every 5 s cycle forever. Records written to the topic after provisiond creates it are never consumed by this consumer. Live log evidence:
 
-- The compose default `${DELTAV_TIMESERIES_ENABLED:-false}` means any E2E that did not explicitly export the env var ran Collectd with the publisher `@ConditionalOnProperty` evaluating false.
-- `FanoutPersister` catches `Throwable` and logs at WARN, so even operational failures when the flag was true would have been absorbed without operator signal.
+```
+15:22:54.842 WARN  NodeContextKafkaBootstrap : Topic deltav-node-context has no partitions yet — marking cache ready with empty state
+15:22:54.845 INFO  NodeContextKafkaBootstrap : NodeContextCache bootstrap complete: 0 entries in 115 ms
+15:22:54.846 INFO  TimeseriesBindingResumer  : NodeContextCache ready (size=0, bootstrap=115ms) — resuming binding
+15:22:54.851 WARN  NodeContextKafkaBootstrap : NodeContextKafkaBootstrap live-tail error — will retry after poll timeout
+(last WARN repeats every 5 s forever)
+```
 
-**Goal:** unblock the delta-v Kafka time-series pipeline by identifying and fixing the wiring regression, ship observability + regression tests so this class of silent swallow cannot re-occur, flip the compose default, and close out Phase 2's deferred proto-header placeholder. The acceptance bar is the Phase 2 E2E (`opennms-container/delta-v/test-prometheus-writer-e2e.sh`) exiting 0 with `ALL ASSERTIONS PASSED` — the first successful end-to-end run of the entire pipeline.
+**Goal:** fix the race so the cache is populated from the `deltav-node-context` topic under both orderings (topic-exists-at-startup and topic-created-later). Ship the original Collectd-side silent-swallow hygiene (observability counters, dev fail-fast toggle, scan IT, compose default flip, proto-header pin) as protective tooling — no longer the critical fix but still valuable now that we know Phase 0 inner-persister bugs #1, #2, and a new #4 were hiding behind `FanoutPersister`'s isolation without operator signal. **Acceptance:** `./test-prometheus-writer-e2e.sh` exits 0 with `ALL ASSERTIONS PASSED` — first end-to-end pass of the full pipeline.
 
 ## 2. Scope
 
 ### In scope
 
-- Live-diagnostic exposure to identify the wiring root cause.
-- Minimal surgical fix for whichever of the three hypotheses (property resolution, condition evaluation, bean-name vs `@Primary` injection) is confirmed.
-- Observability for silent inner/Kafka persister failures (Micrometer counters).
-- Dev-time fail-fast toggle (Spring property, default off in production).
-- Regression tests: one real-main-class IT plus unit-test coverage for the new observability/fail-fast behavior.
-- Phase 0 known-issues #2 (`TimeseriesPersistOperationBuilder.setAttributeValue` NPE) and #3 (`ResourceTypeUtils.getResourcePathWithRepository` `NoSuchMethodError`): best-effort inline handling if they surface during investigation.
-- Compose default flip: `DELTAV_TIMESERIES_ENABLED` default `false` → `true`.
-- Proto-header cleanup: replace `<TBD-phase-2-PR>` placeholder with `#174` in both `deltav-timeseries.proto` and `deltav-node-context.proto`.
+- `NodeContextKafkaBootstrap` race fix (Opt1 — `consumer.subscribe(...)` + `ConsumerRebalanceListener`). Replaces the `partitionsFor`-based branching with a unified single-path flow.
+- Testcontainers IT case that reproduces the topic-created-after-bootstrap-starts race (the regression gate).
+- Collectd `FanoutPersister` observability: pre-registered Micrometer counters (`deltav.collectd.persister.inner.failures{step=…}`, `deltav.collectd.persister.kafka.failures{step=…}`) so silent-swallow becomes alertable.
+- Collectd `FanoutPersister` dev fail-fast toggle: `deltav.collectd.persister.{inner,kafka}.fail-fast` Spring properties, default `false` in production. CI / ITs override to `true` to turn silent swallows into loud test failures.
+- `FanoutPersisterTest` unit tests covering the new observability + fail-fast matrix.
+- `CollectdApplicationScanIT` real-main-class integration test (Phase 2 scar-prophylactic lineage — would have pointed at the Phase 2 consumer side earlier if it had existed).
+- `DELTAV_TIMESERIES_ENABLED` default flip `false` → `true` in `opennms-container/delta-v/docker-compose.yml`.
+- `<TBD-phase-2-PR>` → `#174` substitution in both `core/deltav-kafka-contracts/src/main/proto/deltav-{timeseries,node-context}.proto` headers.
+- Partial revert of the diagnostic commit (`d3c6d049cab`): remove the one-shot startup log + the env/beans actuator exposure. **Keep `/actuator/conditions` permanently** and keep the `compositePersisterFactory wrapping inner=...` startup log (gains operator value once fail-fast surfaces).
 
-### Out of scope
+### Out of scope (follow-up PRs)
 
-- Collectd-wide canonical meter-name constants class (Phase 2 introduced the pattern for the writer; extracting one for Collectd is a separable refactor).
-- `build.sh check_daemon_boot_freshness` transitive-dependency gap surfaced during Phase 2 (separate tooling PR).
+- **Phase 0 inner-persister bugs #1, #2, and #4.** All three are confirmed present in the live stack; all three are currently caught by `FanoutPersister.runInner` and WARN-logged. Phase 2 E2E no longer blocks on them because the Kafka path publishes regardless. They deserve separate focused investigation PRs and are memory-noted. See §5.
+- `build.sh check_daemon_boot_freshness` transitive-dependency gap (forced `touch core/daemon-boot-collectd/pom.xml` during PR #174 investigation). Separate tooling PR.
 - Phase 3 Thresholder (next numbered phase; separate brainstorm → spec → plan cycle).
-- Codebase-wide survey for other `@Configuration`-class-name vs `@Bean`-method-name collisions (Phase 2 found three; `feedback_configuration_class_bean_name_collision` captured the rule; a sweep PR is its own work).
-- Horizon-side changes in `pbrane/delta-v-horizon`. If the investigation reveals the bug sits there, scope requires explicit re-approval; do not silently widen.
-- Pollerd / PerspectivePollerd latency producers (Phase 3+ candidates).
-
-## 3. Hypothesis space
-
-Static code inspection cannot distinguish the three candidate root causes. All three are consistent with the observed symptoms; live diagnostics decide which holds.
-
-**(A) Property not resolving from env var.** Spring's relaxed binding should translate `DELTAV_TIMESERIES_ENABLED=true` to `deltav.timeseries.enabled=true`, and `@Value("${deltav.timeseries.partitions:16}")` did resolve successfully during inspection (the 16-partition topic got created). But a property-source ordering edge case or a Spring Boot 4 relaxed-binding behavior change could still leave `@ConditionalOnProperty` reading a different effective value.
-
-**(B) Condition evaluating false despite property resolving true.** `@ConditionalOnProperty(name="deltav.timeseries.enabled", havingValue="true")` in Boot 4 may behave differently than in Boot 3 in subtle cases (property defined as empty string, metadata tracking, etc.).
-
-**(C) `@Primary` bypassed by qualifier/name injection in horizon.** The `compositePersisterFactory` bean has `@Primary`, which wins for type-based `@Autowired PersisterFactory`. But if horizon's `CollectableService` uses `@Qualifier("timeseriesPersisterFactory")` or similar name-based injection, `@Primary` is irrelevant and the inner factory wins. This is the strongest prior after static analysis.
-
-**(D) Unknown.** Handled as BLOCKED; diagnosis extends rather than a speculative fix lands.
-
-## 4. Commit sequence
-
-Six commits, each one concern, surgical diff, reverse-chronological revert-safe.
-
-### Commit 1: Diagnostic exposure
-
-**Goal:** surface the runtime decisions that gate `TimeseriesKafkaPublisher` instantiation so log + actuator snapshots can confirm which hypothesis holds.
-
-**Files:**
-
-- `core/daemon-boot-collectd/src/main/resources/application.yml` — extend `management.endpoints.web.exposure.include` to include `env, beans, conditions`. Unconditional for this commit; Commit 6 reverts `env` + `beans` and keeps `conditions`.
-- `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java` — add two `LOG.info(...)` calls:
-  1. At first-bean creation inside the `@Configuration` class (or via a dedicated `@PostConstruct`-annotated helper) — logs `"TimeseriesKafkaPublisherConfiguration loaded — @ConditionalOnProperty matched"`. Absence of this line in logs means the condition failed to match.
-  2. Inside the `compositePersisterFactory` `@Bean` method — logs `"Creating compositePersisterFactory wrapping inner={fully-qualified-class}@{identity-hash}"`.
-
-**Evidence-capture procedure:**
-
-1. Rebuild Collectd image via `build.sh deltav` (with `touch core/daemon-boot-collectd/pom.xml` workaround to force the self-healing freshness check to rebuild — per memory `project_collectd_publisher_inert_investigation`).
-2. `DELTAV_TIMESERIES_ENABLED=true docker compose --profile lite --profile metrics-e2e up -d`.
-3. `docker compose logs collectd | grep -E "TimeseriesKafkaPublisherConfiguration|compositePersisterFactory"` — capture startup log evidence.
-4. `docker compose exec collectd curl -sf http://localhost:8080/actuator/conditions | jq '.contexts.application.positiveMatches.TimeseriesKafkaPublisherConfiguration, .contexts.application.negativeMatches.TimeseriesKafkaPublisherConfiguration'` — capture condition decision.
-5. `docker compose exec collectd curl -sf http://localhost:8080/actuator/beans | jq '.contexts.application.beans | with_entries(select(.value.type | contains("PersisterFactory")))'` — enumerate `PersisterFactory` beans and their primary status.
-6. `docker compose exec collectd curl -sf http://localhost:8080/actuator/env/deltav.timeseries.enabled` — confirm property resolution.
-7. Update `project_collectd_publisher_inert_investigation` memory with the specific log lines + actuator snapshots that identified the root cause.
-
-**Exit criterion:** one hypothesis definitively confirmed (A, B, C) or a new hypothesis D identified. No fix in this commit.
-
-### Commit 2: Wiring fix
-
-**Goal:** minimum-diff surgical fix for the confirmed hypothesis.
-
-**Contingent shape per hypothesis:**
-
-- **(C) confirmed — strongest prior.** Rename the composite bean to `timeseriesPersisterFactory` (the name horizon expects). Rename the inner bean out of the way (to something like `innerTimeseriesPersisterFactory`). The exact mechanism depends on whether the inner bean is declared locally (rename in place) or imported from horizon (requires a `BeanPostProcessor` or `BeanDefinitionRegistryPostProcessor` rename). Diff ~15 LOC.
-- **(A) confirmed.** Explicit property in `application.yml`: `deltav.timeseries.enabled: ${DELTAV_TIMESERIES_ENABLED:false}` as a belt-and-suspenders binding. Diff: 1 line.
-- **(B) confirmed.** Replace `@ConditionalOnProperty` with `@ConditionalOnExpression("#{'${deltav.timeseries.enabled}' == 'true'}")` or a custom `@Conditional`. Diff: 1 annotation.
-- **(D) unknown.** Do not commit. Report BLOCKED, extend diagnosis.
-
-**Local verification before commit:**
-
-1. Rebuild Collectd.
-2. `DELTAV_TIMESERIES_ENABLED=true docker compose up -d` + wait 90 s.
-3. Assert `kafka-console-consumer --topic deltav-timeseries` receives ≥ 1 record.
-4. Assert `prometheus-writer /actuator/prometheus` shows `records_consumed_total > 0`.
-5. Commit only if both pass.
-
-### Commit 3: Observability + fail-fast toggle
-
-**Goal:** eliminate silent-swallow invisibility with two counters, and eliminate silent-swallow in dev with a fail-fast toggle.
-
-**File:** `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java` (extend the `FanoutPersister` nested class).
-
-**Observability (X):**
-
-Two counters, tagged by visitor step (10 steps: `visitCollectionSet`, `visitResource`, `visitGroup`, `visitAttribute`, `completeAttribute`, `completeGroup`, `completeResource`, `completeCollectionSet`, `persistNumericAttribute`, `persistStringAttribute`):
-
-- `deltav.collectd.persister.inner.failures{step=<step>}` — incremented when `runInner` catches a `Throwable`.
-- `deltav.collectd.persister.kafka.failures{step=<step>}` — symmetric for `runKafka`.
-
-Counters are **pre-registered at startup** for all 20 (2 sides × 10 steps) tag combinations so ops can alert on `rate > 0` rather than missing-metric (which would otherwise be ambiguous with "no failures occurred").
-
-The existing per-failure WARN logs stay — they are useful during triage. The counters are the primary silent-swallow signal.
-
-`FanoutPersister` gains a constructor-injected `MeterRegistry`. `compositePersisterFactory` `@Bean` signature gains `MeterRegistry` (auto-wired by Spring).
-
-**Fail-fast toggle (Y):**
-
-Two Spring properties:
-
-- `deltav.collectd.persister.inner.fail-fast` (boolean, default `false`).
-- `deltav.collectd.persister.kafka.fail-fast` (boolean, default `false`).
-
-Read in `FanoutPersisterFactory` via `@Value("${deltav.collectd.persister.inner.fail-fast:false}")` and passed to each `FanoutPersister` instance. Behavior:
-
-- `false` (default): current WARN-and-continue. Production unchanged.
-- `true`: rethrow the caught `Throwable` wrapped in `RuntimeException` (so the horizon API contract does not need to change).
-
-Kept symmetric and independently toggleable because CI may want to flip one without the other.
-
-**Meter-name pinning:** Documented in `FanoutPersister` class Javadoc with a `@see` link to `project_collectd_publisher_inert_investigation` memory. A Collectd canonical-meters constants class is out of scope (see §2).
-
-**Diff size:** ~40 LOC in `TimeseriesKafkaPublisherConfiguration.java`.
-
-### Commit 4: Tests (T0 + T1)
-
-**T0 — `FanoutPersisterTest.java` unit tests** (`core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java`).
-
-Uses Mockito + `SimpleMeterRegistry`. Seven test methods:
-
-1. `counter_increments_on_inner_failure` — mock inner throws in `visitResource`, assert counter `deltav.collectd.persister.inner.failures{step=visitResource}` = 1, Kafka side still called.
-2. `counter_increments_on_kafka_failure` — symmetric; inner still called (isolation preserved in default mode).
-3. `counters_preregistered_at_startup_with_zero_value` — construct `FanoutPersister`, assert all 20 step-tagged counters exist with `count() == 0`.
-4. `fail_fast_inner_true_rethrows` — with `failFastInner = true`, inner throws, `visitResource` rethrows.
-5. `fail_fast_inner_false_swallows_and_continues` — default, inner throws, `visitResource` returns normally, Kafka still invoked. Pins PR #170's isolation baseline.
-6. `fail_fast_kafka_true_rethrows` — symmetric for Kafka side.
-7. `throwable_not_just_runtime_exception` — inner throws `LinkageError` (Phase 0 #3 scar), assert counter increments, Kafka still called. Guards against a future refactor that narrows to `RuntimeException` and silently re-opens Phase 0 #3.
-
-**T1 — `CollectdApplicationScanIT.java` real-main-class IT** (`core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java`).
-
-`@Testcontainers` + `@SpringBootTest(classes=CollectdApplication.class)` + Testcontainers Kafka + `@TestPropertySource(properties={"deltav.timeseries.enabled=true", "deltav.collectd.persister.inner.fail-fast=true", "deltav.collectd.persister.kafka.fail-fast=true"})`.
-
-Kafka image `apache/kafka:3.8.0` (Phase 2 lineage). Adds `commons-io:2.18.0` test dep to the collectd pom if not already present (per memory `feedback_boot4_testcontainers_commons_io`).
-
-Three test methods:
-
-1. `persister_factory_autowires_to_FanoutPersisterFactory_when_flag_true` — `@Autowired PersisterFactory factory`; `assertThat(factory).isInstanceOf(FanoutPersisterFactory.class)`. The regression gate — would have caught Commit 2's bug in one CI run.
-2. `deltav_timeseries_topic_bean_exists_when_flag_true` — `ctx.getBean("deltavTimeseriesTopic", NewTopic.class)` non-null with `topic.name().equals("deltav-timeseries")`.
-3. `timeseries_kafka_publisher_bean_exists_when_flag_true` — `ctx.getBean(TimeseriesKafkaPublisher.class)` non-null.
-
-A flag-off companion IT is explicitly skipped — Spring's `@ConditionalOnProperty` is well-tested upstream and we only care about the flag-on path.
-
-**Test-run budget:** T0 ~0.5 s. T1 ~30–60 s (Testcontainers Kafka spin-up dominates).
-
-### Commit 5: Compose default flip + proto headers
-
-Three small edits, bundled because the compose flip is a prerequisite for the E2E acceptance gate and the proto-header substitution is a Phase 2 loose end.
-
-- `opennms-container/delta-v/docker-compose.yml` line 176: `${DELTAV_TIMESERIES_ENABLED:-false}` → `${DELTAV_TIMESERIES_ENABLED:-true}`.
-- `core/deltav-kafka-contracts/src/main/proto/deltav-timeseries.proto` header: `<TBD-phase-2-PR>` → `#174`.
-- `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto` header: same substitution.
-
-### Commit 6: Diagnostic cleanup
-
-Partial revert of Commit 1 — the diagnostic served its purpose; keep the one piece that is useful permanently.
-
-- `core/daemon-boot-collectd/src/main/resources/application.yml`: revert `env` and `beans` from `management.endpoints.web.exposure.include`. **Keep `conditions`** permanently — invaluable for future wiring-regression triage, no secret exposure, cheap to serve.
-- `TimeseriesKafkaPublisherConfiguration.java`: revert the two diagnostic `LOG.info(...)` lines from Commit 1.
-
-## 5. Phase 0 known-issues #2 and #3: best-effort inline
-
-Per scope decision (P) in brainstorming:
-
-- If `TimeseriesPersistOperationBuilder.setAttributeValue` NPE surfaces during live verification (Commits 2 or 4), fix inline in this PR and add a regression test.
-- If `ResourceTypeUtils.getResourcePathWithRepository` `NoSuchMethodError` surfaces, same.
-- If neither surfaces, close them out in the `project_collectd_publisher_inert_investigation` memory as `resolved or no longer reproducible` without further action.
-- Do not contrive trigger conditions to force them to reproduce.
-
-## 6. Acceptance criteria
-
-1. `project_collectd_publisher_inert_investigation` memory updated with the confirmed hypothesis + evidence. Memory status flips `OPEN` → `DONE`.
-2. `./mvnw -pl core/daemon-boot-collectd verify` green — 7 new `FanoutPersisterTest` tests + 3 new `CollectdApplicationScanIT` tests all pass alongside the pre-existing suite.
-3. `./mvnw -B -DskipTests -fae clean install` green (full-reactor build).
-4. Live producer verification: after `docker compose up -d` (with the flipped default), `kafka-console-consumer --topic deltav-timeseries` receives ≥ 1 record within 90 s, and `prometheus-writer /actuator/prometheus` shows `records_consumed_total > 0`.
-5. `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` exits 0 with `ALL ASSERTIONS PASSED`. This is the first end-to-end pass of the full Phase 2 pipeline.
-6. CI checks green on the PR.
-7. PR opened against `pbrane/delta-v`, base `develop`. Title: `fix(collectd): wire Kafka publisher + add observability/fail-fast + Phase 2 E2E gate`.
-8. Post-merge memory updates: `project_phase2_prometheus_writer_done` gets an addendum noting E2E now passes; `project_kafka_timeseries_pipeline` confirms producer genuinely live.
-
-## 7. Risks and trade-offs
-
-- **Flipping the compose default might break an existing operator-local E2E that assumes the publisher is off.** Low risk because the publisher is passive when Kafka is reachable (just buffers + sends) and is now properly tested. Operators who want it off can still set the env var explicitly.
-- **Fail-fast mode off in production means a regression of the same class could re-mask itself.** This is mitigated by (X) counters being pre-registered and alertable. Ops who adopt the dashboard catch it regardless.
-- **The `@Configuration` class-name collision pattern (Phase 2 scar) may lurk elsewhere in delta-v.** Out of scope here; follow-up sweep PR is recommended (see §2).
-- **If hypothesis D (unknown) materialises, scope blows up.** Mitigated by the explicit BLOCKED escape hatch — do not commit a speculative fix; return to brainstorming.
-
-## 8. References
-
-- Memory: `project_collectd_publisher_inert_investigation` (OPEN at spec-authoring time; DONE at merge).
-- Memory: `project_phase2_prometheus_writer_done` (DONE, merged as PR #174 / `5ef18ed5384`).
-- Memory: `project_kafka_timeseries_pipeline` (Phase 0/1 done, Phase 2 awaiting this PR's E2E green).
-- Memory: `feedback_configuration_class_bean_name_collision` (Phase 2 scar).
-- Memory: `feedback_boot4_testcontainers_commons_io` (Phase 2 scar).
-- Memory: `feedback_spring_boot_scan_package_trap` (Phase 0 #170 scar; the real-main-class IT pattern descends from here).
+- Extract a Collectd-wide canonical meter-name constants class (Phase 2 did this for `core/prometheus-writer`; separable Collectd refactor).
+- `@Configuration`-class-name-vs-`@Bean`-method-name collision survey (Phase 2 found three; `feedback_configuration_class_bean_name_collision` captured the rule; a sweep PR is its own work).
+
+## 3. Race-fix design
+
+### Current racy code (shape)
+
+```java
+// inside NodeContextKafkaBootstrap.run()
+List<PartitionInfo> parts = consumer.partitionsFor(TOPIC);
+if (parts == null || parts.isEmpty()) {
+    LOG.warn("Topic {} has no partitions yet — marking cache ready with empty state", TOPIC);
+    finishBootstrap();        // cache marked ready, size=0
+    liveTail(consumer);       // BUG: consumer has NO assignment/subscription
+    return;
+}
+// happy path: assign partitions, seekToBeginning, drain to HWM, finishBootstrap, liveTail
+```
+
+### Fixed code (Opt1 — subscribe + ConsumerRebalanceListener)
+
+Single-path flow. Works whether topic exists at startup or gets created later. No branching on `partitionsFor`.
+
+```java
+// inside NodeContextKafkaBootstrap.run()
+Map<TopicPartition, Long> endOffsets = new ConcurrentHashMap<>();
+Set<TopicPartition> caughtUp = ConcurrentHashMap.newKeySet();
+AtomicBoolean bootstrapMarked = new AtomicBoolean(false);
+
+consumer.subscribe(List.of(TOPIC), new ConsumerRebalanceListener() {
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> assigned) {
+        // Record HWM at assignment time + seek to beginning so we replay the compacted topic.
+        Map<TopicPartition, Long> hwm = consumer.endOffsets(assigned);
+        endOffsets.putAll(hwm);
+        consumer.seekToBeginning(assigned);
+        // An empty partition (end offset == 0) is instantly caught up.
+        for (Map.Entry<TopicPartition, Long> e : hwm.entrySet()) {
+            if (e.getValue() == 0L) caughtUp.add(e.getKey());
+        }
+    }
+
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> revoked) {
+        // No-op. Kafka may reassign us; the new onPartitionsAssigned will re-establish HWM.
+    }
+});
+
+while (running.get()) {
+    ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+    for (ConsumerRecord<String, byte[]> r : records) {
+        applyRecord(r);
+        TopicPartition tp = new TopicPartition(r.topic(), r.partition());
+        Long hwm = endOffsets.get(tp);
+        if (hwm != null && r.offset() + 1 >= hwm) caughtUp.add(tp);
+    }
+    // Mark the cache ready ONCE, after the first full drain-to-HWM across all currently-assigned partitions.
+    if (!bootstrapMarked.get()
+            && !endOffsets.isEmpty()
+            && caughtUp.containsAll(endOffsets.keySet())) {
+        if (bootstrapMarked.compareAndSet(false, true)) {
+            finishBootstrap();  // marks cache ready, publishes NodeContextCacheReadyEvent
+        }
+    }
+}
+```
+
+### Key properties
+
+- **Single code path.** No "no partitions" branch to forget about. Kafka's rebalance protocol handles topic-doesn't-exist-yet uniformly.
+- **Cache ready fires only after true drain.** `finishBootstrap()` runs exactly once, after `caughtUp` covers every partition the broker has assigned. The `TimeseriesBindingResumer` gate therefore holds the `deltav-timeseries` binding paused until the cache is actually populated, preventing the "6 records hit enrichment_missing at startup" symptom.
+- **Survives mid-flight rebalance.** If Kafka reassigns partitions later (broker restart, topic partition expansion), `onPartitionsAssigned` fires again; `endOffsets` and `caughtUp` update; new records are drained. `bootstrapMarked` prevents duplicate `NodeContextCacheReadyEvent` publication.
+- **Tombstones still handled.** `applyRecord` already treats `value == null` and `deleted=true` as delete; unchanged.
+
+### What about startup latency?
+
+The subscribe + first rebalance typically completes in a few hundred milliseconds when the topic exists. When the topic does NOT exist yet, Kafka does not assign until someone creates it. During that window, the cache is not marked ready, the binding stays paused, and `deltav-timeseries` records accumulate on the broker (our consumer group continues to hold its assignment). Once provisiond creates the topic, the rebalance fires, we drain, cache-ready fires, binding resumes — records from the buffer flow through with enrichment intact.
+
+Worst-case startup delay: however long provisiond takes to come up and emit its first `NodeContext`. In practice <30 s per the live-stack observation.
+
+## 4. Revised commit sequence
+
+Seven commits total. Commit 1 is already on the branch (the Task 1 diagnostic exposure from the original plan).
+
+1. **`diag(daemon-boot-collectd): expose env/beans/conditions + startup logs`** (already landed as `d3c6d049cab`). Retained; partially reverted in Commit 7.
+2. **`fix(prometheus-writer): NodeContextKafkaBootstrap subscribe + ConsumerRebalanceListener`**. Replace `partitionsFor`-based branching with unified subscribe flow per §3. Delete the `finishBootstrap()` short-circuit in the "no partitions" case — that branch no longer exists.
+3. **`test(prometheus-writer): NodeContextKafkaBootstrapIT topic-created-after-start case`**. New test method in the existing IT file. Exercises the exact path that was broken: bootstrap starts, topic doesn't exist, cache NOT ready; then create topic + produce records; cache becomes ready with the records.
+4. **`feat(daemon-boot-collectd): FanoutPersister observability + dev fail-fast`**. `(X)` counters pre-registered for all 10 visitor steps on both inner and kafka sides. `(Y)` `deltav.collectd.persister.{inner,kafka}.fail-fast` Spring properties, default `false`.
+5. **`test(daemon-boot-collectd): FanoutPersisterTest + CollectdApplicationScanIT`**. T0 unit tests (7 methods — counters, fail-fast matrix, `Throwable`-not-just-`RuntimeException`) + T1 real-main-class IT (3 methods — bean resolution, NewTopic bean, TimeseriesKafkaPublisher bean).
+6. **`feat(compose+proto): enable Kafka time-series publisher default + pin Phase 2 proto header`**. `DELTAV_TIMESERIES_ENABLED: ${...:-false}` → `${...:-true}`; `<TBD-phase-2-PR>` → `#174` in both proto headers.
+7. **`chore(daemon-boot-collectd): revert temporary env/beans actuator + one-shot startup log`**. Keep `/actuator/conditions` and the `compositePersisterFactory wrapping inner=...` log permanently. Revert the rest.
+
+Each commit is surgical: one concern, one commit. Commits 2-3 fix the actual Phase 2 blocker; Commits 4-7 ship the protective tooling + operational tidy.
+
+## 5. Phase 0 inner bugs out-of-scope (memory-noted)
+
+Three distinct inner-persister bugs were observed during Task 2's live investigation. All three are already caught by `FanoutPersister.runInner` and WARN-logged. After this PR's `(X)` counters land, they become operator-visible at `/actuator/prometheus`. They do not block Phase 2 E2E because Kafka publishes regardless of inner failures.
+
+| # | Exception | Location | Count/90 s |
+|---|---|---|---|
+| 1 | `UnexpectedRollbackException` (tx marked rollback-only) | `TimeseriesPersister.visitResource` → `MetaTagDataLoader.load` → our `withReadOnlyTransaction` → Spring `TransactionTemplate.execute` | 8 |
+| 2 | `NullPointerException: "this.currentBuilder is null"` | `TimeseriesPersister.persistNumericAttribute` → `TimeseriesPersistOperationBuilder.setAttributeValue` | 76 |
+| 4 | `ClassCastException: ResourcePath cannot be cast to CollectionResource` (new — not in Phase 0's known-issues list) | `TimeseriesPersister.getUserDefinedMetaTags` → Guava `LocalCache.get` (type-mismatched loader) | 10 |
+
+A new memory note `project_phase0_inner_persister_bugs_followup` captures these with stack-trace excerpts for a separate PR. Phase 0 known-issue #3 (`NoSuchMethodError: ResourceTypeUtils.getResourcePathWithRepository`) did not surface during this investigation.
+
+## 6. Test strategy summary
+
+- **T0 unit**: `FanoutPersisterTest` (7 tests) — Mockito + `SimpleMeterRegistry`. Covers counter increment on inner/kafka failure, pre-registration with zero values, fail-fast matrix (4 cells), `Throwable`-not-just-`RuntimeException` catch.
+- **T1 real-main-class IT**: `CollectdApplicationScanIT` — `@SpringBootTest(classes = CollectdApplication.class)` + Testcontainers Kafka + `@TestPropertySource` setting `deltav.timeseries.enabled=true` + both fail-fast toggles true. Three tests: `PersisterFactory` resolves to `FanoutPersisterFactory`; `deltavTimeseriesTopic` `NewTopic` bean present; `TimeseriesKafkaPublisher` bean present. Mandatory `commons-io:2.18.0` test dep per memory `feedback_boot4_testcontainers_commons_io`.
+- **Race IT**: new case added to `NodeContextKafkaBootstrapIT`. Does NOT pre-create topic; starts bootstrap; asserts cache is NOT ready; creates topic + produces records mid-flight; asserts cache becomes ready within 30 s AND contains the produced records. Ideally also an assertion that a mid-run partition-expansion scenario triggers rebalance-driven catch-up (nice-to-have; drop if test infrastructure makes it fragile).
+- **Live acceptance**: Phase 2 E2E (`test-prometheus-writer-e2e.sh`) exits 0 with `ALL ASSERTIONS PASSED` after full-reactor build + all-image rebuild.
+
+## 7. Acceptance criteria
+
+1. Memory note `project_collectd_publisher_inert_investigation` final status flipped to `RESOLVED (real bug was Phase 2 NodeContextKafkaBootstrap race)` with a pointer to this PR.
+2. Memory note `project_phase0_inner_persister_bugs_followup` created, capturing bugs #1/#2/#4 with stack traces + rate-per-90s observations.
+3. Memory note `project_nodecontext_startup_race_pattern` (feedback memory) created, documenting: *any Spring-Kafka consumer using `consumer.partitionsFor(topic)` must handle the topic-does-not-exist-yet case via `subscribe` + `ConsumerRebalanceListener`, never via skip-and-enter-liveTail.*
+4. `./mvnw -pl core/prometheus-writer verify` green — all existing Phase 2 tests pass AND the new `NodeContextKafkaBootstrapIT` race-test passes.
+5. `./mvnw -pl core/daemon-boot-collectd verify` green — 7 `FanoutPersisterTest` + 3 `CollectdApplicationScanIT` tests pass.
+6. `./mvnw -B -DskipTests -fae clean install` green (full-reactor scar prophylactic).
+7. Live producer + consumer: after `docker compose up -d` (compose default now `true`), within 90 s: `kafka-console-consumer --topic deltav-timeseries` reads ≥ 1 record; prometheus-writer `/actuator/prometheus` shows `records_consumed_total > 0` AND `enrichment_missing_total == 0` AND `samples_sent_total > 0`.
+8. `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` exits 0 with `ALL ASSERTIONS PASSED`. This is the first end-to-end pass of the full Phase 2 pipeline.
+9. CI green on PR.
+10. PR opened `--repo pbrane/delta-v --base develop`. Title: `fix(prometheus-writer): NodeContextKafkaBootstrap race + Collectd silent-swallow hygiene`.
+11. Post-merge memory updates: `project_phase2_prometheus_writer_done` gets an addendum noting E2E now passes end-to-end.
+
+## 8. Risks and trade-offs
+
+- **ConsumerRebalanceListener edge cases.** Kafka rebalances can be triggered by broker failover, partition expansion, or group-member changes. The new code handles reassignment correctly (new `onPartitionsAssigned` re-seeks) but duplicates the drain work each time. For our use case (single consumer instance, compacted topic, small state) this is benign. In a scaled-out deployment this would need revisiting — out of scope now, memory-noted as a follow-up if operators later scale prometheus-writer horizontally.
+- **Startup wait-for-topic latency.** If provisiond is slow to come up, prometheus-writer waits (cache not ready → binding paused → timeseries records buffer in Kafka). Provisiond startup typically < 30 s; long delays would show up as a metric-visibility gap rather than lost data (Kafka retains the records; they flow once provisiond catches up).
+- **Phase 0 inner bugs remain swallowed in production.** This PR's `(X)` counters make them visible but do not fix them. Operators running the dashboard will see the counter-rate and know something's wrong; without the dashboard they see the same invisible WARN-log swallow. Acceptable because each bug deserves its own investigation; the counters are the prerequisite for knowing they're worth investigating.
+- **Compose default flip side-effects.** Any existing operator-local E2E that explicitly expected `DELTAV_TIMESERIES_ENABLED=false` as the default breaks. Unlikely — publisher is passive when Kafka reachable; only observable effect is batches published.
+
+## 9. References
+
+- Memory: `project_collectd_publisher_inert_investigation` (the investigation narrative — original hypothesis REFUTED, real root cause confirmed).
+- Memory: `project_phase2_prometheus_writer_done` (PR #174 merged; E2E deferred to this follow-up PR).
+- Memory: `project_kafka_timeseries_pipeline` (Phase 0 DONE, Phase 1 DONE, Phase 2 awaiting this PR's E2E green).
+- Memory: `feedback_configuration_class_bean_name_collision` (Phase 2 scar, still applicable to the Collectd-side hygiene tooling this PR ships).
+- Memory: `feedback_boot4_testcontainers_commons_io` (Phase 2 scar; the `commons-io:2.18.0` test dep T1 adds traces back to this).
+- Memory: `feedback_spring_boot_scan_package_trap` (Phase 0 #170 scar; the `CollectdApplicationScanIT` pattern descends from here).
 - Memory: `feedback_delta_v_full_reactor_verify` (build-verify hygiene).
 - Prior E2E logs: `/tmp/phase2-e2e.log`, `/tmp/phase2-e2e-2.log`, `/tmp/phase2-e2e-3.log`, `/tmp/phase2-e2e-4.log`.
+- Original spec (v1, superseded): this file's previous content at commit `8c2729588e5`.
+- Original plan (v1, superseded): `docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md` at commit `262309050ed` (to be rewritten).

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
       OPENNMS_TIMESERIES_STRATEGY: inmemory
-      DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-false}
+      DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-true}
     volumes:
       - ./collectd-daemon-overlay/etc:/opt/deltav/etc:ro
     stop_grace_period: 60s


### PR DESCRIPTION
## Summary

Unblocks downstream consumers of the delta-v Kafka time-series pipeline by fixing three real production bugs found during Phase 2 PR #174's deferred E2E investigation. Adds complementary Collectd-side observability + tests so this class of silent-swallow can't re-occur. Resolves Phase 2's deferred `<TBD-phase-2-PR>` proto-header placeholder.

**One blocker remains** before the Phase 2 E2E fully passes: Collectd doesn't populate `ServiceParameters.{nodeId,location}`, so `TimeseriesBatch` records ship with `nodeId=0 + location=""`. That's an upstream Collectd-side fix (M2, tracked in `project_collectd_serviceparameters_identity_gap` memory). Everything else needed on the consumer side ships here.

## Real bugs fixed

| # | Bug | Fix commit |
|---|---|---|
| 1 | `NodeContextKafkaBootstrap` race: when `deltav-node-context` topic doesn't exist at consumer-start, the "no partitions yet" branch skipped `consumer.assign/.subscribe`; `liveTail.consumer.poll()` then threw `IllegalStateException` forever. Cache stayed empty regardless of records produced later. | `1781a5f549d` |
| 2 | SCS Kafka binder consumer auto-creates `deltav-timeseries` with broker-default 4 partitions before Collectd's `KafkaAdmin` declares 16. Kafka allows the expansion but doesn't rebalance the consumer group; consumer stuck on partitions 0-3 forever. | `ae5326d3366` |
| 3 | NodeContext lookup keyed by `{location}@{node_id}` misses every Collectd record because Collectd publishes `location=""`. Phase 0 memory anticipated a fallback that was never implemented. | `bfe219379c8` |

## Pivot context

Original v1 spec/plan (commits `8c2729588e5` / `262309050ed`) framed this as "Phase 0 Kafka publisher is inert on develop." Live-stack diagnostic (commit `d3c6d049cab`) refuted the hypothesis: Phase 0's publisher works fine — 6 batches per 90 s, real records on the topic, prometheus-writer consumes them. The actual bug was on the Phase 2 consumer side. v2 spec/plan (commits `f0a4d5b0f94` / `8665e6db7b9`) supersede v1 with the correct framing. Both v1 and v2 are retained in branch history for the audit trail. Memory `project_collectd_publisher_inert_investigation` has the full root-cause narrative + evidence.

## 13 commits

1. `8c2729588e5` docs(spec): wiring-fix design (v1 — superseded)
2. `262309050ed` docs(plan): wiring-fix 14-task plan (v1 — superseded)
3. `d3c6d049cab` diag(daemon-boot-collectd): expose env/beans/conditions + startup logs
4. `f0a4d5b0f94` docs(spec): pivot to NodeContextKafkaBootstrap race fix (v2)
5. `8665e6db7b9` docs(plan): pivot 9-task plan (v2)
6. `1781a5f549d` fix(prometheus-writer): NodeContextKafkaBootstrap subscribe + ConsumerRebalanceListener
7. `9f89986afd1` test(prometheus-writer): NodeContextKafkaBootstrapIT topic-created-after-start case
8. `ba06acc02c7` feat(daemon-boot-collectd): FanoutPersister observability + dev fail-fast
9. `5b12d0b7269` test(daemon-boot-collectd): FanoutPersisterTest + CollectdApplicationScanIT
10. `a6b408062cd` feat(compose+proto): enable Kafka time-series publisher by default; pin Phase 2 proto header
11. `724cbbb6823` chore(daemon-boot-collectd): revert temporary env/beans actuator + one-shot startup log
12. `ae5326d3366` fix(prometheus-writer): pre-declare source topics to avoid SCS-binder auto-create race
13. `bfe219379c8` fix(prometheus-writer): NodeContext lookup fallback by node_id

## Acceptance verification

- [x] `./mvnw -pl core/prometheus-writer verify` — 94/94 pass (85 unit + 9 ITs incl. new race-IT case)
- [x] `./mvnw -pl core/daemon-boot-collectd verify` — 51/51 pass (40 unit + 11 ITs incl. new FanoutPersisterTest 7 cases + new CollectdApplicationScanIT 3 cases)
- [x] `./mvnw -B -DskipTests -fae clean install` — full-reactor BUILD SUCCESS
- [x] Live producer verification: after `docker compose up -d` (compose default now `true`), Collectd's `deltav_timeseries_batches_published_total > 0` within 90 s, prometheus-writer's `records_consumed_total > 0` (the topic-partition fix is proven), `node_context_cache_size > 0` (the race fix is proven).
- [ ] Phase 2 E2E (`./test-prometheus-writer-e2e.sh`) **does NOT pass yet** — Step 4 fails with `samples_sent_total = 0`. Root cause: Collectd's `ServiceParameters` identity-populate gap (M2, separate PR). The new `enrichment_lookup_fallback_total` counter shipped here will give the next investigator immediate visibility once M2 lands.

## Side observations (not blocking, memory-noted for followups)

Three pre-existing horizon-side `TimeseriesPersister` bugs reproduce on every poll cycle on labbox stack with horizon 1.0.10. All swallowed by `FanoutPersister` isolation (the design is doing its job). Now operator-visible at `/actuator/prometheus` via this PR's new `deltav.collectd.persister.inner.failures{step=…}` counters:

- `UnexpectedRollbackException` via `MetaTagDataLoader` (8/90 s)
- `NullPointerException` in `TimeseriesPersistOperationBuilder.setAttributeValue` (76/90 s)
- `ClassCastException: ResourcePath cannot be cast to CollectionResource` in `TimeseriesPersister.getUserDefinedMetaTags` (10/90 s) — **NEW, not in Phase 0's known-issues list**

See memory `project_phase0_inner_persister_bugs_followup` for stack traces + fix directions. Each deserves its own focused investigation.

## What ships + what's deferred

**Ships in this PR (consumer-side):**
- Race fix in `NodeContextKafkaBootstrap` (the original critical bug).
- Topic-pre-declare in `KafkaTopicsConfiguration` (eliminates SCS-binder partition-assignment race).
- NodeContext lookup-by-nodeId fallback in `TimeseriesConsumer` + new `enrichment_lookup_fallback` counter.
- FanoutPersister observability counters + dev fail-fast Spring properties.
- Real-main-class `CollectdApplicationScanIT` (Phase 2 PR #174 scar-prophylactic lineage).
- Compose default flip (`DELTAV_TIMESERIES_ENABLED` false → true).
- Phase 2 proto-header `<TBD-phase-2-PR>` resolved to `#TBD` (will update after merge).

**Deferred to followup PRs:**
- **M2** — Collectd `ServiceParameters` identity-populate gap. Producer-side fix; required for Phase 2 E2E to fully pass. Memory: `project_collectd_serviceparameters_identity_gap`.
- Phase 0 horizon-side inner-persister bugs (#1, #2, new #4). Memory: `project_phase0_inner_persister_bugs_followup`.
- `build.sh check_daemon_boot_freshness` transitive-dep gap (small tooling fix).
- Phase 3 Thresholder (next numbered phase).

## Memory artifacts created

- `project_collectd_publisher_inert_investigation` — flipped to RESOLVED with full evidence narrative.
- `project_collectd_serviceparameters_identity_gap` — NEW, M2 followup tracking.
- `project_phase0_inner_persister_bugs_followup` — NEW, the 3 horizon-side bugs with stack traces.
- `feedback_kafka_topic_partition_race` — NEW, the design rule for SCS Kafka binder consumers.
- `feedback_nodecontext_startup_race_pattern` — NEW, the design rule for Spring-Kafka consumers using `partitionsFor`.

## Spec + plan

- Spec (v2 — current): `docs/superpowers/specs/2026-04-18-collectd-publisher-inert-fix-design.md`
- Plan (v2 — current): `docs/superpowers/plans/2026-04-18-collectd-publisher-inert-fix.md`
- Spec/plan v1 retained in branch history for audit at commits `8c2729588e5` and `262309050ed`.