### PR TITLE
fix(e2e): make Phase 2 Prometheus Remote Write E2E pass self-contained

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -620,7 +620,11 @@ services:
     image: victoriametrics/victoria-metrics:v1.106.1
     profiles: [metrics-e2e]
     command:
-      - "-retentionPeriod=1h"
+      # VM v1.106.1 rejects retentionPeriod smaller than 1 day; "1h" causes
+      # exit code 255 at startup with fatal log:
+      #   -retentionPeriod cannot be smaller than a day; got 1h
+      # E2E only needs a few minutes of retention, but the floor is 1d.
+      - "-retentionPeriod=1d"
       - "-storageDataPath=/tmp/vm"
       - "-search.latencyOffset=1s"
     healthcheck:

--- a/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -7,6 +7,23 @@
                    import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
     <cron-schedule>0/30 * * * * ?</cron-schedule>
   </requisition-def>
+  <!--
+    rpc-canary: self-contained Default-location SNMP canary (node at 172.18.0.2
+    → the in-compose snmp-agent container). Imported here so Phase 2 E2E
+    (test-prometheus-writer-e2e.sh) has a working SNMP data path entirely
+    inside the delta-v_default Docker network, without requiring an external
+    labbox Minion at location=mhuot-labs.
+
+    History: originally added in commit 1f4bc22243c (Phase 3 gate canary),
+    removed in 3d3baf881fd during PerspectivePollerd E2E cleanup — removal
+    silently broke self-contained Phase 2 E2E runs. Restored so the E2E runs
+    on any workstation, labbox connected or not. The mhuot-labs cron below
+    remains for the labbox-connected developer path (parallel, no conflict).
+  -->
+  <requisition-def import-name="rpc-canary"
+                   import-url-resource="file:///opt/deltav/etc/imports/rpc-canary.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
   <requisition-def import-name="cloud-services"
                    import-url-resource="file:///opt/deltav/etc/imports/cloud-services.xml">
     <cron-schedule>0/30 * * * * ?</cron-schedule>

