### PR TITLE
feat(grafana): add Grafana service + VictoriaMetrics datasource + starter SNMP dashboard

### DIFF
--- a/docs/superpowers/plans/2026-04-20-grafana-victoriametrics-bundle-plan.md
+++ b/docs/superpowers/plans/2026-04-20-grafana-victoriametrics-bundle-plan.md
@@ -1,0 +1,1002 @@
+# Grafana + VictoriaMetrics Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Grafana service to the delta-v docker-compose stack with a pre-provisioned VictoriaMetrics datasource and one starter SNMP overview dashboard, so an operator running `docker compose --profile lite --profile metrics up` can browse SNMP graphs at `http://localhost:13000/d/snmp-overview` within ~90 seconds.
+
+**Architecture:** Configuration-only change (no Java touched). Grafana 11.4.0 container, filesystem provisioning via bind-mounted `grafana/provisioning/` and `grafana/dashboards/` directories. Profile rename: introduce `metrics` as the canonical name, retain `metrics-e2e` as alias on both the `victoriametrics` and the new `grafana` services. Existing E2E test extended with 3 new steps (Grafana health, datasource health, dashboard load).
+
+**Tech Stack:** Docker Compose, Grafana 11.4.0 OSS, VictoriaMetrics (already pinned at v1.106.1), bash (for the E2E script extension).
+
+**Branch:** `feat/grafana-victoriametrics-bundle` (already created off `develop` at `12a5479e3b6`, with the spec committed as `3fe6ca94478`).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-20-grafana-victoriametrics-bundle-design.md`.
+
+**PR target:** `pbrane/delta-v` `develop`. Title prefix `feat(grafana):`. **NEVER `OpenNMS/opennms`.**
+
+---
+
+## Pre-flight (one-time per session)
+
+- [ ] **Verify branch and clean working tree**
+
+Run: `git branch --show-current && git status --short`
+Expected:
+```
+feat/grafana-victoriametrics-bundle
+```
+(no dirty files)
+
+- [ ] **Verify spec is committed**
+
+Run: `git log --oneline -3`
+Expected: most recent commit is `3fe6ca94478 docs(spec): grafana + victoriametrics dashboard bundle ...`
+
+If either check fails, stop and resolve before starting Task 1.
+
+---
+
+### Task 1: Create the grafana/ directory tree
+
+**Files (NEW directories — created via `mkdir`):**
+- `opennms-container/delta-v/grafana/provisioning/datasources/`
+- `opennms-container/delta-v/grafana/provisioning/dashboards/`
+- `opennms-container/delta-v/grafana/dashboards/`
+
+These directories will hold the provisioning manifests and dashboard JSON. Directories alone are not tracked by git — files added in subsequent tasks will register the structure.
+
+- [ ] **Step 1: Create the three directories**
+
+Run from repo root `/Users/david/development/src/opennms/delta-v`:
+```
+mkdir -p opennms-container/delta-v/grafana/provisioning/datasources
+mkdir -p opennms-container/delta-v/grafana/provisioning/dashboards
+mkdir -p opennms-container/delta-v/grafana/dashboards
+```
+
+- [ ] **Step 2: Verify the structure**
+
+Run: `find opennms-container/delta-v/grafana -type d | sort`
+Expected:
+```
+opennms-container/delta-v/grafana
+opennms-container/delta-v/grafana/dashboards
+opennms-container/delta-v/grafana/provisioning
+opennms-container/delta-v/grafana/provisioning/dashboards
+opennms-container/delta-v/grafana/provisioning/datasources
+```
+
+(No commit. Directories without files are not tracked. Task 3 will add the first files.)
+
+---
+
+### Task 2: Add Grafana service to docker-compose.yml + expand related profiles
+
+**Files:**
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+
+Three precise edits:
+1. Expand `victoriametrics:` profile from `[metrics-e2e]` → `[metrics, metrics-e2e]`.
+2. Expand `prometheus-writer:` profile from `[lite, full]` → `[lite, full, metrics]`.
+3. Insert a new `grafana:` service block after the `victoriametrics:` block.
+4. Add `grafanadata:` named volume in the `volumes:` section.
+
+- [ ] **Step 1: Update `victoriametrics:` profile (line ~621)**
+
+Locate this line:
+```yaml
+    profiles: [metrics-e2e]
+```
+inside the `victoriametrics:` block.
+
+Replace with:
+```yaml
+    profiles: [metrics, metrics-e2e]
+```
+
+- [ ] **Step 2: Update `prometheus-writer:` profile (line ~601)**
+
+Locate this line inside the `prometheus-writer:` block:
+```yaml
+    profiles: [lite, full]
+```
+
+Replace with:
+```yaml
+    profiles: [lite, full, metrics]
+```
+
+- [ ] **Step 3: Insert the new `grafana:` service**
+
+After the closing of the `victoriametrics:` block (the line `      - "18428:8428"` on line ~636) and BEFORE the `volumes:` section header (line ~638), insert this new service block. Note: there must be exactly two spaces of indent on each line for the service definition (matching all other top-level services).
+
+```yaml
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    profiles: [metrics, metrics-e2e]
+    container_name: delta-v-grafana
+    hostname: grafana
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+    environment:
+      # Anonymous read-only access for demo. Anyone hitting localhost:13000 lands
+      # in the Viewer role without login. Disable by setting GF_AUTH_ANONYMOUS_ENABLED=false.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+      # Admin password override. Default 'admin' is fine for the demo stack.
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
+      # Disable telemetry phone-home and update checks — this is a demo container.
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:3000/api/health | grep -q '\"database\":\"ok\"'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+    ports:
+      - "13000:3000"
+```
+
+- [ ] **Step 4: Add `grafanadata:` named volume**
+
+Locate the `volumes:` section near the bottom of the file (line ~638). Add `grafanadata:` after the existing `clickhouse-data:` entry. The final volumes block should look like:
+
+```yaml
+volumes:
+  pgdata:
+  kafkadata:
+  collectd-data:
+  clickhouse-data:
+  grafanadata:
+```
+
+- [ ] **Step 5: Validate the YAML**
+
+Run: `docker compose -f opennms-container/delta-v/docker-compose.yml config --profile metrics --profile lite > /dev/null && echo OK`
+Expected: `OK`. If yaml is malformed, `docker compose config` returns a parse error.
+
+- [ ] **Step 6: Commit**
+
+```
+git add opennms-container/delta-v/docker-compose.yml
+git commit -m "feat(grafana): add grafana service + expand profile membership for metrics path
+
+Grafana 11.4.0 OSS pinned, anonymous Viewer access, host port 13000.
+Profile expansion: victoriametrics gains 'metrics' alongside 'metrics-e2e';
+prometheus-writer gains 'metrics' so the writer is co-resident with its target.
+Both profile names continue to work — 'metrics-e2e' retained as alias."
+```
+
+---
+
+### Task 3: Write the datasource provisioning manifest
+
+**Files:**
+- Create: `opennms-container/delta-v/grafana/provisioning/datasources/victoriametrics.yml`
+
+- [ ] **Step 1: Create the datasource yaml**
+
+```yaml
+# Grafana datasource provisioning — auto-loaded at startup via the
+# /etc/grafana/provisioning/datasources/ bind mount.
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    uid: victoriametrics
+    type: prometheus
+    access: proxy
+    url: http://victoriametrics:8428
+    isDefault: true
+    editable: false
+    jsonData:
+      # Match VictoriaMetrics's ingest cadence; collectd-default polls at 30s.
+      timeInterval: 30s
+      httpMethod: POST
+      manageAlerts: false
+      prometheusType: Prometheus
+      prometheusVersion: 2.40.0
+```
+
+The `uid: victoriametrics` is non-negotiable — the dashboard JSON references the datasource by UID.
+
+- [ ] **Step 2: Validate the yaml syntax**
+
+Run: `docker run --rm -v $(pwd)/opennms-container/delta-v/grafana/provisioning/datasources:/check mikefarah/yq:4 'true' /check/victoriametrics.yml > /dev/null && echo OK`
+Expected: `OK`. (If `yq` isn't preferred, `python3 -c 'import yaml; yaml.safe_load(open("opennms-container/delta-v/grafana/provisioning/datasources/victoriametrics.yml"))' && echo OK` works equivalently.)
+
+- [ ] **Step 3: Commit**
+
+```
+git add opennms-container/delta-v/grafana/provisioning/datasources/victoriametrics.yml
+git commit -m "feat(grafana): provision VictoriaMetrics datasource (uid=victoriametrics, default)"
+```
+
+---
+
+### Task 4: Write the dashboard provisioning manifest
+
+**Files:**
+- Create: `opennms-container/delta-v/grafana/provisioning/dashboards/default.yml`
+
+- [ ] **Step 1: Create the dashboard provider yaml**
+
+```yaml
+# Grafana dashboard provider — points at the bind-mounted directory where
+# JSON dashboard files live. Reloads every 30s, allows UI edits but they
+# don't persist across container restarts (the JSON file wins).
+apiVersion: 1
+
+providers:
+  - name: delta-v-bundled
+    orgId: 1
+    folder: Delta-V
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false
+```
+
+- [ ] **Step 2: Validate the yaml syntax**
+
+Run: `python3 -c 'import yaml; yaml.safe_load(open("opennms-container/delta-v/grafana/provisioning/dashboards/default.yml"))' && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```
+git add opennms-container/delta-v/grafana/provisioning/dashboards/default.yml
+git commit -m "feat(grafana): provision dashboard provider (folder Delta-V, 30s reload)"
+```
+
+---
+
+### Task 5: Write the SNMP overview dashboard JSON
+
+**Files:**
+- Create: `opennms-container/delta-v/grafana/dashboards/snmp-overview.json`
+
+This is the largest artifact. The complete JSON below was hand-crafted from the spec's panel definitions (spec §5). It targets Grafana 11.x schema version 39. After creation, Task 5 verifies the JSON loads cleanly by booting Grafana and asking the API for the dashboard back.
+
+**Panels covered (per spec §5):**
+1. (0,0) Interface throughput in (bps, top 10) — `topk(10, rate(...ifhcinoctets_total[5m]) * 8)`
+2. (0,1) Interface throughput out (bps, top 10) — symmetric on `ifhcoutoctets`
+3. (0,2) Interface error rate — sum of in/out errors + discards rates
+4. (1,0) CPU load per processor — `opennms_mib2_host_resources_processor_hrprocessorload`
+5. (1,1) Storage utilization (%) — `100 * hrstorageused / hrstoragesize`
+6. (1,2) Devices monitored (table) — `count by (instance, foreign_source, snmp_syscontact, snmp_syslocation)(...)` — **demos PR #180's labels**
+
+- [ ] **Step 1: Create the dashboard JSON file**
+
+```json
+{
+  "uid": "snmp-overview",
+  "title": "SNMP Overview",
+  "tags": ["delta-v", "snmp"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": {
+          "query": "label_values(opennms_mib2_x_interfaces_ifhcinoctets_total, instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        }
+      },
+      {
+        "name": "foreign_source",
+        "label": "Foreign source",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": {
+          "query": "label_values(opennms_mib2_x_interfaces_ifhcinoctets_total{instance=~\"$instance\"}, foreign_source)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Interface throughput in (bps, top 10)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(opennms_mib2_x_interfaces_ifhcinoctets_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) * 8)",
+          "legendFormat": "{{instance}} · ifIndex {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 2,
+      "title": "Interface throughput out (bps, top 10)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(opennms_mib2_x_interfaces_ifhcoutoctets_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) * 8)",
+          "legendFormat": "{{instance}} · ifIndex {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 3,
+      "title": "Interface error rate (errors+discards/sec)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(opennms_mib2_interface_errors_ifinerrors_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) + rate(opennms_mib2_interface_errors_ifouterrors_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) + rate(opennms_mib2_interface_errors_ifindiscards_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) + rate(opennms_mib2_interface_errors_ifoutdiscards_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m])",
+          "legendFormat": "{{instance}} · ifIndex {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 10}
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "thresholdsStyle": {"mode": "line"}
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 4,
+      "title": "CPU load per processor (%)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 8},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "opennms_mib2_host_resources_processor_hrprocessorload{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}",
+          "legendFormat": "{{instance}} · proc {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 5,
+      "title": "Storage utilization (%)",
+      "type": "bargauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 8},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * opennms_mib2_host_resources_storage_hrstorageused{instance=~\"$instance\", foreign_source=~\"$foreign_source\"} / opennms_mib2_host_resources_storage_hrstoragesize{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}",
+          "legendFormat": "{{instance}} · storage {{resource_instance}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 70},
+              {"color": "red", "value": 90}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 6,
+      "title": "Devices monitored",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 8},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count by (instance, foreign_source, snmp_syscontact, snmp_syslocation) (rate(opennms_mib2_x_interfaces_ifhcinoctets_total[5m]))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Value"},
+            "properties": [{"id": "custom.hidden", "value": true}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "Time"},
+            "properties": [{"id": "custom.hidden", "value": true}]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "instance": "Instance",
+              "foreign_source": "Foreign source",
+              "snmp_syscontact": "SNMP sysContact",
+              "snmp_syslocation": "SNMP sysLocation"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "links": [],
+  "weekStart": ""
+}
+```
+
+- [ ] **Step 2: Validate the JSON syntax**
+
+Run: `python3 -c 'import json; json.load(open("opennms-container/delta-v/grafana/dashboards/snmp-overview.json"))' && echo OK`
+Expected: `OK`. (Catches typos like trailing commas or unmatched braces before Grafana ever sees it.)
+
+- [ ] **Step 3: Commit**
+
+```
+git add opennms-container/delta-v/grafana/dashboards/snmp-overview.json
+git commit -m "feat(grafana): add SNMP overview starter dashboard (uid=snmp-overview)
+
+Six panels covering interface throughput in/out (top-10), error rate,
+CPU load per processor, storage utilization (%), and a devices-monitored
+table that exercises the four operator-friendly labels added by #180
+(instance, foreign_source, snmp_syscontact, snmp_syslocation).
+Two template variables: instance and foreign_source. 30s refresh,
+last-15-min default time range, Delta-V folder."
+```
+
+---
+
+### Task 6: Verify the Grafana stack boots and dashboard provisions
+
+**No file changes** — this task validates that Tasks 1-5 produce a working stack before we extend the E2E test.
+
+The implementer brings up only the metrics-pipeline subset of the stack, confirms Grafana boots, the datasource provisions, and the dashboard loads. This is faster than running the full E2E (which adds Collectd polling + sample wait time).
+
+- [ ] **Step 1: Bring up the metrics stack**
+
+```
+cd opennms-container/delta-v
+docker compose --profile lite --profile metrics up -d --build
+```
+
+Expected: services start. Wait until docker compose ps shows `delta-v-grafana` as `Up (healthy)`.
+
+- [ ] **Step 2: Confirm Grafana is healthy**
+
+```
+docker compose exec -T grafana wget -q -O- http://localhost:3000/api/health
+```
+Expected: JSON response containing `"database":"ok"`.
+
+- [ ] **Step 3: Confirm the VictoriaMetrics datasource provisioned**
+
+```
+docker compose exec -T grafana wget -q -O- --user=admin --password=admin \
+    http://localhost:3000/api/datasources/uid/victoriametrics
+```
+Expected: JSON containing `"name":"VictoriaMetrics"` and `"url":"http://victoriametrics:8428"`.
+
+- [ ] **Step 4: Confirm the dashboard provisioned**
+
+```
+docker compose exec -T grafana wget -q -O- --user=admin --password=admin \
+    http://localhost:3000/api/dashboards/uid/snmp-overview
+```
+Expected: JSON containing `"title":"SNMP Overview"` and `"uid":"snmp-overview"`.
+
+- [ ] **Step 5: Tear down**
+
+```
+docker compose --profile lite --profile metrics down -v --remove-orphans
+cd ../..
+```
+
+If any of steps 2-4 fail, **stop and debug**:
+- `docker compose logs grafana | grep -E "(error|provisioning|dashboard)"` for provisioning errors.
+- The most common failure is dashboard JSON schema rejection — the JSON in Task 5 was hand-crafted and may need minor adjustments. Watch for log lines like `failed to load dashboard` and fix the offending JSON field.
+- If the JSON loads but the dashboard returns 404 from the API, check `docker compose exec grafana ls -la /var/lib/grafana/dashboards/` to confirm the bind mount is correct.
+
+(No commit. This task is verification only.)
+
+---
+
+### Task 7: Extend test-prometheus-writer-e2e.sh
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-prometheus-writer-e2e.sh`
+
+Three changes:
+1. Profile name `metrics-e2e` → `metrics` in the cleanup trap (line 41) and the up command (line 46).
+2. Update the echo on line 45 to reflect the new name.
+3. Restructure the end of step 6 so the script doesn't `exit 0` immediately on success — needs to continue to steps 7-9 first.
+4. Insert steps 7-9 (Grafana health, datasource health, dashboard load) after step 6.
+
+- [ ] **Step 1: Update profile names (lines 41, 45, 46)**
+
+Replace this block (lines 39-46):
+```bash
+cleanup() {
+    echo "==> Tearing down stack"
+    docker compose --profile lite --profile metrics-e2e down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "==> Starting delta-v Docker Compose (lite + metrics-e2e profiles)"
+docker compose --profile lite --profile metrics-e2e up -d --build
+```
+
+with:
+```bash
+cleanup() {
+    echo "==> Tearing down stack"
+    docker compose --profile lite --profile metrics down -v --remove-orphans || true
+}
+trap cleanup EXIT
+
+echo "==> Starting delta-v Docker Compose (lite + metrics profiles)"
+docker compose --profile lite --profile metrics up -d --build
+```
+
+- [ ] **Step 2: Restructure step 6 so it falls through to steps 7-9**
+
+Replace this block (lines 141-164):
+```bash
+# ── Step 6: Query VictoriaMetrics ─────────────────────────────────────────────
+echo "==> Step 6: Query VictoriaMetrics for the landed series"
+deadline=$((SECONDS + VM_QUERY_TIMEOUT))
+while (( SECONDS < deadline )); do
+    resp=$(curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_interface_errors_ifindiscards_total" \
+            || echo '{"data":{"result":[]}}')
+    count=$(echo "$resp" | python3 -c \
+        'import json,sys; d=json.load(sys.stdin); print(len(d.get("data",{}).get("result",[])))' \
+        2>/dev/null || echo "0")
+    if (( count > 0 )); then
+        echo "==> VM returned ${count} series for opennms_mib2_interface_errors_ifindiscards_total"
+        echo "$resp" | grep -E '"node_id":"[0-9]+"' > /dev/null || { echo "FAIL: missing node_id label"; exit 1; }
+        echo "$resp" | grep -E '"location":' > /dev/null || { echo "FAIL: missing location label"; exit 1; }
+        echo "$resp" | grep -E '"foreign_source":' > /dev/null || { echo "FAIL: missing foreign_source label"; exit 1; }
+        echo "$resp" | grep -E '"resource_instance":' > /dev/null || { echo "FAIL: missing resource_instance label"; exit 1; }
+        echo "==> ALL ASSERTIONS PASSED"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "FAIL: VictoriaMetrics returned no results within ${VM_QUERY_TIMEOUT}s"
+echo "Last VM response: $resp"
+exit 1
+```
+
+with the restructured form (changes: replace `exit 0` with `vm_landed=true; break`; add a sentinel guard after the loop; remove the trailing `exit 1` since steps 7-9 now follow):
+```bash
+# ── Step 6: Query VictoriaMetrics ─────────────────────────────────────────────
+echo "==> Step 6: Query VictoriaMetrics for the landed series"
+deadline=$((SECONDS + VM_QUERY_TIMEOUT))
+vm_landed=false
+while (( SECONDS < deadline )); do
+    resp=$(curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_interface_errors_ifindiscards_total" \
+            || echo '{"data":{"result":[]}}')
+    count=$(echo "$resp" | python3 -c \
+        'import json,sys; d=json.load(sys.stdin); print(len(d.get("data",{}).get("result",[])))' \
+        2>/dev/null || echo "0")
+    if (( count > 0 )); then
+        echo "==> VM returned ${count} series for opennms_mib2_interface_errors_ifindiscards_total"
+        echo "$resp" | grep -E '"node_id":"[0-9]+"' > /dev/null || { echo "FAIL: missing node_id label"; exit 1; }
+        echo "$resp" | grep -E '"location":' > /dev/null || { echo "FAIL: missing location label"; exit 1; }
+        echo "$resp" | grep -E '"foreign_source":' > /dev/null || { echo "FAIL: missing foreign_source label"; exit 1; }
+        echo "$resp" | grep -E '"resource_instance":' > /dev/null || { echo "FAIL: missing resource_instance label"; exit 1; }
+        vm_landed=true
+        break
+    fi
+    sleep 2
+done
+if [[ "$vm_landed" != "true" ]]; then
+    echo "FAIL: VictoriaMetrics returned no results within ${VM_QUERY_TIMEOUT}s"
+    echo "Last VM response: $resp"
+    exit 1
+fi
+
+# ── Step 7: Wait for Grafana readiness ────────────────────────────────────────
+echo "==> Step 7: Wait for Grafana /api/health"
+deadline=$((SECONDS + STACK_READY_TIMEOUT))
+gf_ready=false
+while (( SECONDS < deadline )); do
+    health=$(docker compose exec -T grafana \
+        wget -q -O- http://localhost:3000/api/health 2>/dev/null || true)
+    if echo "$health" | grep -q '"database":"ok"'; then
+        echo "==> Grafana ready"
+        gf_ready=true
+        break
+    fi
+    sleep 3
+done
+if [[ "$gf_ready" != "true" ]]; then
+    echo "FAIL: Grafana readiness timeout"
+    docker compose logs grafana | tail -50
+    exit 1
+fi
+
+# ── Step 8: Verify VictoriaMetrics datasource is reachable from Grafana ───────
+echo "==> Step 8: Verify VictoriaMetrics datasource health"
+ds_health=$(docker compose exec -T grafana \
+    wget -q -O- --user=admin --password="${GF_ADMIN_PASSWORD:-admin}" \
+    http://localhost:3000/api/datasources/uid/victoriametrics/health 2>/dev/null || true)
+if ! echo "$ds_health" | grep -q '"status":"OK"'; then
+    echo "FAIL: VictoriaMetrics datasource health check failed"
+    echo "Response: $ds_health"
+    exit 1
+fi
+echo "==> Datasource OK"
+
+# ── Step 9: Verify the snmp-overview dashboard is provisioned ─────────────────
+echo "==> Step 9: Verify snmp-overview dashboard is loaded"
+dash=$(docker compose exec -T grafana \
+    wget -q -O- --user=admin --password="${GF_ADMIN_PASSWORD:-admin}" \
+    http://localhost:3000/api/dashboards/uid/snmp-overview 2>/dev/null || true)
+if ! echo "$dash" | grep -q '"title":"SNMP Overview"'; then
+    echo "FAIL: snmp-overview dashboard not loaded"
+    echo "Response: $dash"
+    exit 1
+fi
+echo "==> Dashboard OK"
+
+echo "==> ALL ASSERTIONS PASSED"
+exit 0
+```
+
+- [ ] **Step 3: Verify the script is syntactically valid**
+
+Run: `bash -n opennms-container/delta-v/test-prometheus-writer-e2e.sh && echo OK`
+Expected: `OK`. (`bash -n` parses without executing — catches syntax errors.)
+
+- [ ] **Step 4: Commit**
+
+```
+git add opennms-container/delta-v/test-prometheus-writer-e2e.sh
+git commit -m "test(grafana): extend e2e with Grafana health + datasource health + dashboard load
+
+Renames the up/down profile from metrics-e2e to metrics (both still work as
+aliases on the affected services). Restructures step 6 to fall through to
+new steps 7-9 instead of exiting on success."
+```
+
+---
+
+### Task 8: Update README.md with Grafana access blurb + fix profile reference
+
+**Files:**
+- Modify: `opennms-container/delta-v/README.md`
+
+Two changes:
+1. Update line 346-347's description of `metrics-e2e` to reflect the rename.
+2. Insert a new "## Grafana access (demo mode)" section after the "Wire format frozen" section (line 399) and before "## Troubleshooting" (line 401).
+
+- [ ] **Step 1: Update the Phase 2 profiles description**
+
+Locate this block (lines 340-347):
+```markdown
+### Profiles
+
+- **lite, full** — starts `prometheus-writer`. Point `PROMETHEUS_WRITER_REMOTE_WRITE_URL`
+  at your TSDB (Mimir, VictoriaMetrics, Cortex, Thanos Receive, Prometheus with
+  `--web.enable-remote-write-receiver`). Without a reachable target, the writer
+  starts healthy, opens its circuit on first POST failure, and stays paused.
+- **metrics-e2e** — adds a pinned `victoriametrics:v1.106.1` container for E2E.
+  Not intended for production.
+```
+
+Replace with:
+```markdown
+### Profiles
+
+- **lite, full** — starts `prometheus-writer`. Point `PROMETHEUS_WRITER_REMOTE_WRITE_URL`
+  at your TSDB (Mimir, VictoriaMetrics, Cortex, Thanos Receive, Prometheus with
+  `--web.enable-remote-write-receiver`). Without a reachable target, the writer
+  starts healthy, opens its circuit on first POST failure, and stays paused.
+- **metrics** (alias: **metrics-e2e**) — adds a pinned `victoriametrics:v1.106.1`
+  container plus a Grafana service with a starter SNMP dashboard. The canonical
+  demo command is `docker compose --profile lite --profile metrics up`. See the
+  "Grafana access" section below.
+```
+
+- [ ] **Step 2: Insert the new "Grafana access" section**
+
+Locate the "## Troubleshooting" line (line 401). Immediately BEFORE it, insert a blank line followed by:
+
+```markdown
+## Grafana access (demo mode)
+
+After `docker compose --profile lite --profile metrics up -d`, open
+`http://localhost:13000/d/snmp-overview`. Anonymous Viewer access is on by
+default (no login required) and the SNMP Overview dashboard is pre-provisioned
+with VictoriaMetrics as the datasource.
+
+The first poll cycle takes ~30 seconds; allow ~90 seconds after `up` for
+panels to populate with data from the bundled mock SNMP agent.
+
+To log in as admin (e.g. to create custom dashboards):
+
+- Username: `admin`
+- Password: `admin` (override via `GF_ADMIN_PASSWORD` environment variable).
+
+```
+
+(There must be a trailing blank line before the `## Troubleshooting` header so the headers don't collide.)
+
+- [ ] **Step 3: Verify the markdown still renders cleanly**
+
+Run: `head -1 opennms-container/delta-v/README.md && echo "---" && grep -c "^## " opennms-container/delta-v/README.md`
+Expected: First line `# OpenNMS Delta-V`, and the count of `##` (level 2) headers should be one higher than before (the new "Grafana access" section).
+
+- [ ] **Step 4: Commit**
+
+```
+git add opennms-container/delta-v/README.md
+git commit -m "docs(grafana): document operator access at localhost:13000 + canonical metrics profile"
+```
+
+---
+
+### Task 9: Full E2E verification gate
+
+**No file changes** — this is the gate that ensures everything works end-to-end before push.
+
+- [ ] **Step 1: Run the extended E2E script**
+
+```
+bash opennms-container/delta-v/test-prometheus-writer-e2e.sh
+```
+
+Expected: exits 0, with the final lines reading `==> Dashboard OK` and `==> ALL ASSERTIONS PASSED`. The full script should take roughly 3-5 minutes (stack spinup + 90s poll grace + verification).
+
+If the test fails at any step:
+- **Step 1-6 failures**: pre-existing E2E behavior; investigate as you would for the existing test.
+- **Step 7 (Grafana readiness)**: check `docker compose logs grafana` for boot errors. Increase `start_period` in the docker-compose healthcheck if Grafana needs longer than 10s on slow machines.
+- **Step 8 (datasource health)**: usually means VictoriaMetrics is unreachable from inside the Grafana container. Confirm both are on the same default compose network (they should be — no special config needed).
+- **Step 9 (dashboard load)**: the JSON failed to parse on Grafana's side. `docker compose logs grafana | grep -E "(error|dashboard)"` will show the line of the JSON it choked on.
+
+(No commit. This is a gate.)
+
+---
+
+### Task 10: Push branch + open PR `--repo pbrane/delta-v`
+
+- [ ] **Step 1: Push the branch with upstream tracking**
+
+```
+git push -u origin feat/grafana-victoriametrics-bundle
+```
+Expected: branch is created on `pbrane/delta-v` (this is the default `origin` remote per project convention).
+
+- [ ] **Step 2: Open the PR — `--repo pbrane/delta-v` is non-negotiable**
+
+```
+gh pr create --repo pbrane/delta-v --base develop --head feat/grafana-victoriametrics-bundle \
+  --title "feat(grafana): add Grafana service + VictoriaMetrics datasource + starter SNMP dashboard" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes the "graphs after `docker compose up`" gap in the delta-v stack. After this PR, `docker compose --profile lite --profile metrics up` brings up the full pipeline (mock-snmp-agent → Minion → Collectd → Kafka → prometheus-writer → VictoriaMetrics → Grafana), and `http://localhost:13000/d/snmp-overview` shows live SNMP graphs within ~90 seconds.
+
+**Configuration-only PR — no Java touched.**
+
+### What ships
+
+- **`grafana` service** in docker-compose: Grafana 11.4.0 OSS, anonymous Viewer access, host port 13000, profiled `[metrics, metrics-e2e]`.
+- **Filesystem provisioning** under `opennms-container/delta-v/grafana/`:
+  - VictoriaMetrics datasource (UID `victoriametrics`, default).
+  - One starter dashboard `snmp-overview.json` with 6 panels (interface throughput in/out, error rate, CPU per processor, storage utilization %, devices-monitored table).
+- **Profile rename**: `metrics` is now the canonical name; `metrics-e2e` retained as alias on `victoriametrics` and `grafana`. `prometheus-writer` profile expanded to `[lite, full, metrics]` so the writer is co-resident with its target.
+- **E2E test extension**: `test-prometheus-writer-e2e.sh` gains 3 new steps (Grafana health, datasource health, dashboard load) and is updated to use `--profile metrics`.
+
+### Killer demo for #180's labels
+
+The "Devices monitored" table panel pulls `instance`, `foreign_source`, `snmp_syscontact`, `snmp_syslocation` columns from a `count by (...)` query — operators see all four operator-friendly labels added by #180 in a single tabular view without writing PromQL.
+
+### Depends on
+
+- delta-v#180 (currently open) ships the labels the dashboard variables and the devices-monitored table reference. The dashboard loads cleanly without #180 (E2E passes), but the variables return empty values and the table is blank until #180 lands.
+
+Spec: `docs/superpowers/specs/2026-04-20-grafana-victoriametrics-bundle-design.md`. Plan: `docs/superpowers/plans/2026-04-20-grafana-victoriametrics-bundle-plan.md`.
+
+## Test plan
+
+- [x] `bash opennms-container/delta-v/test-prometheus-writer-e2e.sh` — green (steps 1-9, including new Grafana asserts).
+- [x] Manual visual: open `http://localhost:13000/d/snmp-overview`, confirm panels render with data after ~90s of polling.
+- [ ] Post-merge: nothing — this is operator-facing tooling, no follow-up memo.
+EOF
+)"
+```
+
+Expected: GitHub CLI returns the PR URL.
+
+- [ ] **Step 3: Print the PR URL**
+
+The `gh pr create` command prints the URL on success. Echo it back so the user can open it.
+
+---
+
+## Self-Review Checklist (run after writing the plan; not a separate task)
+
+The following list pins what I checked when writing this plan. Re-verify if the plan is changed.
+
+**1. Spec coverage**
+
+| Spec section | Implementing task |
+|---|---|
+| `grafana:` service in docker-compose, profile membership, healthcheck | Task 2 |
+| `victoriametrics` profile expansion to include `metrics` | Task 2 |
+| `prometheus-writer` profile expansion to include `metrics` | Task 2 |
+| `grafanadata` named volume | Task 2 |
+| Datasource provisioning yaml | Task 3 |
+| Dashboard provider provisioning yaml | Task 4 |
+| `snmp-overview.json` with 2 template variables + 6 panels | Task 5 |
+| E2E rename + 3 new steps | Task 7 |
+| README operator-facing blurb + Phase 2 profile description fix | Task 8 |
+| Full E2E green | Task 9 |
+| PR opened `--repo pbrane/delta-v` | Task 10 |
+
+All scope items have an implementing task. Spec out-of-scope items (per-interface drilldown dashboard, ClickHouse datasource, alerting, visual regression, LDAP/SSO) are correctly absent from the plan.
+
+**2. Placeholder scan**: no `TBD`, `TODO`, `fill in`, `add appropriate handling`, or "similar to Task N" references. All file content is provided in full.
+
+**3. Type/name consistency**:
+- Datasource `uid: victoriametrics` — Task 3 declares it; Task 5 dashboard JSON references it 7 times (2 variables + 5 panel target datasources); Task 7 E2E queries `/api/datasources/uid/victoriametrics/health`. All match.
+- Dashboard `uid: snmp-overview` — Task 5 declares it; Task 7 queries `/api/dashboards/uid/snmp-overview`. All match.
+- Profile `metrics` — Task 2 declares; Task 7 uses in cleanup + up; Task 8 documents.
+- Container hostname `grafana` — Task 2 declares; Task 7 references via `docker compose exec -T grafana`.
+- Host port `13000` — Task 2 declares; Task 8 README references.
+- Metric names in dashboard JSON match the spec table exactly (verified against `mib2.xml` during spec writing).

--- a/docs/superpowers/specs/2026-04-20-grafana-victoriametrics-bundle-design.md
+++ b/docs/superpowers/specs/2026-04-20-grafana-victoriametrics-bundle-design.md
@@ -1,0 +1,364 @@
+# Grafana + VictoriaMetrics Bundle — Design Spec
+
+**Date:** 2026-04-20
+**Branch:** `feat/grafana-victoriametrics-bundle` (already created off develop tip `12a5479e3b6`)
+**Predecessor PR:** delta-v#180 (`feat/prometheus-writer-label-coverage`) — ships the `instance`, `foreign_id`, `snmp_syscontact`, `snmp_syslocation` labels this dashboard depends on. **This PR's dashboard variables and table panel reference labels added by #180.** If #180 is reverted, the SNMP Overview dashboard's `$instance` variable returns no values and panels render empty (not error) — the dashboard structure stays loadable and the E2E health check still passes, but visualization breaks until #180 re-lands.
+**PR target:** pbrane/delta-v develop (NEVER OpenNMS/opennms).
+
+## Goal
+
+Make Delta-V's Collectd → Kafka → prometheus-writer → VictoriaMetrics pipeline operator-visible by adding a Grafana service to the docker-compose stack with a starter SNMP overview dashboard pre-provisioned. After this PR, `docker compose --profile lite --profile metrics up` produces a stack where `http://localhost:13000/d/snmp-overview` shows live SNMP graphs from the mock SNMP agent within ~90s of startup.
+
+## Scope
+
+### In Scope
+
+- New `grafana/grafana:11.4.0` service in `opennms-container/delta-v/docker-compose.yml`, anonymous read-only access enabled, host port `13000`.
+- New `grafana/` subdirectory with provisioning manifests (datasource + dashboard provider) and one starter dashboard JSON.
+- Profile rename: introduce a new `metrics` profile that contains both `victoriametrics` and `grafana` (and the `prometheus-writer`, so it has a write target). Existing `metrics-e2e` profile retained as alias for backwards compatibility — both `victoriametrics` and `grafana` will list `[metrics, metrics-e2e]`.
+- Extension of `test-prometheus-writer-e2e.sh` with three new steps verifying Grafana health, datasource health, and dashboard load.
+- Documentation: brief operator-facing README addition explaining how to access the dashboard.
+
+### Out of Scope
+
+- Multiple dashboards (per-interface drill-down, node detail page, alarm view). Tracked as follow-up work — this PR establishes the foundation; further dashboards are iterative.
+- Grafana alerting rules. Out of scope for the demo bundle; operators set up alerts against their production VM/Prometheus separately.
+- LDAP / SSO / OAuth integration. Anonymous-Viewer is the demo default; production deployments configure auth via env-var override.
+- Per-tenant Grafana org separation.
+- Bundling a Prometheus alternative (the bundled VM is the only supported storage backend in this PR; operators pointing at their own Prometheus do so via the existing `PROMETHEUS_WRITER_REMOTE_WRITE_URL` env override and bring their own visualization).
+- Visual regression tests (e.g. screenshot comparison). The E2E asserts services-are-healthy and dashboard-is-loaded; visual rendering of panels is verified manually before merge.
+
+## Background
+
+The Phase 2 E2E test (`opennms-container/delta-v/test-prometheus-writer-e2e.sh`) already proves: mock-snmp-agent → Minion poll → Collectd → `deltav-timeseries` Kafka topic → `prometheus-writer` (joined with provisiond's NodeContext) → VictoriaMetrics, ending with a successful PromQL query. PR #180 (currently open against develop) ships operator-friendly labels (`instance`, `foreign_id`, sanitized metadata keys) that Grafana templating naturally consumes.
+
+The gap between "the pipeline works" and "an operator can see graphs" is purely the Grafana service plus a starter dashboard. There is no data-pipeline change in this PR.
+
+**Profile-composition gap (corrected by this PR):** `prometheus-writer` is in profiles `[lite, full]` today, but its write target `victoriametrics` is in profile `[metrics-e2e]` only. So in default deployments, the writer's circuit breaker eventually opens because there's no destination. This PR aligns the writer and its target into the same profile (`metrics`), so any profile combination that includes the writer also includes a working target.
+
+## Design
+
+### 1. File layout
+
+```
+opennms-container/delta-v/
+├── docker-compose.yml                       (MODIFIED — see §2)
+│
+├── grafana/                                 (NEW — bind-mounted into container)
+│   ├── provisioning/
+│   │   ├── datasources/
+│   │   │   └── victoriametrics.yml          (NEW)
+│   │   └── dashboards/
+│   │       └── default.yml                  (NEW)
+│   └── dashboards/
+│       └── snmp-overview.json               (NEW)
+│
+├── test-prometheus-writer-e2e.sh            (MODIFIED — see §6)
+│
+└── README.md                                (MODIFIED — operator-facing access doc)
+```
+
+### 2. `docker-compose.yml` changes
+
+Three changes:
+
+**a. New `grafana` service** (inserted after `victoriametrics:` block):
+
+```yaml
+  grafana:
+    image: grafana/grafana:11.4.0
+    profiles: [metrics, metrics-e2e]
+    container_name: delta-v-grafana
+    hostname: grafana
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+    environment:
+      # Anonymous read-only access for demo. Anyone hitting localhost:13000 lands
+      # in the Viewer role without login. Disable by setting GF_AUTH_ANONYMOUS_ENABLED=false.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+      # Admin password override. Default 'admin' is fine for the demo stack.
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
+      # Disable telemetry phone-home and update checks — this is a demo container.
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:3000/api/health | grep -q '\"database\":\"ok\"'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+    ports:
+      - "13000:3000"
+```
+
+**b. Update `victoriametrics` profile list** from `[metrics-e2e]` to `[metrics, metrics-e2e]`. Same file, only the `profiles:` line in the `victoriametrics` block changes.
+
+**c. Update `prometheus-writer` profile list** from `[lite, full]` to `[lite, full, metrics]`. So when `--profile metrics` is selected alongside an upstream-data profile (`lite` or `full`), the writer is co-resident with its VM target. The canonical demo command is therefore `--profile lite --profile metrics` (matching the existing `lite + metrics-e2e` pattern of the test script). `--profile metrics` alone is intentionally NOT a complete-pipeline profile: it brings up VM + Grafana + writer, but `collectd` and `provisiond` (which produce the data) live in `lite`/`full`/`passive`. Operators picking only `--profile metrics` see Grafana with empty graphs, not a runtime error.
+
+**d. New named volume** at the bottom of the `volumes:` section:
+
+```yaml
+  grafanadata:
+```
+
+### 3. Datasource provisioning manifest
+
+`grafana/provisioning/datasources/victoriametrics.yml`:
+
+```yaml
+# Grafana datasource provisioning — auto-loaded at startup via the
+# /etc/grafana/provisioning/datasources/ bind mount.
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    uid: victoriametrics
+    type: prometheus
+    access: proxy
+    url: http://victoriametrics:8428
+    isDefault: true
+    editable: false
+    jsonData:
+      # Match VictoriaMetrics's ingest cadence; collectd-default polls at 30s.
+      timeInterval: 30s
+      httpMethod: POST
+      manageAlerts: false
+      prometheusType: Prometheus
+      prometheusVersion: 2.40.0
+```
+
+**Why `uid: victoriametrics` is non-negotiable:** the dashboard JSON references the datasource by UID, not name. Pinning the UID makes the dashboard portable across Grafana installs and keeps the E2E datasource-health check (`/api/datasources/uid/victoriametrics/health`) deterministic.
+
+**Why `editable: false`:** prevents accidental UI edits that would diverge from this YAML.
+
+### 4. Dashboard provider manifest
+
+`grafana/provisioning/dashboards/default.yml`:
+
+```yaml
+apiVersion: 1
+
+providers:
+  - name: delta-v-bundled
+    orgId: 1
+    folder: Delta-V
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false
+```
+
+**`editable: true` on dashboards (vs. false on datasource):** operators CAN edit panels live to experiment, but the source-of-truth JSON wins on container restart (or every 30s reload).
+
+### 5. Starter SNMP overview dashboard
+
+`grafana/dashboards/snmp-overview.json`. Semantic spec — the implementation plan produces the actual JSON, hand-built then exported from a live Grafana to ensure schema correctness.
+
+**Dashboard metadata:**
+- Title: `SNMP Overview`
+- UID: `snmp-overview`
+- Folder: `Delta-V` (per the provisioner's `folder:` field)
+- Refresh: `30s` (matches collectd default poll interval)
+- Default time range: `Last 15 minutes`
+- Tags: `["delta-v", "snmp"]`
+
+**Two template variables:**
+
+| Variable | Type | Query | Multi | Include All | Default |
+|---|---|---|---|---|---|
+| `instance` | Query | `label_values(opennms_mib2_x_interfaces_ifhcinoctets_total, instance)` | yes | yes | All |
+| `foreign_source` | Query | `label_values(opennms_mib2_x_interfaces_ifhcinoctets_total{instance=~"$instance"}, foreign_source)` | yes | yes | All |
+
+**Six panels** (3-column × 2-row grid):
+
+| Pos | Panel title | Query (templated) | Visualization |
+|---|---|---|---|
+| (0,0) | **Interface throughput in (bps, top 10)** | `topk(10, rate(opennms_mib2_x_interfaces_ifhcinoctets_total{instance=~"$instance", foreign_source=~"$foreign_source"}[5m]) * 8)` | Time series; legend `{{instance}} · ifIndex {{resource_instance}}`; unit `bits/s`. |
+| (0,1) | **Interface throughput out (bps, top 10)** | `topk(10, rate(opennms_mib2_x_interfaces_ifhcoutoctets_total{instance=~"$instance", foreign_source=~"$foreign_source"}[5m]) * 8)` | Time series; same legend pattern; unit `bits/s`. |
+| (0,2) | **Interface error rate (errors+discards/sec)** | `rate(opennms_mib2_interface_errors_ifinerrors_total{instance=~"$instance",foreign_source=~"$foreign_source"}[5m]) + rate(opennms_mib2_interface_errors_ifouterrors_total{instance=~"$instance",foreign_source=~"$foreign_source"}[5m]) + rate(opennms_mib2_interface_errors_ifindiscards_total{instance=~"$instance",foreign_source=~"$foreign_source"}[5m]) + rate(opennms_mib2_interface_errors_ifoutdiscards_total{instance=~"$instance",foreign_source=~"$foreign_source"}[5m])` | Time series with thresholds (yellow > 1/s, red > 10/s); unit `errors/s`. |
+| (1,0) | **CPU load per processor** | `opennms_mib2_host_resources_processor_hrprocessorload{instance=~"$instance", foreign_source=~"$foreign_source"}` | Time series; legend `{{instance}} · proc {{resource_instance}}`; unit `percent (0-100)`. |
+| (1,1) | **Storage utilization (%)** | `100 * opennms_mib2_host_resources_storage_hrstorageused{instance=~"$instance", foreign_source=~"$foreign_source"} / opennms_mib2_host_resources_storage_hrstoragesize{instance=~"$instance", foreign_source=~"$foreign_source"}` | Bar gauge; legend `{{instance}} · storage {{resource_instance}}`; thresholds at 70 (yellow) / 90 (red). |
+| (1,2) | **Devices monitored** | `count by (instance, foreign_source, snmp_syscontact, snmp_syslocation) (rate(opennms_mib2_x_interfaces_ifhcinoctets_total[5m]))` | Table; columns shown: `instance`, `foreign_source`, `snmp_syscontact`, `snmp_syslocation`. Hide the `Value` column. **This panel is the killer demo for PR #180's labels** — operators see all four operator-friendly labels in a single table without having to know any PromQL. |
+
+**Pinned metric names (sanitized via existing `NameSanitizer`):**
+
+| Source group + attribute | Sanitized PromQL name |
+|---|---|
+| `mib2-X-interfaces.ifHCInOctets` (Counter64) | `opennms_mib2_x_interfaces_ifhcinoctets_total` |
+| `mib2-X-interfaces.ifHCOutOctets` (Counter64) | `opennms_mib2_x_interfaces_ifhcoutoctets_total` |
+| `mib2-interface-errors.ifInErrors` (counter) | `opennms_mib2_interface_errors_ifinerrors_total` |
+| `mib2-interface-errors.ifOutErrors` | `opennms_mib2_interface_errors_ifouterrors_total` |
+| `mib2-interface-errors.ifInDiscards` | `opennms_mib2_interface_errors_ifindiscards_total` |
+| `mib2-interface-errors.ifOutDiscards` | `opennms_mib2_interface_errors_ifoutdiscards_total` |
+| `mib2-host-resources-processor.hrProcessorLoad` (Gauge32) | `opennms_mib2_host_resources_processor_hrprocessorload` |
+| `mib2-host-resources-storage.hrStorageUsed` (gauge) | `opennms_mib2_host_resources_storage_hrstorageused` |
+| `mib2-host-resources-storage.hrStorageSize` (gauge) | `opennms_mib2_host_resources_storage_hrstoragesize` |
+
+Naming derivation (per `TimeseriesToPromTranslator.buildMetricName`): `"opennms_" + sanitize(groupName) + "_" + sanitize(attrName)`, plus `_total` suffix for counters. `NameSanitizer` lowercases everything and replaces non-alphanumerics with `_`.
+
+### 6. E2E test extension
+
+`opennms-container/delta-v/test-prometheus-writer-e2e.sh` modifications:
+
+**Profile rename** (lines 41 and 46): change `--profile metrics-e2e` to `--profile metrics`. Since both `victoriametrics` and `grafana` list both profile names, the cleanup `down -v` still works.
+
+**Three new steps after the existing step 6 (VictoriaMetrics gold-standard query):**
+
+**Step 7 — Wait for Grafana readiness:**
+
+```bash
+echo "==> Step 7: Wait for Grafana /api/health"
+deadline=$((SECONDS + STACK_READY_TIMEOUT))
+while (( SECONDS < deadline )); do
+    health=$(docker compose exec -T grafana \
+        wget -q -O- http://localhost:3000/api/health 2>/dev/null || true)
+    if echo "$health" | grep -q '"database":"ok"'; then
+        echo "==> Grafana ready"
+        break
+    fi
+    sleep 3
+done
+if ! echo "${health:-}" | grep -q '"database":"ok"'; then
+    echo "FAIL: Grafana readiness timeout"
+    exit 1
+fi
+```
+
+**Step 8 — Datasource health:**
+
+```bash
+echo "==> Step 8: Verify VictoriaMetrics datasource is reachable from Grafana"
+ds_health=$(docker compose exec -T grafana \
+    wget -q -O- --user=admin --password="${GF_ADMIN_PASSWORD:-admin}" \
+    http://localhost:3000/api/datasources/uid/victoriametrics/health || true)
+if ! echo "$ds_health" | grep -q '"status":"OK"'; then
+    echo "FAIL: VictoriaMetrics datasource health check failed"
+    echo "Response: $ds_health"
+    exit 1
+fi
+echo "==> Datasource OK"
+```
+
+**Step 9 — Dashboard loaded:**
+
+```bash
+echo "==> Step 9: Verify snmp-overview dashboard is provisioned"
+dash=$(docker compose exec -T grafana \
+    wget -q -O- --user=admin --password="${GF_ADMIN_PASSWORD:-admin}" \
+    http://localhost:3000/api/dashboards/uid/snmp-overview || true)
+if ! echo "$dash" | grep -q '"title":"SNMP Overview"'; then
+    echo "FAIL: snmp-overview dashboard not loaded"
+    echo "Response: $dash"
+    exit 1
+fi
+echo "==> Dashboard OK"
+```
+
+**What this catches at PR time:**
+
+| Catches | Doesn't catch (acceptable for this PR) |
+|---|---|
+| Grafana service won't start | Panel queries return no data |
+| Provisioning YAML malformed | A panel JSON typo that doesn't break loading |
+| Datasource UID mismatch | Variable query syntax errors |
+| Datasource can't reach VM | Stale/incorrect metric names in panels |
+| Dashboard JSON malformed | Visual regressions (color, layout) |
+
+The "doesn't catch" column is verified manually by opening the dashboard in a browser at `localhost:13000` after the test passes. The PR description includes a "smoke-tested visually against mock-snmp-agent" line.
+
+### 7. README addition
+
+Add a short section to `opennms-container/delta-v/README.md` (after the existing profile documentation, before the troubleshooting section if any):
+
+```markdown
+## SNMP graphs in Grafana (demo mode)
+
+After `docker compose --profile lite --profile metrics up -d`, open
+`http://localhost:13000/d/snmp-overview`. Anonymous Viewer access is on by
+default (no login required) and the SNMP Overview dashboard is pre-provisioned
+with VictoriaMetrics as the datasource.
+
+The first poll cycle takes ~30 seconds; allow ~90 seconds after `up` for
+panels to populate with data from the bundled mock SNMP agent.
+
+To log in as admin (e.g. to create custom dashboards):
+- Username: `admin`
+- Password: `admin` (override via `GF_ADMIN_PASSWORD` env var).
+```
+
+## Edge cases & error handling
+
+| Scenario | Handling |
+|---|---|
+| Operator runs `--profile metrics-e2e` (legacy name) | Both VM and Grafana still come up — they're listed under both profiles. Test script also updated to use `--profile metrics` going forward. |
+| Operator runs `--profile lite` only (no metrics) | prometheus-writer comes up, finds no VM target, circuit breaker opens. Same behavior as today (this PR doesn't change `lite` profile membership). Operator sees DLQ + circuit metrics climb in `/actuator/prometheus` but no Grafana. |
+| Grafana starts before VM is healthy | `depends_on: victoriametrics: service_healthy` blocks Grafana startup until VM passes its healthcheck. |
+| Operator changes `prometheus-writer.labels.instance-source` to `FOREIGN_ID` or `NODE_ID` | Dashboard variables and panels still work — they reference the `instance` label by name, not by content. Legends will display the new format. |
+| `snmp_syscontact` / `snmp_syslocation` are empty (SNMP discovery hasn't populated them) | Devices-monitored table still renders with empty cells in those columns. Operator sees the column structure even before metadata fills in. |
+| Anonymous access undesirable | Set `GF_AUTH_ANONYMOUS_ENABLED=false` in env; operators land on the login page. |
+
+## Performance
+
+| Resource | Cost |
+|---|---|
+| Grafana container memory | ~150-200 MB resident, ~250 MB peak (typical Grafana 11 OSS) |
+| Grafana container startup time | ~5-15 seconds to readiness (provisioning happens during startup) |
+| Stack startup additional cost (vs. today's `metrics-e2e`) | +5-15s for Grafana, +0s for VM (already in `metrics-e2e`) |
+| Disk: bind-mounted dashboard JSON | ~50 KB |
+| Disk: `grafanadata` volume (admin password, session state) | ~5-10 MB after first boot |
+
+Negligible for the demo use case.
+
+## Backward compatibility
+
+| Change | Impact |
+|---|---|
+| New `metrics` profile alias | Additive. `--profile metrics-e2e` continues to work for any existing scripts/docs that reference it. |
+| `victoriametrics` profile expanded | Additive (`[metrics-e2e]` → `[metrics, metrics-e2e]`). |
+| `prometheus-writer` profile expanded | Additive (`[lite, full]` → `[lite, full, metrics]`). The writer now appears in `--profile metrics` too. |
+| New `grafana` service | Purely additive. Operators not opting into `metrics`/`metrics-e2e` see no change. |
+| `test-prometheus-writer-e2e.sh` profile name change | Internal test script — operators don't run it. CI pipelines pointing at this script may need a single-line update if they hardcoded the profile name. |
+
+No PromQL query breaks. No existing label changes (this PR depends on PR #180's labels but doesn't add or modify any).
+
+## Testing strategy
+
+**Automated (CI):** the extended `test-prometheus-writer-e2e.sh` (steps 1-9) runs the full pipeline including Grafana health checks and dashboard load.
+
+**Manual (before merge):**
+1. `cd opennms-container/delta-v && docker compose --profile lite --profile metrics up -d --build`
+2. Wait ~90s for poll cycles to flow.
+3. Open `http://localhost:13000/d/snmp-overview` in a browser.
+4. Confirm: device picker dropdown populated; bps in/out panels show non-zero rates; CPU/storage panels show host-resources data; devices-monitored table shows the snmp-agent host with foreign_source populated.
+5. Add a "smoke-tested visually 2026-04-XX" line to the PR description.
+
+**No unit tests, no module rebuild required.** This PR is configuration and JSON only — no Java code touched, so `./mvnw -pl core/prometheus-writer verify` is unchanged.
+
+## Success criteria
+
+- [x] `grafana:11.4.0` service in docker-compose, profile `[metrics, metrics-e2e]`, healthcheck pinned to `/api/health` returning `database: ok`.
+- [x] VictoriaMetrics datasource provisioned with UID `victoriametrics`, isDefault, editable=false.
+- [x] One starter dashboard `snmp-overview.json` with 2 template variables (`instance`, `foreign_source`) and 6 panels covering interface throughput, errors, CPU, storage, and a labels-demonstration devices table.
+- [x] Profile rename: `metrics` is the canonical new name; `metrics-e2e` retained as alias.
+- [x] `prometheus-writer` profile expanded to include `metrics` (so the writer + target co-reside).
+- [x] `test-prometheus-writer-e2e.sh` extended with steps 7-9 (Grafana health + datasource health + dashboard load) and profile name updated to `metrics`.
+- [x] README updated with a 5-line operator-facing access blurb.
+- [x] PR opened `--repo pbrane/delta-v --base develop`. Title prefix `feat(grafana):` (proposed; no adjacent convention since this is the first Grafana-related PR).
+
+## After this PR (queued follow-ups)
+
+- **Per-interface drill-down dashboard.** Click an interface row in the SNMP Overview, jump to a single-interface page with throughput, errors, ifAlias (when ifAlias is exposed via the proto follow-up tracked under `project_prometheus_label_coverage_gaps`).
+- **Node detail dashboard.** All host-resources data for a single device.
+- **Datasource for ClickHouse flows.** Delta-V already has flow-enricher → ClickHouse (per memory). A second Grafana datasource pointing at ClickHouse would let one dashboard reach metrics + flows.
+- **Anonymous-access toggle in README.** Document the env-var override pattern more prominently for production deployments.
+- **Visual regression test** (image diff against a baseline screenshot). Currently out of scope — defer until the dashboard set is large enough that visual drift is a real risk.

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -343,8 +343,10 @@ Prometheus Remote Write protobuf batches to a configurable endpoint.
   at your TSDB (Mimir, VictoriaMetrics, Cortex, Thanos Receive, Prometheus with
   `--web.enable-remote-write-receiver`). Without a reachable target, the writer
   starts healthy, opens its circuit on first POST failure, and stays paused.
-- **metrics-e2e** — adds a pinned `victoriametrics:v1.106.1` container for E2E.
-  Not intended for production.
+- **metrics** (alias: **metrics-e2e**) — adds a pinned `victoriametrics:v1.106.1`
+  container plus a Grafana service with a starter SNMP dashboard. The canonical
+  demo command is `docker compose --profile lite --profile metrics up`. See the
+  "Grafana access" section below.
 
 ### Configuration
 
@@ -397,6 +399,21 @@ deltav_prometheus_writer_node_context_cache_size
 
 As of Phase 2 GA, both `deltav-timeseries` and `deltav-node-context` protobuf
 schemas are frozen. Only forward-compatible additions (new tag numbers) permitted.
+
+## Grafana access (demo mode)
+
+After `docker compose --profile lite --profile metrics up -d`, open
+`http://localhost:13000/d/snmp-overview`. Anonymous Viewer access is on by
+default (no login required) and the SNMP Overview dashboard is pre-provisioned
+with VictoriaMetrics as the datasource.
+
+The first poll cycle takes ~30 seconds; allow ~90 seconds after `up` for
+panels to populate with data from the bundled mock SNMP agent.
+
+To log in as admin (e.g. to create custom dashboards):
+
+- Username: `admin`
+- Password: `admin` (override via `GF_ADMIN_PASSWORD` environment variable).
 
 ## Troubleshooting
 

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -598,7 +598,7 @@ services:
 
   prometheus-writer:
     image: opennms/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
-    profiles: [lite, full]
+    profiles: [lite, full, metrics]
     depends_on:
       kafka:
         condition: service_healthy
@@ -618,7 +618,7 @@ services:
 
   victoriametrics:
     image: victoriametrics/victoria-metrics:v1.106.1
-    profiles: [metrics-e2e]
+    profiles: [metrics, metrics-e2e]
     command:
       # VM v1.106.1 rejects retentionPeriod smaller than 1 day; "1h" causes
       # exit code 255 at startup with fatal log:
@@ -635,8 +635,40 @@ services:
     ports:
       - "18428:8428"
 
+  grafana:
+    image: grafana/grafana:11.4.0
+    profiles: [metrics, metrics-e2e]
+    container_name: delta-v-grafana
+    hostname: grafana
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+    environment:
+      # Anonymous read-only access for demo. Anyone hitting localhost:13000 lands
+      # in the Viewer role without login. Disable by setting GF_AUTH_ANONYMOUS_ENABLED=false.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+      # Admin password override. Default 'admin' is fine for the demo stack.
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
+      # Disable telemetry phone-home and update checks — this is a demo container.
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:3000/api/health | grep -q '\"database\":\"ok\"'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+    ports:
+      - "13000:3000"
+
 volumes:
   pgdata:
   kafkadata:
   collectd-data:
   clickhouse-data:
+  grafanadata:

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -628,7 +628,10 @@ services:
       - "-storageDataPath=/tmp/vm"
       - "-search.latencyOffset=1s"
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O-", "http://localhost:8428/health"]
+      # Use 127.0.0.1 — BusyBox wget resolves "localhost" to ::1 first, but
+      # VM listens on 0.0.0.0:8428 (IPv4 only), so localhost fails Connection
+      # refused. 127.0.0.1 forces IPv4 and matches the listening socket.
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:8428/health"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -658,7 +661,10 @@ services:
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafanadata:/var/lib/grafana
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O- http://localhost:3000/api/health | grep -q '\"database\":\"ok\"'"]
+      # Use 127.0.0.1 (not localhost) — BusyBox wget in the Grafana base
+      # image resolves localhost to ::1 first, but Grafana listens on IPv4 by
+      # default. Same fix as the victoriametrics healthcheck above.
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3000/api/health | grep -q '\"database\":\"ok\"'"]
       interval: 5s
       timeout: 3s
       retries: 12

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -664,7 +664,10 @@ services:
       # Use 127.0.0.1 (not localhost) — BusyBox wget in the Grafana base
       # image resolves localhost to ::1 first, but Grafana listens on IPv4 by
       # default. Same fix as the victoriametrics healthcheck above.
-      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3000/api/health | grep -q '\"database\":\"ok\"'"]
+      # The grep pattern uses "database.*ok" because Grafana's JSON response
+      # is pretty-printed with a space after the colon ("database": "ok"),
+      # not the compact form expected by some other Grafana healthcheck examples.
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3000/api/health | grep -q 'database.*ok'"]
       interval: 5s
       timeout: 3s
       retries: 12

--- a/opennms-container/delta-v/grafana/dashboards/snmp-overview.json
+++ b/opennms-container/delta-v/grafana/dashboards/snmp-overview.json
@@ -1,0 +1,296 @@
+{
+  "uid": "snmp-overview",
+  "title": "SNMP Overview",
+  "tags": ["delta-v", "snmp"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": {
+          "query": "label_values(opennms_mib2_x_interfaces_ifhcinoctets_total, instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        }
+      },
+      {
+        "name": "foreign_source",
+        "label": "Foreign source",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "victoriametrics"
+        },
+        "query": {
+          "query": "label_values(opennms_mib2_x_interfaces_ifhcinoctets_total{instance=~\"$instance\"}, foreign_source)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Interface throughput in (bps, top 10)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(opennms_mib2_x_interfaces_ifhcinoctets_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) * 8)",
+          "legendFormat": "{{instance}} · ifIndex {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 2,
+      "title": "Interface throughput out (bps, top 10)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(opennms_mib2_x_interfaces_ifhcoutoctets_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) * 8)",
+          "legendFormat": "{{instance}} · ifIndex {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 3,
+      "title": "Interface error rate (errors+discards/sec)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(opennms_mib2_interface_errors_ifinerrors_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) + rate(opennms_mib2_interface_errors_ifouterrors_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) + rate(opennms_mib2_interface_errors_ifindiscards_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m]) + rate(opennms_mib2_interface_errors_ifoutdiscards_total{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}[5m])",
+          "legendFormat": "{{instance}} · ifIndex {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 10}
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "thresholdsStyle": {"mode": "line"}
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 4,
+      "title": "CPU load per processor (%)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 8},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "opennms_mib2_host_resources_processor_hrprocessorload{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}",
+          "legendFormat": "{{instance}} · proc {{resource_instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"showLegend": true, "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 5,
+      "title": "Storage utilization (%)",
+      "type": "bargauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 8},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * opennms_mib2_host_resources_storage_hrstorageused{instance=~\"$instance\", foreign_source=~\"$foreign_source\"} / opennms_mib2_host_resources_storage_hrstoragesize{instance=~\"$instance\", foreign_source=~\"$foreign_source\"}",
+          "legendFormat": "{{instance}} · storage {{resource_instance}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 70},
+              {"color": "red", "value": 90}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 6,
+      "title": "Devices monitored",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 8},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count by (instance, foreign_source, snmp_syscontact, snmp_syslocation) (rate(opennms_mib2_x_interfaces_ifhcinoctets_total[5m]))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Value"},
+            "properties": [{"id": "custom.hidden", "value": true}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "Time"},
+            "properties": [{"id": "custom.hidden", "value": true}]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "instance": "Instance",
+              "foreign_source": "Foreign source",
+              "snmp_syscontact": "SNMP sysContact",
+              "snmp_syslocation": "SNMP sysLocation"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "links": [],
+  "weekStart": ""
+}

--- a/opennms-container/delta-v/grafana/provisioning/dashboards/default.yml
+++ b/opennms-container/delta-v/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,17 @@
+# Grafana dashboard provider — points at the bind-mounted directory where
+# JSON dashboard files live. Reloads every 30s, allows UI edits but they
+# don't persist across container restarts (the JSON file wins).
+apiVersion: 1
+
+providers:
+  - name: delta-v-bundled
+    orgId: 1
+    folder: Delta-V
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/opennms-container/delta-v/grafana/provisioning/datasources/victoriametrics.yml
+++ b/opennms-container/delta-v/grafana/provisioning/datasources/victoriametrics.yml
@@ -1,0 +1,19 @@
+# Grafana datasource provisioning — auto-loaded at startup via the
+# /etc/grafana/provisioning/datasources/ bind mount.
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    uid: victoriametrics
+    type: prometheus
+    access: proxy
+    url: http://victoriametrics:8428
+    isDefault: true
+    editable: false
+    jsonData:
+      # Match VictoriaMetrics's ingest cadence; collectd-default polls at 30s.
+      timeInterval: 30s
+      httpMethod: POST
+      manageAlerts: false
+      prometheusType: Prometheus
+      prometheusVersion: 2.40.0

--- a/opennms-container/delta-v/test-prometheus-writer-e2e.sh
+++ b/opennms-container/delta-v/test-prometheus-writer-e2e.sh
@@ -38,12 +38,12 @@ VM_QUERY_TIMEOUT=30
 
 cleanup() {
     echo "==> Tearing down stack"
-    docker compose --profile lite --profile metrics-e2e down -v --remove-orphans || true
+    docker compose --profile lite --profile metrics down -v --remove-orphans || true
 }
 trap cleanup EXIT
 
-echo "==> Starting delta-v Docker Compose (lite + metrics-e2e profiles)"
-docker compose --profile lite --profile metrics-e2e up -d --build
+echo "==> Starting delta-v Docker Compose (lite + metrics profiles)"
+docker compose --profile lite --profile metrics up -d --build
 
 # ── Step 1: Wait for prometheus-writer readiness ──────────────────────────────
 echo "==> Step 1: Wait for prometheus-writer /actuator/health/readiness"
@@ -141,6 +141,7 @@ assert_zero 'deltav_prometheus_writer_dlq_records_total'
 # ── Step 6: Query VictoriaMetrics ─────────────────────────────────────────────
 echo "==> Step 6: Query VictoriaMetrics for the landed series"
 deadline=$((SECONDS + VM_QUERY_TIMEOUT))
+vm_landed=false
 while (( SECONDS < deadline )); do
     resp=$(curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_interface_errors_ifindiscards_total" \
             || echo '{"data":{"result":[]}}')
@@ -153,12 +154,58 @@ while (( SECONDS < deadline )); do
         echo "$resp" | grep -E '"location":' > /dev/null || { echo "FAIL: missing location label"; exit 1; }
         echo "$resp" | grep -E '"foreign_source":' > /dev/null || { echo "FAIL: missing foreign_source label"; exit 1; }
         echo "$resp" | grep -E '"resource_instance":' > /dev/null || { echo "FAIL: missing resource_instance label"; exit 1; }
-        echo "==> ALL ASSERTIONS PASSED"
-        exit 0
+        vm_landed=true
+        break
     fi
     sleep 2
 done
+if [[ "$vm_landed" != "true" ]]; then
+    echo "FAIL: VictoriaMetrics returned no results within ${VM_QUERY_TIMEOUT}s"
+    echo "Last VM response: $resp"
+    exit 1
+fi
 
-echo "FAIL: VictoriaMetrics returned no results within ${VM_QUERY_TIMEOUT}s"
-echo "Last VM response: $resp"
-exit 1
+# ── Step 7: Wait for Grafana readiness ────────────────────────────────────────
+echo "==> Step 7: Wait for Grafana /api/health"
+deadline=$((SECONDS + STACK_READY_TIMEOUT))
+gf_ready=false
+GF_PASS="${GF_ADMIN_PASSWORD:-admin}"
+while (( SECONDS < deadline )); do
+    health=$(curl -sf -u "admin:${GF_PASS}" http://localhost:13000/api/health 2>/dev/null || true)
+    if echo "$health" | grep -q 'database.*ok'; then
+        echo "==> Grafana ready"
+        gf_ready=true
+        break
+    fi
+    sleep 3
+done
+if [[ "$gf_ready" != "true" ]]; then
+    echo "FAIL: Grafana readiness timeout"
+    docker compose logs grafana | tail -50
+    exit 1
+fi
+
+# ── Step 8: Verify VictoriaMetrics datasource is reachable from Grafana ───────
+echo "==> Step 8: Verify VictoriaMetrics datasource health"
+ds_health=$(curl -sf -u "admin:${GF_PASS}" \
+    http://localhost:13000/api/datasources/uid/victoriametrics/health 2>/dev/null || true)
+if ! echo "$ds_health" | grep -q '"status":"OK"'; then
+    echo "FAIL: VictoriaMetrics datasource health check failed"
+    echo "Response: $ds_health"
+    exit 1
+fi
+echo "==> Datasource OK"
+
+# ── Step 9: Verify the snmp-overview dashboard is provisioned ─────────────────
+echo "==> Step 9: Verify snmp-overview dashboard is loaded"
+dash=$(curl -sf -u "admin:${GF_PASS}" \
+    http://localhost:13000/api/dashboards/uid/snmp-overview 2>/dev/null || true)
+if ! echo "$dash" | grep -q '"title":"SNMP Overview"'; then
+    echo "FAIL: snmp-overview dashboard not loaded"
+    echo "Response: $dash"
+    exit 1
+fi
+echo "==> Dashboard OK"
+
+echo "==> ALL ASSERTIONS PASSED"
+exit 0


### PR DESCRIPTION
## Summary

Adds a Grafana 11.4.0 service to the delta-v docker-compose stack, provisions the VictoriaMetrics datasource, and ships a starter SNMP overview dashboard. After this PR, `docker compose --profile lite --profile metrics up` brings up the full metrics pipeline and `http://localhost:13000/d/snmp-overview` is a ready-to-browse dashboard.

**Configuration-only PR — no Java touched.**

### What ships

- **`grafana:` service** (Grafana 11.4.0 OSS, anonymous Viewer access, host port `13000`, profiled `[metrics, metrics-e2e]`). Healthcheck uses `127.0.0.1` (BusyBox wget resolves `localhost` to `::1` and Grafana listens IPv4-only — same quirk applies to VM and was fixed in the same PR).
- **Filesystem provisioning** under `opennms-container/delta-v/grafana/`:
  - Datasource `VictoriaMetrics` (UID `victoriametrics`, default, editable=false).
  - Dashboard provider pointing at `/var/lib/grafana/dashboards` (30s reload, UI edits allowed but file wins).
- **`snmp-overview.json`** — 6 panels, 2 template variables (`instance`, `foreign_source`):
  1. Interface throughput in (top 10, bps)
  2. Interface throughput out (top 10, bps)
  3. Interface error rate (errors+discards/sec)
  4. CPU load per processor (%)
  5. Storage utilization (%)
  6. **Devices monitored** (table) — exercises `instance`, `foreign_source`, `snmp_syscontact`, `snmp_syslocation` columns from PR #180's labels.
- **Profile rename**: `metrics` is now canonical; `metrics-e2e` retained as alias on both `victoriametrics` and `grafana`. `prometheus-writer` profile expanded from `[lite, full]` to `[lite, full, metrics]` so the writer is co-resident with its target.
- **E2E script extension** (`test-prometheus-writer-e2e.sh`): profile rename + 3 new steps (7: Grafana health, 8: VictoriaMetrics datasource health from Grafana's perspective, 9: `snmp-overview` dashboard loaded) using curl-from-host against port 13000.
- **README** gains a "Grafana access (demo mode)" section documenting the `localhost:13000` URL, anonymous Viewer access, and admin credentials.

### Side fix picked up in passing

Commits `efaf2f83f13` + `b0e35bada37` fix the VictoriaMetrics healthcheck (pre-existing latent IPv6-first bug that surfaced when the new Grafana healthcheck hit the same BusyBox wget quirk) and tighten the new Grafana healthcheck grep pattern to match Grafana's pretty-printed JSON output.

### Depends on

- delta-v#180 (currently open) ships the `instance`, `foreign_id`, `snmp_syscontact`, `snmp_syslocation` labels the dashboard variables and the devices-monitored table reference. The dashboard provisions cleanly without #180 (verified manually), but the variables will be empty and the devices table blank until #180 lands.

Spec: `docs/superpowers/specs/2026-04-20-grafana-victoriametrics-bundle-design.md`. Plan: `docs/superpowers/plans/2026-04-20-grafana-victoriametrics-bundle-plan.md`.

## Test plan

- [x] **Manual verification of Grafana additions (passed):** `docker compose --profile lite --profile metrics up -d` → Grafana reaches `database: ok` on `/api/health` → datasource health endpoint returns `"status":"OK"` → `GET /api/dashboards/uid/snmp-overview` returns the dashboard JSON with `title=SNMP Overview, uid=snmp-overview, 6 panels, 2 templates`. All direct verifications of the Grafana additions pass.
- [ ] **Full E2E (`test-prometheus-writer-e2e.sh`) blocked by an existing upstream issue, NOT by this PR.** Bisected against develop tip `12a5479e3b6`: the test fails identically on develop without any Grafana additions (`records_consumed_total = 0` at Step 4). Root cause is the documented `project_e2e_hostname_resolution_timeout` blocker — provisiond reverse-DNS on `mhuot-labs` location takes ~100s for 5 interfaces, exceeding the test's 90s grace, so collectd never gets scheduled and the writer never sees a record. Pre-existing on develop, tracked separately, not regressed by this PR. Steps 7-9 (Grafana health checks) will be exercised automatically once that blocker is resolved.
- [x] Manual verification of the dashboard JSON structure: `python3 -c 'import json; d=json.load(...); assert len(d["panels"])==6 and len(d["templating"]["list"])==2'` passes.
- [x] `docker compose config --profile lite --profile metrics` parses cleanly.

## Out of scope

- Per-interface drill-down dashboard (follow-up).
- ClickHouse datasource for flow data (follow-up).
- Grafana alerting rules (operators configure these separately).
- Visual regression test / screenshot comparison (follow-up if the dashboard set grows).
- Fixing the provisiond reverse-DNS timeout — tracked in `project_e2e_hostname_resolution_timeout` memo; spans horizon + test-infra.