### PR TITLE
fix(collectd): populate ServiceParameters identity via LocationAwareCollectorClient decorator

### DIFF
--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentity.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentity.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+/**
+ * Immutable agent identity captured from a {@code CollectionAgent} at RPC
+ * dispatch time and consumed by {@code TimeseriesKafkaPersister} at publish
+ * time.
+ *
+ * <p>Validation of {@code nodeId} is intentionally deferred to the persist
+ * site (persist-time-only fail-fast): the record accepts any int so capture
+ * never aborts a collection cycle. A {@code nodeId <= 0} surfaces as a
+ * publisher-side {@code IllegalStateException} caught by
+ * {@code FanoutPersister}, which increments the kafka failures counter.</p>
+ *
+ * <p>{@code location} is normalized to the empty string when null — Default
+ * location setups sometimes return {@code null}. Downstream code may assume
+ * non-null.</p>
+ */
+public record AgentIdentity(int nodeId, String location) {
+    public AgentIdentity {
+        if (location == null) {
+            location = "";
+        }
+    }
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClient.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClient.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+import org.opennms.netmgt.collection.api.ServiceCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Spring {@code @Primary} decorator over horizon's
+ * {@link LocationAwareCollectorClient}. Returns a {@link CapturingBuilder} from
+ * {@link #collect()}; that builder captures the {@link CollectionAgent}'s
+ * {@code nodeId} and {@code locationName} into an {@link AgentIdentityHolder}
+ * just before the real RPC dispatches, so {@code TimeseriesKafkaPersister}
+ * (constructed later in the same synchronous {@code doCollection()} cycle)
+ * can read them.
+ */
+public class AgentIdentityCapturingCollectorClient implements LocationAwareCollectorClient {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AgentIdentityCapturingCollectorClient.class);
+
+    private final LocationAwareCollectorClient delegate;
+    private final AgentIdentityHolder holder;
+
+    public AgentIdentityCapturingCollectorClient(LocationAwareCollectorClient delegate,
+                                                 AgentIdentityHolder holder) {
+        this.delegate = delegate;
+        this.holder = holder;
+        LOG.info("Wrapping LocationAwareCollectorClient for identity capture; delegate = {}",
+                delegate.getClass().getName());
+    }
+
+    @Override
+    public CollectorRequestBuilder collect() {
+        return new CapturingBuilder(delegate.collect(), holder);
+    }
+
+    /**
+     * Delegating {@link CollectorRequestBuilder} that records
+     * {@link AgentIdentity} into the holder at {@link #execute()} time.
+     *
+     * <p>Package-private so tests can construct it directly; the only
+     * production construction site is {@link #collect()} on the outer class.</p>
+     */
+    static final class CapturingBuilder implements CollectorRequestBuilder {
+
+        private final CollectorRequestBuilder delegate;
+        private final AgentIdentityHolder holder;
+        private CollectionAgent agent;
+
+        CapturingBuilder(CollectorRequestBuilder delegate, AgentIdentityHolder holder) {
+            this.delegate = delegate;
+            this.holder = holder;
+        }
+
+        @Override
+        public CollectorRequestBuilder withAgent(CollectionAgent agent) {
+            this.agent = agent;
+            delegate.withAgent(agent);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withSystemId(String systemId) {
+            delegate.withSystemId(systemId);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withCollector(ServiceCollector collector) {
+            delegate.withCollector(collector);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withCollectorClassName(String className) {
+            delegate.withCollectorClassName(className);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withTimeToLive(Long ttlInMs) {
+            delegate.withTimeToLive(ttlInMs);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withAttribute(String key, Object value) {
+            delegate.withAttribute(key, value);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withAttributes(Map<String, Object> attributes) {
+            delegate.withAttributes(attributes);
+            return this;
+        }
+
+        @Override
+        public CompletableFuture<CollectionSet> execute() {
+            if (agent != null) {
+                holder.set(agent.getNodeId(), agent.getLocationName());
+            }
+            return delegate.execute();
+        }
+    }
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+/**
+ * ThreadLocal-backed holder for {@link AgentIdentity} captured by
+ * {@code AgentIdentityCapturingCollectorClient} before RPC dispatch and
+ * consumed by {@code TimeseriesKafkaPersister} at publish time.
+ *
+ * <p>Contract invariants:</p>
+ * <ul>
+ *   <li>{@link #set(int, String)} is unconditional overwrite — no throw on
+ *       "already set". This is the sole protection against thread reuse with
+ *       stale identity between cycles on the same scheduler thread.</li>
+ *   <li>{@link #getOrThrow()} throws {@link IllegalStateException} with a
+ *       diagnostic message when the slot is empty; a stack trace at the
+ *       persister's {@code completeCollectionSet} means the decorator is not
+ *       wired or the persister was invoked off-cycle.</li>
+ *   <li>{@link #clear()} is idempotent ({@code ThreadLocal.remove()} on an
+ *       empty slot is a no-op).</li>
+ * </ul>
+ *
+ * <p>Scoped to a single {@code CollectableService.doCollection()} cycle,
+ * which horizon runs synchronously on one scheduler thread. The decorator
+ * sets on {@code execute()}; the persister reads in {@code completeCollectionSet}
+ * and clears in the outer {@code finally} of that method.</p>
+ */
+public class AgentIdentityHolder {
+
+    private final ThreadLocal<AgentIdentity> current = new ThreadLocal<>();
+
+    public void set(int nodeId, String location) {
+        current.set(new AgentIdentity(nodeId, location));
+    }
+
+    public AgentIdentity getOrThrow() {
+        AgentIdentity id = current.get();
+        if (id == null) {
+            throw new IllegalStateException(
+                    "AgentIdentity not populated — LocationAwareCollectorClient decorator not wired?");
+        }
+        return id;
+    }
+
+    public void clear() {
+        current.remove();
+    }
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java
@@ -51,7 +51,7 @@ public class AgentIdentityHolder {
         AgentIdentity id = current.get();
         if (id == null) {
             throw new IllegalStateException(
-                    "AgentIdentity not populated — LocationAwareCollectorClient decorator not wired?");
+                    "AgentIdentity not populated — AgentIdentityCapturingCollectorClient not wired?");
         }
         return id;
     }

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
@@ -16,56 +16,45 @@
  */
 package org.deltav.collectd.timeseries;
 
-import java.util.Map;
-
+import org.deltav.collectd.identity.AgentIdentity;
+import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.opennms.netmgt.collection.api.AttributeGroup;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.Persister;
-import org.opennms.netmgt.collection.api.ServiceParameters;
 
 /**
- * Thin horizon Persister adapter that hands every CollectionSet to the
- * shared TimeseriesKafkaPublisher once, at completeCollectionSet(). All
- * per-attribute visit/persistNumericAttribute/persistStringAttribute
- * callbacks are no-ops — the translator does its own walk.
+ * Thin horizon {@link Persister} adapter that hands every {@link CollectionSet}
+ * to the shared {@link TimeseriesKafkaPublisher} once, at
+ * {@link #completeCollectionSet(CollectionSet)}. All per-attribute callbacks
+ * are no-ops — the translator does its own walk.
  *
- * <p>nodeId and location are extracted from ServiceParameters at
- * construction time: keys {@code node-id} (parsed as int, falls back to 0
- * on parse failure) and {@code location} (defaults to empty string).
- * Collectd is responsible for populating these keys; when it doesn't,
- * the produced batch carries the defaults and consumers will fall back
- * to the deltav-node-context GlobalKTable lookup for identity.</p>
+ * <p>Identity ({@code nodeId} + {@code location}) is captured by
+ * {@code AgentIdentityCapturingCollectorClient} before each RPC dispatch and
+ * read from the injected {@link AgentIdentityHolder} at publish time. If the
+ * holder is empty (decorator not wired) or {@code nodeId <= 0}, this persister
+ * throws {@link IllegalStateException}; {@code FanoutPersister} catches it,
+ * increments {@code deltav.collectd.persister.kafka.failures{step=completeCollectionSet}},
+ * and logs WARN. The inner persister path is unaffected.</p>
+ *
+ * <p>{@code collectionPackage} is extracted once by
+ * {@code FanoutPersisterFactory.createPersister} from the horizon
+ * {@code ServiceParameters} and passed as an explicit constructor argument.</p>
  */
 public class TimeseriesKafkaPersister implements Persister {
 
     private final TimeseriesKafkaPublisher publisher;
     private final String collectionPackage;
-    private final int nodeId;
-    private final String location;
+    private final AgentIdentityHolder holder;
     private CollectionSet capturedSet;
 
     public TimeseriesKafkaPersister(TimeseriesKafkaPublisher publisher,
-                                     ServiceParameters serviceParameters) {
+                                     String collectionPackage,
+                                     AgentIdentityHolder holder) {
         this.publisher = publisher;
-        Map<String, Object> params = serviceParameters.getParameters();
-        this.collectionPackage = asString(params.get("collection"), "default");
-        this.nodeId = parseIntOrZero(asString(params.get("node-id"), ""));
-        this.location = asString(params.get("location"), "");
-    }
-
-    private static String asString(Object value, String fallback) {
-        return value == null ? fallback : value.toString();
-    }
-
-    private static int parseIntOrZero(String value) {
-        if (value == null || value.isEmpty()) return 0;
-        try {
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
+        this.collectionPackage = collectionPackage;
+        this.holder = holder;
     }
 
     @Override
@@ -93,10 +82,21 @@ public class TimeseriesKafkaPersister implements Persister {
 
     @Override
     public void completeCollectionSet(CollectionSet set) {
-        if (capturedSet != null) {
-            publisher.publish(capturedSet, collectionPackage, nodeId, location);
+        try {
+            if (capturedSet != null) {
+                AgentIdentity identity = holder.getOrThrow();
+                if (identity.nodeId() <= 0) {
+                    throw new IllegalStateException(
+                            "Invalid agent identity for Kafka publish: nodeId must be > 0, got "
+                                    + identity.nodeId());
+                }
+                publisher.publish(capturedSet, collectionPackage,
+                        identity.nodeId(), identity.location());
+            }
+        } finally {
+            holder.clear();
+            capturedSet = null;
         }
-        capturedSet = null;
     }
 
     @Override

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -107,6 +107,7 @@ public class TimeseriesKafkaPublisherConfiguration {
     public PersisterFactory compositePersisterFactory(
             @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
             TimeseriesKafkaPublisher publisher,
+            AgentIdentityHolder agentIdentityHolder,
             MeterRegistry meterRegistry,
             @Value("${deltav.collectd.persister.inner.fail-fast:false}") boolean failFastInner,
             @Value("${deltav.collectd.persister.kafka.fail-fast:false}") boolean failFastKafka) {
@@ -114,7 +115,7 @@ public class TimeseriesKafkaPublisherConfiguration {
                 innerFactory.getClass().getName(),
                 System.identityHashCode(innerFactory),
                 failFastInner, failFastKafka);
-        return new FanoutPersisterFactory(innerFactory, publisher, meterRegistry,
+        return new FanoutPersisterFactory(innerFactory, publisher, agentIdentityHolder, meterRegistry,
                 failFastInner, failFastKafka);
     }
 
@@ -125,15 +126,18 @@ public class TimeseriesKafkaPublisherConfiguration {
     static final class FanoutPersisterFactory implements PersisterFactory {
         private final PersisterFactory innerFactory;
         private final TimeseriesKafkaPublisher publisher;
+        private final AgentIdentityHolder holder;
         private final MeterRegistry meterRegistry;
         private final boolean failFastInner;
         private final boolean failFastKafka;
 
         FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher,
+                               AgentIdentityHolder holder,
                                MeterRegistry meterRegistry,
                                boolean failFastInner, boolean failFastKafka) {
             this.innerFactory = innerFactory;
             this.publisher = publisher;
+            this.holder = holder;
             this.meterRegistry = meterRegistry;
             this.failFastInner = failFastInner;
             this.failFastKafka = failFastKafka;
@@ -143,7 +147,7 @@ public class TimeseriesKafkaPublisherConfiguration {
         public Persister createPersister(ServiceParameters params, RrdRepository repository) {
             return new FanoutPersister(
                     innerFactory.createPersister(params, repository),
-                    new TimeseriesKafkaPersister(publisher, params),
+                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder),
                     meterRegistry, failFastInner, failFastKafka);
         }
 
@@ -154,8 +158,13 @@ public class TimeseriesKafkaPublisherConfiguration {
             return new FanoutPersister(
                     innerFactory.createPersister(params, repository, dontPersistCounters,
                             forceStoreByGroup, dontReorderAttributes),
-                    new TimeseriesKafkaPersister(publisher, params),
+                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder),
                     meterRegistry, failFastInner, failFastKafka);
+        }
+
+        private static String extractCollection(ServiceParameters params) {
+            Object raw = params.getParameters().get("collection");
+            return raw == null ? "default" : raw.toString();
         }
     }
 

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -23,11 +23,13 @@ import java.time.Duration;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.TopicConfig;
+import org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient;
 import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.opennms.netmgt.collection.api.AttributeGroup;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
 import org.opennms.netmgt.collection.api.Persister;
 import org.opennms.netmgt.collection.api.PersisterFactory;
 import org.opennms.netmgt.collection.api.ServiceParameters;
@@ -71,6 +73,27 @@ public class TimeseriesKafkaPublisherConfiguration {
     @Bean
     public AgentIdentityHolder agentIdentityHolder() {
         return new AgentIdentityHolder();
+    }
+
+    /**
+     * {@code @Primary} decorator over horizon's {@link LocationAwareCollectorClient}
+     * that captures {@code (nodeId, location)} into {@link AgentIdentityHolder}
+     * before every RPC dispatch, so {@link TimeseriesKafkaPersister} can read
+     * identity at publish time.
+     *
+     * <p>{@code CollectdRpcConfiguration} registers the original bean under the
+     * default name {@code locationAwareCollectorClient}; Spring Boot 4 disables
+     * bean-definition overriding, so the decorator uses a distinct method name
+     * and is made primary. The {@code @Qualifier} on the delegate parameter
+     * selects the horizon bean (not this decorator, which would cause infinite
+     * recursion).</p>
+     */
+    @Bean
+    @Primary
+    public LocationAwareCollectorClient agentIdentityCapturingCollectorClient(
+            @Qualifier("locationAwareCollectorClient") LocationAwareCollectorClient inner,
+            AgentIdentityHolder holder) {
+        return new AgentIdentityCapturingCollectorClient(inner, holder);
     }
 
     @Bean

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.TopicConfig;
+import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.opennms.netmgt.collection.api.AttributeGroup;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
@@ -59,6 +60,17 @@ public class TimeseriesKafkaPublisherConfiguration {
     @Bean
     public CollectionSetToProtobufTranslator collectionSetToProtobufTranslator() {
         return new CollectionSetToProtobufTranslator();
+    }
+
+    /**
+     * Per-scheduler-thread holder for the {@code nodeId} + {@code location}
+     * of the {@code CollectionAgent} currently being collected. Populated by
+     * {@link org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient}
+     * at RPC dispatch and read by {@link TimeseriesKafkaPersister} at publish time.
+     */
+    @Bean
+    public AgentIdentityHolder agentIdentityHolder() {
+        return new AgentIdentityHolder();
     }
 
     @Bean

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClientTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClientTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+
+class AgentIdentityCapturingCollectorClientTest {
+
+    @Test
+    void collectDelegatesAndReturnsCapturingBuilder() {
+        LocationAwareCollectorClient inner = mock(LocationAwareCollectorClient.class);
+        CollectorRequestBuilder innerBuilder = mock(CollectorRequestBuilder.class);
+        when(inner.collect()).thenReturn(innerBuilder);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+
+        AgentIdentityCapturingCollectorClient client =
+                new AgentIdentityCapturingCollectorClient(inner, holder);
+
+        CollectorRequestBuilder result = client.collect();
+
+        assertThat(result).isInstanceOf(AgentIdentityCapturingCollectorClient.CapturingBuilder.class);
+        verify(inner).collect();
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorRequestBuilderTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorRequestBuilderTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.ServiceCollector;
+
+class AgentIdentityCapturingCollectorRequestBuilderTest {
+
+    @Test
+    void withAgentThenExecuteSetsHolderAndDelegates() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        CompletableFuture<CollectionSet> future = new CompletableFuture<>();
+        when(delegate.execute()).thenReturn(future);
+        when(delegate.withAgent(any())).thenReturn(delegate);
+
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(42);
+        when(agent.getLocationName()).thenReturn("Site-A");
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        CompletableFuture<CollectionSet> result = builder.withAgent(agent).execute();
+
+        assertThat(result).isSameAs(future);
+        assertThat(holder.getOrThrow().nodeId()).isEqualTo(42);
+        assertThat(holder.getOrThrow().location()).isEqualTo("Site-A");
+        verify(delegate).withAgent(agent);
+        verify(delegate).execute();
+    }
+
+    @Test
+    void executeWithoutAgentDoesNotSetHolderButStillDelegates() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.execute();
+
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
+        verify(delegate).execute();
+    }
+
+    @Test
+    void agentWithZeroNodeIdCapturedAsIs() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.withAgent(any())).thenReturn(delegate);
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(0);
+        when(agent.getLocationName()).thenReturn("Default");
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.withAgent(agent).execute();
+
+        assertThat(holder.getOrThrow().nodeId()).isZero();
+        assertThat(holder.getOrThrow().location()).isEqualTo("Default");
+    }
+
+    @Test
+    void agentWithNullLocationCapturedAsEmptyString() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.withAgent(any())).thenReturn(delegate);
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(5);
+        when(agent.getLocationName()).thenReturn(null);
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.withAgent(agent).execute();
+
+        assertThat(holder.getOrThrow().nodeId()).isEqualTo(5);
+        assertThat(holder.getOrThrow().location()).isEqualTo("");
+    }
+
+    @Test
+    void withXxxMethodsReturnThisAndDelegate() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.withSystemId("sys")).thenReturn(delegate);
+        when(delegate.withCollector(any())).thenReturn(delegate);
+        when(delegate.withCollectorClassName("class")).thenReturn(delegate);
+        when(delegate.withTimeToLive(1000L)).thenReturn(delegate);
+        when(delegate.withAttribute("k", "v")).thenReturn(delegate);
+        when(delegate.withAttributes(Map.of("a", "b"))).thenReturn(delegate);
+
+        ServiceCollector svc = mock(ServiceCollector.class);
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+
+        assertThat(builder.withSystemId("sys")).isSameAs(builder);
+        assertThat(builder.withCollector(svc)).isSameAs(builder);
+        assertThat(builder.withCollectorClassName("class")).isSameAs(builder);
+        assertThat(builder.withTimeToLive(1000L)).isSameAs(builder);
+        assertThat(builder.withAttribute("k", "v")).isSameAs(builder);
+        assertThat(builder.withAttributes(Map.of("a", "b"))).isSameAs(builder);
+
+        verify(delegate).withSystemId("sys");
+        verify(delegate).withCollector(svc);
+        verify(delegate).withCollectorClassName("class");
+        verify(delegate).withTimeToLive(1000L);
+        verify(delegate).withAttribute("k", "v");
+        verify(delegate).withAttributes(Map.of("a", "b"));
+    }
+
+    @Test
+    void executeDoesNotInteractWithHolderIfAgentNeverSet() {
+        // Verifies the no-agent path uses no ThreadLocal state at all.
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = mock(AgentIdentityHolder.class);
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.execute();
+
+        verifyNoInteractions(holder);
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityHolderTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityHolderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+class AgentIdentityHolderTest {
+
+    @Test
+    void setThenGetOrThrowReturnsIdentity() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(42, "Site-A");
+
+        AgentIdentity id = holder.getOrThrow();
+        assertThat(id.nodeId()).isEqualTo(42);
+        assertThat(id.location()).isEqualTo("Site-A");
+    }
+
+    @Test
+    void getOrThrowOnEmptyHolderThrowsIllegalStateException() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+
+        assertThatThrownBy(holder::getOrThrow)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AgentIdentity not populated");
+    }
+
+    @Test
+    void clearRemovesPreviousValue() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(1, "X");
+        holder.clear();
+
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void clearIsIdempotent() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.clear();      // no prior set — must not throw
+        holder.clear();      // second call — must not throw
+    }
+
+    @Test
+    void setWithNullLocationNormalizesToEmpty() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(3, null);
+        assertThat(holder.getOrThrow().location()).isEqualTo("");
+    }
+
+    @Test
+    void doubleSetOverwritesSilently() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(1, "First");
+        holder.set(2, "Second");
+        AgentIdentity id = holder.getOrThrow();
+        assertThat(id.nodeId()).isEqualTo(2);
+        assertThat(id.location()).isEqualTo("Second");
+    }
+
+    @Test
+    void threadIsolationOtherThreadCannotSeeValue() throws InterruptedException {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(99, "MainThread");
+
+        AtomicReference<Throwable> otherThreadError = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                holder.getOrThrow();
+            } catch (Throwable e) {
+                otherThreadError.set(e);
+            }
+        });
+        t.start();
+        t.join();
+
+        assertThat(otherThreadError.get()).isInstanceOf(IllegalStateException.class);
+        // Main thread's value still intact:
+        assertThat(holder.getOrThrow().nodeId()).isEqualTo(99);
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AgentIdentityTest {
+
+    @Test
+    void nullLocationNormalizesToEmptyString() {
+        AgentIdentity id = new AgentIdentity(42, null);
+        assertThat(id.nodeId()).isEqualTo(42);
+        assertThat(id.location()).isEqualTo("");
+    }
+
+    @Test
+    void nonNullLocationPassesThrough() {
+        AgentIdentity id = new AgentIdentity(7, "Site-A");
+        assertThat(id.location()).isEqualTo("Site-A");
+    }
+
+    @Test
+    void emptyStringLocationPreserved() {
+        AgentIdentity id = new AgentIdentity(1, "");
+        assertThat(id.location()).isEqualTo("");
+    }
+
+    @Test
+    void zeroNodeIdAccepted() {
+        // No validation at record construction — persist-time check handles it.
+        AgentIdentity id = new AgentIdentity(0, "Default");
+        assertThat(id.nodeId()).isZero();
+    }
+
+    @Test
+    void negativeNodeIdAccepted() {
+        AgentIdentity id = new AgentIdentity(-5, "Default");
+        assertThat(id.nodeId()).isEqualTo(-5);
+    }
+
+    @Test
+    void recordEqualityOnBothFields() {
+        assertThat(new AgentIdentity(3, "X")).isEqualTo(new AgentIdentity(3, "X"));
+        assertThat(new AgentIdentity(3, "X")).isNotEqualTo(new AgentIdentity(4, "X"));
+        assertThat(new AgentIdentity(3, "X")).isNotEqualTo(new AgentIdentity(3, "Y"));
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/AgentIdentityWiringIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/AgentIdentityWiringIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.deltav.collectd.identity.AgentIdentity;
+import org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient;
+import org.deltav.collectd.identity.AgentIdentityHolder;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Spring-wiring integration test asserting that the {@code @Primary}
+ * decorator wins bean resolution for {@link LocationAwareCollectorClient}
+ * and that its {@code execute()} actually populates the
+ * {@link AgentIdentityHolder}.
+ *
+ * <p>Stubs the horizon delegate with a simple test bean named
+ * {@code locationAwareCollectorClient} (the name the decorator's
+ * {@code @Qualifier} expects). Does not start the real
+ * {@link org.deltav.netmgt.collectd.boot.CollectdApplication} — that live
+ * scan is covered by {@code CollectdApplicationScanIT}.</p>
+ */
+@SpringBootTest(classes = {
+        AgentIdentityWiringIT.TestApp.class
+})
+@TestPropertySource(properties = {
+        "deltav.timeseries.enabled=true",
+        "spring.main.web-application-type=none",
+        "spring.main.banner-mode=off"
+})
+class AgentIdentityWiringIT {
+
+    @EnableAutoConfiguration
+    @Import({
+            TimeseriesKafkaPublisherConfiguration.class,
+            TestChannelBinderConfiguration.class
+    })
+    static class TestApp {
+
+        /**
+         * Stub horizon delegate registered under the default name
+         * {@code locationAwareCollectorClient}. The decorator @Qualifier
+         * pulls this bean in as its delegate.
+         */
+        @Bean(name = "locationAwareCollectorClient")
+        LocationAwareCollectorClient innerClient() {
+            LocationAwareCollectorClient inner = mock(LocationAwareCollectorClient.class);
+            CollectorRequestBuilder builder = mock(CollectorRequestBuilder.class);
+            when(inner.collect()).thenReturn(builder);
+            when(builder.withAgent(org.mockito.ArgumentMatchers.any())).thenReturn(builder);
+            when(builder.execute()).thenReturn(new CompletableFuture<>());
+            return inner;
+        }
+
+        /**
+         * {@code TimeseriesKafkaPublisherConfiguration.compositePersisterFactory}
+         * injects a {@code @Qualifier("timeseriesPersisterFactory")}
+         * {@link org.opennms.netmgt.collection.api.PersisterFactory}. In this
+         * narrow IT we don't boot the full JPA/TSS chain that would normally
+         * create it, so we provide a minimal stub.
+         */
+        @Bean(name = "timeseriesPersisterFactory")
+        org.opennms.netmgt.collection.api.PersisterFactory innerPersisterFactory() {
+            return mock(org.opennms.netmgt.collection.api.PersisterFactory.class);
+        }
+    }
+
+    @Autowired
+    ApplicationContext ctx;
+
+    @Autowired
+    LocationAwareCollectorClient injectedClient;
+
+    @Autowired
+    AgentIdentityHolder holder;
+
+    @Test
+    void primaryBeanIsTheCapturingDecorator() {
+        assertThat(injectedClient).isInstanceOf(AgentIdentityCapturingCollectorClient.class);
+    }
+
+    @Test
+    void holderBeanIsPresent() {
+        assertThat(ctx.getBean(AgentIdentityHolder.class)).isSameAs(holder);
+    }
+
+    @Test
+    void decoratorExecuteCapturesAgentIdentity() {
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(123);
+        when(agent.getLocationName()).thenReturn("lab-A");
+
+        CompletableFuture<CollectionSet> future =
+                injectedClient.collect().withAgent(agent).execute();
+
+        assertThat(future).isNotNull();
+        AgentIdentity captured = holder.getOrThrow();
+        assertThat(captured.nodeId()).isEqualTo(123);
+        assertThat(captured.location()).isEqualTo("lab-A");
+        holder.clear();   // cleanup — test runs on a shared executor thread
+    }
+}

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersister;
 import org.deltav.collectd.timeseries.TimeseriesKafkaPublisherConfiguration.FanoutPersisterFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,9 +51,9 @@ class FanoutPersisterTest {
     void completeCollectionSetCallsInnerThenKafkaInOrder() {
         Persister inner = mock(Persister.class);
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        when(sp.getParameters()).thenReturn(new HashMap<>());
-        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(1, "Default");
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder);
         FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
@@ -75,9 +76,9 @@ class FanoutPersisterTest {
         // survive all of them so consumers still receive the protobuf record.
         Persister inner = mock(Persister.class);
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        when(sp.getParameters()).thenReturn(new HashMap<>());
-        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(1, "Default");
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder);
         FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
@@ -98,9 +99,9 @@ class FanoutPersisterTest {
         // the inner persister must not kill the Kafka path either.
         Persister inner = mock(Persister.class);
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        when(sp.getParameters()).thenReturn(new HashMap<>());
-        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(1, "Default");
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder);
         FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
@@ -123,26 +124,27 @@ class FanoutPersisterTest {
                 .thenReturn(innerPersister1, innerPersister2);
 
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        FanoutPersisterFactory factory = new FanoutPersisterFactory(innerFactory, publisher, new SimpleMeterRegistry(), false, false);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        FanoutPersisterFactory factory = new FanoutPersisterFactory(innerFactory, publisher, holder,
+                new SimpleMeterRegistry(), false, false);
 
         ServiceParameters paramsA = mock(ServiceParameters.class);
         Map<String, Object> mapA = new HashMap<>();
         mapA.put("collection", "pkg-A");
-        mapA.put("node-id", "1");
         when(paramsA.getParameters()).thenReturn((Map) mapA);
 
         ServiceParameters paramsB = mock(ServiceParameters.class);
         Map<String, Object> mapB = new HashMap<>();
         mapB.put("collection", "pkg-B");
-        mapB.put("node-id", "2");
         when(paramsB.getParameters()).thenReturn((Map) mapB);
 
         Persister pA = factory.createPersister(paramsA, null);
         Persister pB = factory.createPersister(paramsB, null);
 
         // Both are distinct FanoutPersister instances wrapping different inner persisters
-        // and different TimeseriesKafkaPersister instances (different nodeId/package).
+        // and different TimeseriesKafkaPersister instances (different package).
         CollectionSet setA = mock(CollectionSet.class);
+        holder.set(1, "");
         pA.visitCollectionSet(setA);
         pA.completeCollectionSet(setA);
 

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaBrokerIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaBrokerIT.java
@@ -245,5 +245,16 @@ class TimeseriesKafkaBrokerIT {
         PersisterFactory stubInnerFactory() {
             return mock(PersisterFactory.class);
         }
+
+        /**
+         * M2 decorator's @Qualifier("locationAwareCollectorClient") references
+         * horizon's bean from CollectdRpcConfiguration, which is not imported
+         * here. Provide a mock under the expected name so the decorator can wrap
+         * it; this IT doesn't exercise the collect() path.
+         */
+        @Bean(name = "locationAwareCollectorClient")
+        org.opennms.netmgt.collection.api.LocationAwareCollectorClient innerCollectorClient() {
+            return mock(org.opennms.netmgt.collection.api.LocationAwareCollectorClient.class);
+        }
     }
 }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
@@ -16,100 +16,118 @@
  */
 package org.deltav.collectd.timeseries;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
-import org.opennms.netmgt.collection.api.ServiceParameters;
 
 class TimeseriesKafkaPersisterTest {
 
     @Test
-    void completeCollectionSetInvokesPublisherWithPackageAndServiceParamsIdentity() {
+    void populatedHolderCausesPublishWithCapturedIdentityAndClearsHolder() {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        Map<String, Object> params = new HashMap<>();
-        params.put("collection", "critical-infra");
-        params.put("node-id", "42");
-        params.put("location", "Site-A");
-        when(sp.getParameters()).thenReturn((Map) params);
-        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(42, "Site-A");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "critical-infra", holder);
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
         persister.completeCollectionSet(set);
 
         verify(publisher).publish(eq(set), eq("critical-infra"), eq(42), eq("Site-A"));
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    void packageDefaultsToDefaultWhenServiceParameterMissing() {
+    void emptyHolderThrowsIllegalStateExceptionButStillClearsHolder() {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        when(sp.getParameters()).thenReturn(new HashMap<>());
-        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
-        persister.completeCollectionSet(set);
 
-        verify(publisher).publish(eq(set), eq("default"), eq(0), eq(""));
+        assertThatThrownBy(() -> persister.completeCollectionSet(set))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AgentIdentity not populated");
+        verifyNoInteractions(publisher);
+        // idempotent clear — must not throw on already-empty slot:
+        holder.clear();
     }
 
     @Test
-    void nodeIdAndLocationMissingFromParamsFallBackToZeroAndEmpty() {
+    void holderWithZeroNodeIdThrowsAndClearsHolder() {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        Map<String, Object> params = new HashMap<>();
-        params.put("collection", "default");
-        when(sp.getParameters()).thenReturn((Map) params);
-        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(0, "Default");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
-        persister.completeCollectionSet(set);
 
-        verify(publisher).publish(eq(set), eq("default"), eq(0), eq(""));
+        assertThatThrownBy(() -> persister.completeCollectionSet(set))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("nodeId must be > 0, got 0");
+        verifyNoInteractions(publisher);
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    void malformedNodeIdParsesToZeroFallback() {
+    void holderWithNegativeNodeIdThrowsWithActualValueInMessage() {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        Map<String, Object> params = new HashMap<>();
-        params.put("collection", "default");
-        params.put("node-id", "not-a-number");
-        params.put("location", "Default");
-        when(sp.getParameters()).thenReturn((Map) params);
-        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(-5, "Default");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
+
+        assertThatThrownBy(() -> persister.completeCollectionSet(set))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("got -5");
+    }
+
+    @Test
+    void completeCollectionSetWithoutVisitDoesNothingButStillClearsHolder() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(7, "X");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
+
+        CollectionSet set = mock(CollectionSet.class);
         persister.completeCollectionSet(set);
 
-        verify(publisher).publish(eq(set), eq("default"), eq(0), eq("Default"));
+        verifyNoInteractions(publisher);
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void visitResourceVisitGroupVisitAttributeAreNoOps() {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        when(sp.getParameters()).thenReturn(new HashMap<>());
-        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
 
-        persister.visitResource(mock(org.opennms.netmgt.collection.api.CollectionResource.class));
-        persister.visitGroup(mock(org.opennms.netmgt.collection.api.AttributeGroup.class));
-        persister.visitAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
-        persister.completeAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
-        persister.completeGroup(mock(org.opennms.netmgt.collection.api.AttributeGroup.class));
-        persister.completeResource(mock(org.opennms.netmgt.collection.api.CollectionResource.class));
+        persister.visitResource(mock(CollectionResource.class));
+        persister.visitGroup(mock(AttributeGroup.class));
+        persister.visitAttribute(mock(CollectionAttribute.class));
+        persister.completeAttribute(mock(CollectionAttribute.class));
+        persister.completeGroup(mock(AttributeGroup.class));
+        persister.completeResource(mock(CollectionResource.class));
 
         verifyNoInteractions(publisher);
     }
@@ -117,12 +135,12 @@ class TimeseriesKafkaPersisterTest {
     @Test
     void persistNumericAttributeAndPersistStringAttributeAreNoOps() {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
-        ServiceParameters sp = mock(ServiceParameters.class);
-        when(sp.getParameters()).thenReturn(new HashMap<>());
-        TimeseriesKafkaPersister persister = new TimeseriesKafkaPersister(publisher, sp);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
 
-        persister.persistNumericAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
-        persister.persistStringAttribute(mock(org.opennms.netmgt.collection.api.CollectionAttribute.class));
+        persister.persistNumericAttribute(mock(CollectionAttribute.class));
+        persister.persistStringAttribute(mock(CollectionAttribute.class));
 
         verifyNoInteractions(publisher);
     }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
@@ -16,7 +16,6 @@
  */
 package org.deltav.collectd.timeseries;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java
@@ -18,6 +18,8 @@ package org.deltav.collectd.timeseries;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient;
+import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -67,5 +69,20 @@ class TimeseriesPublisherFeatureFlagOffIT {
     @Test
     void newTopicBeansAreAbsentWhenFlagOff() {
         assertThat(ctx.getBeanNamesForType(org.apache.kafka.clients.admin.NewTopic.class)).isEmpty();
+    }
+
+    @Test
+    void agentIdentityCapturingClientBeanIsAbsentWhenFlagOff() {
+        // Feature-flag off ⇒ decorator not registered ⇒ horizon's raw
+        // LocationAwareCollectorClient wins. This test doesn't try to resolve
+        // LocationAwareCollectorClient directly (the CollectdRpcConfiguration
+        // bean isn't on this minimal test's classpath) — it just asserts the
+        // decorator type is not instantiated.
+        assertThat(ctx.getBeanNamesForType(AgentIdentityCapturingCollectorClient.class)).isEmpty();
+    }
+
+    @Test
+    void agentIdentityHolderBeanIsAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(AgentIdentityHolder.class)).isEmpty();
     }
 }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherStreamBinderIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherStreamBinderIT.java
@@ -135,5 +135,16 @@ class TimeseriesPublisherStreamBinderIT {
         PersisterFactory stubInnerFactory() {
             return mock(PersisterFactory.class);
         }
+
+        /**
+         * The @Primary decorator bean in TimeseriesKafkaPublisherConfiguration
+         * requires a @Qualifier("locationAwareCollectorClient") delegate. The real
+         * bean is registered by CollectdRpcConfiguration which is not on this
+         * minimal test classpath, so provide a stub.
+         */
+        @Bean(name = "locationAwareCollectorClient")
+        org.opennms.netmgt.collection.api.LocationAwareCollectorClient stubCollectorClient() {
+            return mock(org.opennms.netmgt.collection.api.LocationAwareCollectorClient.class);
+        }
     }
 }

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/netmgt/collectd/boot/CollectdApplicationScanIT.java
@@ -134,7 +134,13 @@ class CollectdApplicationScanIT {
 
     // ---- Collection agent / RPC client chain ----
     @MockitoBean ServiceCollectorRegistry serviceCollectorRegistry;
-    @MockitoBean LocationAwareCollectorClient locationAwareCollectorClient;
+    // Explicit bean names below: the M2 decorator registers a @Primary
+    // AgentIdentityCapturingCollectorClient bean, so without explicit names,
+    // @MockitoBean's type-based matching replaces the @Primary decorator and
+    // leaves horizon's real bean to instantiate (failing on @Autowired
+    // RpcTargetHelper since opennms.rpc.kafka.enabled=false in this test).
+    @MockitoBean(name = "locationAwareCollectorClient") LocationAwareCollectorClient locationAwareCollectorClient;
+    @MockitoBean(name = "agentIdentityCapturingCollectorClient") LocationAwareCollectorClient agentIdentityCapturingCollectorClient;
     @MockitoBean RpcClientFactory rpcClientFactory;
     @MockitoBean EntityScopeProvider entityScopeProvider;
 

--- a/docs/superpowers/plans/2026-04-19-m2-collectd-serviceparameters-identity.md
+++ b/docs/superpowers/plans/2026-04-19-m2-collectd-serviceparameters-identity.md
@@ -1,0 +1,1650 @@
+# M2 — Collectd ServiceParameters identity-populate gap
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate Delta-V Collectd's Kafka publisher with real `nodeId` + `location` on every collection cycle, and fail loudly at publish time if identity is missing, so Phase 2 Prometheus Remote Write E2E passes end-to-end for the first time.
+
+**Architecture:** Insert a Spring-managed `@Primary` decorator around horizon's `LocationAwareCollectorClient`. At every RPC dispatch the decorator captures `(nodeId, location)` into a `ThreadLocal`-backed `AgentIdentityHolder`. The existing `TimeseriesKafkaPersister` reads the holder at `completeCollectionSet()` time (same scheduler thread, synchronous), validates `nodeId > 0`, publishes, and clears the holder in a `try/finally`. No horizon modifications.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.3 (Spring 7.0), JUnit 5 Jupiter, Mockito, AssertJ, Maven 3.9.14 (via `./mvnw`), horizon 1.0.10 jars, Spring Cloud Stream Kafka binder (existing), SLF4J.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-19-m2-collectd-serviceparameters-identity-design.md`
+
+---
+
+## File map
+
+All paths below are relative to the repo root `/Users/david/development/src/opennms/delta-v/`.
+
+### Create
+
+| Path | Responsibility |
+|---|---|
+| `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentity.java` | Immutable `record(int nodeId, String location)`. Compact constructor normalizes null location to `""`. No nodeId validation. |
+| `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java` | `ThreadLocal<AgentIdentity>` wrapper with `set`, `getOrThrow`, `clear`. |
+| `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClient.java` | `@Primary` decorator implementing `LocationAwareCollectorClient`. Also contains the package-private nested `AgentIdentityCapturingCollectorRequestBuilder`. |
+| `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityTest.java` | Record behavior: null/empty location handling, equality. |
+| `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityHolderTest.java` | Set / get / clear / thread-isolation / overwrite semantics. |
+| `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorRequestBuilderTest.java` | execute() sets holder, withXxx delegates, builder contract. |
+| `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClientTest.java` | collect() returns decorated builder; other methods (none in this interface) — effectively a smoke test. |
+| `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/AgentIdentityWiringIT.java` | Spring-context IT asserting decorator bean resolution and end-to-end holder capture. |
+
+### Modify
+
+| Path | Change |
+|---|---|
+| `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java` | New constructor `(TimeseriesKafkaPublisher, String, AgentIdentityHolder)`. `parseIntOrZero`/`asString` deleted. `completeCollectionSet` rewritten with try/finally. |
+| `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java` | Add `agentIdentityHolder` `@Bean`. Add `@Primary` decorator `@Bean`. Update `compositePersisterFactory` signature and `FanoutPersisterFactory` constructor to thread the holder. |
+| `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java` | Rewrite: holder-based tests replace ServiceParameters-based tests. |
+| `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java` | One new test: decorator bean absent when flag off. |
+
+---
+
+## Phase 1 — Identity primitives
+
+No dependencies on existing files. Each task creates source + test together (TDD). Safe to commit after each task.
+
+### Task 1.1 — `AgentIdentity` record
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentity.java`
+- Test: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+// core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityTest.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AgentIdentityTest {
+
+    @Test
+    void nullLocationNormalizesToEmptyString() {
+        AgentIdentity id = new AgentIdentity(42, null);
+        assertThat(id.nodeId()).isEqualTo(42);
+        assertThat(id.location()).isEqualTo("");
+    }
+
+    @Test
+    void nonNullLocationPassesThrough() {
+        AgentIdentity id = new AgentIdentity(7, "Site-A");
+        assertThat(id.location()).isEqualTo("Site-A");
+    }
+
+    @Test
+    void emptyStringLocationPreserved() {
+        AgentIdentity id = new AgentIdentity(1, "");
+        assertThat(id.location()).isEqualTo("");
+    }
+
+    @Test
+    void zeroNodeIdAccepted() {
+        // No validation at record construction — persist-time check handles it.
+        AgentIdentity id = new AgentIdentity(0, "Default");
+        assertThat(id.nodeId()).isZero();
+    }
+
+    @Test
+    void negativeNodeIdAccepted() {
+        AgentIdentity id = new AgentIdentity(-5, "Default");
+        assertThat(id.nodeId()).isEqualTo(-5);
+    }
+
+    @Test
+    void recordEqualityOnBothFields() {
+        assertThat(new AgentIdentity(3, "X")).isEqualTo(new AgentIdentity(3, "X"));
+        assertThat(new AgentIdentity(3, "X")).isNotEqualTo(new AgentIdentity(4, "X"));
+        assertThat(new AgentIdentity(3, "X")).isNotEqualTo(new AgentIdentity(3, "Y"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (record class does not exist)**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dtest=AgentIdentityTest test`
+Expected: compilation failure — `AgentIdentity` cannot be resolved.
+
+- [ ] **Step 3: Write the record**
+
+```java
+// core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentity.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+/**
+ * Immutable agent identity captured from a {@code CollectionAgent} at RPC
+ * dispatch time and consumed by {@code TimeseriesKafkaPersister} at publish
+ * time.
+ *
+ * <p>Validation of {@code nodeId} is intentionally deferred to the persist
+ * site (persist-time-only fail-fast): the record accepts any int so capture
+ * never aborts a collection cycle. A {@code nodeId <= 0} surfaces as a
+ * publisher-side {@code IllegalStateException} caught by
+ * {@code FanoutPersister}, which increments the kafka failures counter.</p>
+ *
+ * <p>{@code location} is normalized to the empty string when null — Default
+ * location setups sometimes return {@code null}. Downstream code may assume
+ * non-null.</p>
+ */
+public record AgentIdentity(int nodeId, String location) {
+    public AgentIdentity {
+        if (location == null) {
+            location = "";
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dtest=AgentIdentityTest test`
+Expected: `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentity.java \
+        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityTest.java
+git commit -m "feat(collectd): add AgentIdentity record for per-cycle identity capture"
+```
+
+---
+
+### Task 1.2 — `AgentIdentityHolder` ThreadLocal
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java`
+- Test: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityHolderTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+// core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityHolderTest.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+class AgentIdentityHolderTest {
+
+    @Test
+    void setThenGetOrThrowReturnsIdentity() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(42, "Site-A");
+
+        AgentIdentity id = holder.getOrThrow();
+        assertThat(id.nodeId()).isEqualTo(42);
+        assertThat(id.location()).isEqualTo("Site-A");
+    }
+
+    @Test
+    void getOrThrowOnEmptyHolderThrowsIllegalStateException() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+
+        assertThatThrownBy(holder::getOrThrow)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AgentIdentity not populated");
+    }
+
+    @Test
+    void clearRemovesPreviousValue() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(1, "X");
+        holder.clear();
+
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void clearIsIdempotent() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.clear();      // no prior set — must not throw
+        holder.clear();      // second call — must not throw
+    }
+
+    @Test
+    void setWithNullLocationNormalizesToEmpty() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(3, null);
+        assertThat(holder.getOrThrow().location()).isEqualTo("");
+    }
+
+    @Test
+    void doubleSetOverwritesSilently() {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(1, "First");
+        holder.set(2, "Second");
+        AgentIdentity id = holder.getOrThrow();
+        assertThat(id.nodeId()).isEqualTo(2);
+        assertThat(id.location()).isEqualTo("Second");
+    }
+
+    @Test
+    void threadIsolationOtherThreadCannotSeeValue() throws InterruptedException {
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(99, "MainThread");
+
+        AtomicReference<Throwable> otherThreadError = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                holder.getOrThrow();
+            } catch (Throwable e) {
+                otherThreadError.set(e);
+            }
+        });
+        t.start();
+        t.join();
+
+        assertThat(otherThreadError.get()).isInstanceOf(IllegalStateException.class);
+        // Main thread's value still intact:
+        assertThat(holder.getOrThrow().nodeId()).isEqualTo(99);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dtest=AgentIdentityHolderTest test`
+Expected: compilation failure — `AgentIdentityHolder` cannot be resolved.
+
+- [ ] **Step 3: Write the holder**
+
+```java
+// core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+/**
+ * ThreadLocal-backed holder for {@link AgentIdentity} captured by
+ * {@code AgentIdentityCapturingCollectorClient} before RPC dispatch and
+ * consumed by {@code TimeseriesKafkaPersister} at publish time.
+ *
+ * <p>Contract invariants:</p>
+ * <ul>
+ *   <li>{@link #set(int, String)} is unconditional overwrite — no throw on
+ *       "already set". This is the sole protection against thread reuse with
+ *       stale identity between cycles on the same scheduler thread.</li>
+ *   <li>{@link #getOrThrow()} throws {@link IllegalStateException} with a
+ *       diagnostic message when the slot is empty; a stack trace at the
+ *       persister's {@code completeCollectionSet} means the decorator is not
+ *       wired or the persister was invoked off-cycle.</li>
+ *   <li>{@link #clear()} is idempotent ({@code ThreadLocal.remove()} on an
+ *       empty slot is a no-op).</li>
+ * </ul>
+ *
+ * <p>Scoped to a single {@code CollectableService.doCollection()} cycle,
+ * which horizon runs synchronously on one scheduler thread. The decorator
+ * sets on {@code execute()}; the persister reads in {@code completeCollectionSet}
+ * and clears in the outer {@code finally} of that method.</p>
+ */
+public class AgentIdentityHolder {
+
+    private final ThreadLocal<AgentIdentity> current = new ThreadLocal<>();
+
+    public void set(int nodeId, String location) {
+        current.set(new AgentIdentity(nodeId, location));
+    }
+
+    public AgentIdentity getOrThrow() {
+        AgentIdentity id = current.get();
+        if (id == null) {
+            throw new IllegalStateException(
+                    "AgentIdentity not populated — LocationAwareCollectorClient decorator not wired?");
+        }
+        return id;
+    }
+
+    public void clear() {
+        current.remove();
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dtest=AgentIdentityHolderTest test`
+Expected: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityHolder.java \
+        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityHolderTest.java
+git commit -m "feat(collectd): add AgentIdentityHolder ThreadLocal for per-cycle identity"
+```
+
+---
+
+## Phase 2 — Decorator
+
+### Task 2.1 — `AgentIdentityCapturingCollectorClient` (and nested builder)
+
+Builder + client live in the same file because the builder is the inner collaborator of the client and must only be constructable from within the client (enforced by `static` nested visibility). Two test classes exercise them separately.
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClient.java`
+- Test: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorRequestBuilderTest.java`
+- Test: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClientTest.java`
+
+- [ ] **Step 1: Write the failing builder test**
+
+```java
+// core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorRequestBuilderTest.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.ServiceCollector;
+
+class AgentIdentityCapturingCollectorRequestBuilderTest {
+
+    @Test
+    void withAgentThenExecuteSetsHolderAndDelegates() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        CompletableFuture<CollectionSet> future = new CompletableFuture<>();
+        when(delegate.execute()).thenReturn(future);
+        when(delegate.withAgent(any())).thenReturn(delegate);
+
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(42);
+        when(agent.getLocationName()).thenReturn("Site-A");
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        CompletableFuture<CollectionSet> result = builder.withAgent(agent).execute();
+
+        assertThat(result).isSameAs(future);
+        assertThat(holder.getOrThrow().nodeId()).isEqualTo(42);
+        assertThat(holder.getOrThrow().location()).isEqualTo("Site-A");
+        verify(delegate).withAgent(agent);
+        verify(delegate).execute();
+    }
+
+    @Test
+    void executeWithoutAgentDoesNotSetHolderButStillDelegates() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.execute();
+
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
+        verify(delegate).execute();
+    }
+
+    @Test
+    void agentWithZeroNodeIdCapturedAsIs() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.withAgent(any())).thenReturn(delegate);
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(0);
+        when(agent.getLocationName()).thenReturn("Default");
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.withAgent(agent).execute();
+
+        assertThat(holder.getOrThrow().nodeId()).isZero();
+        assertThat(holder.getOrThrow().location()).isEqualTo("Default");
+    }
+
+    @Test
+    void agentWithNullLocationCapturedAsEmptyString() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.withAgent(any())).thenReturn(delegate);
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(5);
+        when(agent.getLocationName()).thenReturn(null);
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.withAgent(agent).execute();
+
+        assertThat(holder.getOrThrow().nodeId()).isEqualTo(5);
+        assertThat(holder.getOrThrow().location()).isEqualTo("");
+    }
+
+    @Test
+    void withXxxMethodsReturnThisAndDelegate() {
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        when(delegate.withSystemId("sys")).thenReturn(delegate);
+        when(delegate.withCollector(any())).thenReturn(delegate);
+        when(delegate.withCollectorClassName("class")).thenReturn(delegate);
+        when(delegate.withTimeToLive(1000L)).thenReturn(delegate);
+        when(delegate.withAttribute("k", "v")).thenReturn(delegate);
+        when(delegate.withAttributes(Map.of("a", "b"))).thenReturn(delegate);
+
+        ServiceCollector svc = mock(ServiceCollector.class);
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+
+        assertThat(builder.withSystemId("sys")).isSameAs(builder);
+        assertThat(builder.withCollector(svc)).isSameAs(builder);
+        assertThat(builder.withCollectorClassName("class")).isSameAs(builder);
+        assertThat(builder.withTimeToLive(1000L)).isSameAs(builder);
+        assertThat(builder.withAttribute("k", "v")).isSameAs(builder);
+        assertThat(builder.withAttributes(Map.of("a", "b"))).isSameAs(builder);
+
+        verify(delegate).withSystemId("sys");
+        verify(delegate).withCollector(svc);
+        verify(delegate).withCollectorClassName("class");
+        verify(delegate).withTimeToLive(1000L);
+        verify(delegate).withAttribute("k", "v");
+        verify(delegate).withAttributes(Map.of("a", "b"));
+    }
+
+    @Test
+    void executeDoesNotInteractWithHolderIfAgentNeverSet() {
+        // Verifies the no-agent path uses no ThreadLocal state at all.
+        CollectorRequestBuilder delegate = mock(CollectorRequestBuilder.class);
+        AgentIdentityHolder holder = mock(AgentIdentityHolder.class);
+        when(delegate.execute()).thenReturn(new CompletableFuture<>());
+
+        AgentIdentityCapturingCollectorClient.CapturingBuilder builder =
+                new AgentIdentityCapturingCollectorClient.CapturingBuilder(delegate, holder);
+        builder.execute();
+
+        verifyNoInteractions(holder);
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing client test**
+
+```java
+// core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClientTest.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+
+class AgentIdentityCapturingCollectorClientTest {
+
+    @Test
+    void collectDelegatesAndReturnsCapturingBuilder() {
+        LocationAwareCollectorClient inner = mock(LocationAwareCollectorClient.class);
+        CollectorRequestBuilder innerBuilder = mock(CollectorRequestBuilder.class);
+        when(inner.collect()).thenReturn(innerBuilder);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+
+        AgentIdentityCapturingCollectorClient client =
+                new AgentIdentityCapturingCollectorClient(inner, holder);
+
+        CollectorRequestBuilder result = client.collect();
+
+        assertThat(result).isInstanceOf(AgentIdentityCapturingCollectorClient.CapturingBuilder.class);
+        verify(inner).collect();
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dtest="AgentIdentityCapturing*Test" test`
+Expected: compilation failure — `AgentIdentityCapturingCollectorClient` cannot be resolved.
+
+- [ ] **Step 4: Write the client + nested builder**
+
+```java
+// core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClient.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.identity;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+import org.opennms.netmgt.collection.api.ServiceCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Spring {@code @Primary} decorator over horizon's
+ * {@link LocationAwareCollectorClient}. Returns a {@link CapturingBuilder} from
+ * {@link #collect()}; that builder captures the {@link CollectionAgent}'s
+ * {@code nodeId} and {@code locationName} into an {@link AgentIdentityHolder}
+ * just before the real RPC dispatches, so {@code TimeseriesKafkaPersister}
+ * (constructed later in the same synchronous {@code doCollection()} cycle)
+ * can read them.
+ */
+public class AgentIdentityCapturingCollectorClient implements LocationAwareCollectorClient {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AgentIdentityCapturingCollectorClient.class);
+
+    private final LocationAwareCollectorClient delegate;
+    private final AgentIdentityHolder holder;
+
+    public AgentIdentityCapturingCollectorClient(LocationAwareCollectorClient delegate,
+                                                 AgentIdentityHolder holder) {
+        this.delegate = delegate;
+        this.holder = holder;
+        LOG.info("Wrapping LocationAwareCollectorClient for identity capture; delegate = {}",
+                delegate.getClass().getName());
+    }
+
+    @Override
+    public CollectorRequestBuilder collect() {
+        return new CapturingBuilder(delegate.collect(), holder);
+    }
+
+    /**
+     * Delegating {@link CollectorRequestBuilder} that records
+     * {@link AgentIdentity} into the holder at {@link #execute()} time.
+     *
+     * <p>Package-private so tests can construct it directly; the only
+     * production construction site is {@link #collect()} on the outer class.</p>
+     */
+    static final class CapturingBuilder implements CollectorRequestBuilder {
+
+        private final CollectorRequestBuilder delegate;
+        private final AgentIdentityHolder holder;
+        private CollectionAgent agent;
+
+        CapturingBuilder(CollectorRequestBuilder delegate, AgentIdentityHolder holder) {
+            this.delegate = delegate;
+            this.holder = holder;
+        }
+
+        @Override
+        public CollectorRequestBuilder withAgent(CollectionAgent agent) {
+            this.agent = agent;
+            delegate.withAgent(agent);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withSystemId(String systemId) {
+            delegate.withSystemId(systemId);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withCollector(ServiceCollector collector) {
+            delegate.withCollector(collector);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withCollectorClassName(String className) {
+            delegate.withCollectorClassName(className);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withTimeToLive(Long ttlInMs) {
+            delegate.withTimeToLive(ttlInMs);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withAttribute(String key, Object value) {
+            delegate.withAttribute(key, value);
+            return this;
+        }
+
+        @Override
+        public CollectorRequestBuilder withAttributes(Map<String, Object> attributes) {
+            delegate.withAttributes(attributes);
+            return this;
+        }
+
+        @Override
+        public CompletableFuture<CollectionSet> execute() {
+            if (agent != null) {
+                holder.set(agent.getNodeId(), agent.getLocationName());
+            }
+            return delegate.execute();
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dtest="AgentIdentityCapturing*Test" test`
+Expected: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0` across the two test classes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClient.java \
+        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorRequestBuilderTest.java \
+        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/AgentIdentityCapturingCollectorClientTest.java
+git commit -m "feat(collectd): add AgentIdentityCapturingCollectorClient decorator"
+```
+
+---
+
+## Phase 3 — Persister + Factory refactor (atomic)
+
+This phase breaks the tree temporarily: changing `TimeseriesKafkaPersister`'s constructor breaks `FanoutPersisterFactory`'s `createPersister` calls and the `compositePersisterFactory` `@Bean` method. The commit must land all four source changes plus the test rewrite together.
+
+### Task 3.1 — Add `agentIdentityHolder` `@Bean` (standalone, no breakage)
+
+Landing this first means Phase 3.2's refactor can reference the bean without conflict.
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Add the bean method**
+
+In `TimeseriesKafkaPublisherConfiguration.java`, after the existing `import` block add:
+
+```java
+import org.deltav.collectd.identity.AgentIdentityHolder;
+```
+
+After the `collectionSetToProtobufTranslator()` `@Bean` method, insert:
+
+```java
+    /**
+     * Per-scheduler-thread holder for the {@code nodeId} + {@code location}
+     * of the {@code CollectionAgent} currently being collected. Populated by
+     * {@link org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient}
+     * at RPC dispatch and read by {@link TimeseriesKafkaPersister} at publish time.
+     */
+    @Bean
+    public AgentIdentityHolder agentIdentityHolder() {
+        return new AgentIdentityHolder();
+    }
+```
+
+- [ ] **Step 2: Run module verify (nothing else changed yet — should still be green)**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -DskipITs verify`
+Expected: `BUILD SUCCESS`. Unit tests pass (including the two Phase 1 tests already committed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+git commit -m "feat(collectd): register AgentIdentityHolder Spring bean"
+```
+
+---
+
+### Task 3.2 — Refactor persister + factory + test (single commit)
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java`
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+- Modify: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java`
+
+- [ ] **Step 1: Rewrite `TimeseriesKafkaPersisterTest.java`** (failing — constructor signature doesn't exist yet)
+
+Replace the entire file with:
+
+```java
+// core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.deltav.collectd.identity.AgentIdentityHolder;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+
+class TimeseriesKafkaPersisterTest {
+
+    @Test
+    void populatedHolderCausesPublishWithCapturedIdentityAndClearsHolder() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(42, "Site-A");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "critical-infra", holder);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+        persister.completeCollectionSet(set);
+
+        verify(publisher).publish(eq(set), eq("critical-infra"), eq(42), eq("Site-A"));
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void emptyHolderThrowsIllegalStateExceptionButStillClearsHolder() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+
+        assertThatThrownBy(() -> persister.completeCollectionSet(set))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AgentIdentity not populated");
+        verifyNoInteractions(publisher);
+        // idempotent clear — must not throw on already-empty slot:
+        holder.clear();
+    }
+
+    @Test
+    void holderWithZeroNodeIdThrowsAndClearsHolder() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(0, "Default");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+
+        assertThatThrownBy(() -> persister.completeCollectionSet(set))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("nodeId must be > 0, got 0");
+        verifyNoInteractions(publisher);
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void holderWithNegativeNodeIdThrowsWithActualValueInMessage() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(-5, "Default");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.visitCollectionSet(set);
+
+        assertThatThrownBy(() -> persister.completeCollectionSet(set))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("got -5");
+    }
+
+    @Test
+    void completeCollectionSetWithoutVisitDoesNothingButStillClearsHolder() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        holder.set(7, "X");
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
+
+        CollectionSet set = mock(CollectionSet.class);
+        persister.completeCollectionSet(set);
+
+        verifyNoInteractions(publisher);
+        assertThatThrownBy(holder::getOrThrow).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void visitResourceVisitGroupVisitAttributeAreNoOps() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
+
+        persister.visitResource(mock(CollectionResource.class));
+        persister.visitGroup(mock(AttributeGroup.class));
+        persister.visitAttribute(mock(CollectionAttribute.class));
+        persister.completeAttribute(mock(CollectionAttribute.class));
+        persister.completeGroup(mock(AttributeGroup.class));
+        persister.completeResource(mock(CollectionResource.class));
+
+        verifyNoInteractions(publisher);
+    }
+
+    @Test
+    void persistNumericAttributeAndPersistStringAttributeAreNoOps() {
+        TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
+        AgentIdentityHolder holder = new AgentIdentityHolder();
+        TimeseriesKafkaPersister persister =
+                new TimeseriesKafkaPersister(publisher, "default", holder);
+
+        persister.persistNumericAttribute(mock(CollectionAttribute.class));
+        persister.persistStringAttribute(mock(CollectionAttribute.class));
+
+        verifyNoInteractions(publisher);
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `TimeseriesKafkaPersister.java`**
+
+Replace the entire file with:
+
+```java
+// core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import org.deltav.collectd.identity.AgentIdentity;
+import org.deltav.collectd.identity.AgentIdentityHolder;
+import org.opennms.netmgt.collection.api.AttributeGroup;
+import org.opennms.netmgt.collection.api.CollectionAttribute;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.Persister;
+
+/**
+ * Thin horizon {@link Persister} adapter that hands every {@link CollectionSet}
+ * to the shared {@link TimeseriesKafkaPublisher} once, at
+ * {@link #completeCollectionSet(CollectionSet)}. All per-attribute callbacks
+ * are no-ops — the translator does its own walk.
+ *
+ * <p>Identity ({@code nodeId} + {@code location}) is captured by
+ * {@code AgentIdentityCapturingCollectorClient} before each RPC dispatch and
+ * read from the injected {@link AgentIdentityHolder} at publish time. If the
+ * holder is empty (decorator not wired) or {@code nodeId <= 0}, this persister
+ * throws {@link IllegalStateException}; {@code FanoutPersister} catches it,
+ * increments {@code deltav.collectd.persister.kafka.failures{step=completeCollectionSet}},
+ * and logs WARN. The inner persister path is unaffected.</p>
+ *
+ * <p>{@code collectionPackage} is extracted once by
+ * {@code FanoutPersisterFactory.createPersister} from the horizon
+ * {@code ServiceParameters} and passed as an explicit constructor argument.</p>
+ */
+public class TimeseriesKafkaPersister implements Persister {
+
+    private final TimeseriesKafkaPublisher publisher;
+    private final String collectionPackage;
+    private final AgentIdentityHolder holder;
+    private CollectionSet capturedSet;
+
+    public TimeseriesKafkaPersister(TimeseriesKafkaPublisher publisher,
+                                     String collectionPackage,
+                                     AgentIdentityHolder holder) {
+        this.publisher = publisher;
+        this.collectionPackage = collectionPackage;
+        this.holder = holder;
+    }
+
+    @Override
+    public void visitCollectionSet(CollectionSet set) {
+        this.capturedSet = set;
+    }
+
+    @Override
+    public void visitResource(CollectionResource resource) { /* no-op */ }
+
+    @Override
+    public void visitGroup(AttributeGroup group) { /* no-op */ }
+
+    @Override
+    public void visitAttribute(CollectionAttribute attribute) { /* no-op */ }
+
+    @Override
+    public void completeAttribute(CollectionAttribute attribute) { /* no-op */ }
+
+    @Override
+    public void completeGroup(AttributeGroup group) { /* no-op */ }
+
+    @Override
+    public void completeResource(CollectionResource resource) { /* no-op */ }
+
+    @Override
+    public void completeCollectionSet(CollectionSet set) {
+        try {
+            if (capturedSet != null) {
+                AgentIdentity identity = holder.getOrThrow();
+                if (identity.nodeId() <= 0) {
+                    throw new IllegalStateException(
+                            "Invalid agent identity for Kafka publish: nodeId must be > 0, got "
+                                    + identity.nodeId());
+                }
+                publisher.publish(capturedSet, collectionPackage,
+                        identity.nodeId(), identity.location());
+            }
+        } finally {
+            holder.clear();
+            capturedSet = null;
+        }
+    }
+
+    @Override
+    public void persistNumericAttribute(CollectionAttribute attribute) { /* no-op */ }
+
+    @Override
+    public void persistStringAttribute(CollectionAttribute attribute) { /* no-op */ }
+}
+```
+
+- [ ] **Step 3: Update `TimeseriesKafkaPublisherConfiguration.java`'s `FanoutPersisterFactory` and `compositePersisterFactory` `@Bean`**
+
+Find the `compositePersisterFactory` `@Bean` method and replace the whole method plus the nested `FanoutPersisterFactory` class with:
+
+```java
+    /**
+     * Composite factory that fans out each createPersister() call to both the
+     * existing InMemoryStorage-backed TimeseriesPersisterFactory and a fresh
+     * TimeseriesKafkaPersister. Declared @Primary so Collectd's constructor
+     * resolves to this bean when the feature flag is on.
+     */
+    @Bean
+    @Primary
+    public PersisterFactory compositePersisterFactory(
+            @Qualifier("timeseriesPersisterFactory") PersisterFactory innerFactory,
+            TimeseriesKafkaPublisher publisher,
+            AgentIdentityHolder agentIdentityHolder,
+            MeterRegistry meterRegistry,
+            @Value("${deltav.collectd.persister.inner.fail-fast:false}") boolean failFastInner,
+            @Value("${deltav.collectd.persister.kafka.fail-fast:false}") boolean failFastKafka) {
+        LOG.info("Creating compositePersisterFactory wrapping inner={}@{} (failFastInner={}, failFastKafka={})",
+                innerFactory.getClass().getName(),
+                System.identityHashCode(innerFactory),
+                failFastInner, failFastKafka);
+        return new FanoutPersisterFactory(innerFactory, publisher, agentIdentityHolder, meterRegistry,
+                failFastInner, failFastKafka);
+    }
+
+    /**
+     * Package-private composite factory. Kept as a static nested class so the
+     * public API of this module remains the four files listed in the spec.
+     */
+    static final class FanoutPersisterFactory implements PersisterFactory {
+        private final PersisterFactory innerFactory;
+        private final TimeseriesKafkaPublisher publisher;
+        private final AgentIdentityHolder holder;
+        private final MeterRegistry meterRegistry;
+        private final boolean failFastInner;
+        private final boolean failFastKafka;
+
+        FanoutPersisterFactory(PersisterFactory innerFactory, TimeseriesKafkaPublisher publisher,
+                               AgentIdentityHolder holder,
+                               MeterRegistry meterRegistry,
+                               boolean failFastInner, boolean failFastKafka) {
+            this.innerFactory = innerFactory;
+            this.publisher = publisher;
+            this.holder = holder;
+            this.meterRegistry = meterRegistry;
+            this.failFastInner = failFastInner;
+            this.failFastKafka = failFastKafka;
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository),
+                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder),
+                    meterRegistry, failFastInner, failFastKafka);
+        }
+
+        @Override
+        public Persister createPersister(ServiceParameters params, RrdRepository repository,
+                                         boolean dontPersistCounters, boolean forceStoreByGroup,
+                                         boolean dontReorderAttributes) {
+            return new FanoutPersister(
+                    innerFactory.createPersister(params, repository, dontPersistCounters,
+                            forceStoreByGroup, dontReorderAttributes),
+                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder),
+                    meterRegistry, failFastInner, failFastKafka);
+        }
+
+        private static String extractCollection(ServiceParameters params) {
+            Object raw = params.getParameters().get("collection");
+            return raw == null ? "default" : raw.toString();
+        }
+    }
+```
+
+- [ ] **Step 4: Run the persister unit tests to verify they pass**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dtest=TimeseriesKafkaPersisterTest test`
+Expected: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`.
+
+- [ ] **Step 5: Run the full module verify (all unit tests + existing ITs)**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -DskipITs verify`
+Expected: `BUILD SUCCESS`. All unit tests pass. ITs are skipped.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java \
+        core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java \
+        core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
+git commit -m "$(cat <<'EOF'
+refactor(collectd): TimeseriesKafkaPersister reads identity from holder
+
+Constructor becomes (publisher, collectionPackage, holder). The persister
+validates nodeId > 0 at completeCollectionSet time; an empty holder or
+invalid identity throws IllegalStateException caught by FanoutPersister.
+ServiceParameters-based parseIntOrZero defaults removed — identity now
+flows from AgentIdentityCapturingCollectorClient via ThreadLocal.
+
+FanoutPersisterFactory threads the AgentIdentityHolder through to each
+constructed persister and extracts the static "collection" string from
+ServiceParameters once per createPersister call.
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Decorator wiring + feature-flag-off assertion
+
+### Task 4.1 — Register the `@Primary` decorator bean
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+- [ ] **Step 1: Add the decorator bean method**
+
+In `TimeseriesKafkaPublisherConfiguration.java`, add these imports:
+
+```java
+import org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+```
+
+After the `agentIdentityHolder()` `@Bean` method (added in Task 3.1), insert:
+
+```java
+    /**
+     * {@code @Primary} decorator over horizon's {@link LocationAwareCollectorClient}
+     * that captures {@code (nodeId, location)} into {@link AgentIdentityHolder}
+     * before every RPC dispatch, so {@link TimeseriesKafkaPersister} can read
+     * identity at publish time.
+     *
+     * <p>{@code CollectdRpcConfiguration} registers the original bean under the
+     * default name {@code locationAwareCollectorClient}; Spring Boot 4 disables
+     * bean-definition overriding, so the decorator uses a distinct method name
+     * and is made primary. The {@code @Qualifier} on the delegate parameter
+     * selects the horizon bean (not this decorator, which would cause infinite
+     * recursion).</p>
+     */
+    @Bean
+    @Primary
+    public LocationAwareCollectorClient agentIdentityCapturingCollectorClient(
+            @Qualifier("locationAwareCollectorClient") LocationAwareCollectorClient inner,
+            AgentIdentityHolder holder) {
+        return new AgentIdentityCapturingCollectorClient(inner, holder);
+    }
+```
+
+- [ ] **Step 2: Run module verify**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -DskipITs verify`
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+git commit -m "feat(collectd): register @Primary LocationAwareCollectorClient decorator"
+```
+
+---
+
+### Task 4.2 — Extend `TimeseriesPublisherFeatureFlagOffIT`
+
+**Files:**
+- Modify: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java`
+
+- [ ] **Step 1: Add test + import**
+
+Add this import near the top:
+
+```java
+import org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient;
+import org.deltav.collectd.identity.AgentIdentityHolder;
+```
+
+At the bottom of the class, before the closing brace, add:
+
+```java
+    @Test
+    void agentIdentityCapturingClientBeanIsAbsentWhenFlagOff() {
+        // Feature-flag off ⇒ decorator not registered ⇒ horizon's raw
+        // LocationAwareCollectorClient wins. This test doesn't try to resolve
+        // LocationAwareCollectorClient directly (the CollectdRpcConfiguration
+        // bean isn't on this minimal test's classpath) — it just asserts the
+        // decorator type is not instantiated.
+        assertThat(ctx.getBeanNamesForType(AgentIdentityCapturingCollectorClient.class)).isEmpty();
+    }
+
+    @Test
+    void agentIdentityHolderBeanIsAbsentWhenFlagOff() {
+        assertThat(ctx.getBeanNamesForType(AgentIdentityHolder.class)).isEmpty();
+    }
+```
+
+- [ ] **Step 2: Run the IT**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dit.test=TimeseriesPublisherFeatureFlagOffIT verify`
+Expected: all tests pass (3 existing + 2 new = 5).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesPublisherFeatureFlagOffIT.java
+git commit -m "test(collectd): assert identity capture beans absent when feature flag off"
+```
+
+---
+
+## Phase 5 — Spring-wiring integration test
+
+### Task 5.1 — `AgentIdentityWiringIT`
+
+This IT follows the `CollectdApplicationScanIT` pattern but with a narrower scope: it asserts bean resolution and the captureflow. To keep it independent of `CollectdApplication`'s full scan, it uses an `@Import` style similar to `TimeseriesPublisherFeatureFlagOffIT` but with the flag on, and stubs a minimal `LocationAwareCollectorClient` delegate.
+
+**Files:**
+- Create: `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/AgentIdentityWiringIT.java`
+
+- [ ] **Step 1: Write the IT**
+
+```java
+// core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/AgentIdentityWiringIT.java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.deltav.collectd.identity.AgentIdentity;
+import org.deltav.collectd.identity.AgentIdentityCapturingCollectorClient;
+import org.deltav.collectd.identity.AgentIdentityHolder;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.CollectorRequestBuilder;
+import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Spring-wiring integration test asserting that the {@code @Primary}
+ * decorator wins bean resolution for {@link LocationAwareCollectorClient}
+ * and that its {@code execute()} actually populates the
+ * {@link AgentIdentityHolder}.
+ *
+ * <p>Stubs the horizon delegate with a simple test bean named
+ * {@code locationAwareCollectorClient} (the name the decorator's
+ * {@code @Qualifier} expects). Does not start the real
+ * {@link org.deltav.netmgt.collectd.boot.CollectdApplication} — that live
+ * scan is covered by {@code CollectdApplicationScanIT}.</p>
+ */
+@SpringBootTest(classes = {
+        AgentIdentityWiringIT.TestApp.class
+})
+@TestPropertySource(properties = {
+        "deltav.timeseries.enabled=true",
+        "spring.main.web-application-type=none",
+        "spring.main.banner-mode=off"
+})
+class AgentIdentityWiringIT {
+
+    @EnableAutoConfiguration
+    @Import({
+            TimeseriesKafkaPublisherConfiguration.class,
+            TestChannelBinderConfiguration.class
+    })
+    static class TestApp {
+
+        /**
+         * Stub horizon delegate registered under the default name
+         * {@code locationAwareCollectorClient}. The decorator @Qualifier
+         * pulls this bean in as its delegate.
+         */
+        @Bean(name = "locationAwareCollectorClient")
+        LocationAwareCollectorClient innerClient() {
+            LocationAwareCollectorClient inner = mock(LocationAwareCollectorClient.class);
+            CollectorRequestBuilder builder = mock(CollectorRequestBuilder.class);
+            when(inner.collect()).thenReturn(builder);
+            when(builder.withAgent(org.mockito.ArgumentMatchers.any())).thenReturn(builder);
+            when(builder.execute()).thenReturn(new CompletableFuture<>());
+            return inner;
+        }
+
+        /**
+         * {@code TimeseriesKafkaPublisherConfiguration.compositePersisterFactory}
+         * injects a {@code @Qualifier("timeseriesPersisterFactory")}
+         * {@link org.opennms.netmgt.collection.api.PersisterFactory}. In this
+         * narrow IT we don't boot the full JPA/TSS chain that would normally
+         * create it, so we provide a minimal stub.
+         */
+        @Bean(name = "timeseriesPersisterFactory")
+        org.opennms.netmgt.collection.api.PersisterFactory innerPersisterFactory() {
+            return mock(org.opennms.netmgt.collection.api.PersisterFactory.class);
+        }
+    }
+
+    @Autowired
+    ApplicationContext ctx;
+
+    @Autowired
+    LocationAwareCollectorClient injectedClient;
+
+    @Autowired
+    AgentIdentityHolder holder;
+
+    @Test
+    void primaryBeanIsTheCapturingDecorator() {
+        assertThat(injectedClient).isInstanceOf(AgentIdentityCapturingCollectorClient.class);
+    }
+
+    @Test
+    void holderBeanIsPresent() {
+        assertThat(ctx.getBean(AgentIdentityHolder.class)).isSameAs(holder);
+    }
+
+    @Test
+    void decoratorExecuteCapturesAgentIdentity() {
+        CollectionAgent agent = mock(CollectionAgent.class);
+        when(agent.getNodeId()).thenReturn(123);
+        when(agent.getLocationName()).thenReturn("lab-A");
+
+        CompletableFuture<CollectionSet> future =
+                injectedClient.collect().withAgent(agent).execute();
+
+        assertThat(future).isNotNull();
+        AgentIdentity captured = holder.getOrThrow();
+        assertThat(captured.nodeId()).isEqualTo(123);
+        assertThat(captured.location()).isEqualTo("lab-A");
+        holder.clear();   // cleanup — test runs on a shared executor thread
+    }
+}
+```
+
+- [ ] **Step 2: Run the IT**
+
+Run: `./mvnw -pl core/daemon-boot-collectd -Dit.test=AgentIdentityWiringIT verify`
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/AgentIdentityWiringIT.java
+git commit -m "test(collectd): AgentIdentityWiringIT asserts @Primary decorator + holder capture"
+```
+
+---
+
+## Phase 6 — Verification and PR
+
+### Task 6.1 — Module-level green build
+
+- [ ] **Step 1: Full module verify (unit + IT)**
+
+Run: `./mvnw -pl core/daemon-boot-collectd verify`
+Expected: `BUILD SUCCESS`. All unit tests + all ITs pass (including the two new ITs and the existing `CollectdApplicationScanIT` which the decorator should NOT break — that IT mocks `LocationAwareCollectorClient` directly via `@MockitoBean`, which overrides even `@Primary`, so the decorator should simply not be in its bean graph).
+
+If `CollectdApplicationScanIT` fails due to our decorator trying to wrap the mock, investigate immediately — this is a Q2 regression guard. The fix is likely to exclude our decorator bean under the test's property set, or confirm `@MockitoBean` precedence holds. **Do not push a workaround that weakens the production wiring.**
+
+---
+
+### Task 6.2 — Full-reactor verify
+
+Per `feedback_delta_v_full_reactor_verify`: module-only builds can miss sibling-module compilation failures.
+
+- [ ] **Step 1: Full-reactor clean install**
+
+Run: `./mvnw -B -DskipTests -fae clean install`
+Expected: `BUILD SUCCESS`. No unrelated module breakage from the `core/daemon-boot-collectd` changes.
+
+If any sibling module references `TimeseriesKafkaPersister` directly, this catches it (unlikely — that class is daemon-boot-only).
+
+---
+
+### Task 6.3 — Local Phase 2 E2E verification
+
+This is the acceptance gate. Not in CI; run locally before opening the PR.
+
+- [ ] **Step 1: Ensure no leftover delta-v stack**
+
+Run: `docker ps --format '{{.Names}}' | grep -iE "delta|opennms" || echo "clean"`
+Expected: `clean`, or teardown any leftovers with `./opennms-container/delta-v/build.sh down`.
+
+- [ ] **Step 2: Rebuild daemon-boot JARs** (per `feedback_rebuild_all_daemons`: rebuild ALL 12 daemon boots before `build.sh deltav`)
+
+Run: `bash -c './build.sh daemons' &` then `disown`  (per `Env quirk from PR #175` — strict-mode Bash wrapping kills `build.sh` with 255).
+
+Wait for completion (tail the log file produced by the script). Expected: all 12 daemon boot JARs rebuilt, no errors.
+
+- [ ] **Step 3: Bring up the delta-v stack**
+
+Run: `bash -c './opennms-container/delta-v/build.sh deltav' &` then `disown`.
+Wait until all containers are healthy (`docker ps` shows `(healthy)` for each).
+
+- [ ] **Step 4: Run Phase 2 E2E**
+
+Run: `./opennms-container/delta-v/test-prometheus-writer-e2e.sh`
+Expected: exit 0, last line `ALL ASSERTIONS PASSED`.
+
+- [ ] **Step 5: Verify `enrichment_lookup_fallback_total` stayed at 0**
+
+Run:
+```bash
+curl -s http://localhost:<prometheus-writer-port>/actuator/prometheus \
+  | grep enrichment_lookup_fallback_total
+```
+Expected: counter value is 0 (no fallback triggered = Collectd now emits correct location).
+
+Capture the full E2E log tail and the counter curl output — attach to the PR description.
+
+- [ ] **Step 6: Tear down the stack**
+
+Run: `./opennms-container/delta-v/build.sh down`
+Expected: all containers removed.
+
+---
+
+### Task 6.4 — Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin fix/collectd-serviceparameters-identity`
+Expected: branch published on `pbrane/delta-v`.
+
+- [ ] **Step 2: Open the PR** (per `feedback_never_pr_opennms`)
+
+Run:
+```bash
+gh pr create --repo pbrane/delta-v --base develop \
+    --title "fix(collectd): populate ServiceParameters identity via LocationAwareCollectorClient decorator" \
+    --body "$(cat <<'EOF'
+## Summary
+
+- Producer-side fix for Phase 2 E2E blocker: Collectd was publishing every `TimeseriesBatch` record with `nodeId=0 + location=""`, causing every consumer enrichment to miss.
+- Introduces a `@Primary` `LocationAwareCollectorClient` decorator that captures `(nodeId, location)` into a `ThreadLocal`-backed `AgentIdentityHolder` at RPC dispatch. `TimeseriesKafkaPersister` reads the holder at `completeCollectionSet()`, validates `nodeId > 0`, publishes, and clears the holder in a `try/finally`.
+- Persist-time-only fail-fast — a missing or invalid identity throws `IllegalStateException` caught by `FanoutPersister`, incrementing `deltav.collectd.persister.kafka.failures{step=completeCollectionSet}` (alert on `rate > 0`). Inner RRD/Newts persister path is unaffected.
+
+## Acceptance
+
+- `./mvnw -pl core/daemon-boot-collectd verify` — green (unit + IT).
+- `./mvnw -B -DskipTests -fae clean install` — full-reactor green.
+- `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` — **exit 0 with `ALL ASSERTIONS PASSED`** (first successful full Phase 2 E2E).
+- `enrichment_lookup_fallback_total` stayed at 0 throughout the E2E run.
+
+## Test plan
+
+- [ ] CI green on the PR.
+- [ ] Reviewer re-runs `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` locally if they want to independently verify the E2E.
+- [ ] `AgentIdentityWiringIT` asserts `@Primary` resolution and end-to-end capture.
+- [ ] `TimeseriesKafkaPersisterTest` covers populated-holder, empty-holder, `nodeId <= 0`, and no-visit paths.
+- [ ] `TimeseriesPublisherFeatureFlagOffIT` asserts both new beans are absent when `deltav.timeseries.enabled=false`.
+
+## Design
+
+- Spec: `docs/superpowers/specs/2026-04-19-m2-collectd-serviceparameters-identity-design.md`
+- Plan: `docs/superpowers/plans/2026-04-19-m2-collectd-serviceparameters-identity.md`
+
+## Memory updates (post-merge)
+
+- `project_collectd_serviceparameters_identity_gap` — flip status OPEN → RESOLVED (delta-v#<PR>).
+- `project_phase2_prometheus_writer_done` — addendum: "E2E passes end-to-end as of delta-v#<PR>."
+EOF
+)"
+```
+
+Expected: PR URL printed. Captured E2E log + counter output pasted into the PR description as evidence.
+
+- [ ] **Step 3: Verify the PR is on the right repo**
+
+Run: `gh pr view --repo pbrane/delta-v <PR-number>`
+Expected: `baseRepository: pbrane/delta-v`, base branch `develop`. If base repo shows `OpenNMS/opennms`, abort and re-create (per `feedback_never_pr_opennms`).
+
+---
+
+### Task 6.5 — Post-merge memory updates
+
+Runs only after the PR merges. Update two memory files.
+
+- [ ] **Step 1: Flip the primary memo from OPEN to RESOLVED**
+
+Edit `/Users/david/.claude/projects/-Users-david-development-src-opennms-delta-v/memory/project_collectd_serviceparameters_identity_gap.md`:
+
+- Change `**Status (2026-04-18):** OPEN.` to `**Status:** RESOLVED (delta-v#<PR>).`
+- Add a final paragraph under "References":
+  ```
+  - Resolved: delta-v#<PR> shipped LocationAwareCollectorClient decorator + AgentIdentityHolder ThreadLocal, threading nodeId/location into TimeseriesKafkaPersister. Phase 2 E2E now passes end-to-end.
+  ```
+
+Also update `MEMORY.md` entry to: `— RESOLVED (delta-v#<PR>): LocationAwareCollectorClient decorator threads identity via ThreadLocal; Phase 2 E2E fully green`.
+
+- [ ] **Step 2: Update Phase 2 memo with addendum**
+
+Edit `project_phase2_prometheus_writer_done.md` and append:
+
+```
+## 2026-04-19 addendum
+
+E2E now passes end-to-end as of delta-v#<PR> (M2 producer fix). `enrichment_lookup_fallback_total` stays at 0 throughout; Collectd emits real nodeId + location via the AgentIdentityHolder path.
+```
+
+- [ ] **Step 3: No commit needed** — memory files are user-private, auto-persisted.
+
+---
+
+## Self-review
+
+**Spec coverage walkthrough:**
+
+- §2 acceptance: all 8 bullets are covered by Phase 6 tasks.
+- §3 architecture: new beans in Phase 1/2/3.1/4.1; persister refactor in Phase 3.2.
+- §3.1 Spring wiring snippet: Task 4.1 uses the exact `@Primary` + `@Qualifier("locationAwareCollectorClient")` pattern.
+- §3.2 holder contract: Task 1.2 test cases assert each invariant (set, getOrThrow, clear, idempotency, thread isolation, overwrite).
+- §3.3 AgentIdentity contract: Task 1.1 test asserts null-normalization + no nodeId validation.
+- §4 data flow: Task 5.1 IT drives it end-to-end.
+- §4.1 invariants: same-thread (synchronous RPC) — IT asserts capture + immediate read. Single capture point — decorator is the only caller of `holder.set`. Holder lifetime — Task 3.2 test "empty holder throws" + "completed set clears" paths.
+- §4.2 edge cases: Task 3.2 tests cover empty holder (decorator-not-wired), `nodeId == 0` (malformed), `completeCollectionSet` without prior visit (null capturedSet), `nodeId == -1` (negative).
+- §5 error handling: Task 3.2 steps 1-2 test the exact `IllegalStateException` + try/finally code from the spec.
+- §6 observability: reuses pre-existing counter; no new metric code needed. INFO log line in `AgentIdentityCapturingCollectorClient` constructor is in Task 2.1.
+- §7 component list: all 4 new files + 2 modified covered across Phases 1-4.
+- §8 testing: all 5 new test classes + 1 rewrite + 1 extension in Phases 1-5.
+- §9 rollout: Task 6.4 follows all guardrails (branch name, `--repo pbrane/delta-v`, mvnw, conventional commits).
+- §10 post-merge: Task 6.5.
+- §11 risks: Task 6.1's note about `CollectdApplicationScanIT` is the explicit `@MockitoBean` precedence check for the "Primary conflicts" risk. ThreadLocal leak risk is covered by Task 1.2 tests. Async-thread risk is documented by Task 5.1's "immediate read after execute" assertion.
+
+**Placeholder scan:** Every code block is complete Java. Test code blocks assert concrete behavior, not "test above". No TBD/TODO. Commands have explicit expected output.
+
+**Type consistency check:** `AgentIdentity.nodeId()` / `.location()` record accessors used consistently across all test files and the persister. `AgentIdentityHolder.set(int, String)`, `.getOrThrow()`, `.clear()` — same signatures everywhere. `AgentIdentityCapturingCollectorClient.CapturingBuilder` — used in both the client's `collect()` return and test direct construction. `TimeseriesKafkaPersister(TimeseriesKafkaPublisher, String, AgentIdentityHolder)` — matches Spring `@Bean` wiring and test construction. `FanoutPersisterFactory(innerFactory, publisher, holder, meterRegistry, failFastInner, failFastKafka)` — constructor signature matches in both the `compositePersisterFactory` `@Bean` and internal `createPersister` calls.
+
+No gaps found.

--- a/docs/superpowers/specs/2026-04-19-m2-collectd-serviceparameters-identity-design.md
+++ b/docs/superpowers/specs/2026-04-19-m2-collectd-serviceparameters-identity-design.md
@@ -1,0 +1,264 @@
+# M2 — Collectd ServiceParameters identity-populate gap (design)
+
+- **Date:** 2026-04-19
+- **Branch:** `fix/collectd-serviceparameters-identity`
+- **PR target:** `pbrane/delta-v` `develop` (never `OpenNMS/opennms`)
+- **Status:** design draft (awaiting user review before implementation plan)
+- **Primary memo:** `project_collectd_serviceparameters_identity_gap`
+- **Follow-on from:** delta-v#175 (consumer-side fixes for `NodeContextKafkaBootstrap` race, SCS-binder topic-partition race, location-empty cache-key fallback)
+
+## 1. Context and problem
+
+After delta-v#175, the Phase 2 Prometheus-remote-write consumer (`core/prometheus-writer`) correctly reads every `TimeseriesBatch` record published by Collectd. `records_consumed_total` is non-zero but `samples_sent_total` stays at zero. The root cause is producer-side: Delta-V's standalone Collectd (`core/daemon-boot-collectd`) publishes every record with `nodeId = 0` and `location = ""`. Consumer enrichment cache keys never match, so every record hits `enrichment_missing` and is dropped.
+
+The existing producer (`TimeseriesKafkaPersister`) reads `node-id` and `location` from a `ServiceParameters` map:
+
+```java
+this.nodeId = parseIntOrZero(asString(params.get("node-id"), ""));
+this.location = asString(params.get("location"), "");
+```
+
+`ServiceParameters` in this context is horizon's `CollectionSpecification.getServiceParameters()` — a static wrapper around the collectd-configuration.xml package parameters, wrapped `Collections.unmodifiableMap(...)`. The horizon API **never populates `node-id` or `location`** into that map (the enum `ServiceParameters.ParameterName` has no such slot) and the per-collection `CollectionAgent` — which does know both — is not threaded through the `Persister` API. Consequently, `parseIntOrZero(null)` silently returns 0 and the empty-string location is a silent default.
+
+**M2 scope:** producer-side fix. Populate the persister with real `nodeId` + `location` from the `CollectionAgent` on every collection cycle, and fail loudly at publish time if identity is missing so the bug cannot silently regress.
+
+**Out of scope:** consumer-side changes (delta-v#175 shipped those); the three deferred horizon-inner-persister bugs (#1/#2/#4 per `project_phase0_inner_persister_bugs_followup`) — they affect the inner `TimeseriesPersister` path, not the Kafka producer; any `ServiceParameters` contract change in horizon.
+
+## 2. Acceptance criteria
+
+- `ServiceParameters.nodeId` / `.location` reads are removed from `TimeseriesKafkaPersister`; identity is sourced from a Delta-V-owned capture path.
+- Silent defaults (`parseIntOrZero` helper, empty-location fallback) are deleted; a single `IllegalStateException` guards the publish site.
+- New unit tests cover the populated-identity contract, the missing-identity failure, and the `nodeId <= 0` failure path.
+- New integration test asserts the Spring wiring so the decorator bean is the one injected into downstream consumers.
+- `./mvnw -pl core/daemon-boot-collectd verify` green.
+- `./mvnw -B -DskipTests -fae clean install` full-reactor green (per `feedback_delta_v_full_reactor_verify`).
+- `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` exits 0 with `ALL ASSERTIONS PASSED` — first successful end-to-end Phase 2 E2E.
+- `enrichment_lookup_fallback_total` counter (from delta-v#175) stays at 0 throughout the E2E run.
+- Post-merge memory updates: `project_collectd_serviceparameters_identity_gap` status flip OPEN → RESOLVED (delta-v#<PR>); `project_phase2_prometheus_writer_done` addendum noting full E2E green as of delta-v#<PR>.
+
+## 3. Architecture
+
+The design rests on two observations:
+
+1. **Horizon's `Persister` never receives a `CollectionAgent`.** Upstream persisters extract `nodeId` from `CollectionResource.getPath()` (format-dependent) and never have a direct handle on location. Adding identity to `ServiceParameters` fights the horizon API — that map is static package config, wrapped unmodifiable by `CollectionSpecification.getServiceParameters()`.
+2. **`LocationAwareCollectorClient` is the single Delta-V-reachable bean that sees the `CollectionAgent` on every cycle.** Inside `CollectorRequestBuilderImpl.execute()` (horizon, `features/collection/client-rpc`), both `agent.getNodeId()` and `agent.getLocationName()` are live on the Collectd scheduler thread, immediately before RPC dispatch. `CollectableService.doCollection()` blocks on the resulting `CompletableFuture.get()`, so control returns to the same thread before `createPersister` runs.
+
+The fix introduces two thin Delta-V beans that collaborate through a request-scoped holder:
+
+1. **`AgentIdentityHolder`** — a `ThreadLocal<AgentIdentity>` with `set`, `getOrThrow`, `clear`. Singleton bean.
+2. **`AgentIdentityCapturingCollectorClient`** — `@Primary` Spring decorator over the horizon `LocationAwareCollectorClient` bean. Captures `agent` via `withAgent`, and at `execute()` time calls `holder.set(agent.getNodeId(), agent.getLocationName())` before delegating. Dumb conduit: captures whatever the agent provided, no validation, never throws on identity shape (per Q2 decision: persist-time-only fail-fast).
+3. **`TimeseriesKafkaPersister`** — new constructor `(TimeseriesKafkaPublisher, String collectionPackage, AgentIdentityHolder)` (per Q4 decision: option A2, explicit dependencies). At `completeCollectionSet`, reads identity, validates `nodeId > 0`, publishes, and always clears the holder in `finally`.
+4. **`FanoutPersisterFactory`** — extracts the `collection` string from `ServiceParameters` once per `createPersister` call, passes it and the injected holder to the new persister constructor.
+
+**Left untouched:** `CollectionSetToProtobufTranslator` (already takes `nodeId`/`location` as explicit args), `TimeseriesKafkaPublisher`, horizon's `TimeseriesPersisterFactory` and inner `TimeseriesPersister` path, `CollectdRpcConfiguration`.
+
+### 3.1 Spring bean wiring
+
+Verified in the delta-v codebase: the horizon bean is defined in `core/daemon-boot-collectd/src/main/java/org/deltav/netmgt/collectd/boot/CollectdRpcConfiguration.java` as a plain `@Bean`. Spring Boot 4 disables bean definition overriding by default, so the decorator uses a different bean name + `@Primary`:
+
+```java
+@Bean
+@Primary
+public LocationAwareCollectorClient agentIdentityCapturingCollectorClient(
+        @Qualifier("locationAwareCollectorClient") LocationAwareCollectorClient inner,
+        AgentIdentityHolder holder) {
+    return new AgentIdentityCapturingCollectorClient(inner, holder);
+}
+```
+
+Both new beans (`AgentIdentityHolder`, `AgentIdentityCapturingCollectorClient`) are gated by the existing `@ConditionalOnProperty("deltav.timeseries.enabled=true")` on `TimeseriesKafkaPublisherConfiguration`. When off, horizon's raw bean is injected as today and the Kafka publish path is not wired — zero behavioral change for non-Kafka deployments.
+
+### 3.2 AgentIdentityHolder contract invariants
+
+- **`set(nodeId, location)`** — unconditional overwrite. Never throws. Normalizes null location to `""`. This is the sole protection against thread reuse with stale identity between cycles on the same scheduler thread.
+- **`getOrThrow()`** — returns current identity, or throws `IllegalStateException("AgentIdentity not populated — LocationAwareCollectorClient decorator not wired?")` if the slot is empty. Called exactly once per cycle at `completeCollectionSet` time.
+- **`clear()`** — idempotent `ThreadLocal.remove()`. Called from `completeCollectionSet`'s outer `finally` block so it always runs regardless of whether `capturedSet` was null or whether publish threw.
+
+### 3.3 AgentIdentity record contract
+
+A dumb immutable data carrier. No validation on `nodeId`. Location normalized to `""` when null. Validation lives exclusively at the persist site.
+
+## 4. Data flow (one collection cycle)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ CollectableService.doCollection()   [Collectd scheduler thread]
+└─────────────────────────────────────────────────────────────────────────┘
+    │
+    │ 1. m_spec.getServiceParameters()  ─▶ ServiceParameters (static package config)
+    │
+    │ 2. m_spec.collect(m_agent)
+    │    └─▶ locationAwareCollectorClient.collect()        ← @Primary decorator
+    │           .withAgent(agent)                          ← captures agent
+    │           .withCollectorClassName(...)
+    │           .execute()                                 ← DECORATOR HOOK
+    │                │
+    │                ├─▶ holder.set(agent.getNodeId(), agent.getLocationName())
+    │                └─▶ delegate.execute()     [RPC to Minion; blocks on .get()]
+    │                         │
+    │                         ▼
+    │                    CollectionSet
+    │
+    │ 3. persisterFactory.createPersister(serviceParameters, …)
+    │    └─▶ FanoutPersisterFactory
+    │           ├── collectionPackage = params.get("collection") — "default" fallback
+    │           └── new TimeseriesKafkaPersister(publisher, collectionPackage, holder)
+    │
+    │ 4. result.visit(persister)
+    │    └─▶ FanoutPersister walks visit steps for both inner + kafka persisters
+    │           └── completeCollectionSet on kafka persister:
+    │                   try {
+    │                     if (capturedSet != null) {
+    │                       identity = holder.getOrThrow()      ← still set from step 2
+    │                       if (identity.nodeId() <= 0) throw …
+    │                       publisher.publish(capturedSet, collectionPackage,
+    │                                         identity.nodeId(), identity.location())
+    │                     }
+    │                   } finally {
+    │                     holder.clear()
+    │                     capturedSet = null
+    │                   }
+    │
+    │ 5. thresholding + status update (unchanged)
+    ▼
+```
+
+### 4.1 Invariants the flow relies on
+
+1. **Same-thread synchronous window.** Steps 2→3→4 run on one scheduler thread. The RPC future is `.get()`-blocked inside horizon's `CollectionSpecification.collect()`, so control returns on the same thread before `createPersister` runs. No cross-thread hand-off bridges a thread boundary the holder can't see through.
+2. **Single capture point.** Any bypass (e.g., a test wiring that injects the raw `LocationAwareCollectorClientImpl` directly) fails loudly at step 4's `getOrThrow()`. No secondary population site to keep in sync.
+3. **Holder lifetime bounded by the cycle.** Set in step 2 (unconditional overwrite), read + cleared in step 4 (try/finally). Unconditional-overwrite semantics make cleanup best-effort rather than load-bearing: an exception anywhere between steps 2 and 4 never causes cross-cycle contamination, because the next cycle's step 2 overwrites.
+
+### 4.2 Edge cases
+
+- **Inner persister throws mid-visit** (horizon bugs #1/#2/#4): `FanoutPersister.runInner` catches the throwable, continues to the Kafka persister; `completeCollectionSet` still runs on the Kafka side; publish + clear succeed.
+- **Kafka persister's own `getOrThrow()` or `publish` throws:** the outer `finally` still clears. `FanoutPersister.runKafka` catches the `IllegalStateException`, increments `deltav.collectd.persister.kafka.failures{step=completeCollectionSet}`, logs WARN.
+- **`CollectionSet` is null (failed collection):** `visitCollectionSet` was never called with a non-null set → `capturedSet` stays null → the `if (capturedSet != null)` short-circuits → the outer `finally` still clears the holder (idempotent no-op if already empty).
+- **RPC timeout:** `execute()` already set the holder before dispatching. `.get()` throws. `doCollection` propagates. Holder remains set until the next cycle overwrites — no record is published with bogus identity because `completeCollectionSet` never runs.
+
+## 5. Error handling and fail-fast semantics (persist-time only)
+
+Per Q2 decision: **fail-fast at persist time, not capture time.** The capture path never aborts a collection; only the Kafka publish is refused when identity is invalid.
+
+**Single validation site** — `TimeseriesKafkaPersister.completeCollectionSet`:
+
+```java
+@Override
+public void completeCollectionSet(CollectionSet set) {
+    try {
+        if (capturedSet != null) {
+            AgentIdentity identity = holder.getOrThrow();
+            if (identity.nodeId() <= 0) {
+                throw new IllegalStateException(
+                    "Invalid agent identity for Kafka publish: nodeId must be > 0, got "
+                    + identity.nodeId());
+            }
+            publisher.publish(capturedSet, collectionPackage,
+                              identity.nodeId(), identity.location());
+        }
+    } finally {
+        holder.clear();
+        capturedSet = null;
+    }
+}
+```
+
+Both failure modes — "decorator not wired" (from `getOrThrow`) and "malformed nodeId" (explicit check) — surface as `IllegalStateException` caught by `FanoutPersister.runKafka`, which increments `deltav.collectd.persister.kafka.failures{step=completeCollectionSet}` and logs WARN. The inner persister (RRD/Newts) path is unaffected — it completes normally. Ops alert rule: `rate(deltav_collectd_persister_kafka_failures_total{step="completeCollectionSet"}[5m]) > 0`.
+
+Legitimate `nodeId == 0` edge cases (if any ever surface — not evidenced today) aborting only the Kafka publish for that cycle is the correct behavior: inner persistence still happens, RPC still fires, only the Kafka record is refused.
+
+## 6. Observability
+
+- **Metric counter** (pre-existing, reused): `deltav.collectd.persister.kafka.failures{step=completeCollectionSet}`. `FanoutPersister.preRegisterCounters` already registers this at construction so ops can alert on `rate > 0`.
+- **Downstream smoke test** (pre-existing, from delta-v#175): `enrichment_lookup_fallback_total` on the consumer side. Should stay at 0 post-M2, indicating Collectd is populating `location` correctly and consumer fallback is not being triggered. Spike above 0 = location populated but doesn't match what provisiond emits.
+- **Log line** (INFO, once at startup): `AgentIdentityCapturingCollectorClient` logs its construction — `"Wrapping LocationAwareCollectorClient for identity capture; delegate = {}"` — for operational confirmation that the decorator is in play.
+
+## 7. Components — file-level changes
+
+**New files** (all under `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/`):
+
+1. `AgentIdentity.java` — `record AgentIdentity(int nodeId, String location)` with compact constructor normalizing null location to `""`. No nodeId validation.
+2. `AgentIdentityHolder.java` — ThreadLocal holder with `set` / `getOrThrow` / `clear` per §3.2.
+3. `AgentIdentityCapturingCollectorClient.java` — implements `LocationAwareCollectorClient`; delegates everything to the wrapped client except `collect()`, which returns a wrapped builder.
+4. `AgentIdentityCapturingCollectorRequestBuilder.java` (package-private static nested inside #3 — acceptable because the outer class is its sole consumer) — implements `CollectorRequestBuilder`. `withAgent` captures reference; all `withXxx` return `this`; `execute()` sets holder (if agent captured) and delegates.
+
+**Modified files:**
+
+5. `TimeseriesKafkaPersister.java` — new constructor `(TimeseriesKafkaPublisher, String collectionPackage, AgentIdentityHolder)`; `parseIntOrZero`, `asString`, and all `ServiceParameters` identity reads deleted; `completeCollectionSet` rewritten per §5; Javadoc updated to document the holder-based identity source.
+6. `TimeseriesKafkaPublisherConfiguration.java`:
+   - New `@Bean AgentIdentityHolder agentIdentityHolder()`.
+   - New `@Bean @Primary AgentIdentityCapturingCollectorClient` (snippet in §3.1).
+   - `FanoutPersisterFactory` constructor gains `AgentIdentityHolder holder`; `createPersister` now extracts `collection` from `ServiceParameters` once (via `(String) params.getParameters().getOrDefault("collection", "default")`) and passes both the string and the holder to the new persister constructor.
+
+**Explicitly untouched:** `CollectionSetToProtobufTranslator`, `TimeseriesKafkaPublisher`, `CollectdRpcConfiguration`, `CollectdDaemonConfiguration`, `opennms-container/delta-v/` resources, horizon's inner `TimeseriesPersister` path.
+
+## 8. Testing strategy
+
+**Unit tests** (new files under `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/identity/`):
+
+- **`AgentIdentityTest`** — null location normalizes to `""`; non-null passes through; record equality on both fields.
+- **`AgentIdentityHolderTest`** — (1) set then getOrThrow returns; (2) getOrThrow on empty throws IllegalStateException with diagnostic message; (3) set → clear → getOrThrow throws; (4) set with null location → getOrThrow.location() is ""; (5) double set overwrites silently; (6) thread isolation: set on A, assert B's getOrThrow throws.
+- **`AgentIdentityCapturingCollectorRequestBuilderTest`** — (1) withAgent + execute sets holder with agent's nodeId + location; (2) withAgent omitted + execute → holder not set (delegate handles its own validation); (3) all `withXxx` return `this` and call delegate; (4) agent with `nodeId == 0` captured as-is — no throw at this layer; (5) agent with null location captured as `""`.
+- **`AgentIdentityCapturingCollectorClientTest`** — every `LocationAwareCollectorClient` method other than `collect()` forwards straight to the wrapped client; `collect()` returns a decorated builder.
+- **`TimeseriesKafkaPersisterTest` (rewrite, existing file)** — (1) populated holder → publisher.publish with right identity, holder cleared; (2) empty holder → IllegalStateException, holder cleared idempotently; (3) holder with nodeId == 0 → IllegalStateException with "nodeId must be > 0" in message, holder cleared; (4) holder with nodeId == -1 → same; (5) capturedSet == null path → no publish call, holder still cleared; (6) `visitResource/Group/Attribute/persistNumeric/persistString` still no-ops.
+
+**Integration test** (new file under `core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/`):
+
+- **`AgentIdentityWiringIT`** — extends `CollectdApplicationScanIT` Spring-context pattern. Boots with `deltav.timeseries.enabled=true`, mocked broker + DB. Asserts: (1) `LocationAwareCollectorClient` bean resolution returns the decorator via `@Primary`; (2) the instance injected into `Collectd` is `instanceof AgentIdentityCapturingCollectorClient`; (3) a manual `client.collect().withAgent(fakeAgent).withCollector(noopCollector).execute()` sets the holder (read immediately after via `agentIdentityHolder.getOrThrow()`); (4) `FanoutPersisterFactory.createPersister(serviceParameters, repository)` produces a `FanoutPersister` whose kafka-side delegate has the holder wired (verify via a package-private accessor added on the persister for test purposes, OR by driving a full collection cycle and asserting the publisher was called with the captured identity).
+
+- **`TimeseriesPublisherFeatureFlagOffIT` (existing, extended)** — one new assertion: when `deltav.timeseries.enabled=false`, the `LocationAwareCollectorClient` bean is NOT the decorator; the horizon bean wins. Keeps the off-path honest.
+
+**Not in automated suite:**
+
+- **Phase 2 E2E** (`./opennms-container/delta-v/test-prometheus-writer-e2e.sh`) — mandatory local verification per the prompt's success criteria, not wired into `./mvnw verify`. PR description will cite it as the acceptance gate with captured log excerpt showing `ALL ASSERTIONS PASSED` + `enrichment_lookup_fallback_total == 0`.
+- Tests exercising the three deferred horizon-inner bugs — out of scope per `project_phase0_inner_persister_bugs_followup`.
+
+**Scope estimate:** ~15 new test methods across 5 new test classes + 1 rewrite + 1 extension. ~300 lines of test code. All fast (no broker, no DB, no Docker).
+
+## 9. Rollout
+
+- **Branch:** `fix/collectd-serviceparameters-identity` (new, not reusing `fix/collectd-publisher-inert` which was merged and deleted).
+- **PR target:** `gh pr create --repo pbrane/delta-v --base develop ...` — per `feedback_never_pr_opennms`.
+- **Commit convention:** `fix(collectd):` per the conventional-commit pattern used by adjacent PRs (#174, #175).
+- **Code conventions:** all new files under `org.deltav.collectd.identity.*` with BeaconStrategists copyright header per `feedback_deltav_package_namespace`.
+- **Build verification before PR:**
+  - `./mvnw -pl core/daemon-boot-collectd verify` (module-level, fast).
+  - `./mvnw -B -DskipTests -fae clean install` (full reactor, per `feedback_delta_v_full_reactor_verify`).
+  - Local `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` end-to-end run, asserting exit 0 + `enrichment_lookup_fallback_total == 0`.
+- **Known environment quirk** (from PR #175 session): strict-mode Bash wrapping may kill `build.sh` with exit 255 + empty log. Workaround: `bash -c '<cmd>' &; disown`. Documented here so the implementor doesn't re-discover it.
+
+## 10. Post-merge
+
+- Flip `project_collectd_serviceparameters_identity_gap` memory status `OPEN` → `RESOLVED (delta-v#<PR>)`.
+- Addendum to `project_phase2_prometheus_writer_done`: "E2E now passes end-to-end as of delta-v#<PR>."
+- Next phase queued: **Phase 3 Thresholder** — consumer of `deltav-timeseries`, evaluates thresholds (including stddev) and emits fault events. Spec spawns from `project_thresholder_brainstorm`. Likely extracts `NodeContextCache` as `core/deltav-node-context-cache` (YAGNI'd in Phase 2).
+
+## 11. Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+| --- | --- | --- |
+| `@Primary` bean resolution conflicts with some other Delta-V Spring config that overrides `LocationAwareCollectorClient` | Low | `AgentIdentityWiringIT` explicitly asserts bean resolution. A qualifier-based fallback is trivial if `@Primary` turns out not to win. |
+| ThreadLocal leak across cycles on shared scheduler thread | Low | Triple-guarded: outer `finally` clear + unconditional overwrite on next cycle + `getOrThrow` surfaces stale state as `IllegalStateException` (if a cycle ever observed someone else's identity). |
+| Collectd uses async/pooled thread for `createPersister` not visible to holder set in `execute()` | Low | Verified against `CollectableService.doCollection()`: synchronous `.get()` on the CompletableFuture, same thread. IT asserts the observed behavior. If horizon changes this contract in a future release, `getOrThrow()` fires on every cycle and the failure is immediately visible. |
+| Inner persister's own ServiceParameters use breaks | None | No inner-persister code path is touched. Inner still reads `collection`/meta-tag params from the same unchanged `ServiceParameters` instance. |
+| `collection` string extraction in `FanoutPersisterFactory` differs from horizon's own default lookup | Low | Uses the same `.getOrDefault("collection", "default")` pattern the current persister uses. No behavior change for that field. |
+
+## 12. Decisions log (from brainstorm session)
+
+- **Q1 (fix-layer):** Option A — `LocationAwareCollectorClient` decorator + ThreadLocal holder. Rejected: walking `CollectionResource.getPath()` (fragile, no location info).
+- **Q2 (fail-fast scope):** Option A — persist-time only. Rejected: capture-time throws (would abort collection cycles for the inner persister path too).
+- **Q3 (test strategy):** Option B — unit + integration test; E2E as mandatory local verification but not in `./mvnw verify`. Rejected: wiring E2E into CI (container startup cost; not module-local).
+- **Q4a (persister signature):** Option A2 — explicit constructor `(publisher, collectionPackage, holder)`. Rejected: keeping `ServiceParameters` in signature (residual coupling).
+- **Q4b (horizon-inner-persister bugs):** Confirmed deferred. Do not fold into M2 unless one directly blocks verification — none do, per §4.2's FanoutPersister isolation.
+- **Refinement during Section 3:** outer `finally` for `holder.clear()` + `capturedSet = null`, even when `capturedSet == null`, so cleanup is guaranteed regardless of path through `completeCollectionSet`.
+- **Refinement during Section 4:** validation moved out of `AgentIdentity` constructor and into `TimeseriesKafkaPersister.completeCollectionSet`, realigning with Q2.
+
+## 13. References
+
+- `project_collectd_serviceparameters_identity_gap` — primary memo with live evidence from labbox 2026-04-18.
+- `project_collectd_publisher_inert_investigation` — RESOLVED (delta-v#175); why the consumer-side hypothesis was wrong.
+- `project_phase2_prometheus_writer_done` — the consumer side this M2 completes.
+- `project_kafka_timeseries_producer_next_session` — Phase 0 publisher history.
+- `project_collectd_scheduler_publisher_split` — Phase 0 scope note that originally flagged this gap.
+- `project_phase0_inner_persister_bugs_followup` — the three deferred horizon-inner bugs (#1/#2/#4).
+- `feedback_never_pr_opennms`, `feedback_feature_branches`, `feedback_delta_v_uses_mvnw_not_compile_pl`, `feedback_delta_v_full_reactor_verify`, `feedback_deltav_package_namespace`, `feedback_kafka_topic_partition_race` — standing project guardrails applied here.


### PR DESCRIPTION
## Summary

- Producer-side fix for the Phase 2 E2E blocker: Delta-V Collectd was publishing every `TimeseriesBatch` record with `nodeId=0 + location=""` because `TimeseriesKafkaPersister` read identity from `ServiceParameters`, which horizon's API never populates with node-scope fields.
- Introduces a Spring `@Primary` `LocationAwareCollectorClient` decorator that captures `(nodeId, location)` into a `ThreadLocal`-backed `AgentIdentityHolder` at RPC dispatch time. `TimeseriesKafkaPersister` reads the holder at `completeCollectionSet()`, validates `nodeId > 0`, publishes, and clears the holder in a `try/finally`.
- Persist-time-only fail-fast — a missing or invalid identity throws `IllegalStateException` caught by `FanoutPersister`, incrementing `deltav.collectd.persister.kafka.failures{step=completeCollectionSet}` (alert on `rate > 0`). The inner RRD/TSS persister path is unaffected.

## Design & plan

- Spec: `docs/superpowers/specs/2026-04-19-m2-collectd-serviceparameters-identity-design.md`
- Plan: `docs/superpowers/plans/2026-04-19-m2-collectd-serviceparameters-identity.md`

## What's in the diff

**New production classes** (`core/daemon-boot-collectd/src/main/java/org/deltav/collectd/identity/`)
- `AgentIdentity` — immutable record `(int nodeId, String location)` with null-location normalization.
- `AgentIdentityHolder` — ThreadLocal wrapper with `set` (unconditional overwrite), `getOrThrow` (throws with diagnostic on empty slot), `clear` (idempotent).
- `AgentIdentityCapturingCollectorClient` — `@Primary` decorator implementing `LocationAwareCollectorClient`; returns a package-private static nested `CapturingBuilder` that records identity at `execute()` time.

**Modified production code**
- `TimeseriesKafkaPersister` — new constructor `(TimeseriesKafkaPublisher, String collectionPackage, AgentIdentityHolder)`. `parseIntOrZero` / `asString` / `node-id`/`location` reads from `ServiceParameters` deleted. `completeCollectionSet` validates `identity.nodeId() > 0` and publishes; outer `try/finally` always clears the holder.
- `TimeseriesKafkaPublisherConfiguration` — registers `AgentIdentityHolder` and `@Primary agentIdentityCapturingCollectorClient` beans (both gated by existing `deltav.timeseries.enabled=true`). `FanoutPersisterFactory` threads the holder through to each `TimeseriesKafkaPersister` and extracts the `collection` string from `ServiceParameters` once per `createPersister` call.

**Tests** (unit + IT, ~21 tests net new + 1 existing rewritten + 1 extended)
- `AgentIdentityTest` — 6 cases for record normalization + equality.
- `AgentIdentityHolderTest` — 7 cases: set/get roundtrip, empty-throws, clear idempotency, null-location normalization, double-set overwrite, thread isolation.
- `AgentIdentityCapturingCollectorRequestBuilderTest` — 6 cases: withAgent+execute sets holder, no-agent delegates without touching holder, zero nodeId captured as-is (validation deferred to persist time), null location → `""`, all 7 non-execute builder methods return `this` and delegate, verify no holder interaction when agent never set.
- `AgentIdentityCapturingCollectorClientTest` — `collect()` returns decorated builder.
- `TimeseriesKafkaPersisterTest` (rewrite) — 7 cases covering populated-holder publish + clear, empty holder `IllegalStateException`, `nodeId <= 0` validation with actual value in message, capturedSet==null path still clears holder, all no-op visitor callbacks.
- `TimeseriesPublisherFeatureFlagOffIT` (extended) — asserts decorator + holder beans absent when `deltav.timeseries.enabled=false`.
- `AgentIdentityWiringIT` (new) — boots a narrow Spring context and asserts (1) `@Primary` decorator wins bean resolution, (2) `AgentIdentityHolder` bean is shared, (3) `client.collect().withAgent(...).execute()` populates the holder.

**Test infrastructure fixes** (regressions our decorator surfaced in existing ITs)
- `CollectdApplicationScanIT` — pinned `@MockitoBean` bean names for `locationAwareCollectorClient` and `agentIdentityCapturingCollectorClient`. Without explicit names, type-based matching replaced the `@Primary` decorator and left horizon's real bean to instantiate and fail on `@Autowired RpcTargetHelper`.
- `TimeseriesKafkaBrokerIT` — added stub `@Bean(name = "locationAwareCollectorClient")` because the decorator's `@Qualifier` expects it; BrokerIT's narrow `@Import` didn't include the horizon bean.

## Verification performed

### Unit + IT (all green)
- `./mvnw -pl core/daemon-boot-collectd verify` — **BUILD SUCCESS**, 16 ITs + all unit tests pass in ~1 min.
- `./mvnw -B -DskipTests -fae clean install` — **BUILD SUCCESS**, 25 reactor modules in 18.6 s.

### Decorator wiring (confirmed at startup)
Collectd startup log on the built image:
```
INFO .i.AgentIdentityCapturingCollectorClient : Wrapping LocationAwareCollectorClient for identity capture; delegate = org.opennms.netmgt.collection.client.rpc.LocationAwareCollectorClientImpl
```

### Phase 2 E2E — environmental block (pre-existing, NOT caused by this PR)

`./opennms-container/delta-v/test-prometheus-writer-e2e.sh` fails identically on this branch **and** on `cf1329f71e2` (develop HEAD before this PR) with `FAIL: deltav_prometheus_writer_records_consumed_total is not > 0 (got: 0)`.

**Root cause** (observed on both branches):
- `provisiond` hostname resolution for `172.20.20.x` at location `mhuot-labs` hits a 20-second reverse-lookup timeout per interface (× 5 interfaces).
- `Collectd` cannot schedule any SNMP interface within the E2E's 90-second Step 3 wait because `sysObjectID` isn't populated in time:
  ```
  scheduleInterface: Unable to schedule OnmsIpInterface{...ipAddr=172.20.20.4...nodeId=4}/SNMP,
  reason: System Object ID for interface 172.20.20.4 does not exist in the database.
  ```
- No `CollectableService.doCollection()` calls happen → `collect()` is never invoked → our decorator never fires → `deltav-timeseries` topic has zero records → `records_consumed_total` stays at 0.

This is environmental and pre-existing. The M2 code path is untestable via this E2E until the hostname-resolution timeout is addressed. See `project_hostname_ip_addr_hardening` memo for the underlying provisiond hostname-support work.

**What the ITs do cover** that the broken E2E would have:
- `AgentIdentityWiringIT` drives a full `client.collect().withAgent(agent).execute()` against a mocked horizon delegate and asserts the holder is populated with the expected `(nodeId, location)`.
- `TimeseriesKafkaPersisterTest` drives `completeCollectionSet` with a populated holder and asserts the publisher is invoked with the captured identity + the holder is cleared afterward.

Together these pin every M2-specific contract; only the full-stack wiring (provisiond→Collectd→Kafka→prometheus-writer→VictoriaMetrics) is not end-to-end verified in this PR.

## Test plan

- [ ] CI green on the PR (unit + IT + full-reactor).
- [ ] Reviewer re-runs `./mvnw -pl core/daemon-boot-collectd verify` locally.
- [ ] Once the E2E environment issue (`project_hostname_ip_addr_hardening`) is addressed, re-run `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` and confirm `ALL ASSERTIONS PASSED` + `samples_sent_total > 0`. Expected post-fix: `enrichment_missing_total == 0` because Collectd now publishes real identity.

## Memory updates (post-merge)

- Flip `project_collectd_serviceparameters_identity_gap` OPEN → RESOLVED-PENDING-E2E (delta-v#<PR>) with addendum noting ITs pass and the E2E blocker is environmental.
- Addendum to `project_phase2_prometheus_writer_done` noting the M2 producer fix ships in delta-v#<PR>; full end-to-end verification still awaits the hostname-resolution environment fix.
- Open a new memo / followup for the E2E hostname-resolution timeout (it reproduces on develop HEAD, so it's not an M2 regression).