### PR TITLE
fix(e2e): unblock shared-state + macOS-compat for provisiond overlay

### DIFF
--- a/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/nodecontext/NodeContextPublisher.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/nodecontext/NodeContextPublisher.java
@@ -107,8 +107,15 @@ public class NodeContextPublisher {
             return null;
         }
         if (node == null) {
+            // Benign race: a node can be deleted between the time its id lands
+            // on the debounce queue and the time this publisher pulls it off.
+            // This is expected under normal operation (e.g. a requisition
+            // re-import deletes-and-recreates a foreign node so the old id
+            // becomes orphaned before we read it) and is NOT a failure. Use
+            // the skipped counter so SLO/alerting on records_failed_total
+            // stays clean while ops still see the soft-miss rate here.
             LOG.debug("Node {} not found (likely deleted between event and read)", nodeId);
-            meters.counter("deltav_node_context_records_failed_total",
+            meters.counter("deltav_node_context_records_skipped_total",
                     "location", "", "reason", "node_not_found").increment();
             return null;
         }

--- a/core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeContextPublisherTest.java
+++ b/core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeContextPublisherTest.java
@@ -93,15 +93,19 @@ class NodeContextPublisherTest {
     }
 
     @Test
-    void publishNode_nodeNotFound_incrementsFailureCounterNoSend() {
+    void publishNode_nodeNotFound_incrementsSkippedCounterNoSend() {
         when(nodeDao.get(99)).thenReturn(null);
 
         publisher.publishNode(99);
 
         org.mockito.Mockito.verify(streamBridge, org.mockito.Mockito.never())
                 .send(any(String.class), any(Message.class));
-        assertThat(meters.counter("deltav_node_context_records_failed_total",
+        // node_not_found is a benign race, not a failure — it lives on the
+        // skipped counter so records_failed_total stays clean for SLO alerts.
+        assertThat(meters.counter("deltav_node_context_records_skipped_total",
                 "location", "", "reason", "node_not_found").count()).isEqualTo(1.0);
+        assertThat(meters.counter("deltav_node_context_records_failed_total",
+                "location", "", "reason", "node_not_found").count()).isEqualTo(0.0);
     }
 
     @Test

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -514,11 +514,25 @@ services:
       RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       RPC_KAFKA_FORCE_REMOTE: "true"
     volumes:
-      # Parent overlay is read-only: provisiond only ever mutates imports/ at
-      # runtime. The nested named volume below holds the mutating subdirectory
-      # so working-tree drift is eliminated. The provisiond-imports-init
-      # sidecar seeds the named volume from imports-seed/ on first boot.
-      - ./provisiond-overlay/etc:/opt/deltav/etc:ro
+      # Parent overlay is read-write. The named volume below (provisiond_imports)
+      # is the primary target for all provisiond mutation — it persists
+      # last-import timestamps without touching the host tree on Linux,
+      # where Docker honors the nested child mount.
+      #
+      # On macOS Docker Desktop, VirtioFS silently drops the nested child
+      # mount and the container sees the parent bind mount's imports/
+      # directory instead. A read-only parent would break last-import
+      # write-back on macOS (ModelImportException), so :rw is required for
+      # parity. Safety trade-off: provisiond could in theory mutate other
+      # files under /opt/deltav/etc, but nothing in the current codebase
+      # does. The host imports/ directory is gitignored (see .gitignore —
+      # only .gitkeep is tracked) so runtime drift there stays invisible
+      # to git in either deployment mode.
+      #
+      # Long-term fix tracked in memory project_provisiond_cloud_native_requisitions:
+      # move last-import state to PostgreSQL and make the overlay fully
+      # read-only.
+      - ./provisiond-overlay/etc:/opt/deltav/etc:rw
       - provisiond_imports:/opt/deltav/etc/imports
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]

--- a/opennms-container/delta-v/test-node-context-e2e.sh
+++ b/opennms-container/delta-v/test-node-context-e2e.sh
@@ -46,9 +46,20 @@ METRICS_TIMEOUT=180
 E2E_FOREIGN_SOURCE="node-context-e2e"
 E2E_REQUISITION_FILE="provisiond-overlay/etc/imports/${E2E_FOREIGN_SOURCE}.xml"
 
+PROVISIOND_CONFIG="provisiond-overlay/etc/provisiond-configuration.xml"
+PROVISIOND_CONFIG_BACKUP="$(mktemp -t provisiond-config.XXXXXX.xml)"
+
 cleanup() {
     echo "==> Tearing down stack"
     rm -f "${E2E_REQUISITION_FILE}"
+    # Restore provisiond-configuration.xml from the committed state (captured
+    # before mutation in Step 3) so this test never leaves the working tree
+    # in a state that breaks other e2e tests that depend on the full set of
+    # requisition-defs (rpc-canary, cloud-services, l8opensim-lab, …).
+    if [ -f "${PROVISIOND_CONFIG_BACKUP}" ]; then
+        cp "${PROVISIOND_CONFIG_BACKUP}" "${PROVISIOND_CONFIG}"
+        rm -f "${PROVISIOND_CONFIG_BACKUP}"
+    fi
     docker compose down -v --remove-orphans || true
 }
 trap cleanup EXIT
@@ -113,25 +124,29 @@ cat > "${E2E_REQUISITION_FILE}" <<'REQEOF'
 REQEOF
 
 # Add the requisition-def to provisiond-configuration.xml so provisiond
-# auto-imports.  We append a second import schedule alongside any existing
-# ones; provisiond reloads its config on restart.
-mkdir -p provisiond-overlay/etc
-cat > provisiond-overlay/etc/provisiond-configuration.xml <<PROVEOF
-<?xml version="1.0" encoding="UTF-8"?>
-<provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
-  foreign-source-dir="/opt/deltav/etc/foreign-sources"
-  requistion-dir="/opt/deltav/etc/imports"
-  importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4">
-  <requisition-def import-name="delta-v"
-                   import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-  <requisition-def import-name="${E2E_FOREIGN_SOURCE}"
-                   import-url-resource="file:///opt/deltav/etc/imports/${E2E_FOREIGN_SOURCE}.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-</provisiond-configuration>
-PROVEOF
+# auto-imports.  Insert our E2E requisition-def immediately before the
+# closing </provisiond-configuration> tag, preserving every other
+# requisition-def (delta-v, rpc-canary, cloud-services, l8opensim-lab,
+# perspective-test, flow-test) that other e2e tests depend on.
+# The committed state is backed up in cleanup()'s trap and restored on exit.
+echo "==> Injecting ${E2E_FOREIGN_SOURCE} requisition-def into ${PROVISIOND_CONFIG}"
+cp "${PROVISIOND_CONFIG}" "${PROVISIOND_CONFIG_BACKUP}"
+python3 - "${PROVISIOND_CONFIG}" "${E2E_FOREIGN_SOURCE}" <<'PYEOF'
+import sys
+path, fs = sys.argv[1], sys.argv[2]
+snippet = (
+    f'  <requisition-def import-name="{fs}"\n'
+    f'                   import-url-resource="file:///opt/deltav/etc/imports/{fs}.xml">\n'
+    f'    <cron-schedule>0/30 * * * * ?</cron-schedule>\n'
+    f'  </requisition-def>\n'
+)
+with open(path) as f: content = f.read()
+marker = '</provisiond-configuration>'
+if marker not in content:
+    sys.exit(f"marker {marker!r} not found in {path}")
+content = content.replace(marker, snippet + marker, 1)
+with open(path, 'w') as f: f.write(content)
+PYEOF
 
 echo "==> Restarting provisiond to pick up E2E requisition"
 docker compose restart provisiond

--- a/opennms-container/delta-v/test-prometheus-writer-e2e.sh
+++ b/opennms-container/delta-v/test-prometheus-writer-e2e.sh
@@ -34,7 +34,12 @@ cd "$(dirname "$0")"
 STACK_READY_TIMEOUT=180
 POLL_GRACE_SECONDS=90
 METRICS_TIMEOUT=180
-VM_QUERY_TIMEOUT=30
+# Bumped from 30s to 90s to accommodate cold-start SNMP warmup. Collectd's
+# first poll cycle lands ~30s after provisiond reports the node; on a slow
+# host the combination of Kafka producer/consumer bootstrap, Collectd's own
+# warmup, and Prometheus remote-write batching can push the first sample's
+# arrival in VictoriaMetrics to 60-80s. A 30s budget made Step 6 flaky.
+VM_QUERY_TIMEOUT=90
 CLICKHOUSE_QUERY_TIMEOUT=60
 
 cleanup() {
@@ -144,13 +149,21 @@ echo "==> Step 6: Query VictoriaMetrics for the landed series"
 deadline=$((SECONDS + VM_QUERY_TIMEOUT))
 vm_landed=false
 while (( SECONDS < deadline )); do
-    resp=$(curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_interface_errors_ifindiscards_total" \
+    # Query opennms_mib2_x_interfaces_ifhcinoctets_total instead of the
+    # narrower opennms_mib2_interface_errors_ifindiscards_total: the HC
+    # interface counters come from the MIB-2 mib2-X-interfaces group which
+    # every MIB-2-compliant device serves, so the l8opensim-lab simulator
+    # (reliable) produces them alongside rpc-canary (which goes through the
+    # flaky in-compose mock-snmp-agent, see project_mock_snmp_agent_systemgroup_bug).
+    # Any reliable opennms_ metric proves the pipeline+labels work; there is
+    # no need to couple Step 6 to the flaky mock-agent path.
+    resp=$(curl -sf "http://localhost:18428/api/v1/query?query=opennms_mib2_x_interfaces_ifhcinoctets_total" \
             || echo '{"data":{"result":[]}}')
     count=$(echo "$resp" | python3 -c \
         'import json,sys; d=json.load(sys.stdin); print(len(d.get("data",{}).get("result",[])))' \
         2>/dev/null || echo "0")
     if (( count > 0 )); then
-        echo "==> VM returned ${count} series for opennms_mib2_interface_errors_ifindiscards_total"
+        echo "==> VM returned ${count} series for opennms_mib2_x_interfaces_ifhcinoctets_total"
         echo "$resp" | grep -E '"node_id":"[0-9]+"' > /dev/null || { echo "FAIL: missing node_id label"; exit 1; }
         echo "$resp" | grep -E '"location":' > /dev/null || { echo "FAIL: missing location label"; exit 1; }
         echo "$resp" | grep -E '"foreign_source":' > /dev/null || { echo "FAIL: missing foreign_source label"; exit 1; }


### PR DESCRIPTION
## Summary

Four fixes that bring the local E2E suite to a clean baseline on macOS Docker Desktop.

### Fix 1 — destructive test-node-context-e2e.sh

Test was *overwriting* the committed \`provisiond-configuration.xml\` with a minimal version containing only \`delta-v\` + \`node-context-e2e\`. Stripped every other requisition-def → cascading failures for any subsequent test run.

**Change:** rewrite Step 3 to back up the committed file, inject the E2E requisition-def with a Python string replace before \`</provisiond-configuration>\`, restore in EXIT trap.

### Fix 2 — macOS Docker Desktop nested bind mount silently dropped

PR #187's \`provisiond_imports\` named volume is nested under the \`:ro\` parent bind mount; Docker Desktop VirtioFS drops the child on macOS, leaving the container with read-only parent → provisiond can't persist \`last-import\`.

**Change:** parent mount \`:ro\` → \`:rw\`. Linux unchanged (named volume still takes precedence). macOS now writes to the gitignored host \`imports/\` directory.

### Fix 3 — node_not_found race as a non-failure

\`NodeContextPublisher\` incremented \`records_failed_total{reason=\"node_not_found\"}\` when a debounced node id couldn't be found in DB — but this is a benign race (node deleted between enqueue and publish), not a failure.

**Change:** route the null-node case to a new \`records_skipped_total\` counter so SLO alerts on \`records_failed_total\` stay clean while ops retain visibility into the soft-miss rate.

### Fix 4 — test-prometheus-writer Step 6 coupled to flaky mock-snmp-agent

Step 6 queried \`opennms_mib2_interface_errors_ifindiscards_total\`, a metric produced only by devices matching the Enterprise sysoid in \`mib2-interface-errors\`. In the local stack that meant rpc-canary → in-compose mock-snmp-agent, which times out intermittently on SNMP systemGroup scans (memory \`project_mock_snmp_agent_systemgroup_bug\`).

**Change:** switch query to \`opennms_mib2_x_interfaces_ifhcinoctets_total\` (every MIB-2 device serves this; l8opensim-lab produces it reliably). Same label-enrichment coverage. Also bump VM_QUERY_TIMEOUT 30 → 90 for cold-start SNMP warmup.

## Local E2E baseline — all 8 tests

| Test | Before | After |
|---|---|---|
| test-e2e.sh | ✅ 12/12 | ✅ 12/12 |
| test-collectd-e2e.sh | ✅ | ✅ |
| test-syslog-e2e.sh | ✅ | ✅ |
| test-passive-e2e.sh | ✅ | ✅ |
| test-minion-e2e.sh | ✅ 15/15 | ✅ 15/15 |
| **test-node-context-e2e.sh** | ❌ mid-Step-3 crash | ✅ Steps 1-5 end-to-end |
| **test-prometheus-writer-e2e.sh** | ❌ Step 6 flake | ✅ ALL 12 ASSERTIONS PASS |
| test-flows-e2e.sh | 17/18 conditional | 17/18 consistent; 1 assertion on NetFlow v5/v9 exporter-IP docker-bridge quirk (pre-existing infra, out of scope) |

## Unit tests

- \`NodeContextPublisherTest\`: 9/9 (updated the one assertion for the counter rename; asserts both skipped=1 AND failed=0 to lock in the separation).

## Out of scope (pre-existing infra, tracked in memory)

- NetFlow v5/v9 exporter IP arriving as 127.0.0.1 in test-flows (Docker bridge UDP source rewrite). sFlow works (agent IP in payload).
- \`project_mock_snmp_agent_systemgroup_bug\` — mock-snmp-agent SNMP timeouts. Fix 4 decouples the prometheus-writer test from this; mock-agent itself is still broken but no test depends on it.
- \`project_provisiond_cloud_native_requisitions\` — durable last-import-to-Postgres redesign.

## Test plan

- [x] All 5 local-only tests pass
- [x] test-node-context-e2e now passes end-to-end
- [x] test-prometheus-writer-e2e now passes ALL 12 assertions
- [x] Unit test suite for NodeContextPublisher passes (9/9)
- [x] \`git status\` clean after any E2E test run
- [x] Provisiond writable on macOS Docker Desktop