### PR TITLE
fix(horizon): bump to 1.0.11 for TimeseriesPersister ClassCastException cascade fix

### DIFF
--- a/opennms-container/delta-v/test-timeseries-e2e.sh
+++ b/opennms-container/delta-v/test-timeseries-e2e.sh
@@ -99,5 +99,29 @@ if echo "${metrics}" | grep -E '^deltav_timeseries_batches_failed_total' | \
     exit 1
 fi
 
+# Regression guard for the horizon TimeseriesPersister ClassCastException
+# cascade fixed in delta-v-horizon PR #8 (horizon 1.0.11). The ClassCastException
+# on visitGroup and the NPE cascade on visitAttribute/persistNumeric/String
+# must all stay at 0 — if any of these fires, a regression has re-introduced
+# the bug and FanoutPersister's isolation would otherwise hide it.
+# step=visitResource is deliberately NOT asserted: Bug #1 (MetaTagDataLoader
+# rollback) is a separate investigation and may still tick on labbox today.
+echo "==> Asserting inner-persister cascade counters stay at zero"
+for step in visitGroup visitAttribute persistNumericAttribute persistStringAttribute; do
+    value=$(echo "${metrics}" | \
+        grep -E "^deltav_collectd_persister_inner_failures_total\{.*step=\"${step}\"" | \
+        awk '{print $NF}')
+    if [ -z "${value}" ]; then
+        echo "WARN: counter deltav_collectd_persister_inner_failures_total{step=${step}} not registered"
+        continue
+    fi
+    if [ "${value}" != "0.0" ]; then
+        echo "ERROR: deltav_collectd_persister_inner_failures_total{step=${step}} = ${value} (expected 0.0)"
+        echo "${metrics}" | grep deltav_collectd_persister || true
+        exit 1
+    fi
+done
+echo "==> Inner-persister cascade counters verified at zero"
+
 echo "==> PASS"
 exit 0

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Horizon JAR version (published by pbrane/delta-v-horizon) -->
-    <deltav.horizon.version>1.0.10</deltav.horizon.version>
+    <deltav.horizon.version>1.0.11</deltav.horizon.version>
 
     <!-- Spring Cloud release train (for flow-enricher / flow-aggregator) -->
     <spring-cloud.version>2025.1.1</spring-cloud.version>


### PR DESCRIPTION
## Summary

Bumps `<deltav.horizon.version>` from 1.0.10 to 1.0.11 to pick up the horizon-side fix for the three-exception cascade in `TimeseriesPersister` (pbrane/delta-v-horizon#8).

### What 1.0.11 fixes

The `TimeseriesPersister` inner-persister path hit three cascaded exceptions every Collectd poll cycle on Delta-V labbox with 1.0.10:

| Bug | Exception | Counter | Rate |
|---|---|---|---|
| #1 | `UnexpectedRollbackException` from `MetaTagDataLoader.load` | `step=visitResource` | 8/90s |
| #4 | `ClassCastException: ResourcePath cannot be cast to CollectionResource` | `step=visitGroup` | 10/90s |
| #2 | `NullPointerException` on `currentBuilder` | `step=visitAttribute` | 76/90s |

**Root cause** (Bug #4 specifically): `MetaTagDataLoader` extends `CacheLoader<CollectionResource, Set<Tag>>`, but `TimeseriesPersister.configuredAdditionalMetaTagCache` is a `Cache<ResourcePath, Set<Tag>>`. Type erasure hides the key-type mismatch at compile time; any cache miss invokes the loader's generated bridge method which casts `ResourcePath` → `CollectionResource` and throws.

`visitResource` pre-populates the cache, so the mismatch only triggers when that pre-population itself fails (Bug #1). Once it does, every subsequent `visitGroup` → cache miss → loader → throw, and `currentBuilder` never gets assigned → every `persistNumericAttribute` NPEs.

### What 1.0.11 does

Horizon-side changes in `TimeseriesPersister.java`:
1. `visitResource` swallows `RuntimeException` from `metaDataLoader.load`
2. `getUserDefinedMetaTags` uses `cache.getIfCached` instead of `cache.get` — loader never invoked from the read path
3. `persistNumericAttribute` and `persistStringAttribute` null-guard `currentBuilder`

Plus a new `TimeseriesPersisterTest` covering the three regression paths.

### Delta-V side

- `pom.xml`: `<deltav.horizon.version>` 1.0.10 → 1.0.11
- `test-timeseries-e2e.sh`: added regression assertion verifying `deltav_collectd_persister_inner_failures_total{step=visitGroup|visitAttribute|persistNumericAttribute|persistStringAttribute}` all stay at `0.0`. `step=visitResource` is deliberately not asserted — Bug #1 (`MetaTagDataLoader` rollback) is a separate investigation that may still tick until we track down the transactional root cause.

## Test plan

- [x] `./mvnw clean install -DskipTests -fae` full reactor — BUILD SUCCESS in 18.7s
- [x] Horizon 1.0.11 `TimeseriesPersisterTest` — 4 tests pass locally
- [ ] `test-timeseries-e2e.sh` end-to-end on a Linux host or labbox (macOS Docker Desktop has an unrelated nested-bind-mount bug that prevents provisiond from seeing seed requisitions, so the full E2E can't execute locally on macOS today; the regression assertion is added to guard the path once the test runs anywhere)

## Follow-on

Bug #1 (`UnexpectedRollbackException` in `MetaTagDataLoader.load`'s read-only transaction) remains open. With 1.0.11 it's logged but no longer cascades — `deltav_collectd_persister_inner_failures_total{step=visitResource}` will still tick but no other counter will. Tracked in memory `project_phase0_inner_persister_bugs_followup` and can be picked up in a future session once a live stack trace is available.