### PR TITLE
docs(v1.2.0): app-observability parity across containers design

### DIFF
--- a/docs/plans/2026-04-23-v1.2.0-app-observability-design.md
+++ b/docs/plans/2026-04-23-v1.2.0-app-observability-design.md
@@ -1,0 +1,234 @@
+# v1.2.0: Application Observability Parity Across Containers
+
+> **Status:** Design / roadmap. No implementation started. Scope captured 2026-04-23 during the v1.1.1 GA cycle.
+
+## Goal
+
+Every delta-v daemon exposes *domain-level* Micrometer metrics at
+`/actuator/prometheus` — not just JVM and Spring Boot defaults. This gives
+the future Kubernetes operator enough signal to autoscale on
+**application-aware** criteria (queue depth, throughput, domain-operation
+latency) rather than CPU/memory heuristics that are notoriously wrong for
+JVM workloads with event-driven backlogs.
+
+Flow-enricher is the reference implementation. This work brings the other
+12 daemons (and the auxiliary services) to the same bar.
+
+## Context
+
+### What flow-enricher got right (PR #161)
+
+The flow-enricher container established two reusable patterns:
+
+1. **`DropwizardToPrometheusBridge`** — a `MeterBinder` + `MetricRegistryListener`
+   that exposes any Dropwizard `MetricRegistry` at `/actuator/prometheus`.
+   Essential because horizon-lib emits through Dropwizard and we can't edit
+   horizon-lib source.
+2. **`LoggingEventForwarder`** — a drop-in `EventForwarder` bean that logs
+   rather than publishes, so horizon-lib's internal signalling via
+   `EventBuilder.sendNow(...)` doesn't leak onto Kafka fault-events as
+   pseudo-alarms.
+
+Both are ~5-line beans. Both ship in flow-enricher today.
+
+### What the other daemons look like
+
+Spot-check of the 12 daemons' `/actuator/prometheus` outputs as of v1.1.1:
+
+- **JVM metrics:** heap, GC, threads, classloader — yes, via micrometer-registry-prometheus
+- **Spring Boot metrics:** HTTP endpoints, connection pools, caches — yes
+- **Domain metrics:** **almost nothing.** Each daemon runs its business
+  logic (poll scheduling, alarm creation, node scans, trap/syslog
+  ingestion) and emits essentially zero counters, gauges, or timers that
+  describe the volume or state of that work.
+- **Dropwizard-sourced horizon metrics:** emitted into a horizon
+  `MetricRegistry`, but no bridge → invisible at `/actuator/prometheus`.
+
+### Why autoscaling needs this
+
+Kubernetes HPA v2 can scale on external metrics, but external metrics only
+help if the metrics exist. For JVM workloads with Kafka-backed ingest (all
+the delta-v daemons), the CPU/memory signals are particularly bad because:
+
+- **CPU lags backlog.** A pollerd that's catching up on 10,000 queued
+  polls may run at 60% CPU; the operator sees "plenty of headroom"
+  while outage reporting is 15 min stale.
+- **Memory is flat until it isn't.** JVM heaps tend to sit at steady-state
+  until an unrelated allocation storm; scaling on heap is usually too late.
+- **The real signal is queue depth.** Kafka consumer lag, in-flight RPC
+  count, scan-queue size — these move in proportion to load and lead
+  trouble by a useful margin.
+
+## Two-part scope
+
+### Scope A — horizon-metric bridging (mechanical)
+
+Apply the flow-enricher pattern verbatim to each daemon that carries
+horizon-lib code. Per daemon:
+
+```java
+@Configuration
+class ObservabilityConfig {
+    @Bean
+    MeterRegistryCustomizer<PrometheusMeterRegistry> dropwizardBridge(
+            MetricRegistry dropwizardRegistry) {
+        return registry -> dropwizardRegistry.addListener(
+            new DropwizardToPrometheusBridge(registry));
+    }
+
+    @Bean
+    EventForwarder loggingEventForwarder() {
+        return new LoggingEventForwarder();
+    }
+}
+```
+
+Per-daemon effort: ~30 min (copy, rename package, wire into the
+daemon's `@Configuration` bean graph, verify `/actuator/prometheus`
+now shows horizon metric names).
+
+Grep-and-delete sweep of delta-v-owned `EventBuilder.sendNow(...)` calls
+for daemon-internal signals — replace with Micrometer counters.
+
+Total effort: **1–2 days for all 12 daemons.**
+
+### Scope B — domain-metric audit
+
+For each daemon, identify the business signals that matter for autoscaling
+and add explicit Micrometer counters/gauges/timers. Per-daemon target
+metric surfaces (starting point, refined in implementation):
+
+| Daemon | Key metric candidates |
+|---|---|
+| **pollerd** | `deltav_pollerd_polls_dispatched_total`, `_polls_completed_total`, `_rpc_latency_seconds` (histogram), `_outages_opened_total`, `_outages_closed_total` |
+| **collectd** | `deltav_collectd_collections_scheduled_total`, `_batches_published_total`, `_collector_success_ratio` (per-collector tag), `_snmp_fetch_latency_seconds` |
+| **alarmd** | `deltav_alarmd_alarms_created_total`, `_alarms_cleared_total`, `_alarms_escalated_total`, `drools_working_memory_size` (gauge) |
+| **provisiond** | `deltav_provisiond_requisitions_imported_total`, `_nodes_scanned_total`, `_scan_threadpool_saturation_ratio`, `_import_duration_seconds` |
+| **trapd** | `deltav_trapd_traps_ingested_total` (by source), `_traps_dropped_total`, `_traps_parsed_total` |
+| **syslogd** | `deltav_syslogd_messages_ingested_total`, `_messages_filtered_total`, `_convertToEvent_duration_seconds` |
+| **enlinkd** | `deltav_enlinkd_nodes_discovered_total`, `_lldp_links_total` (gauge), `_bft_rows_total` (gauge), `_topology_build_duration_seconds` |
+| **bsmd** | `deltav_bsmd_services_tracked_total` (gauge), `_state_transitions_total`, `_calculation_duration_seconds` |
+| **eventtranslator** | `deltav_eventtranslator_events_in_total`, `_events_out_total`, `_translation_latency_seconds` |
+| **perspectivepollerd** | `deltav_perspective_polls_dispatched_total`, `_polls_completed_total`, `_rpc_latency_seconds` |
+| **discovery** | `deltav_discovery_ranges_scanned_total`, `_suspects_found_total`, `_range_scan_duration_seconds` |
+| **telemetryd** | `deltav_telemetryd_packets_received_total` (by protocol), `_packets_forwarded_total`, `_forward_latency_seconds` |
+| **minion-boot** | `deltav_minion_rpc_received_total` (by location), `_rpc_dispatched_total`, `_sink_backlog_depth` (gauge) |
+| **flow-enricher** | **done** — reference implementation (PR #161) |
+| **prometheus-writer** | `deltav_prometheus_writer_remote_write_batches_total`, `_remote_write_errors_total`, `_kafka_consumer_lag` (gauge per partition) |
+| **db-init / init-sidecars** | One-shot pass/fail; less interesting for autoscaling but useful for rollout monitoring |
+
+Naming convention: `deltav_<daemon>_<noun>_<unit>_total` for counters,
+`_ratio` for unitless ratios, `_seconds` for timers, `_bytes` for sizes.
+Matches Prometheus conventions.
+
+Per-daemon effort: ~0.5–1 day including design-choice discussion
+(which signals, label cardinality, histogram buckets).
+
+Total effort: **1–2 weeks across all 12 daemons.** Parallel-izable;
+probably one PR per daemon for cleanest review.
+
+## Kubernetes operator consumption
+
+Two ways the operator can consume these metrics for HPA v2:
+
+1. **Prometheus Adapter** (recommended): runs as a cluster service,
+   scrapes VictoriaMetrics/Prometheus, exposes a subset as Custom Metrics
+   API. HPA references metric by name — e.g.,
+   `external.metrics.k8s.io/deltav_pollerd_polls_queued`.
+2. **External Metrics Adapter with direct VictoriaMetrics query** — less
+   standard but more direct.
+
+Either works. Operator scope itself is out-of-scope for this design doc —
+see TBD `project_k8s_operator` design doc when that track kicks off.
+
+Concrete example HPA targeting a domain metric:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: pollerd
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: pollerd
+  minReplicas: 2
+  maxReplicas: 12
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: deltav_pollerd_rpc_latency_seconds_p95
+        target:
+          type: Value
+          value: "2"   # scale up if p95 RPC latency > 2s
+```
+
+## Scope estimate
+
+**2–3 weeks of focused work total.** Parallel-izable with Minion gRPC
+track — different code paths, no merge conflicts.
+
+- Scope A (horizon bridging): 1–2 days, mechanical
+- Scope B (domain-metric audit): 1–2 weeks, thought-intensive per daemon
+
+## Non-goals
+
+- **Building the K8s operator.** This design enables the operator, it
+  isn't the operator itself.
+- **Tracing / spans.** Metrics first; OpenTelemetry tracing is a separate
+  v1.2+ conversation.
+- **Log aggregation.** Already handled via Docker's log driver + external
+  collectors; not part of this track.
+- **Changing Grafana dashboards.** Dashboards will be extended separately
+  once the metrics are exposed.
+
+## Dependencies and ordering
+
+**Can ship independently** of the v1.2.0 self-contained-images and Minion
+gRPC migration tracks — disjoint code paths.
+
+Suggested sequence inside v1.2.0:
+1. **Scope A (horizon bridging)** first — small, mechanical, unblocks
+   verification that horizon-sourced metrics exist in `/actuator/prometheus`.
+2. **Scope B** per-daemon PRs, pipelined. One PR per daemon keeps review
+   tractable and lets each daemon ship its own metric surface iteratively.
+3. **Grafana dashboard extensions** at the end, once the metric names are
+   settled.
+
+## Architectural questions to answer before implementation
+
+1. **Namespace prefix.** `deltav_<daemon>_*` or `deltav_*` (daemon as label)?
+   Former is easier to tab-complete in PromQL; latter is more queryable
+   across daemons. Recommendation: `deltav_<daemon>_*` for counters,
+   `deltav_*` with `daemon` label for cross-daemon gauges.
+2. **Label cardinality.** Per-node labels can explode on large deployments
+   (thousands of nodes). Recommendation: avoid `node_id` / `ip_addr`
+   labels; aggregate by default. Add per-node labels only behind an
+   explicit opt-in env var.
+3. **Histogram bucket choice.** Micrometer default buckets are often
+   too coarse. Need a team-wide convention (e.g., SLO-aligned buckets at
+   50ms / 100ms / 250ms / 500ms / 1s / 2s / 5s / 10s for RPC latency).
+4. **Backwards compatibility with VictoriaMetrics.** VM ingestion already
+   works for flow-enricher metrics. No reason to expect issues, but
+   verify cardinality stays under VM's recommended limits.
+
+## Invariants that must survive
+
+- **`/actuator/prometheus` stays the sole metrics endpoint.** No side-door
+  JMX exporters, no custom HTTP endpoints. Everything through Spring Boot
+  Actuator + micrometer-registry-prometheus.
+- **`feedback_no_local_polling`.** Metric emission is local to each
+  daemon; no daemon scrapes another daemon's metrics.
+- **`project_minion_mandatory`.** Minion still polls network targets;
+  the new metrics describe daemon behavior, not remote targets.
+
+## References
+
+- **Flow-enricher reference implementation:** [PR #161](https://github.com/pbrane/delta-v/pull/161)
+- **Dropwizard→Prometheus bridge pattern:** memory `feedback_dropwizard_prometheus_bridge_pattern`
+- **Related v1.2.0 scope items:**
+  - `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`
+  - `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`
+- **Future K8s operator track:** not yet filed; consumer of these metrics.


### PR DESCRIPTION
## Summary
Third v1.2.0 priority track alongside the two existing design docs (self-contained-images, Minion gRPC migration). Retrofits Micrometer domain metrics across all 12 daemons so the future K8s operator can autoscale on app-aware signals instead of CPU/memory.

## Why this matters for K8s autoscaling
CPU/memory heuristics lag badly on JVM workloads with Kafka-backed ingest:
- **CPU lags backlog** — pollerd catching up on 10,000 queued polls runs at 60% CPU; the operator sees headroom while outage reporting is 15 min stale.
- **Memory is flat until it isn't** — JVM heaps sit at steady-state until an unrelated allocation storm; scaling on heap is too late.
- **Real signal is queue depth** — Kafka consumer lag, in-flight RPC count, scan-queue size — move in proportion to load and lead trouble by a useful margin.

## Two-part scope

**Scope A — horizon-metric bridging** (~1-2 days, mechanical)
Apply flow-enricher's `DropwizardToPrometheusBridge` + `LoggingEventForwarder` pattern (PR #161) to every daemon still carrying horizon-lib code. 5-line template per daemon.

**Scope B — domain-metric audit** (~1-2 weeks, parallel-izable)
Per-daemon counters/gauges/timers. Design doc includes a starting target metric table for each of the 12 daemons plus auxiliary services. One PR per daemon keeps review tractable.

## Relationship to other v1.2.0 tracks
- `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md` (container hygiene)
- `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md` (transport modernization)
- **this doc** (observability)

All three complete the "Delta-V runs well on K8s" theme. Parallel-izable; different code paths.

## Test plan
- [x] Design only — no implementation. Merging just records the roadmap artifact.