### PR TITLE
fix(e2e): labbox baseline — 3 classpath/counter bugs + test harness cleanup

### DIFF
--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -260,6 +260,19 @@
             </exclusions>
         </dependency>
 
+        <!-- OIA common — provides org.opennms.integration.api.v1.timeseries.immutables.*.
+             features.timeseries (above) transitively declares org.opennms.integration.api:api
+             (the interfaces), but its TimeseriesPersistOperationBuilder.persistStringAttributeForMetricLevel
+             calls ImmutableTag from integration.api:common. Without this explicit dep
+             every SNMP attribute persist throws NoClassDefFoundError on the inner
+             persister path, ticking deltav_collectd_persister_inner_failures_total{step=visitAttribute}.
+             (The Kafka path is unaffected — FanoutPersister catches the error.)
+             Version managed by the horizon BOM. -->
+        <dependency>
+            <groupId>org.opennms.integration.api</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+
         <!-- In-memory time-series storage — InMemoryStorage for standalone/test use -->
         <dependency>
             <groupId>org.opennms.features</groupId>

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java
@@ -78,7 +78,16 @@ public class TimeseriesKafkaPublisher {
             }
 
             if (batch.getResourcesCount() == 0) {
-                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                // An empty batch is an expected outcome, not a failure: it
+                // means the translator found no numeric resources in the
+                // CollectionSet (e.g. a collection cycle that produced only
+                // string attributes, or a node whose SNMP response was all
+                // filtered out). Publishing an empty batch wastes a Kafka
+                // record, so we skip. Track on the skipped counter so SLO
+                // alerts on batches_failed_total stay clean for real errors
+                // (translator_error, serialization_error, send_error) while
+                // ops still see the skip rate here.
+                meterRegistry.counter("deltav_timeseries_batches_skipped_total",
                         "location", loc, "producer", "collectd",
                         "reason", "empty_batch").increment();
                 return;

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherTest.java
@@ -94,9 +94,15 @@ class TimeseriesKafkaPublisherTest {
         publisher.publish(set, "default", 42, "Site-A");
 
         verify(streamBridge, never()).send(any(String.class), any(Message.class));
-        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+        // empty_batch is a benign skip, tracked on the skipped counter;
+        // the failed counter stays at zero for empty batches so SLO alerts
+        // on batches_failed_total fire only for real errors.
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_skipped_total",
                 "location", "Site-A", "producer", "collectd", "reason", "empty_batch").count())
                 .isEqualTo(1.0);
+        assertThat(meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                "location", "Site-A", "producer", "collectd", "reason", "empty_batch").count())
+                .isEqualTo(0.0);
     }
 
     @Test

--- a/core/dao-jpa-support/src/main/java/org/opennms/netmgt/dao/support/UpsertTemplate.java
+++ b/core/dao-jpa-support/src/main/java/org/opennms/netmgt/dao/support/UpsertTemplate.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.deltav.netmgt.dao.support;
+package org.opennms.netmgt.dao.support;
 
 import org.opennms.netmgt.dao.api.OnmsDao;
 import org.springframework.transaction.PlatformTransactionManager;

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -445,10 +445,10 @@ services:
     volumes:
       - ./enlinkd-overlay/etc:/opt/deltav/etc:ro
     depends_on:
-      postgres:
-        condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
       kafka:
-        condition: service_started
+        condition: service_healthy
 
   # One-shot sidecar that seeds the provisiond_imports named volume from
   # the committed imports-seed/ directory on first boot. Provisiond runs as
@@ -797,6 +797,8 @@ services:
     image: opennms/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
     profiles: [lite, full, metrics]
     depends_on:
+      db-init:
+        condition: service_completed_successfully
       kafka:
         condition: service_healthy
       provisiond:

--- a/opennms-container/delta-v/test-enlinkd-e2e.sh
+++ b/opennms-container/delta-v/test-enlinkd-e2e.sh
@@ -83,11 +83,22 @@ ok()   { echo "  [PASS] $*"; PASS=$((PASS + 1)); }
 fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
 err()  { echo "ERROR: $*" >&2; exit 2; }
 
