### PR TITLE
fix: three clean-Linux-consumer bugs found by v1.1.1-rc1 smoke test

### DIFF
--- a/opennms-container/delta-v/deploy.sh
+++ b/opennms-container/delta-v/deploy.sh
@@ -15,8 +15,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Source version
-VERSION=$(cat .env | grep VERSION | cut -d= -f2)
+# Source .env so IMAGE_PREFIX and VERSION are available to both this script
+# and every `docker compose` child invocation below.
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
+fi
+IMAGE_PREFIX="${IMAGE_PREFIX:-deltav}"
 
 log() { echo "==> $*"; }
 err() { echo "ERROR: $*" >&2; exit 1; }
@@ -25,8 +32,8 @@ do_up() {
     log "Starting Delta-V (version $VERSION)..."
 
     # Check a sample daemon image exists (Delta-V layered images)
-    for img in "deltav/trapd:$VERSION" "deltav/minion-boot:$VERSION"; do
-        docker image inspect "$img" >/dev/null 2>&1 || err "Image $img not found. Run ./build.sh deltav first."
+    for img in "$IMAGE_PREFIX/trapd:$VERSION" "$IMAGE_PREFIX/minion-boot:$VERSION"; do
+        docker image inspect "$img" >/dev/null 2>&1 || err "Image $img not found. Run ./build.sh deltav first, or set IMAGE_PREFIX in .env to a registry prefix you've pulled from (e.g. ghcr.io/pbrane)."
     done
 
     local profile="${1:-}"

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -465,6 +465,13 @@ services:
     volumes:
       - ./provisiond-overlay/etc/imports-seed:/seed:ro
       - provisiond_imports:/runtime
+      # Bind the host foreign-sources dir so this root-privileged sidecar can
+      # ensure `pending/` exists and is writable by provisiond (uid 100). On
+      # macOS Docker Desktop the VirtioFS UID mapping hides the ownership
+      # mismatch; on Linux it's fatal — provisiond's DirectoryWatcher fails
+      # to create pending/, throws NoSuchFileException, and startup stalls
+      # before any requisition import fires. See delta-v#200.
+      - ./provisiond-overlay/etc/foreign-sources:/foreign-sources
     command:
       - sh
       - -c
@@ -477,6 +484,10 @@ services:
             echo "[provisiond-imports-init] /runtime already populated — leaving alone"
         fi
         chown -R 100:101 /runtime
+        echo "[provisiond-imports-init] Ensuring /foreign-sources/pending exists and is writable"
+        mkdir -p /foreign-sources/pending
+        chown 100:101 /foreign-sources/pending
+        chmod 775 /foreign-sources/pending
 
   provisiond:
     profiles: [lite, passive, full]

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -794,7 +794,7 @@ services:
         ipv4_address: 172.18.0.22
 
   prometheus-writer:
-    image: deltav/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
+    image: ${IMAGE_PREFIX:-deltav}/prometheus-writer:${VERSION}
     profiles: [lite, full, metrics]
     depends_on:
       db-init:


### PR DESCRIPTION
## Summary
Three independent but related bugs, each breaks the delta-v clean-Linux-consumer flow (`curl .env, docker compose pull, ./deploy.sh up full` with `IMAGE_PREFIX=ghcr.io/pbrane` and no host-side pre-configuration). All three hide on macOS Docker Desktop because VirtioFS UID mapping and operator familiarity mask them; all three surface on the very first attempt on a clean Linux VM.

Caught by running a clean-VM smoke test against `v1.1.1-rc1` (Ubuntu 24.04 ARM64, published GHCR images, no local builds).

## Bugs & fixes

**1. `docker-compose.yml` — prometheus-writer hardcoded prefix + legacy env var**
```diff
-    image: deltav/prometheus-writer:${ONMS_DELTAV_VERSION:-latest}
+    image: ${IMAGE_PREFIX:-deltav}/prometheus-writer:${VERSION}
```

**2. `deploy.sh` — hardcoded `deltav/` in preflight, hand-parsed `.env` only caught `VERSION`**
- Source `.env` (exports both `IMAGE_PREFIX` and `VERSION`)
- Preflight uses `$IMAGE_PREFIX` so `ghcr.io/pbrane/...` satisfies it

**3. `docker-compose.yml` — provisiond-imports-init now creates `foreign-sources/pending` with uid 100 ownership**
On Linux Docker (no UID translation), provisiond (uid 100) can't `mkdir` a subdirectory inside a bind mount owned by uid 1000. DirectoryWatcher throws `NoSuchFileException`, startup stalls, no cron imports fire, 0 nodes imported. The existing imports-init sidecar (already privileged for the imports/ named volume) now also bind-mounts foreign-sources/ and ensures pending/ exists + is writable by provisiond.

## Smoke test trace (from the VM)
- PR #199/1: pull failed on `deltav/prometheus-writer:latest` → other pulls aborted mid-batch
- PR #199/2: after pulling via `--ignore-pull-failures`, `./deploy.sh up full` refused with `Image deltav/trapd:1.1.1-SNAPSHOT not found`
- PR #199/3: stack came up fully healthy after workaround, but provisiond DirectoryWatcher exception meant 0 nodes imported. Manual `sudo chown 100:101 provisiond-overlay/etc/foreign-sources; mkdir pending` + `docker compose restart provisiond` unblocked cron imports → 28 nodes in postgres

## Test plan
- [x] All three diffs verified manually
- [x] Smoke test confirms imports fire after fix #3 manually applied on the VM
- [ ] Merge, tag `v1.1.1-rc2`, GHCR republish
- [ ] Wipe VM + full re-smoke: clone v1.1.1-rc2, IMAGE_PREFIX=ghcr.io/pbrane in .env, `docker compose pull && ./deploy.sh up full`, expect green 22/22 services + 28 nodes imported without any manual intervention

## Related roadmap
- `v1.2.0 self-contained images` (see `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`) eliminates the foreign-sources bind mount altogether — fix #3 is tactical for v1.1.x.