### PR TITLE
chore: image prefix rename + deploy.sh legacy cleanup

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -77,11 +77,11 @@ cd opennms-container/delta-v
 ```
 
 The layered image build:
-1. `opennms/jre-deltav:21` — jlink custom JRE on Alpine 3.21 (22 modules, ~143MB)
-2. `opennms/daemon-base` — shared libraries (~321 JARs deduped across 12 daemons, ~415MB)
+1. `deltav/jre-deltav:21` — jlink custom JRE on Alpine 3.21 (22 modules, ~143MB)
+2. `deltav/daemon-base` — shared libraries (~321 JARs deduped across 12 daemons, ~415MB)
 3. `opennms/<daemon>` — per-daemon overlay (unique libs + thin app JAR)
-4. `opennms/minion-boot` — Spring Boot 4 Minion fat JAR
-5. `opennms/db-init` — one-shot Liquibase schema migration
+4. `deltav/minion-boot` — Spring Boot 4 Minion fat JAR
+5. `deltav/db-init` — one-shot Liquibase schema migration
 
 ### 3. Full Build (All Steps)
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Delta-V code lives in the `org.deltav` package namespace with `org.deltav.core` 
 
 | Image | Base | Contents |
 |-------|------|----------|
-| `opennms/jre-deltav:21` | `alpine:3.21` | jlink custom JRE (22 modules) + diagnostic tools |
-| `opennms/daemon-base` | `jre-deltav:21` | Shared libraries (~321 JARs deduped across 12 daemons) |
+| `deltav/jre-deltav:21` | `alpine:3.21` | jlink custom JRE (22 modules) + diagnostic tools |
+| `deltav/daemon-base` | `jre-deltav:21` | Shared libraries (~321 JARs deduped across 12 daemons) |
 | `opennms/<daemon>` | `daemon-base` | Per-daemon unique libs + thin app JAR (12 images) |
-| `opennms/minion-boot` | `jre-deltav:21` | Spring Boot 4 Minion — Kafka RPC server + Sink listeners + Twin API |
-| `opennms/db-init` | `jre-deltav:21` | One-shot Liquibase schema migration |
+| `deltav/minion-boot` | `jre-deltav:21` | Spring Boot 4 Minion — Kafka RPC server + Sink listeners + Twin API |
+| `deltav/db-init` | `jre-deltav:21` | One-shot Liquibase schema migration |
 
 ### Shared Infrastructure
 
@@ -103,7 +103,7 @@ OpenNMS Horizon is an enterprise-grade open-source network monitoring platform. 
 - **Events never touch PostgreSQL** — only alarms are persisted to the database
 - **Layered Docker images** — shared `daemon-base` (~415MB) + 12 per-daemon overlay images on a 143MB jlink Alpine JRE
 - **Spring Boot 4 migration complete** — all 12 daemons + Minion run as JARs (2-4s startup); Karaf fully retired
-- **One-shot database initialization** — `opennms/db-init` replaces the Core container for schema setup
+- **One-shot database initialization** — `deltav/db-init` replaces the Core container for schema setup
 - **`org.deltav` package namespace** — original delta-v code uses `org.deltav.*` packages; horizon-derived model-jakarta stays `org.opennms`
 
 ## Architecture

--- a/opennms-container/delta-v/Dockerfile.daemon-base
+++ b/opennms-container/delta-v/Dockerfile.daemon-base
@@ -7,7 +7,7 @@
 # Build with: ./build.sh deltav  (built automatically)
 # Rebuild when: shared dependencies change (Spring Boot, Hibernate, Kafka, etc.)
 
-ARG JRE_IMAGE=opennms/jre-deltav:21
+ARG JRE_IMAGE=deltav/jre-deltav:21
 FROM ${JRE_IMAGE}
 
 LABEL org.opencontainers.image.title="Delta-V Daemon Base" \

--- a/opennms-container/delta-v/Dockerfile.daemon-per
+++ b/opennms-container/delta-v/Dockerfile.daemon-per
@@ -8,7 +8,7 @@
 # Built automatically by build.sh for each of the 12 daemons.
 
 ARG VERSION
-ARG DAEMON_BASE_IMAGE=opennms/daemon-base
+ARG DAEMON_BASE_IMAGE=deltav/daemon-base
 FROM ${DAEMON_BASE_IMAGE}:${VERSION}
 
 ARG DAEMON_NAME

--- a/opennms-container/delta-v/Dockerfile.minion-boot
+++ b/opennms-container/delta-v/Dockerfile.minion-boot
@@ -1,4 +1,4 @@
-ARG JRE_IMAGE=opennms/jre-deltav:21
+ARG JRE_IMAGE=deltav/jre-deltav:21
 FROM ${JRE_IMAGE}
 
 LABEL org.opencontainers.image.title="Delta-V Minion (Spring Boot)"

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -46,7 +46,7 @@ All 12 daemons share infrastructure from `core/daemon-common`:
 
 ### Karaf Image Retirement
 
-With all 12 daemons on Spring Boot, the Karaf-based Sentinel image (`opennms/daemon-deltav`) can be retired. The only Karaf component remaining is the Minion, which runs the standard OpenNMS Minion distribution.
+With all 12 daemons on Spring Boot, the Karaf-based Sentinel image (`deltav/daemon-deltav`) can be retired. The only Karaf component remaining is the Minion, which runs the standard OpenNMS Minion distribution.
 
 ## Services
 
@@ -54,26 +54,26 @@ With all 12 daemons on Spring Boot, the Karaf-based Sentinel image (`opennms/dae
 |--------------------|-------------------------------|--------------------------------------------------------------------------|-----------|
 | postgres           | postgres:15                   | Shared database (alarms only)                                            | 5432      |
 | kafka              | apache/kafka                  | Event bus (KRaft mode)                                                   | 19092     |
