### PR TITLE
docs(plans): v1.2.0 roadmap — self-contained images + Minion gRPC migration

### DIFF
--- a/docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md
+++ b/docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md
@@ -1,0 +1,156 @@
+# v1.2.0: Minion ↔ Core Communication — Kafka IPC → gRPC via Spring Cloud Gateway
+
+> **Status:** Design / roadmap. No implementation started. Scope captured 2026-04-22 during the v1.1.1 release cycle.
+
+## Goal
+
+Replace the Kafka-based Minion communication protocol with gRPC, routed through
+Spring Cloud Gateway. Same Gateway instance becomes the HTTP entry point for
+any future external API (e.g., a static UI that delta-v might add later).
+
+Result: one ingress surface for all external-facing traffic, tighter request
+semantics, better observability per-call, and a cleaner story for deployments
+that want to run Minion against a core cluster over the public internet.
+
+## Context
+
+Minion currently talks to Core via Kafka:
+
+- **Sink topics** (Minion → Core, unsolicited): `OpenNMS.Sink.Heartbeat`,
+  `OpenNMS.Sink.Syslog`, `OpenNMS.Sink.Telemetry-IPFIX`, `OpenNMS.Sink.Telemetry-Netflow-{5,9}`,
+  `OpenNMS.Sink.Telemetry-SFlow`, `OpenNMS.Sink.Trap`.
+- **RPC topics** (bidirectional, request/response): `OpenNMS.<location>.rpc-request`,
+  `OpenNMS.rpc-response`.
+- **Twin API** (Core → Minion, config push): `OpenNMS.twin.request`,
+  `OpenNMS.twin.response.<location>`.
+
+This is the horizon-era pattern inherited into Delta-V. It works, but carries
+meaningful costs:
+
+| Cost | Detail |
+|---|---|
+| Latency | Every RPC round-trip touches Kafka twice (request + response). Poll-critical operations (SNMP walks, ICMP pings) pay this on every call. |
+| Heavy dependency | Kafka is a nontrivial piece of infrastructure for what is fundamentally a pair of RPC channels. Consumers running a small Minion footprint still need a Kafka broker. |
+| Hard to observe per-call | RPC timeouts and retries are visible only through consumer-group lag + application-level counters. No distributed tracing on a per-request basis. |
+| No mutual auth | Current deployment relies on network-level trust (shared broker access). Per-Minion identity is by consumer-group name. |
+
+## Target pattern
+
+- **Minion → Core (sink):** gRPC client-streaming for heartbeats, telemetry,
+  syslog ingestion. One open stream per Minion per sink type.
+- **Core → Minion (RPC):** gRPC server-streaming for RPC invocations. Core
+  pushes `RpcRequest` messages; Minion pushes `RpcResponse` back on the same
+  bidi stream.
+- **Twin API:** server-streaming from Core; Minion subscribes on startup and
+  reconnects on disconnect.
+- **Spring Cloud Gateway** fronts all gRPC endpoints. Gateway handles routing,
+  mTLS termination, auth, rate limiting, observability (Micrometer +
+  OpenTelemetry spans per request).
+- **Same Gateway** serves HTTP REST APIs for any future static UI. One ingress,
+  one auth/observability surface, one deployable.
+
+## Why Spring Cloud Gateway specifically
+
+The user's stated rationale:
+
+> "We'll need that anyway for external API calls from any static UI that we
+> decide to add in the future."
+
+Consolidation argument: rather than deploying two separate ingress points (one
+for Minion-gRPC, one for UI-HTTP), route everything through Gateway.
+
+Caveat to revisit at implementation time: Spring Cloud Gateway's primary focus
+is HTTP/1.1 and HTTP/2 routing. gRPC support exists (via the `spring-cloud-gateway-mvc`
+and WebFlux stacks) but is less battle-tested than, say, Envoy or nginx at
+production load. A realistic Minion-load benchmark should run before committing
+to Gateway for the data path; if it doesn't hold up, fall back to Envoy
+fronting gRPC and Gateway only handling the UI HTTP surface.
+
+## Architectural questions to answer before implementation
+
+1. **Per-daemon gRPC services vs. single Minion-facing daemon?** Each Core
+   daemon (pollerd, provisiond, collectd, ...) could expose its own gRPC
+   service behind the Gateway, routed by path. Simpler: a single `minion-api`
+   daemon that translates gRPC calls into daemon-internal Kafka messages.
+   Trade-off: direct per-daemon gRPC eliminates an extra hop but multiplies
+   service definitions; a translator daemon preserves current daemon simplicity
+   but reintroduces Kafka internally.
+2. **Minion identity & auth.** Current pattern: Minion identity embedded in
+   Kafka consumer group. Target: mTLS cert or signed JWT from a Delta-V auth
+   endpoint? Per-location cert provisioning workflow?
+3. **Failure mode when Gateway unreachable.** Kafka's durability buffer goes
+   away. Minion needs local queuing + retry logic, or we accept that an
+   offline Gateway = offline Minion for that span.
+4. **Twin API migration.** Currently Kafka-based config push from Core → Minion.
+   gRPC server-streaming fits naturally. Migration path: run both in parallel
+   for a release, then cut over.
+5. **Rolling compatibility.** Can a v1.2 Minion talk to a v1.1 Core (still
+   Kafka-only), or is it a hard-cut? Recommendation: support both for a
+   release so operators can stage upgrades.
+6. **Observability story.** gRPC gives us per-call tracing for free via
+   OpenTelemetry. What's the sink? (Tempo, Jaeger, Grafana Cloud, ...?) Needs
+   a deployment-layer decision.
+7. **Backwards compat with labbox test harness.** The `test-enlinkd-e2e.sh`
+   and `test-perspective-e2e.sh` tests rely on the Kafka RPC pattern. Both
+   must be updated to verify the gRPC path during the migration.
+
+## Scope estimate
+
+**2-4 weeks of focused work.** Significantly larger than the v1.2.0
+self-contained-images track. Includes:
+
+- Protobuf service definitions for sink + RPC + Twin
+- Core-side gRPC service implementations (one per sink category; RPC dispatcher)
+- Spring Cloud Gateway deployment + config
+- mTLS cert generation + distribution pipeline
+- Minion client library refactor (gRPC client-streaming + bidi-streaming)
+- Migration path (parallel Kafka + gRPC for a release)
+- E2E test updates for the new communication path
+
+Deserves its own `docs/plans/YYYY-MM-DD-minion-grpc-migration-implementation.md`
+when implementation starts, following the same design/implementation split as
+the earlier `eventbus-redesign-design.md` / `eventbus-redesign-implementation.md`
+pair.
+
+## Non-goals
+
+- **Minion-to-Minion communication.** Remains out of scope; Minions only talk
+  to Core.
+- **Replacing Kafka entirely.** Kafka stays for event streaming between Core
+  daemons (which this work doesn't touch) and for any new sinks that
+  specifically want the durability/replay semantics.
+- **A UI.** The Gateway positioning is infrastructure for a future UI, not
+  the UI itself. Deciding whether/what UI delta-v needs is a separate
+  conversation.
+
+## Invariants that must survive the migration
+
+- **`feedback_no_local_polling`**: Daemons must NEVER poll targets directly;
+  all polls go through Minion. gRPC preserves this — the channel changes, not
+  the topology.
+- **`feedback_rpc_timeout_no_outages`**: RPC timeouts must NEVER create
+  outages/fault events. Existing `test-perspective-e2e.sh` validates this on
+  the Kafka path; must be re-verified on the gRPC path.
+- **`project_minion_mandatory`**: Delta-V's "no direct network access from
+  Core daemons" posture stays.
+
+## Dependencies and ordering
+
+Can ship independently of the v1.2.0 self-contained-images track (tracked in
+`2026-04-22-v1.2.0-self-contained-images-design.md`) — disjoint code paths.
+
+Suggested sequence:
+1. Ship self-contained-images first (faster, smaller scope).
+2. Cut `v1.2.0-alpha` on completion.
+3. Begin gRPC migration on its own RC track (`v1.2.0-beta`, `v1.2.0-rc1`, …).
+4. Cut `v1.2.0` GA when both land.
+
+## References
+
+- **Current Minion client:** `core/daemon-boot-minion/` and
+  `core/daemon-boot-minion-common/`
+- **Current RPC Kafka wrapper:** `org.opennms.core.ipc.rpc.kafka` (in the horizon
+  jar chain at `pbrane/delta-v-horizon`)
+- **Related v1.2.0 scope item:** `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`
+- **Minion mandatory policy:** memory `project_minion_mandatory`
+- **RPC timeout semantics:** memory `feedback_rpc_timeout_no_outages`

--- a/docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md
+++ b/docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md
@@ -1,0 +1,144 @@
+# v1.2.0: Self-Contained Docker Images (eliminate bind mounts)
+
+> **Status:** Design / roadmap. No implementation started. Scope captured 2026-04-22 during the v1.1.1 release cycle.
+
+## Goal
+
+A consumer should be able to run Delta-V with literally:
+
+```bash
+curl -O https://raw.githubusercontent.com/pbrane/delta-v/v1.2.0/docker-compose.yml
+docker compose up -d
+```
+
+No `git clone`, no tarball download, no `.env` editing. The `docker-compose.yml`
+references `ghcr.io/pbrane/*:1.2.0` images, and each image carries its own
+config defaults.
+
+## Context
+
+As of v1.1.1 release cycle, `opennms-container/delta-v/docker-compose.yml` has
+**20 bind-mounted paths** that the user must have on their local filesystem,
+requiring a `git clone` (or release tarball) before the stack can run.
+
+Mainstream open source stacks (Grafana, Prometheus, etc.) all ship images with
+baked-in defaults. The consumer flow is: pull image, run container. Delta-V's
+current setup adds a "clone the source tree" prerequisite that's unnecessary
+for operators who just want to try the stack.
+
+## Current bind-mount inventory
+
+| Category | Count | Example | Notes |
+|---|---|---|---|
+| Per-daemon overlays | 10 | `./pollerd-overlay/etc:/opt/deltav/etc:ro` | Static configs for pollerd, collectd, discovery, trapd, syslogd, eventtranslator, enlinkd, provisiond, perspectivepollerd, telemetryd |
+| ClickHouse init | 4 | `./clickhouse/init:/delta-v/init:ro` | DDL scripts + format schemas + init runner |
+| Grafana | 2 | `./grafana/provisioning:/etc/grafana/provisioning:ro` | Datasources + dashboards |
+| Flow-enricher protobuf | 2 | `./core/flow-enricher/src/main/proto:/delta-v/proto` | Shared with ClickHouse format_schemas |
+| Init-sidecar seeds | 2 | `./provisiond-overlay/etc/imports-seed:/seed:ro` | Read by init sidecars, copied to named volumes |
+
+Only one is **writable** at runtime (`provisiond-overlay/etc:/opt/deltav/etc:rw`),
+and only for macOS Docker Desktop compatibility. The actual mutating subdirectory
+(`imports/`) already lives in a named volume (`provisiond_imports`).
+
+## Planned refactor
+
+### 1. Per-daemon overlays → `COPY` in `Dockerfile.daemon-per`
+
+Each daemon image carries its own `/opt/deltav/etc`. Refactor `Dockerfile.daemon-per`
+to COPY the appropriate overlay based on the `DAEMON_NAME` build arg. No Maven
+changes; ~20 lines per Dockerfile pattern. Remove the 10 bind mounts from
+`docker-compose.yml`.
+
+### 2. Custom `deltav/clickhouse` image
+
+```dockerfile
+FROM clickhouse/clickhouse-server:25.8
+COPY clickhouse/init /docker-entrypoint-initdb.d/
+COPY clickhouse/user-init /docker-entrypoint-initdb.d/
+COPY clickhouse/config.d/format-schema-path.xml /etc/clickhouse-server/config.d/
+COPY core/flow-enricher/src/main/proto /opt/clickhouse/format_schemas/
+```
+
+Adds a build-and-push step to `.github/workflows/delta-v-build-images.yml`.
+docker-compose.yml switches from `clickhouse/clickhouse-server:25.8` to
+`ghcr.io/pbrane/clickhouse:<version>`.
+
+### 3. Custom `deltav/grafana` image
+
+```dockerfile
+FROM grafana/grafana:11.4.0
+COPY grafana/provisioning /etc/grafana/provisioning
+COPY grafana/dashboards /var/lib/grafana/dashboards
+```
+
+Same pattern — new image published, new step in release workflow.
+
+### 4. Flow-enricher protobuf already ships in its jar
+
+The protobuf schemas are already compiled into the flow-enricher jar's classpath.
+The runtime bind mount exists only for ClickHouse to read format_schemas. Once
+`deltav/clickhouse` carries its own copy of the schemas (see #2), the bind mount
+is eliminated.
+
+### 5. Init-sidecar seeds move into sidecar images
+
+The two init sidecars (`provisiond-imports-init`, `l8opensim-provisioner`) read
+from a `/seed` bind mount. Rebuild both as custom images that carry `/seed`
+internally:
+- `deltav/provisiond-imports-init`: busybox + `/seed` containing `imports-seed/*.xml`
+- `deltav/l8opensim-provisioner`: curl base + `/seed` containing the provisioning payload
+
+## Backward compatibility
+
+The `${IMAGE_PREFIX:-deltav}` pattern established in PR #195 still works. Users
+who want to customize a single config file can do so via a docker-compose
+`override.yml` that re-introduces a specific bind mount. Defaults come from the
+image; overrides are opt-in.
+
+## Scope estimate
+
+**1-2 days of mechanical work.** No daemon source changes.
+
+- 10 per-daemon Dockerfile COPY additions (or one parameterized change in `Dockerfile.daemon-per`)
+- 2 new custom image Dockerfiles (`deltav/clickhouse`, `deltav/grafana`)
+- 2 init-sidecar rebuilds
+- 20 bind-mount removals from docker-compose.yml
+- Release workflow: 4 new build-and-push steps
+
+## Non-goals
+
+- **Runtime config reloading.** Images ship immutable defaults. Users changing
+  configs must rebuild or override. This is consistent with Grafana/Prometheus.
+- **Secrets management.** Spring Boot env vars already cover the delta-v
+  secret surface (DB passwords, Kafka auth). No new mechanism needed.
+- **Version-skew between images and compose.yml.** All images for a release
+  ship together via the existing tagged workflow; consumers pin to a single
+  `VERSION` tag.
+
+## Dependencies and ordering
+
+This work **can ship independently** of the v1.2.0 Minion gRPC migration
+(tracked in `2026-04-22-v1.2.0-minion-grpc-migration-design.md`). They touch
+disjoint code paths and could be merged in either order.
+
+Expected sequence for v1.2.0:
+1. Land this work first (smaller, self-contained).
+2. Cut `v1.2.0-alpha` on completion; smoke-test the single-compose deploy.
+3. Begin Minion gRPC migration (larger, deserves own RC track).
+4. Cut `v1.2.0` when both land.
+
+## Open questions
+
+- **Grafana dashboard versioning.** Are the dashboards in `grafana/dashboards/`
+  regenerated or edited-in-place? If edited, we need a pre-release review to
+  make sure the baked-in versions are the intended ones.
+- **ClickHouse format-schemas update cadence.** These come from
+  `core/flow-enricher/src/main/proto`. Any update to the protobuf definitions
+  requires a coordinated rebuild of both `deltav/flow-enricher` and
+  `deltav/clickhouse`. Worth documenting in BUILD.md.
+
+## References
+
+- **Bind mounts inventory:** `opennms-container/delta-v/docker-compose.yml`
+- **Current release workflow:** `.github/workflows/delta-v-build-images.yml`
+- **Related v1.2.0 scope item:** `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`


### PR DESCRIPTION
## Summary

Captures two strategic v1.2.0 scope items as repo-tracked design docs.

Previously these only existed in Claude-local memory (not visible to collaborators, not reviewable, not versioned with the project). Moving them to \`docs/plans/\` makes them a real planning surface.

## The two tracks

### 1. Self-contained images — eliminate 20 bind mounts

**Goal:** A consumer should be able to run delta-v with literally:
\`\`\`
curl -O https://raw.githubusercontent.com/pbrane/delta-v/v1.2.0/docker-compose.yml
docker compose up -d
\`\`\`
No \`git clone\`, no tarball. Bake all 20 bind-mounted configs into their images. ~1-2 days of mechanical Dockerfile work. Ships independently.

File: \`docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md\`

### 2. Minion ↔ Core: Kafka IPC → gRPC via Spring Cloud Gateway

**Goal:** Replace the Kafka-based Minion communication protocol (sink + rpc + twin) with gRPC, routed through Spring Cloud Gateway. Same Gateway becomes the HTTP entry point for any future external API (static UI, etc.) — one ingress surface for all external traffic.

**Scope:** 2-4 weeks. Captures 7 architectural questions to resolve before implementation starts (per-daemon gRPC vs. translator service, mTLS identity, failure-mode semantics, Twin API migration, rolling compatibility, observability sink, E2E test updates).

File: \`docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md\`

## Why now

v1.1.1 release cycle is wrapping up and v1.2.0 scope is being discussed. Committing these docs now means:

- Future contributors (and future-us) see what's coming, not just what's been done.
- \`docs/plans/\`-convention history-tracks the scope so decisions made today are visible months later.
- The Minion gRPC track in particular deserves architecture-level review before implementation — having the design doc visible invites that conversation.

## Convention / style

Both docs follow the existing \`docs/plans/\` template style: Goal → Context → Target pattern → Scope estimate → Open questions → References. Mirrors the \`2026-03-02-eventbus-redesign-design.md\` / \`2026-03-11-db-init-extraction-design.md\` shape.

Both docs are explicitly **design** / roadmap documents, not implementation plans. When either moves into implementation, it gets its own companion \`-implementation.md\` following the pattern of other delta-v plan pairs.

## Out of scope for this PR

- No code changes.
- No commitment to delivery dates. The "when" is a conversation for after v1.1.1 GA.
- The two tracks are disjoint and can land in either order.

## Test plan

- [x] Both files follow the \`docs/plans/YYYY-MM-DD-\<slug\>-design.md\` convention.
- [x] Cross-references to related memories and other docs are accurate.
- [ ] Review from you (and anyone else on the team) for scope correctness before we start the v1.2.0 cycle.