--- a/opennms-container/delta-v/test-prometheus-writer-e2e.sh
+++ b/opennms-container/delta-v/test-prometheus-writer-e2e.sh
@@ -129,7 +129,13 @@ assert_zero() {
 
 assert_zero 'deltav_prometheus_writer_batches_failed_total'
 assert_zero 'deltav_prometheus_writer_enrichment_missing_total'
-assert_zero 'deltav_prometheus_writer_samples_dropped_total'
+# samples_dropped_total: split by reason. "type_unspecified" must stay zero
+# (indicates a producer bug if it ever fires). "string_attribute" is expected
+# correct behavior when SNMP collection surfaces string OIDs (sysDescr,
+# sysName, sysContact, etc.) — Prometheus samples are float64, so the
+# translator drops strings by design. The rpc-canary data path produces a
+# handful of these on each poll.
+assert_zero 'deltav_prometheus_writer_samples_dropped_total\{reason="type_unspecified"\}'
 assert_zero 'deltav_prometheus_writer_dlq_records_total'
 
 # ── Step 6: Query VictoriaMetrics ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three fixes — each one independently required — to get `test-prometheus-writer-e2e.sh` green on a developer workstation without an external labbox Minion connected. **First successful end-to-end Phase 2 E2E run.** Completes the M2 (delta-v#177) verification loop.

Note: the branch name (`fix/e2e-minion-extra-hosts`) reflects the initial `extra_hosts` hypothesis during investigation. As the archaeology deepened, the real fixes turned out to be elsewhere — see commit message for the actual findings.

## Why all three together

Each fix reveals the next — the failure modes nest. Applying any one alone gives you a different failure signature, not a passing test:

- Without #1 (rpc-canary): `records_consumed_total = 0` because no SNMP-collectable node exists at `location=Default`; the only other SNMP requisition (mhuot-labs) needs an external labbox Minion.
- Without #2 (VM retention): Even with records flowing, every flush fails `UnknownHostException: victoriametrics` because the VM container crashes at startup with exit 255 on the invalid `-retentionPeriod=1h`.
- Without #3 (Step 5 split): Even when samples flow, `samples_dropped_total{reason="string_attribute"}` is non-zero on any real SNMP poll (sysDescr, sysName are strings → correctly dropped by the translator → currently caught by the over-strict zero assertion).

## The three fixes

### 1. Restore `rpc-canary` to `provisiond-configuration.xml` cron

`rpc-canary.xml` defines a Default-location SNMP node at `172.18.0.2` (the in-compose `snmp-agent` container). It was in the cron schedule until commit `3d3baf881fd` ("test: add PerspectivePollerd E2E test with PSM \${nodelabel} resolution") removed it during unrelated cleanup. Since then the E2E has silently depended on an external labbox Minion at `mhuot-labs` — broken on any workstation without labbox connectivity.

Restoring it puts the SNMP data path back inside the compose Docker network:
```
provisiond → Collectd → Minion(Default) → snmp-agent(172.18.0.2)
  → Kafka(deltav-timeseries) → prometheus-writer → VictoriaMetrics
```

The `mhuot-labs.xml` requisition stays in the cron schedule unchanged — labbox-connected developers still get that parallel data path.

### 2. `victoriametrics` retention `1h → 1d`

`victoriametrics/victoria-metrics:v1.106.1` rejects retention periods shorter than a day:

```
fatal VictoriaMetrics/app/vmstorage/main.go:105
  -retentionPeriod cannot be smaller than a day; got 1h
```

Container exits 255 at startup. Compose still registers the service name in the embedded DNS, but the container has no IPAM-assigned IP (`IPAddress: ""`, `EndpointID: ""`). Every `http.post()` from prometheus-writer's `BatchingRwWriter` hits `UnknownHostException` and samples are dropped from the in-memory buffer (`buffer.clear()` runs before the POST in `flushNow`, so failed flushes lose their samples permanently).

E2E only needs a few minutes of retention, but VM's floor is 1 day.

### 3. `test-prometheus-writer-e2e.sh` Step 5 splits drop-reason check

`samples_dropped_total` is a counter labeled by `reason`. Two reasons exist:

- `reason="type_unspecified"` → indicates a producer bug. Must stay zero.
- `reason="string_attribute"` → string-valued SNMP OIDs (sysDescr, sysName, sysContact, …). Prometheus samples are `float64`, so the translator correctly drops them. **Expected non-zero in any real SNMP collection.**

The previous assertion summed both reasons and required total == 0 — guaranteed to fail the moment real SNMP string data lands. Now split:

```sh
assert_zero 'deltav_prometheus_writer_samples_dropped_total\{reason="type_unspecified"\}'
# string_attribute drops are expected — not asserted
```

Follow-up candidate: surface a separate info-level line reporting `samples_dropped_total{reason="string_attribute"}` for operator visibility without gating the test on it.

## Verification (E2E run with all three fixes)

```
==> Step 4: Assert records/samples/batches flowed
==> deltav_prometheus_writer_records_consumed_total = 2
==> deltav_prometheus_writer_samples_sent_total = 26
==> deltav_prometheus_writer_batches_sent_total = 2
==> Circuit closed (state=0)
==> Step 5: Assert zero failure counters
==> deltav_prometheus_writer_batches_failed_total = 0 ✓
==> deltav_prometheus_writer_enrichment_missing_total = 0 ✓
==> deltav_prometheus_writer_samples_dropped_total\{reason="type_unspecified"\} = 0 ✓
==> deltav_prometheus_writer_dlq_records_total = 0 ✓
==> Step 6: Query VictoriaMetrics for the landed series
==> VM returned 1 series for opennms_mib2_interface_errors_ifindiscards_total
==> ALL ASSERTIONS PASSED
```

**M2 smoke-test receipt:** `enrichment_lookup_fallback_total` stayed at 0 across every observation — M2's design goal (Collectd emits real `nodeId` + `location`, consumer enriches via primary cache-hit path, fallback path never fires) is satisfied.

## Test plan

- [ ] CI green.
- [ ] Reviewer runs `./opennms-container/delta-v/test-prometheus-writer-e2e.sh` locally and observes `ALL ASSERTIONS PASSED`.
- [ ] Reviewer confirms the labbox-connected path (mhuot-labs) still works for them if they have that infrastructure.

## Follow-ups (memo candidates)

- Add a labbox preflight banner in the E2E that warns (not fails) when no mhuot-labs Minion is reachable — helps future developers understand which data path they're exercising.
- `BatchingRwWriter.flushNow` loses samples on a failed POST (`buffer.clear()` runs before `http.post()`). On transient DNS/network failures, samples are silently dropped. Consider DLQ or retry on flush failure. Separate investigation.
- `samples_dropped_total{reason="string_attribute"}` is expected nonzero — but nothing today makes that visible to operators at a glance. Add an info metric or dashboard panel.