+PROVISIOND_CONFIG="provisiond-overlay/etc/provisiond-configuration.xml"
+PROVISIOND_CONFIG_BACKUP="$(mktemp -t enlinkd-provisiond-config.XXXXXX.xml)"
+
 cleanup() {
     if $POST_CLEANUP; then
         log "Post-run cleanup (--post-cleanup): removing test data..."
         clean_all_nodes
         clean_all_alarms
+    fi
+    # Restore provisiond-configuration.xml from the committed state (captured
+    # in Phase 0 before any mutation) so this test never leaves the working
+    # tree mutilated for subsequent E2E runs that depend on the full set of
+    # requisition-defs.
+    if [ -f "${PROVISIOND_CONFIG_BACKUP}" ]; then
+        cp "${PROVISIOND_CONFIG_BACKUP}" "${PROVISIOND_CONFIG}"
+        rm -f "${PROVISIOND_CONFIG_BACKUP}"
     fi
 }
 trap cleanup EXIT
@@ -293,36 +304,40 @@ else
 fi
 
 # ── Provisiond config: provisiond-overlay/etc/provisiond-configuration.xml ──
-# Ensure the mhuot-labs requisition-def is present. If the file doesn't exist
-# or doesn't contain a mhuot-labs entry, write the full config.
-if [ ! -f "provisiond-overlay/etc/provisiond-configuration.xml" ] || \
-   ! grep -q 'import-name="mhuot-labs"' "provisiond-overlay/etc/provisiond-configuration.xml"; then
-    log "  Writing provisiond-configuration.xml with mhuot-labs requisition-def"
-    cat > "provisiond-overlay/etc/provisiond-configuration.xml" <<'PROVEOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
-  foreign-source-dir="/opt/deltav/etc/foreign-sources"
-  requistion-dir="/opt/deltav/etc/imports"
-  importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
-  <requisition-def import-name="delta-v"
-                   import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-  <requisition-def import-name="cloud-services"
-                   import-url-resource="file:///opt/deltav/etc/imports/cloud-services.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-  <requisition-def import-name="mhuot-labs"
-                   import-url-resource="file:///opt/deltav/etc/imports/mhuot-labs.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-</provisiond-configuration>
-PROVEOF
-    PROVISIOND_NEEDS_RESTART=true
-    ok "Provisiond configuration written with mhuot-labs requisition-def"
-else
-    ok "Provisiond configuration already contains mhuot-labs"
-fi
+# Ensure the mhuot-labs requisition-def is an *active* (uncommented) entry.
+# The committed config has mhuot-labs wrapped in an XML comment block because
+# the real lab devices at 172.20.20.x require VPN connectivity that most
+# developers don't have. This test IS the labbox-dependent path, so we
+# temporarily activate the requisition-def here and restore the committed
+# state on EXIT (cleanup() trap).
+cp "${PROVISIOND_CONFIG}" "${PROVISIOND_CONFIG_BACKUP}"
+log "  Ensuring active mhuot-labs requisition-def in ${PROVISIOND_CONFIG}"
+python3 - "${PROVISIOND_CONFIG}" <<'PYEOF'
+import re, sys
+path = sys.argv[1]
+with open(path) as f: content = f.read()
+active_pattern = re.compile(
+    r'<requisition-def\s+import-name="mhuot-labs"[\s\S]+?</requisition-def>')
+# Strip from any XML comment blocks so we can detect commented-out entries
+stripped = re.sub(r'<!--[\s\S]*?-->', '', content)
+if active_pattern.search(stripped):
+    print("  (mhuot-labs already active — no change needed)")
+    sys.exit(0)
+snippet = (
+    '  <requisition-def import-name="mhuot-labs"\n'
+    '                   import-url-resource="file:///opt/deltav/etc/imports/mhuot-labs.xml">\n'
+    '    <cron-schedule>0/30 * * * * ?</cron-schedule>\n'
+    '  </requisition-def>\n'
+)
+marker = '</provisiond-configuration>'
+if marker not in content:
+    sys.exit(f"marker {marker!r} not found in {path}")
+new_content = content.replace(marker, snippet + marker, 1)
+with open(path, 'w') as f: f.write(new_content)
+print("  (mhuot-labs requisition-def injected active)")
+PYEOF
+PROVISIOND_NEEDS_RESTART=true
+ok "Provisiond configuration has active mhuot-labs requisition-def"
 
 # ══════════════════════════════════════════════════════════════════
 # Phase 0b: Clean ALL prior node data (lightweight — skipped if --pre-clean already ran)

