### PR TITLE
chore: bump version to 1.1.1-SNAPSHOT for v1.1.1 release cycle

### DIFF
--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>


### PR DESCRIPTION
## Summary

Bumps project version from \`0.0.1-SNAPSHOT\` → \`1.1.1-SNAPSHOT\` to align Docker image tags with git release tags.

## Why

The GHCR publish workflow uses \`project.version\` from the POM to tag Docker images:
\`\`\`yaml
VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
...
-t "${{ env.IMAGE_PREFIX }}/<image>:${VERSION}"
-t "${{ env.IMAGE_PREFIX }}/<image>:latest"
\`\`\`

Project version stayed at \`0.0.1-SNAPSHOT\` across v1.0.x and v1.1.0 tags, so **every release to date has published Docker images as \`:0.0.1-SNAPSHOT\`** (overwriting prior releases). The \`:latest\` tag is accurate, but \`:0.0.1-SNAPSHOT\` is meaningless as a version.

## Effect

After this merges:
- **v1.1.1-rc1** tag → \`ghcr.io/pbrane/<image>:1.1.1-SNAPSHOT\` + \`:latest\`  (for RC smoke testing)
- **v1.1.1** tag later (after a second POM bump to drop \`-SNAPSHOT\`) → \`ghcr.io/pbrane/<image>:1.1.1\` + \`:latest\`  (production)

## Scope

25 POM files updated via \`mvn versions:set\`. No source code changes. Working tree diff is exactly 25 lines (one \`<version>\` per file).

## Follow-up

A future workflow change could use \`\${{ github.ref_name }}\` (the git tag name) directly as the Docker tag instead of POM version. That would make the git tag authoritative and the POM bump becomes optional housekeeping. Not in scope for this PR — it's a larger change that needs its own testing.