-| db-init            | opennms/db-init               | One-shot PostgreSQL schema migration (exits after init)                  | —         |
+| db-init            | deltav/db-init               | One-shot PostgreSQL schema migration (exits after init)                  | —         |
 | clickhouse         | clickhouse/clickhouse-server  | Flow storage: `deltav.flows_raw` + 4 dimension MVs                       | 8123      |
 | clickhouse-init    | one-shot                      | One-shot ClickHouse DDL bootstrap                                         | —         |
-| minion             | opennms/minion-boot           | Spring Boot 4 distributed data collection agent + UDP flow listener      | 4729/udp  |
+| minion             | deltav/minion-boot           | Spring Boot 4 distributed data collection agent + UDP flow listener      | 4729/udp  |
 | snmp-agent         | tandrup/netsnmp               | Local SNMP test target for Collectd / detectors                          | —         |
-| alarmd             | opennms/alarmd                | Alarm processing (Kafka consumer)                                        | —         |
-| pollerd            | opennms/pollerd               | Service polling via Minion RPC                                           | —         |
-| collectd           | opennms/collectd              | SNMP data collection via Minion SNMP proxy                               | —         |
-| discovery          | opennms/discovery             | Network discovery via Minion RPC                                         | —         |
-| provisiond         | opennms/provisiond            | Node provisioning and detection                                          | —         |
-| trapd              | opennms/trapd                 | SNMP trap reception (Kafka Sink)                                         | —         |
-| syslogd            | opennms/syslogd               | Syslog reception (Kafka Sink)                                            | —         |
-| eventtranslator    | opennms/eventtranslator       | Event transformation rules                                               | —         |
-| enlinkd            | opennms/enlinkd               | Link discovery (CDP, LLDP, OSPF, IS-IS, Bridge)                          | —         |
-| bsmd               | opennms/bsmd                  | Business Service Monitor                                                 | 8180      |
-| perspectivepollerd | opennms/perspectivepollerd    | Perspective polling from remote locations                                | —         |
-| telemetryd         | opennms/telemetryd            | Non-flow telemetry ingestion (OpenConfig via Twin API)                   | —         |
-| flow-enricher      | opennms/flow-enricher         | Flow decode (horizon UDP parsers) + enrich + publish to ClickHouse       | 8080      |
+| alarmd             | deltav/alarmd                | Alarm processing (Kafka consumer)                                        | —         |
+| pollerd            | deltav/pollerd               | Service polling via Minion RPC                                           | —         |
+| collectd           | deltav/collectd              | SNMP data collection via Minion SNMP proxy                               | —         |
+| discovery          | deltav/discovery             | Network discovery via Minion RPC                                         | —         |
+| provisiond         | deltav/provisiond            | Node provisioning and detection                                          | —         |
+| trapd              | deltav/trapd                 | SNMP trap reception (Kafka Sink)                                         | —         |
+| syslogd            | deltav/syslogd               | Syslog reception (Kafka Sink)                                            | —         |
+| eventtranslator    | deltav/eventtranslator       | Event transformation rules                                               | —         |
+| enlinkd            | deltav/enlinkd               | Link discovery (CDP, LLDP, OSPF, IS-IS, Bridge)                          | —         |
+| bsmd               | deltav/bsmd                  | Business Service Monitor                                                 | 8180      |
+| perspectivepollerd | deltav/perspectivepollerd    | Perspective polling from remote locations                                | —         |
+| telemetryd         | deltav/telemetryd            | Non-flow telemetry ingestion (OpenConfig via Twin API)                   | —         |
+| flow-enricher      | deltav/flow-enricher         | Flow decode (horizon UDP parsers) + enrich + publish to ClickHouse       | 8080      |
 
-All daemon containers extend a shared `opennms/daemon-base` image built on top of `opennms/jre-deltav:21` (a jlink custom JRE on `alpine:3.21`). Each per-daemon image adds only the libraries unique to that daemon via layered Docker image deduplication.
+All daemon containers extend a shared `deltav/daemon-base` image built on top of `deltav/jre-deltav:21` (a jlink custom JRE on `alpine:3.21`). Each per-daemon image adds only the libraries unique to that daemon via layered Docker image deduplication.
 
 ## Quick Start
 