--- a/opennms-container/delta-v/test-perspective-e2e.sh
+++ b/opennms-container/delta-v/test-perspective-e2e.sh
@@ -145,12 +145,22 @@ show_diagnostics() {
     docker logs delta-v-perspectivepollerd 2>&1 | tail -30 || true
 }
 
+PROVISIOND_CONFIG="${SCRIPT_DIR}/provisiond-overlay/etc/provisiond-configuration.xml"
+PROVISIOND_CONFIG_BACKUP="$(mktemp -t perspective-provisiond-config.XXXXXX.xml)"
+
 cleanup() {
     docker compose exec -T kafka sh -c 'for p in $(ps -eo pid,args 2>/dev/null | grep kafka-console-consumer | grep -v grep | awk "{print \$1}"); do kill "$p" 2>/dev/null; done' || true
     rm -rf "$TEST_TMPDIR"
     # Always undo /etc/hosts override on Default Minion (safety net for early exit)
     docker exec -u root delta-v-minion sh -c \
         'grep -v "192.0.2.1" /etc/hosts > /tmp/h && cat /tmp/h > /etc/hosts && rm /tmp/h' 2>/dev/null || true
+    # Restore provisiond-configuration.xml from the committed state (captured
+    # before the mhuot-labs inject) so the working tree stays clean for other
+    # E2E tests that depend on the canonical committed config.
+    if [ -f "${PROVISIOND_CONFIG_BACKUP}" ]; then
+        cp "${PROVISIOND_CONFIG_BACKUP}" "${PROVISIOND_CONFIG}"
+        rm -f "${PROVISIOND_CONFIG_BACKUP}"
+    fi
     if $POST_CLEANUP; then
         log "Post-run cleanup..."
         psql_query "DELETE FROM application_perspective_location_map WHERE appid IN (SELECT id FROM applications WHERE name = '${APP_NAME}')" || true
@@ -207,6 +217,42 @@ for svc in postgres kafka provisiond perspectivepollerd minion; do
     fi
 done
 ok "Required services running (postgres, kafka, provisiond, perspectivepollerd, minion)"
+
+# The committed provisiond-configuration.xml has the mhuot-labs requisition-def
+# commented out (lab devices at 172.20.20.x need VPN). This test is the labbox-
+# dependent path, so we inject the requisition-def as active, then restore the
+# committed state on EXIT. Provisiond's import of mhuot-labs.xml (which has
+# nodes with location="mhuot-labs") is what populates monitoringlocations with
+# the mhuot-labs row — without this step, the LOC_COUNT check below would fail
+# because only Default (+ l8opensim-lab) get registered.
+cp "${PROVISIOND_CONFIG}" "${PROVISIOND_CONFIG_BACKUP}"
+python3 - "${PROVISIOND_CONFIG}" <<'PYEOF'
+import re, sys
+path = sys.argv[1]
+with open(path) as f: content = f.read()
+active_pattern = re.compile(
+    r'<requisition-def\s+import-name="mhuot-labs"[\s\S]+?</requisition-def>')
+stripped = re.sub(r'<!--[\s\S]*?-->', '', content)
+if active_pattern.search(stripped):
+    sys.exit(0)
+snippet = (
+    '  <requisition-def import-name="mhuot-labs"\n'
+    '                   import-url-resource="file:///opt/deltav/etc/imports/mhuot-labs.xml">\n'
+    '    <cron-schedule>0/30 * * * * ?</cron-schedule>\n'
+    '  </requisition-def>\n'
+)
+marker = '</provisiond-configuration>'
+with open(path, 'w') as f: f.write(content.replace(marker, snippet + marker, 1))
+PYEOF
+docker restart delta-v-provisiond >/dev/null 2>&1
+log "  Waiting up to 60s for provisiond to re-import mhuot-labs and register monitoringlocation..."
+deadline=$(( $(date +%s) + 60 ))
+while (( $(date +%s) < deadline )); do
+    if [ "$(psql_query "SELECT count(*) FROM monitoringlocations WHERE id='${LOCATION_B}'" || echo 0)" = "1" ]; then
+        break
+    fi
+    sleep 3
+done
 
 # Verify both monitoring locations exist
 LOC_COUNT=$(psql_query "SELECT count(*) FROM monitoringlocations WHERE id IN ('${LOCATION_A}', '${LOCATION_B}')")
@@ -270,23 +316,52 @@ cat > "$REQUISITION_FILE" <<EOF
 EOF
 ok "Requisition and foreign source written (no detectors)"
 
-# Ensure provisiond-configuration.xml includes this foreign source
-PROVISIOND_CONFIG="${SCRIPT_DIR}/provisiond-overlay/etc/provisiond-configuration.xml"
-if ! grep -q "${FOREIGN_SOURCE}" "$PROVISIOND_CONFIG" 2>/dev/null; then
-    # Add requisition-def before closing tag
-    sed -i.bak "s|</provisiond-configuration>|  <requisition-def import-name=\"${FOREIGN_SOURCE}\" import-url-resource=\"file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml\">\n    <cron-schedule>0 0/1 * * * ? *</cron-schedule>\n  </requisition-def>\n</provisiond-configuration>|" "$PROVISIOND_CONFIG"
-    rm -f "${PROVISIOND_CONFIG}.bak"
-    ok "Provisiond configuration updated with ${FOREIGN_SOURCE} import"
-    docker restart delta-v-provisiond >/dev/null 2>&1
-    sleep 15
-    if docker compose ps --status running | grep -q provisiond; then
-        ok "Provisiond restarted and healthy"
-    else
-        fail "Provisiond failed to restart"
-        show_diagnostics
+# Ensure provisiond-configuration.xml has an *active* (uncommented)
+# requisition-def for ${FOREIGN_SOURCE}. The committed config already
+# includes perspective-test so the inject is a no-op in the happy path;
+# the Python check skips comment blocks so a commented-out entry
+# wouldn't fool us into leaving it inactive. PROVISIOND_CONFIG_BACKUP
+# was already captured before the mhuot-labs inject, so cleanup()
+# restores both injects in one shot.
+python3 - "${PROVISIOND_CONFIG}" "${FOREIGN_SOURCE}" <<'PYEOF'
+import re, sys
+path, fs = sys.argv[1], sys.argv[2]
+with open(path) as f: content = f.read()
+active = re.compile(
+    rf'<requisition-def\s+import-name="{re.escape(fs)}"[\s\S]+?</requisition-def>')
+stripped = re.sub(r'<!--[\s\S]*?-->', '', content)
+if active.search(stripped):
+    sys.exit(0)
+snippet = (
+    f'  <requisition-def import-name="{fs}" import-url-resource="file:///opt/deltav/etc/imports/{fs}.xml">\n'
+    f'    <cron-schedule>0 0/1 * * * ? *</cron-schedule>\n'
+    f'  </requisition-def>\n'
+)
+marker = '</provisiond-configuration>'
+with open(path, 'w') as f: f.write(content.replace(marker, snippet + marker, 1))
+PYEOF
+# Restart provisiond to pick up the config change. `docker compose ps
+# --status running` shows the container even in its "restarting" state,
+# which fooled the previous check into passing prematurely; instead we
+# poll the /actuator/health endpoint until it returns 200 (or give up
+# at 60s). The first restart for mhuot-labs inject already waited for
+# the monitoringlocations row, so provisiond is known-healthy before we
+# enter this block.
+docker restart delta-v-provisiond >/dev/null 2>&1 || true
+deadline=$(( $(date +%s) + 60 ))
+prov_healthy=false
+while (( $(date +%s) < deadline )); do
+    if docker compose exec -T provisiond curl -sf http://localhost:8080/actuator/health >/dev/null 2>&1; then
+        prov_healthy=true
+        break
     fi
+    sleep 3
+done
+if $prov_healthy; then
+    ok "Provisiond has active ${FOREIGN_SOURCE} requisition-def and restarted healthy"
 else
-    ok "Provisiond configuration already includes ${FOREIGN_SOURCE}"
+    fail "Provisiond failed to become healthy within 60s after restart"
+    show_diagnostics
 fi
 
 # Wait for node to be provisioned

--- a/opennms-container/delta-v/test-timeseries-e2e.sh
+++ b/opennms-container/delta-v/test-timeseries-e2e.sh
@@ -3,68 +3,61 @@
 # Licensed under the GNU Affero General Public License v3.
 # See LICENSE.md in the repository root for full license text.
 #
-# Layer 5 end-to-end smoke test for the Kafka Time Series producer. Starts
-# the delta-v Docker Compose stack with DELTAV_TIMESERIES_ENABLED=true,
-# provisions a test node, waits for Collectd to poll it, then asserts:
+# Layer 5 end-to-end smoke test for the Kafka Time Series producer. Runs
+# against a pre-deployed full stack (./deploy.sh up full), asserts:
 #   1. at least one record arrives on the deltav-timeseries topic
 #      (via kafka-console-consumer, payload not deserialized)
 #   2. deltav_timeseries_batches_published_total{producer="collectd"} > 0
 #      on the Collectd /actuator/prometheus endpoint
 #   3. deltav_timeseries_batches_failed_total counters stay at zero
-# Protobuf deserialization is out of scope for Phase 0; the Prometheus
-# counter assertion is the load-bearing check. Tears down cleanly on
-# success or failure.
+#   4. inner-persister cascade counters stay at zero (regression guard for
+#      horizon TimeseriesPersister ClassCastException cascade fixed in
+#      delta-v-horizon PR #8 / horizon 1.0.11)
+#
+# This test was rewritten (2026-04-22) to drop its previous dependency on
+# the legacy horizon-core webapp REST API (which was removed from delta-v
+# in PR #28 — project_webapp_removed). The committed full stack already
+# imports multiple requisitions at startup (delta-v, cloud-services,
+# rpc-canary, flow-test, l8opensim-lab, perspective-test) so Collectd has
+# plenty of nodes to poll without this test needing to provision its own.
+#
+# Prerequisites:
+#   ./deploy.sh up full  (must be running with all daemons healthy)
+#
+# Usage:
+#   ./test-timeseries-e2e.sh              Run the test
+#   ./test-timeseries-e2e.sh --pre-clean  (no-op, kept for parity with other tests)
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = test failure
+#   2 = prerequisite failure
 
 set -euo pipefail
 
 cd "$(dirname "$0")"
 
-export DELTAV_TIMESERIES_ENABLED=true
-TEST_REQUISITION="timeseries-e2e"
-STACK_READY_TIMEOUT=180
 POLL_TIMEOUT=120
+# Tempfile for kafka-console-consumer output; auto-cleaned on exit.
+MSG_FILE=$(mktemp -t ts-e2e-msg.XXXXXX)
 
 cleanup() {
-    echo "==> Tearing down stack"
-    docker compose down -v --remove-orphans || true
+    rm -f "${MSG_FILE}"
 }
 trap cleanup EXIT
 
-echo "==> Starting delta-v Docker Compose with DELTAV_TIMESERIES_ENABLED=true"
-docker compose up -d --build
-
-echo "==> Waiting for collectd /actuator/health (up to ${STACK_READY_TIMEOUT} s)"
-deadline=$(( $(date +%s) + STACK_READY_TIMEOUT ))
-while (( $(date +%s) < deadline )); do
-    if docker compose exec -T collectd curl -sf http://localhost:8080/actuator/health >/dev/null 2>&1; then
-        echo "==> collectd healthy"
-        break
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+echo "==> Checking prerequisites..."
+RUNNING=$(docker compose ps --status running --format '{{.Name}}' 2>/dev/null)
+for svc in postgres kafka collectd provisiond minion; do
+    if ! echo "$RUNNING" | grep -q "$svc"; then
+        echo "ERROR: Service '$svc' is not running. Deploy with: ./deploy.sh up full" >&2
+        exit 2
     fi
-    sleep 3
 done
-if (( $(date +%s) >= deadline )); then
-    echo "ERROR: collectd did not become healthy within ${STACK_READY_TIMEOUT} s"
-    docker compose logs collectd | tail -60
-    exit 1
-fi
+echo "==> Required services running (postgres, kafka, collectd, provisiond, minion)"
 
-echo "==> Provisioning test requisition ${TEST_REQUISITION}"
-docker compose exec -T horizon-core curl -sf -u admin:admin \
-    -H "Content-Type: application/xml" \
-    -X POST -d '<model-import foreign-source="timeseries-e2e">
-        <node foreign-id="ts-1" node-label="timeseries-e2e-node-1">
-            <interface ip-addr="127.0.0.1">
-                <monitored-service service-name="ICMP"/>
-            </interface>
-        </node>
-    </model-import>' \
-    "http://localhost:8980/opennms/rest/requisitions" || {
-        echo "WARN: requisition POST failed; horizon-core may be on a different port"
-        echo "      checking alternate ports..."
-    }
-docker compose exec -T horizon-core curl -sf -u admin:admin \
-    -X PUT "http://localhost:8980/opennms/rest/requisitions/${TEST_REQUISITION}/import" || true
-
+# ── Step 1: Wait for a record on deltav-timeseries ────────────────────────────
 echo "==> Waiting for a record on deltav-timeseries (up to ${POLL_TIMEOUT} s)"
 timeout "${POLL_TIMEOUT}" docker compose exec -T kafka \
     /opt/kafka/bin/kafka-console-consumer.sh \
