### PR TITLE
fix(release): add flow-enricher + prometheus-writer to image-publish workflow

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -1,6 +1,6 @@
 # Delta-V Build & Push Images
 #
-# Builds all Delta-V Docker images (16 total) and pushes them to GitHub
+# Builds all Delta-V Docker images (18 total) and pushes them to GitHub
 # Container Registry (GHCR) as multi-arch images (linux/amd64 + linux/arm64).
 #
 # Trigger: Push a tag matching 'v*' (e.g., v1.1.0)
@@ -28,6 +28,8 @@
 #   Infrastructure:
 #     - ghcr.io/<owner>/minion-boot:<version>  Spring Boot Minion
 #     - ghcr.io/<owner>/db-init:<version>      Liquibase schema migration
+#     - ghcr.io/<owner>/flow-enricher:<version>      Flow decode + enrich → ClickHouse
+#     - ghcr.io/<owner>/prometheus-writer:<version>  Metrics → Prometheus Remote Write
 #
 # Usage after build:
 #   1. Set IMAGE_PREFIX in opennms-container/delta-v/.env:
@@ -203,6 +205,30 @@ jobs:
             --push \
             .
 
+      - name: Build and push flow-enricher image
+        working-directory: core/flow-enricher
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -t "${{ env.IMAGE_PREFIX }}/flow-enricher:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/flow-enricher:latest" \
+            --push \
+            .
+
+      - name: Build and push prometheus-writer image
+        working-directory: core/prometheus-writer
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -t "${{ env.IMAGE_PREFIX }}/prometheus-writer:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/prometheus-writer:latest" \
+            --push \
+            .
+
       - name: Print image summary
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -224,7 +250,7 @@ jobs:
           echo "     ./deploy.sh up lite"
           echo ""
           echo "### Images"
-          DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init jre-deltav daemon-base"
+          DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init flow-enricher prometheus-writer jre-deltav daemon-base"
           for name in $DAEMONS; do
             echo "  ${{ env.IMAGE_PREFIX }}/$name:${VERSION}"
           done


### PR DESCRIPTION
## Summary

The GHCR release workflow was publishing 16 images, but the current docker-compose.yml references 18. Two standalone Spring Cloud Stream services were missing from the workflow — flow-enricher and prometheus-writer — and any release tag cut after PR #164 would leave consumers unable to \`docker compose pull\` them from \`ghcr.io/pbrane/\`.

## Background

Both services were added as standalone Spring Boot apps outside the 12 horizon-derived daemons:
- **flow-enricher** — flow decode + enrich → ClickHouse (flow pipeline phase, PRs #139 et al.)
- **prometheus-writer** — metrics → Prometheus Remote Write (Kafka Time Series phase, PRs #169 et al.)

Each has its own Dockerfile (\`core/flow-enricher/Dockerfile\`, \`core/prometheus-writer/Dockerfile\`), same pattern as db-init.

## Change

Added two build-and-push steps to the workflow, mirroring the db-init pattern exactly. Also updated the header comment (\"16 total\" → \"18 total\") and the final image-summary DAEMONS variable so the GitHub Actions run summary accurately lists all published images.

## Effect

A release tag cut after this merges will publish all 18 images to \`ghcr.io/pbrane/\`:
- Base layers (2): jre-deltav, daemon-base
- Horizon-derived daemons (12): alarmd, bsmd, collectd, discovery, enlinkd, eventtranslator, perspectivepollerd, pollerd, provisiond, syslogd, telemetryd, trapd
- Infrastructure (4): minion-boot, db-init, **flow-enricher**, **prometheus-writer**

Previous releases (v1.0.x, v1.1.0) are unaffected — this only changes behavior for future workflow runs.

## Test plan

- [ ] Merge.
- [ ] Cut a test release tag (e.g., \`v1.1.1-rc1\`) or trigger workflow_dispatch.
- [ ] Verify all 18 images appear on GHCR at \`ghcr.io/pbrane/<image>:v1.1.1-rc1\`.
- [ ] Verify \`docker compose pull\` against \`IMAGE_PREFIX=ghcr.io/pbrane\` completes cleanly.