--- a/opennms-container/delta-v/build
+++ b/opennms-container/delta-v/build
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SKIP_TESTS="${SKIP_TESTS:-true}"
 DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-DOCKER_ORG="${DOCKER_ORG:-opennms}"
+DOCKER_ORG="${DOCKER_ORG:-deltav}"
 
 # Detect version from POM (skip parent version, get project version)
 VERSION="$(cd "$REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || grep '<version>0\.' "$REPO_ROOT/pom.xml" | head -1 | sed 's/.*<version>\(.*\)<\/version>.*/\1/')"
@@ -72,22 +72,22 @@ do_assemble() {
 }
 
 do_db_init_image() {
-    log "Building db-init image (opennms/db-init:$VERSION)..."
+    log "Building db-init image (deltav/db-init:$VERSION)..."
     cd "$REPO_ROOT"
     ./mvnw -B -f core/db-init/pom.xml -DskipTests package
     cd "$REPO_ROOT/core/db-init"
-    docker build -t "opennms/db-init:$VERSION" -t "opennms/db-init:latest" .
+    docker build -t "deltav/db-init:$VERSION" -t "deltav/db-init:latest" .
 }
 
 do_jre_image() {
-    log "Building opennms/jre-deltav:21..."
+    log "Building deltav/jre-deltav:21..."
     cd "$SCRIPT_DIR"
     docker build -f Dockerfile.jre \
-        -t "opennms/jre-deltav:21" \
-        -t "opennms/jre-deltav:latest" \
+        -t "deltav/jre-deltav:21" \
+        -t "deltav/jre-deltav:latest" \
         .
     log "JRE image built:"
-    docker images opennms/jre-deltav --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}"
+    docker images deltav/jre-deltav --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}"
 }
 
 do_images() {
@@ -99,8 +99,8 @@ do_deltav_images() {
     log "Building Delta-V layered images..."
 
     # Check that JRE base image exists
-    if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
-        err "opennms/jre-deltav:21 not found — run './build.sh jre' first"
+    if ! docker image inspect deltav/jre-deltav:21 >/dev/null 2>&1; then
+        err "deltav/jre-deltav:21 not found — run './build.sh jre' first"
     fi
 
     # Phase 1: Extract and deduplicate
@@ -109,11 +109,11 @@ do_deltav_images() {
     cd "$SCRIPT_DIR"
 
     # Phase 2: Build daemon-base image
-    log "Building opennms/daemon-base:$VERSION..."
+    log "Building deltav/daemon-base:$VERSION..."
     docker build --no-cache \
         -f Dockerfile.daemon-base \
-        -t "opennms/daemon-base:$VERSION" \
-        -t "opennms/daemon-base:latest" \
+        -t "deltav/daemon-base:$VERSION" \
+        -t "deltav/daemon-base:latest" \
         .
 
     # Phase 3: Build per-daemon images
@@ -121,14 +121,14 @@ do_deltav_images() {
     for name in $daemon_names; do
         local main_class
         main_class=$(cat "staging/$name/.main_class")
-        log "Building opennms/$name:$VERSION (main: $main_class)..."
+        log "Building deltav/$name:$VERSION (main: $main_class)..."
         docker build \
             -f Dockerfile.daemon-per \
             --build-arg "VERSION=$VERSION" \
             --build-arg "DAEMON_NAME=$name" \
             --build-arg "MAIN_CLASS=$main_class" \
-            -t "opennms/$name:$VERSION" \
-            -t "opennms/$name:latest" \
+            -t "deltav/$name:$VERSION" \
+            -t "deltav/$name:latest" \
             .
     done
 
@@ -142,12 +142,12 @@ do_deltav_images() {
         -exec cp {} "$SCRIPT_DIR/staging/minion-boot/daemon-boot-minion.jar" \;
 
     # --- Build Minion Boot image ---
-    log "Building opennms/minion-boot:$VERSION..."
+    log "Building deltav/minion-boot:$VERSION..."
     docker build \
         --build-arg "VERSION=$VERSION" \
         -f Dockerfile.minion-boot \
-        -t "opennms/minion-boot:$VERSION" \
-        -t "opennms/minion-boot:latest" \
+        -t "deltav/minion-boot:$VERSION" \
+        -t "deltav/minion-boot:latest" \
         .
 
     # Clean up staging
@@ -167,7 +167,7 @@ Commands:
   compile   Compile only (Maven)
   assemble  Assemble distributions (Daemon + Alarmd + Minion + Sentinel)
   images    Build base Docker images only (requires prior assembly)
-  jre       Build JRE base image (opennms/jre-deltav:21, rarely needed)
+  jre       Build JRE base image (deltav/jre-deltav:21, rarely needed)
   deltav    Build Delta-V layered images (stages JARs into derived images)
   push      Build and push images to registry
   clean     Remove named Docker volumes (fresh start)
@@ -200,7 +200,7 @@ main() {
     case "${1:-all}" in
         all)
             do_compile
-            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+            if ! docker image inspect deltav/jre-deltav:21 >/dev/null 2>&1; then
                 do_jre_image
             fi
             do_deltav_images
@@ -225,7 +225,7 @@ main() {
             do_compile
             do_assemble
             do_images push
-            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+            if ! docker image inspect deltav/jre-deltav:21 >/dev/null 2>&1; then
                 do_jre_image
             fi
             do_deltav_images

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -11,7 +11,7 @@
 #
 # Environment:
 #   DOCKER_REGISTRY   Docker registry (default: docker.io)
-#   DOCKER_ORG        Docker org/user (default: opennms)
+#   DOCKER_ORG        Docker org/user (default: deltav)
 #   SKIP_TESTS        Set to "false" to run tests (default: true)
 #   JAVA_HOME         JDK 21 path (auto-detected if unset)
 #
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SKIP_TESTS="${SKIP_TESTS:-true}"
 DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
-DOCKER_ORG="${DOCKER_ORG:-opennms}"
+DOCKER_ORG="${DOCKER_ORG:-deltav}"
 
 # Detect version from POM (skip parent version, get project version)
 VERSION="$(cd "$REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || grep '<version>0\.' "$REPO_ROOT/pom.xml" | head -1 | sed 's/.*<version>\(.*\)<\/version>.*/\1/')"
@@ -130,38 +130,38 @@ do_assemble() {
 }
 
 do_db_init_image() {
-    log "Building db-init image (opennms/db-init:$VERSION)..."
+    log "Building db-init image (deltav/db-init:$VERSION)..."
     cd "$REPO_ROOT"
     ./mvnw -B -f core/db-init/pom.xml -DskipTests package
     cd "$REPO_ROOT/core/db-init"
-    docker build -t "opennms/db-init:$VERSION" -t "opennms/db-init:latest" .
+    docker build -t "deltav/db-init:$VERSION" -t "deltav/db-init:latest" .
 }
 
 do_flow_enricher_image() {
-    log "Building flow-enricher image (opennms/flow-enricher:$VERSION)..."
+    log "Building flow-enricher image (deltav/flow-enricher:$VERSION)..."
     cd "$REPO_ROOT"
     ./mvnw -B -f core/flow-enricher/pom.xml -DskipTests package
     cd "$REPO_ROOT/core/flow-enricher"
-    docker build -t "opennms/flow-enricher:$VERSION" -t "opennms/flow-enricher:latest" .
+    docker build -t "deltav/flow-enricher:$VERSION" -t "deltav/flow-enricher:latest" .
 }
 
 do_prometheus_writer_image() {
-    log "Building prometheus-writer image (opennms/prometheus-writer:$VERSION)..."
+    log "Building prometheus-writer image (deltav/prometheus-writer:$VERSION)..."
     cd "$REPO_ROOT"
     ./mvnw -B -f core/prometheus-writer/pom.xml -DskipTests package
     cd "$REPO_ROOT/core/prometheus-writer"
-    docker build -t "opennms/prometheus-writer:$VERSION" -t "opennms/prometheus-writer:latest" .
+    docker build -t "deltav/prometheus-writer:$VERSION" -t "deltav/prometheus-writer:latest" .
 }
 
 do_jre_image() {
-    log "Building opennms/jre-deltav:21..."
+    log "Building deltav/jre-deltav:21..."
     cd "$SCRIPT_DIR"
     docker build -f Dockerfile.jre \
-        -t "opennms/jre-deltav:21" \
-        -t "opennms/jre-deltav:latest" \
+        -t "deltav/jre-deltav:21" \
+        -t "deltav/jre-deltav:latest" \
         .
     log "JRE image built:"
-    docker images opennms/jre-deltav --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}"
+    docker images deltav/jre-deltav --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}"
 }
 
 do_images() {
@@ -173,8 +173,8 @@ do_deltav_images() {
     log "Building Delta-V layered images..."
 
     # Check that JRE base image exists
-    if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
-        err "opennms/jre-deltav:21 not found — run './build.sh jre' first"
+    if ! docker image inspect deltav/jre-deltav:21 >/dev/null 2>&1; then
+        err "deltav/jre-deltav:21 not found — run './build.sh jre' first"
     fi
 
     # Phase 0: Self-heal stale daemon-boot JARs before staging. If any
@@ -190,11 +190,11 @@ do_deltav_images() {
     cd "$SCRIPT_DIR"
 
     # Phase 2: Build daemon-base image
-    log "Building opennms/daemon-base:$VERSION..."
+    log "Building deltav/daemon-base:$VERSION..."
     docker build --no-cache \
         -f Dockerfile.daemon-base \
-        -t "opennms/daemon-base:$VERSION" \
-        -t "opennms/daemon-base:latest" \
+        -t "deltav/daemon-base:$VERSION" \
+        -t "deltav/daemon-base:latest" \
         .
 
     # Phase 3: Build per-daemon images
@@ -202,14 +202,14 @@ do_deltav_images() {
     for name in $daemon_names; do
         local main_class
         main_class=$(cat "staging/$name/.main_class")
-        log "Building opennms/$name:$VERSION (main: $main_class)..."
+        log "Building deltav/$name:$VERSION (main: $main_class)..."
         docker build \
             -f Dockerfile.daemon-per \
             --build-arg "VERSION=$VERSION" \
             --build-arg "DAEMON_NAME=$name" \
             --build-arg "MAIN_CLASS=$main_class" \
-            -t "opennms/$name:$VERSION" \
-            -t "opennms/$name:latest" \
+            -t "deltav/$name:$VERSION" \
+            -t "deltav/$name:latest" \
             .
     done
 
@@ -223,16 +223,24 @@ do_deltav_images() {
         -exec cp {} "$SCRIPT_DIR/staging/minion-boot/daemon-boot-minion.jar" \;
 
     # --- Build Minion Boot image ---
-    log "Building opennms/minion-boot:$VERSION..."
+    log "Building deltav/minion-boot:$VERSION..."
     docker build \
         --build-arg "VERSION=$VERSION" \
         -f Dockerfile.minion-boot \
-        -t "opennms/minion-boot:$VERSION" \
-        -t "opennms/minion-boot:latest" \
+        -t "deltav/minion-boot:$VERSION" \
+        -t "deltav/minion-boot:latest" \
         .
 
     # Clean up staging
     rm -rf "$SCRIPT_DIR/staging"
+
+    # --- Build db-init (one-shot PostgreSQL schema migration) ---
+    # db-init is a small standalone image used once at stack startup to
+    # run Liquibase against postgres. Included in `./build.sh deltav`
+    # so a single command produces every image docker-compose.yml
+    # references. Otherwise a freshly-cloned workspace would fail its
+    # first deploy with "pull access denied for deltav/db-init".
+    do_db_init_image
 
     # --- Build flow-enricher (standalone Spring Cloud Stream service) ---
     # flow-enricher does not share daemon-base because its dependency
@@ -263,7 +271,7 @@ Commands:
   compile   Compile only (Maven)
   assemble  Assemble distributions (Daemon + Alarmd + Minion + Sentinel)
   images    Build base Docker images only (requires prior assembly)
-  jre       Build JRE base image (opennms/jre-deltav:21, rarely needed)
+  jre       Build JRE base image (deltav/jre-deltav:21, rarely needed)
   deltav    Build Delta-V layered images (stages JARs into derived images)
   push      Build and push images to registry
   clean     Remove named Docker volumes (fresh start)
@@ -271,7 +279,7 @@ Commands:
 
 Environment variables:
   DOCKER_REGISTRY   Registry (default: docker.io)
-  DOCKER_ORG        Organization (default: opennms)
+  DOCKER_ORG        Organization (default: deltav)
   SKIP_TESTS        Skip tests (default: true)
   JAVA_HOME         JDK 21 path
 
@@ -296,7 +304,7 @@ main() {
     case "${1:-all}" in
         all)
             do_compile
-            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+            if ! docker image inspect deltav/jre-deltav:21 >/dev/null 2>&1; then
                 do_jre_image
             fi
             do_deltav_images
@@ -321,7 +329,7 @@ main() {
             do_compile
             do_assemble
             do_images push
-            if ! docker image inspect opennms/jre-deltav:21 >/dev/null 2>&1; then
+            if ! docker image inspect deltav/jre-deltav:21 >/dev/null 2>&1; then
                 do_jre_image
             fi
             do_deltav_images

--- a/opennms-container/delta-v/deploy.sh
+++ b/opennms-container/delta-v/deploy.sh
@@ -33,7 +33,7 @@ do_up() {
     log "Starting Delta-V (version $VERSION)..."
 
     # Check a sample daemon image exists (Delta-V layered images)
-    for img in "opennms/trapd:$VERSION" "opennms/minion-boot:$VERSION"; do
+    for img in "deltav/trapd:$VERSION" "deltav/minion-boot:$VERSION"; do
         docker image inspect "$img" >/dev/null 2>&1 || err "Image $img not found. Run ./build.sh deltav first."
     done
 

--- a/opennms-container/delta-v/deploy.sh
+++ b/opennms-container/delta-v/deploy.sh
@@ -8,7 +8,6 @@
 #   ./deploy.sh reset       Stop and remove all data
 #   ./deploy.sh status      Show service status
 #   ./deploy.sh logs [svc]  Tail logs (optionally for a specific service)
-#   ./deploy.sh shell <svc> Karaf shell for a service
 #   ./deploy.sh test        Verify deployment is working
 #
 set -euo pipefail
@@ -21,13 +20,6 @@ VERSION=$(cat .env | grep VERSION | cut -d= -f2)
 
 log() { echo "==> $*"; }
 err() { echo "ERROR: $*" >&2; exit 1; }
-
-# Karaf SSH ports per service (host:container)
-declare -A KARAF_PORTS=(
-    [webapp]=8102
-    [pollerd]=8103
-    [collectd]=8104
-)
 
 do_up() {
     log "Starting Delta-V (version $VERSION)..."
@@ -42,13 +34,12 @@ do_up() {
         log "Using profile: $profile"
         COMPOSE_PROFILES="$profile" docker compose up -d
     else
-        log "Starting infrastructure only (db-init + webapp + minion)"
+        log "Starting infrastructure only (postgres + kafka + db-init + minion + snmp-agent)"
         docker compose up -d
     fi
 
     log "Waiting for services to start..."
     log "Run './deploy.sh status' to check progress."
-    log "Web UI: http://localhost:8980/opennms (admin/admin)"
 }
 
 do_down() {
@@ -60,7 +51,8 @@ do_reset() {
     log "Stopping Delta-V and removing all data volumes..."
     docker compose down --remove-orphans 2>/dev/null || true
     # docker compose down -v only removes volumes for active profile services.
-    # Explicitly remove ALL delta-v volumes to ensure clean Karaf bundle caches.
+    # Explicitly remove ALL delta-v volumes to ensure clean data state
+    # (Liquibase schema, Kafka offsets, ClickHouse tables, etc.).
     local stale_vols
     stale_vols=$(docker volume ls --format '{{.Name}}' | grep "^delta-v_" || true)
     if [ -n "$stale_vols" ]; then
@@ -82,23 +74,6 @@ do_logs() {
     fi
 }
 
-do_shell() {
-    local service="${1:-}"
-    [ -z "$service" ] && err "Usage: ./deploy.sh shell <service>"
-
-    local port="${KARAF_PORTS[$service]:-}"
-    if [ -z "$port" ]; then
-        # Daemon containers use port 8181 internally, mapped to various host ports
-        log "Connecting to $service Karaf shell..."
-        docker compose exec "$service" /opt/daemon/bin/client 2>/dev/null \
-            || docker compose exec "$service" /opt/sentinel/bin/client 2>/dev/null \
-            || err "Could not connect to $service Karaf shell"
-    else
-        log "Connecting to $service Karaf shell (SSH port $port)..."
-        ssh -p "$port" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null admin@localhost
-    fi
-}
-
 do_test() {
     log "Testing Delta-V deployment..."
     local pass=0
@@ -115,25 +90,7 @@ do_test() {
         fail=$((fail + 1))
     fi
 
-    # Test 2: Web UI accessible
-    if curl -sf -o /dev/null http://localhost:8980/opennms/login.jsp 2>/dev/null; then
-        log "  [PASS] Web UI accessible"
-        pass=$((pass + 1))
-    else
-        log "  [FAIL] Web UI not accessible at http://localhost:8980/opennms"
-        fail=$((fail + 1))
-    fi
-
-    # Test 3: REST API responds
-    if curl -sf -u admin:admin http://localhost:8980/opennms/rest/info 2>/dev/null | grep -q "version"; then
-        log "  [PASS] REST API responding"
-        pass=$((pass + 1))
-    else
-        log "  [FAIL] REST API not responding"
-        fail=$((fail + 1))
-    fi
-
-    # Test 4: Database accessible
+    # Test 2: Database accessible
     if docker compose exec -T -e PGPASSWORD=opennms postgres psql -U opennms -d opennms -c "SELECT 1" >/dev/null 2>&1; then
         log "  [PASS] PostgreSQL accessible"
         pass=$((pass + 1))
@@ -142,7 +99,7 @@ do_test() {
         fail=$((fail + 1))
     fi
 
-    # Test 5: Kafka topic exists
+    # Test 3: Kafka topic exists
     if docker compose exec -T kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list 2>/dev/null | grep -q "opennms"; then
         log "  [PASS] Kafka topics created"
         pass=$((pass + 1))
@@ -151,9 +108,12 @@ do_test() {
         fail=$((fail + 1))
     fi
 
-    # Test 6: db-init completed successfully
+    # Test 4: db-init completed successfully. Use --all so we see the
+    # exited init container; without --all, `docker compose ps` only shows
+    # running containers and the exited db-init is filtered out, producing
+    # an empty-string status that the equality check rejects.
     local db_init_status
-    db_init_status=$(docker compose ps db-init --format "{{.State}}" 2>/dev/null || echo "unknown")
+    db_init_status=$(docker compose ps --all db-init --format "{{.State}}" 2>/dev/null || echo "unknown")
     if [ "$db_init_status" = "exited" ]; then
         log "  [PASS] db-init completed (exited)"
         pass=$((pass + 1))
@@ -177,27 +137,26 @@ Commands:
   reset           Stop and destroy all data (clean slate)
   status          Show service status
   logs [service]  Tail logs (all or specific service)
-  shell <service> Open Karaf shell (webapp, pollerd, etc.)
   test            Run deployment verification tests
   test-e2e        Run end-to-end trap-to-alarm integration test
   help            Show this help
 
 Profiles:
-  (none)    Infrastructure only: postgres + kafka + db-init + webapp + minion
-  lite      + essential daemons (alarmd, pollerd, collectd, notifd, discovery, rtcd, provisiond, bsmd)
+  (none)    Infrastructure only: postgres + kafka + db-init + minion + snmp-agent
+  lite      + essential daemons (alarmd, pollerd, collectd, discovery, provisiond, bsmd,
+              eventtranslator, perspectivepollerd, flow-enricher, prometheus-writer)
   passive   + trap/syslog receivers (alarmd, trapd, syslogd, eventtranslator, provisiond)
-  full      All 17 services
+  full      All ~20 services (lite + enlinkd + telemetryd + clickhouse + flow testnodes + l8opensim)
 
 Examples:
-  ./deploy.sh up                    # Infrastructure only (5 services)
-  ./deploy.sh up full               # Start everything (17 services)
+  ./deploy.sh up                    # Infrastructure only
+  ./deploy.sh up full               # Start everything
   ./deploy.sh up passive            # Trap/syslog receivers with alarmd
-  ./deploy.sh up lite               # Webapp + essential daemons
+  ./deploy.sh up lite               # Essential daemons
   ./deploy.sh logs alarmd           # Tail alarmd logs
-  ./deploy.sh shell webapp          # Karaf shell on webapp
   ./deploy.sh test                  # Verify deployment
-  ./deploy.sh test-e2e             # Full trap-to-alarm integration test
-  ./deploy.sh test-e2e --verbose   # With Kafka event trace
+  ./deploy.sh test-e2e              # Full trap-to-alarm integration test
+  ./deploy.sh test-e2e --verbose    # With Kafka event trace
   ./deploy.sh reset && ./deploy.sh up  # Fresh start
 USAGE
 }
@@ -209,7 +168,6 @@ main() {
         reset)   do_reset ;;
         status)  do_status ;;
         logs)    shift; do_logs "$@" ;;
-        shell)   shift; do_shell "$@" ;;
         test)    do_test ;;
         test-e2e) shift; "$SCRIPT_DIR/test-e2e.sh" "$@" ;;
         help|-h|--help) usage ;;

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -72,7 +72,7 @@ services:
   # Liquibase migrations, then exits. All services that need PostgreSQL
   # should depend on this with condition: service_completed_successfully.
   db-init:
-    image: ${IMAGE_PREFIX:-opennms}/db-init:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/db-init:${VERSION}
     container_name: delta-v-db-init
     depends_on:
       postgres:
@@ -167,7 +167,7 @@ services:
       - ./l8opensim:/seed:ro
 
   minion:
-    image: ${IMAGE_PREFIX:-opennms}/minion-boot:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/minion-boot:${VERSION}
     container_name: delta-v-minion
     hostname: minion-default-01
     cap_add:
@@ -208,7 +208,7 @@ services:
       start_period: 15s
 
   minion-lab:
-    image: ${IMAGE_PREFIX:-opennms}/minion-boot:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/minion-boot:${VERSION}
     container_name: delta-v-minion-lab
     profiles: [lite, full, metrics]
     network_mode: "container:delta-v-l8opensim"
@@ -240,7 +240,7 @@ services:
 
   pollerd:
     profiles: [lite, full]
-    image: ${IMAGE_PREFIX:-opennms}/pollerd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/pollerd:${VERSION}
     container_name: delta-v-pollerd
     hostname: pollerd
     depends_on:
@@ -271,7 +271,7 @@ services:
 
   collectd:
     profiles: [lite, full]
-    image: ${IMAGE_PREFIX:-opennms}/collectd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/collectd:${VERSION}
     container_name: delta-v-collectd
     hostname: collectd
     depends_on:
@@ -300,7 +300,7 @@ services:
 
   discovery:
     profiles: [passive, full]
-    image: ${IMAGE_PREFIX:-opennms}/discovery:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/discovery:${VERSION}
     container_name: delta-v-discovery
     hostname: discovery
     depends_on:
@@ -332,7 +332,7 @@ services:
 
   trapd:
     profiles: [passive, full]
-    image: ${IMAGE_PREFIX:-opennms}/trapd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/trapd:${VERSION}
     container_name: delta-v-trapd
     hostname: trapd
     depends_on:
@@ -363,7 +363,7 @@ services:
 
   syslogd:
     profiles: [passive, full]
-    image: ${IMAGE_PREFIX:-opennms}/syslogd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/syslogd:${VERSION}
     container_name: delta-v-syslogd
     hostname: syslogd
     depends_on:
@@ -394,7 +394,7 @@ services:
 
   eventtranslator:
     profiles: [passive, full]
-    image: ${IMAGE_PREFIX:-opennms}/eventtranslator:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/eventtranslator:${VERSION}
     container_name: delta-v-eventtranslator
     hostname: eventtranslator
     depends_on:
@@ -423,7 +423,7 @@ services:
 
   enlinkd:
     profiles: [full]
-    image: ${IMAGE_PREFIX:-opennms}/enlinkd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/enlinkd:${VERSION}
     container_name: delta-v-enlinkd
     hostname: enlinkd
     environment:
@@ -480,7 +480,7 @@ services:
 
   provisiond:
     profiles: [lite, passive, full]
-    image: ${IMAGE_PREFIX:-opennms}/provisiond:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/provisiond:${VERSION}
     container_name: delta-v-provisiond
     hostname: provisiond
     depends_on:
@@ -544,7 +544,7 @@ services:
 
   bsmd:
     profiles: [lite, full]
-    image: ${IMAGE_PREFIX:-opennms}/bsmd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/bsmd:${VERSION}
     container_name: delta-v-bsmd
     hostname: bsmd
     depends_on:
@@ -573,7 +573,7 @@ services:
 
   perspectivepollerd:
     profiles: [full]
-    image: ${IMAGE_PREFIX:-opennms}/perspectivepollerd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/perspectivepollerd:${VERSION}
     container_name: delta-v-perspectivepollerd
     hostname: perspectivepollerd
     depends_on:
@@ -604,7 +604,7 @@ services:
 
   alarmd:
     profiles: [lite, passive, full]
-    image: ${IMAGE_PREFIX:-opennms}/alarmd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/alarmd:${VERSION}
     container_name: delta-v-alarmd
     hostname: alarmd
     depends_on:
@@ -631,7 +631,7 @@ services:
 
   telemetryd:
     profiles: [full]
-    image: ${IMAGE_PREFIX:-opennms}/telemetryd:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/telemetryd:${VERSION}
     container_name: delta-v-telemetryd
     hostname: telemetryd
     depends_on:
@@ -712,7 +712,7 @@ services:
 
   flow-enricher:
     profiles: [lite, full, metrics]
-    image: ${IMAGE_PREFIX:-opennms}/flow-enricher:${VERSION}
+    image: ${IMAGE_PREFIX:-deltav}/flow-enricher:${VERSION}
     container_name: delta-v-flow-enricher
     hostname: flow-enricher
     depends_on:
@@ -794,7 +794,7 @@ services:
         ipv4_address: 172.18.0.22
 
   prometheus-writer:
-    image: opennms/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
+    image: deltav/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
     profiles: [lite, full, metrics]
     depends_on:
       db-init:


### PR DESCRIPTION
## Summary

Two related cleanups that improve operator experience:

1. **Image prefix rename** — all delta-v-built Docker images `opennms/*` → `deltav/*` so \`docker ps\` / Docker Desktop / orchestration UIs clearly distinguish Delta-V services from upstream dependencies.
2. **deploy.sh legacy cleanup** — remove dead Karaf/webapp references that accumulated before the Karaf removal (memories \`feedback_karaf_is_dead\`, \`project_webapp_removed\`). The script now accurately describes and tests the current Spring Boot stack.

## Before / after (image prefix)

Before:
\`\`\`
delta-v-alarmd      opennms/alarmd:0.0.1-SNAPSHOT
delta-v-collectd    opennms/collectd:0.0.1-SNAPSHOT
delta-v-minion      opennms/minion-boot:0.0.1-SNAPSHOT
\`\`\`

After:
\`\`\`
delta-v-alarmd      deltav/alarmd:0.0.1-SNAPSHOT
delta-v-collectd    deltav/collectd:0.0.1-SNAPSHOT
delta-v-minion      deltav/minion-boot:0.0.1-SNAPSHOT
\`\`\`

## Scope — renamed
daemon-base + 12 daemon-per + minion-boot + jre-deltav + db-init + flow-enricher + prometheus-writer.

Not touched: legacy Karaf-era Dockerfiles (\`Dockerfile.daemon/minion/webapp\`), upstream images (clickhouse, kafka, postgres, victoriametrics, grafana), docs/plans describing pre-rename state.

## Scope — deploy.sh legacy cleanup

- \`do_shell()\` + \`KARAF_PORTS\` map removed (Spring Boot daemons don't have Karaf shells).
- Tests 2 & 3 (Web UI at /opennms/login.jsp, REST API at /opennms/rest/info) removed — webapp was deleted in PR #28.
- Legacy references in usage/examples/messages updated to match current stack.
- Fixed latent bug in Test 4 (db-init status check was using \`docker compose ps\` without \`--all\`, always returning empty string).

## Bonus fix

\`./build.sh deltav\` was silently skipping db-init image creation — a fresh-clone first deploy would fail with \"pull access denied for deltav/db-init\". Added \`do_db_init_image\` to the deltav target.

## Verification

- \`./build.sh deltav\` → every image tagged \`deltav/*\`, zero \`opennms/*\` tags created (apart from retained legacy Dockerfiles not used in current build).
- \`./deploy.sh up full\` → 21/21 healthy containers on \`deltav/*\` images.
- \`./deploy.sh test\` → 4/4 passing (24 services, PostgreSQL, Kafka topics, db-init exited).
- \`test-e2e.sh\` → 12/12 PASS on renamed stack.
- \`./deploy.sh help\` → accurate description of current command/profile surface.

## Out of scope

If the labbox Minion image is later re-pushed under a \`deltav/\` Docker Hub namespace (currently \`pbrane/minion-boot\`), that's a separate change to \`Dockerfile.minion-boot\` build + push workflow. This PR only affects local tags.