@@ -72,18 +65,18 @@ timeout "${POLL_TIMEOUT}" docker compose exec -T kafka \
         --topic deltav-timeseries \
         --from-beginning \
         --max-messages 1 \
-        --formatter kafka.tools.DefaultMessageFormatter \
-        --property print.key=true > /tmp/ts-e2e-msg.bin || {
+        --property print.key=true > "${MSG_FILE}" 2>/dev/null || {
     echo "ERROR: no record received on deltav-timeseries within ${POLL_TIMEOUT} s"
     docker compose logs collectd | tail -60
     exit 1
 }
-if [ ! -s /tmp/ts-e2e-msg.bin ]; then
-    echo "ERROR: /tmp/ts-e2e-msg.bin is empty"
+if [ ! -s "${MSG_FILE}" ]; then
+    echo "ERROR: ${MSG_FILE} is empty"
     exit 1
 fi
-echo "==> Received record on deltav-timeseries ($(wc -c < /tmp/ts-e2e-msg.bin) bytes)"
+echo "==> Received record on deltav-timeseries ($(wc -c < "${MSG_FILE}") bytes)"
 
+# ── Step 2: Assert Collectd published counter ─────────────────────────────────
 echo "==> Asserting /actuator/prometheus metrics"
 metrics=$(docker compose exec -T collectd curl -sf http://localhost:8080/actuator/prometheus)
 if ! echo "${metrics}" | grep -E '^deltav_timeseries_batches_published_total.*producer="collectd"' | \
@@ -92,27 +85,32 @@ if ! echo "${metrics}" | grep -E '^deltav_timeseries_batches_published_total.*pr
     echo "${metrics}" | grep deltav_timeseries || true
     exit 1
 fi
+echo "==> deltav_timeseries_batches_published_total > 0"
+
 if echo "${metrics}" | grep -E '^deltav_timeseries_batches_failed_total' | \
        awk '{print $NF}' | grep -qE '^[1-9]'; then
     echo "ERROR: deltav_timeseries_batches_failed_total is non-zero"
     echo "${metrics}" | grep deltav_timeseries_batches_failed_total || true
     exit 1
 fi
+echo "==> deltav_timeseries_batches_failed_total = 0"
 
-# Regression guard for the horizon TimeseriesPersister ClassCastException
-# cascade fixed in delta-v-horizon PR #8 (horizon 1.0.11). The ClassCastException
-# on visitGroup and the NPE cascade on visitAttribute/persistNumeric/String
-# must all stay at 0 — if any of these fires, a regression has re-introduced
-# the bug and FanoutPersister's isolation would otherwise hide it.
-# step=visitResource is deliberately NOT asserted: Bug #1 (MetaTagDataLoader
-# rollback) is a separate investigation and may still tick on labbox today.
+# ── Step 3: Regression guard for horizon TimeseriesPersister cascade ──────────
+# Bugs fixed in delta-v-horizon PR #8 (horizon 1.0.11). The
+# ClassCastException on visitGroup and the NPE cascade on
+# visitAttribute/persistNumeric/String must all stay at 0 — if any of
+# these fires, a regression has re-introduced the bug and
+# FanoutPersister's isolation would otherwise hide it.
+# step=visitResource is deliberately NOT asserted: Bug #1
+# (MetaTagDataLoader rollback) is a separate investigation and may still
+# tick on labbox today.
 echo "==> Asserting inner-persister cascade counters stay at zero"
-for step in visitGroup visitAttribute persistNumericAttribute persistStringAttribute; do
+for step in visitGroup visitAttribute persistNumericAttribute persistStringAttribute completeResource; do
     value=$(echo "${metrics}" | \
         grep -E "^deltav_collectd_persister_inner_failures_total\{.*step=\"${step}\"" | \
         awk '{print $NF}')
     if [ -z "${value}" ]; then
-        echo "WARN: counter deltav_collectd_persister_inner_failures_total{step=${step}} not registered"
+        echo "  (counter step=${step} not yet registered — no cascade has fired)"
         continue
     fi
     if [ "${value}" != "0.0" ]; then


### PR DESCRIPTION
## Summary

Brings the labbox-dependent E2E suite to a clean baseline. Three production classpath/counter bugs uncovered by the full labbox run, plus test-harness fixes so the tests no longer sabotage each other.

## Production bugs (3)

### enlinkd + prometheus-writer missing db-init dependency (original PR #194 scope)

Enlinkd waited only on \`postgres: service_healthy\` which reports UP before Liquibase finishes schema creation. Bean factory queried \`monitoringsystems\` during \`KafkaRpcClientFactory\` startup → schema-missing → exit(1). Prometheus-writer had a weaker transitive chain via \`provisiond: service_started\`. Fix: explicit \`db-init: service_completed_successfully\` on both (matching the 10 other daemons).

### daemon-boot-collectd missing OIA common dep

horizon \`features.timeseries-1.0.13\`'s \`TimeseriesPersistOperationBuilder\` calls \`ImmutableTag\` from \`org.opennms.integration.api:common\`. Collectd only pulled the \`api\` (interfaces) artifact transitively. Result: every SNMP attribute persist on the inner path threw \`NoClassDefFoundError\`, ticking \`deltav_collectd_persister_inner_failures_total{step=visitAttribute}\` into the thousands per test run. FanoutPersister caught it (Kafka path unaffected), but test-timeseries-e2e's cascade-counter regression guard legitimately failed.

### UpsertTemplate in wrong package (horizon compiles against \`org.opennms.netmgt.dao.support\`)

The delta-v port placed UpsertTemplate under \`org.deltav.netmgt.dao.support\`. horizon's enlinkd persistence impl compiles against \`org.opennms.netmgt.dao.support.UpsertTemplate\`. Every enlinkd discovery thread that tried to persist an LLDP/CDP/OSPF/IS-IS link threw \`NoClassDefFoundError\` → \`lldplink\` stayed empty even though \`lldpelement\` populated. No delta-v code imports the \`org.deltav\` variant (verified), so the rename is safe.

### empty_batch counted as failure (TimeseriesKafkaPublisher)

Skipping a zero-resource batch is an expected outcome, not a failure. Moving to a new \`deltav_timeseries_batches_skipped_total\` counter keeps SLO alerting on \`batches_failed_total\` clean while retaining ops visibility. Same pattern as PR #193's \`node_context_records_failed/skipped\` split.

## Test harness fixes (3)

- **test-enlinkd-e2e.sh**: replace \`grep -q 'import-name=\"mhuot-labs\"'\` (which matched the committed config's commented-out entry) with a comment-aware Python inject; back up + restore \`provisiond-configuration.xml\` on exit (same pattern as test-node-context-e2e).
- **test-perspective-e2e.sh**: inject \`mhuot-labs\` requisition-def so \`monitoringlocations\` gets populated (needed for the 2-location prereq), same backup/restore. Wait for \`/actuator/health\` on provisiond restart instead of \`docker compose ps\` (which passed during \"restarting\" state).
- **test-timeseries-e2e.sh**: rewrite — prior version used the removed \`horizon-core\` webapp REST API (PR #28 \`project_webapp_removed\`). New version runs against a shared full-stack deploy and tears down its own tempfile only.

## Verification: 12/12 E2E pass

### Local suite (8/8)
test-e2e, test-collectd-e2e, test-syslog-e2e, test-passive-e2e, test-minion-e2e, test-node-context-e2e, test-prometheus-writer-e2e, test-flows-e2e

### Labbox-dependent suite (4/4)
- test-minion-rpc-e2e ✅
- test-enlinkd-e2e ✅ **18/18** (16 LLDP link entries, 8 unique node-pair links on cEOS topology)
- test-perspective-e2e ✅ **22/22** (DNS-block outage cycle + no false outage on mhuot-labs)
- test-timeseries-e2e ✅ (pipeline + cascade counter guards)

### Unit tests
- NodeContextPublisherTest 9/9
- TimeseriesKafkaPublisherTest 10/10

## Out of scope (followups)

- The timestamp in \`provisiond-overlay/etc/foreign-sources/perspective-test.xml\` is rewritten by test-perspective-e2e every run. Making it non-destructive there too is polish; doesn't affect test correctness.