### PR TITLE
docs(v1.2.0): release plan umbrella doc + README roadmap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ cd opennms-container/delta-v
 
 10. **Horizon as pre-built dependency** — Horizon modules are built in `pbrane/delta-v-horizon` and consumed as Maven artifacts, keeping delta-v's 22-module reactor fast (~16s compile).
 
+## Roadmap
+
+**Current release: v1.1.1** — clean Linux consumer flow. Pull the 18 images from GHCR, `docker compose up`, stack comes up hands-off with 28 seed nodes imported. Full 12-test E2E suite passes in isolation.
+
+**Next release: v1.2.0** — "Delta-V runs well on Kubernetes." Three parallel tracks:
+
+- **Container hygiene** — self-contained images (eliminate the remaining bind mounts in `docker-compose.yml` so consumers don't need a git clone). [Design](docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md).
+- **Transport modernization** — Minion Kafka IPC → gRPC via Spring Cloud Gateway (lower latency, lighter dependency, same Gateway will front any future static UI). [Design](docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md).
+- **Operational observability** — Micrometer domain metrics across all 12 daemons so a future K8s operator can autoscale on application-aware signals (backlog depth, throughput, operation latency) instead of CPU/memory. [Design](docs/plans/2026-04-23-v1.2.0-app-observability-design.md).
+
+See the full [v1.2.0 release plan](docs/plans/2026-04-23-v1.2.0-release-plan.md) for the complete scope including second-tier items (test-harness cleanup, SpringServiceDaemon standardization, ActiveMQ/ServiceMix bundle purge, sink topic rename, retiring the "Default" Minion location) and a forward look at **v1.3.0 candidates** (K8s operator, Nephron analytics replacement, REST API gateway, YAML config migration).
+
 ## Documentation
 
 | Document | Description |
@@ -250,7 +262,7 @@ cd opennms-container/delta-v
 | [SECURITY.md](SECURITY.md) | Security policy |
 | [NOTICE](NOTICE) | OpenNMS derivation attribution |
 
-Design documents are in `docs/plans/` and `docs/superpowers/`.
+Design documents and release plans are in `docs/plans/`. Session notes and superpowers agents are in `docs/superpowers/`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ cd opennms-container/delta-v
 - **Transport modernization** — Minion Kafka IPC → gRPC via Spring Cloud Gateway (lower latency, lighter dependency, same Gateway will front any future static UI). [Design](docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md).
 - **Operational observability** — Micrometer domain metrics across all 12 daemons so a future K8s operator can autoscale on application-aware signals (backlog depth, throughput, operation latency) instead of CPU/memory. [Design](docs/plans/2026-04-23-v1.2.0-app-observability-design.md).
 
-See the full [v1.2.0 release plan](docs/plans/2026-04-23-v1.2.0-release-plan.md) for the complete scope including second-tier items (test-harness cleanup, SpringServiceDaemon standardization, ActiveMQ/ServiceMix bundle purge, sink topic rename, retiring the "Default" Minion location) and a forward look at **v1.3.0 candidates** (K8s operator, Nephron analytics replacement, REST API gateway, YAML config migration).
+See the [v1.2.0 release plan](docs/plans/2026-04-23-v1.2.0-release-plan.md) for the full scope and forward look at **v1.3.0 candidates** (K8s operator, Nephron analytics replacement, REST API gateway, YAML config migration, SpringServiceDaemon standardization, cloud-native requisitions, static UI).
 
 ## Documentation
 

--- a/docs/plans/2026-04-23-v1.2.0-release-plan.md
+++ b/docs/plans/2026-04-23-v1.2.0-release-plan.md
@@ -9,17 +9,14 @@ v1.0.x through v1.1.x made Delta-V *run*: Karaf removed, all daemons on
 Spring Boot 4, flow pipeline and time-series pipeline fully validated,
 clean-VM consumer deploy working hands-off.
 
-v1.2.0 makes it *run well on Kubernetes*. Three major tracks, each with
-its own design document, all parallel-izable:
+v1.2.0 makes it *run well on Kubernetes*. Three tracks, each with its
+own design document, all parallel-izable:
 
 - **Container hygiene** — self-contained images (eliminate bind mounts)
 - **Transport modernization** — Minion Kafka IPC → gRPC via Spring Cloud Gateway
 - **Operational observability** — application-aware metrics across all daemons
 
-Plus a second tier of smaller items that belong in the same release for
-thematic coherence.
-
-## Top-tier tracks (each has its own design document)
+## Tracks (each has its own design document)
 
 ### 1. Self-contained images
 
@@ -50,6 +47,23 @@ the HTTP entry point for any future static UI external API.
 **Design doc:** [`2026-04-22-v1.2.0-minion-grpc-migration-design.md`](2026-04-22-v1.2.0-minion-grpc-migration-design.md)
 **Scope:** 2-4 weeks of focused work. Largest track in the release.
 
+Three items are bundled into this track because they touch the same IPC
+stack and are most cheaply done while it's opened up:
+
+- **Minion ActiveMQ + ServiceMix bundle purge** — 17 ActiveMQ + 15
+  ServiceMix bundles still ship in minion-boot as Karaf-era leftovers.
+  Removed as part of the IPC rewrite. Memory reference:
+  [`project_minion_servicemix_activemq_cleanup`](../../memory/project_minion_servicemix_activemq_cleanup.md).
+- **Sink topic rename `OpenNMS.Sink.*` → `DeltaV.Sink.*`** — disruptive
+  in isolation, mechanical inside the gRPC migration. Prerequisite for
+  the future flow-processor topic rename. Memory reference:
+  [`project_sink_topic_rename`](../../memory/project_sink_topic_rename.md).
+- **Retire the "Default" Minion location** — horizon-era semantic that
+  means "here, wherever here is," incompatible with K8s/GitOps where
+  every Minion instance has a named, typed location. The gRPC identity
+  and auth story defines named locations as the only model. Memory
+  reference: [`project_retire_default_minion`](../../memory/project_retire_default_minion.md).
+
 ### 3. Application observability parity across containers
 
 **Problem:** Only `flow-enricher` exposes meaningful domain-level
@@ -66,87 +80,32 @@ for HPA v2 autoscaling. Two-part scope: horizon-metric bridging
 **Design doc:** [`2026-04-23-v1.2.0-app-observability-design.md`](2026-04-23-v1.2.0-app-observability-design.md)
 **Scope:** 2-3 weeks total, pipeline-able per daemon.
 
-## Second-tier scope (no separate design doc; smaller items)
-
-These are smaller, thematically aligned with the "container/K8s hygiene"
-theme, and bundled into v1.2.0 to keep the release cohesive.
-
-### Test-harness cleanup (filed from v1.1.1 smoke-test findings)
-
-- **[#201](https://github.com/pbrane/delta-v/issues/201)** — `test-collectd-e2e.sh`
-  and similar overwrite `provisiond-configuration.xml` rather than appending
-  their requisition-def; silently clobbers other requisitions for later tests.
-- **[#202](https://github.com/pbrane/delta-v/issues/202)** —
-  `test-node-context-e2e.sh` and `test-prometheus-writer-e2e.sh` manage their
-  own `docker compose up`/`down` lifecycle; incompatible with pre-deployed
-  stacks (port conflict → teardown → subsequent tests fail).
-- **[#203](https://github.com/pbrane/delta-v/issues/203)** — Timeouts in
-  `test-syslog-e2e`, `test-minion-rpc-e2e`, `test-timeseries-e2e` tuned for
-  warm dev machines; cold QEMU guests flake without longer defaults.
-
-### SpringServiceDaemon standardization
-
-Several daemons still extend the horizon-era `AbstractServiceDaemon`
-base class. Migrate to the interface-based `SpringServiceDaemon` pattern
-already established elsewhere. Reduces inheritance coupling and eases
-testing.
-
-Memory reference: [`feedback_standardize_springservicedaemon`](../../memory/feedback_standardize_springservicedaemon.md)
-
-### Minion ActiveMQ + ServiceMix bundle purge
-
-Minion-boot still carries 17 ActiveMQ bundles + 15 ServiceMix bundles as
-dependency fallout from the Karaf-era message-bus architecture. These
-are unreferenced at runtime after the IPC migrations but still ship in
-the image. Removing them shrinks minion-boot substantially and is a
-natural companion to the gRPC migration.
-
-Memory reference: [`project_minion_servicemix_activemq_cleanup`](../../memory/project_minion_servicemix_activemq_cleanup.md)
-
-### Retire the "Default" Minion location
-
-Horizon-era semantic: `location=Default` meant "here, wherever here is."
-Incompatible with K8s/GitOps deployments where every Minion instance
-should have a named, typed location. Retarget the test harness onto
-named-location Minions; mock-snmp-agent goes away as a side effect.
-
-Memory reference: [`project_retire_default_minion`](../../memory/project_retire_default_minion.md)
-
-### Provisiond cloud-native requisitions
-
-Today provisiond mutates requisition XML on disk to record `last-import`
-timestamps. On K8s with ephemeral pod filesystems, this state is lost on
-every pod restart. Move to PostgreSQL-backed import state. PR #187 was
-the tactical bandaid (named volume + init sidecar); v1.2.0 is the
-structural fix.
-
-Memory reference: [`project_provisiond_cloud_native_requisitions`](../../memory/project_provisiond_cloud_native_requisitions.md)
-
-### Sink topic rename: `OpenNMS.Sink.*` → `DeltaV.Sink.*`
-
-Cosmetic but disruptive — better to land during the gRPC migration than
-separately. Prerequisite for the future flow-processor topic rename.
-
-Memory reference: [`project_sink_topic_rename`](../../memory/project_sink_topic_rename.md)
-
 ## Tentative sequence and cadence
 
 No firm dates. Suggested order based on dependencies and risk:
 
-1. **`v1.2.0-alpha1`** — self-contained-images landed. Smallest, least
-   risky; proves the consumer UX improvement.
-2. **`v1.2.0-alpha2`** — app-observability Scope A (horizon bridging) +
-   test-harness cleanups. Mechanical, low-risk.
+1. **`v1.2.0-alpha1`** — self-contained images. Smallest, least risky;
+   proves the consumer UX improvement.
+2. **`v1.2.0-alpha2`** — app-observability Scope A (horizon-metric
+   bridging across all daemons). Mechanical, low-risk.
 3. **`v1.2.0-beta1`** — app-observability Scope B (per-daemon domain
-   metrics), SpringServiceDaemon standardization, secondary cleanups.
-4. **`v1.2.0-rc1`** — gRPC migration midpoint: protobuf service
-   definitions published, parallel Kafka+gRPC paths running.
-5. **`v1.2.0-rc2`** — gRPC migration complete: Kafka IPC path removed,
-   full E2E validation.
+   metrics). Pipelined as one PR per daemon.
+4. **`v1.2.0-rc1`** — Minion gRPC migration midpoint: protobuf service
+   definitions published, parallel Kafka+gRPC paths running, ActiveMQ
+   and ServiceMix bundles purged from minion-boot.
+5. **`v1.2.0-rc2`** — Minion gRPC migration complete: Kafka IPC path
+   removed, sink topics renamed, "Default" location retired, full
+   E2E validation.
 6. **`v1.2.0`** — GA.
 
 Each RC is smoke-tested on a clean Linux VM following the same process
 established for v1.1.1.
+
+Test-harness bugs found during v1.1.1 validation
+([#201](https://github.com/pbrane/delta-v/issues/201),
+[#202](https://github.com/pbrane/delta-v/issues/202),
+[#203](https://github.com/pbrane/delta-v/issues/203)) are tracked as
+issues and fixed as normal maintenance work — not blocking on any RC.
 
 ## Looking ahead to v1.3.0
 
@@ -207,6 +166,25 @@ flat dump that resulted from the Karaf-era inheritance. Mostly mechanical
 but touches every POM; best done in a dedicated release.
 
 Memory reference: [`project_module_restructure`](../../memory/project_module_restructure.md)
+
+### SpringServiceDaemon standardization
+
+Several daemons still extend the horizon-era `AbstractServiceDaemon`
+base class. Migrate to the interface-based `SpringServiceDaemon` pattern
+already established elsewhere. Reduces inheritance coupling, eases
+testing, removes a horizon-era abstraction.
+
+Memory reference: [`feedback_standardize_springservicedaemon`](../../memory/feedback_standardize_springservicedaemon.md)
+
+### Cloud-native provisiond requisitions
+
+Today provisiond mutates requisition XML on disk to record `last-import`
+timestamps. On K8s with ephemeral pod filesystems, that state is lost
+on every pod restart. Move to PostgreSQL-backed import state. PR #187
+was the tactical bandaid (named volume + init sidecar); v1.3.0 is the
+structural fix that eliminates the bandaid.
+
+Memory reference: [`project_provisiond_cloud_native_requisitions`](../../memory/project_provisiond_cloud_native_requisitions.md)
 
 ### Static UI
 

--- a/docs/plans/2026-04-23-v1.2.0-release-plan.md
+++ b/docs/plans/2026-04-23-v1.2.0-release-plan.md
@@ -1,0 +1,234 @@
+# Delta-V v1.2.0 Release Plan
+
+> **Status:** Planning. v1.1.1 ships now; v1.2.0 scope captured 2026-04-23.
+> No implementation has started on the v1.2.0 tracks yet.
+
+## Release theme — "Delta-V runs well on Kubernetes"
+
+v1.0.x through v1.1.x made Delta-V *run*: Karaf removed, all daemons on
+Spring Boot 4, flow pipeline and time-series pipeline fully validated,
+clean-VM consumer deploy working hands-off.
+
+v1.2.0 makes it *run well on Kubernetes*. Three major tracks, each with
+its own design document, all parallel-izable:
+
+- **Container hygiene** — self-contained images (eliminate bind mounts)
+- **Transport modernization** — Minion Kafka IPC → gRPC via Spring Cloud Gateway
+- **Operational observability** — application-aware metrics across all daemons
+
+Plus a second tier of smaller items that belong in the same release for
+thematic coherence.
+
+## Top-tier tracks (each has its own design document)
+
+### 1. Self-contained images
+
+**Problem:** v1.1.x's `docker-compose.yml` has 20 bind mounts. Consumers
+can't deploy with just `curl docker-compose.yml && docker compose up -d`
+— they need a git clone to get the bind-mounted config overlays.
+
+**Target:** Every daemon image carries its own `/opt/deltav/etc`.
+Custom `deltav/clickhouse` and `deltav/grafana` images bake in
+format schemas + dashboards. Consumer deploy is one curl + one
+`docker compose up`.
+
+**Design doc:** [`2026-04-22-v1.2.0-self-contained-images-design.md`](2026-04-22-v1.2.0-self-contained-images-design.md)
+**Scope:** ~1-2 days of mechanical work.
+
+### 2. Minion Kafka IPC → gRPC via Spring Cloud Gateway
+
+**Problem:** Every Minion RPC round-trip touches Kafka twice (request +
+response). High latency for poll-critical operations (SNMP walks, ICMP
+pings). Kafka is also a heavy infrastructure dependency for what is
+fundamentally a pair of RPC channels.
+
+**Target:** gRPC streaming for sink topics (heartbeats, telemetry,
+syslog), gRPC bidi-streaming for RPC invocations, gRPC server-streaming
+for Twin API. All fronted by Spring Cloud Gateway, which also becomes
+the HTTP entry point for any future static UI external API.
+
+**Design doc:** [`2026-04-22-v1.2.0-minion-grpc-migration-design.md`](2026-04-22-v1.2.0-minion-grpc-migration-design.md)
+**Scope:** 2-4 weeks of focused work. Largest track in the release.
+
+### 3. Application observability parity across containers
+
+**Problem:** Only `flow-enricher` exposes meaningful domain-level
+metrics at `/actuator/prometheus`. Every other daemon shows JVM and
+Spring Boot boilerplate but essentially zero business signals (polls
+dispatched, alarms created, node scans, trap ingestion rates, etc.).
+A future K8s operator can't autoscale on what it can't see.
+
+**Target:** Every daemon exposes domain-level Micrometer metrics suitable
+for HPA v2 autoscaling. Two-part scope: horizon-metric bridging
+(mechanical, 1-2 days) + per-daemon domain-metric audit (per-daemon PRs,
+1-2 weeks total).
+
+**Design doc:** [`2026-04-23-v1.2.0-app-observability-design.md`](2026-04-23-v1.2.0-app-observability-design.md)
+**Scope:** 2-3 weeks total, pipeline-able per daemon.
+
+## Second-tier scope (no separate design doc; smaller items)
+
+These are smaller, thematically aligned with the "container/K8s hygiene"
+theme, and bundled into v1.2.0 to keep the release cohesive.
+
+### Test-harness cleanup (filed from v1.1.1 smoke-test findings)
+
+- **[#201](https://github.com/pbrane/delta-v/issues/201)** — `test-collectd-e2e.sh`
+  and similar overwrite `provisiond-configuration.xml` rather than appending
+  their requisition-def; silently clobbers other requisitions for later tests.
+- **[#202](https://github.com/pbrane/delta-v/issues/202)** —
+  `test-node-context-e2e.sh` and `test-prometheus-writer-e2e.sh` manage their
+  own `docker compose up`/`down` lifecycle; incompatible with pre-deployed
+  stacks (port conflict → teardown → subsequent tests fail).
+- **[#203](https://github.com/pbrane/delta-v/issues/203)** — Timeouts in
+  `test-syslog-e2e`, `test-minion-rpc-e2e`, `test-timeseries-e2e` tuned for
+  warm dev machines; cold QEMU guests flake without longer defaults.
+
+### SpringServiceDaemon standardization
+
+Several daemons still extend the horizon-era `AbstractServiceDaemon`
+base class. Migrate to the interface-based `SpringServiceDaemon` pattern
+already established elsewhere. Reduces inheritance coupling and eases
+testing.
+
+Memory reference: [`feedback_standardize_springservicedaemon`](../../memory/feedback_standardize_springservicedaemon.md)
+
+### Minion ActiveMQ + ServiceMix bundle purge
+
+Minion-boot still carries 17 ActiveMQ bundles + 15 ServiceMix bundles as
+dependency fallout from the Karaf-era message-bus architecture. These
+are unreferenced at runtime after the IPC migrations but still ship in
+the image. Removing them shrinks minion-boot substantially and is a
+natural companion to the gRPC migration.
+
+Memory reference: [`project_minion_servicemix_activemq_cleanup`](../../memory/project_minion_servicemix_activemq_cleanup.md)
+
+### Retire the "Default" Minion location
+
+Horizon-era semantic: `location=Default` meant "here, wherever here is."
+Incompatible with K8s/GitOps deployments where every Minion instance
+should have a named, typed location. Retarget the test harness onto
+named-location Minions; mock-snmp-agent goes away as a side effect.
+
+Memory reference: [`project_retire_default_minion`](../../memory/project_retire_default_minion.md)
+
+### Provisiond cloud-native requisitions
+
+Today provisiond mutates requisition XML on disk to record `last-import`
+timestamps. On K8s with ephemeral pod filesystems, this state is lost on
+every pod restart. Move to PostgreSQL-backed import state. PR #187 was
+the tactical bandaid (named volume + init sidecar); v1.2.0 is the
+structural fix.
+
+Memory reference: [`project_provisiond_cloud_native_requisitions`](../../memory/project_provisiond_cloud_native_requisitions.md)
+
+### Sink topic rename: `OpenNMS.Sink.*` → `DeltaV.Sink.*`
+
+Cosmetic but disruptive — better to land during the gRPC migration than
+separately. Prerequisite for the future flow-processor topic rename.
+
+Memory reference: [`project_sink_topic_rename`](../../memory/project_sink_topic_rename.md)
+
+## Tentative sequence and cadence
+
+No firm dates. Suggested order based on dependencies and risk:
+
+1. **`v1.2.0-alpha1`** — self-contained-images landed. Smallest, least
+   risky; proves the consumer UX improvement.
+2. **`v1.2.0-alpha2`** — app-observability Scope A (horizon bridging) +
+   test-harness cleanups. Mechanical, low-risk.
+3. **`v1.2.0-beta1`** — app-observability Scope B (per-daemon domain
+   metrics), SpringServiceDaemon standardization, secondary cleanups.
+4. **`v1.2.0-rc1`** — gRPC migration midpoint: protobuf service
+   definitions published, parallel Kafka+gRPC paths running.
+5. **`v1.2.0-rc2`** — gRPC migration complete: Kafka IPC path removed,
+   full E2E validation.
+6. **`v1.2.0`** — GA.
+
+Each RC is smoke-tested on a clean Linux VM following the same process
+established for v1.1.1.
+
+## Looking ahead to v1.3.0
+
+These are **candidates only** — captured here so the direction is
+transparent, not committed. Scope and priorities may change after v1.2.0
+ships.
+
+### K8s operator + HPA policy
+
+The natural consumer of v1.2.0's observability track. An operator
+written (likely) in Go using the operator-sdk, targeting delta-v as a
+workload resource with HPA v2 policies referencing the domain metrics
+exposed in v1.2.0. Includes:
+
+- `DeltaVDeployment` CRD (one deployment = one delta-v stack)
+- Per-daemon scale policies (backlog-driven, latency-driven)
+- Prometheus Adapter bridging `/actuator/prometheus` metrics to the
+  Custom Metrics API
+- Installation documentation: Helm chart or operator-hub manifest
+
+### Analytics phase (Nephron replacement → Spring Cloud Stream)
+
+Today flow-enricher does light enrichment (application classification,
+NodeInfo lookup). Deeper analytics (conversation aggregation, top-N by
+interval, DSCP/ToS rollups) were historically done by Nephron on
+Beam/Flink. Replace with Spring Cloud Stream consumers reading from the
+`deltav-flows` Kafka topic, writing aggregated results to ClickHouse
+dimension tables. Covered in several memory notes:
+
+- [`project_nephron_analytics_phase`](../../memory/project_nephron_analytics_phase.md)
+- [`project_thresholder_brainstorm`](../../memory/project_thresholder_brainstorm.md)
+  (same architecture, applied to thresholding)
+
+### REST API gateway
+
+v1.1.x has no external API surface; daemons don't expose REST. v1.3.0
+scope: decompose the horizon-era webapp REST APIs into per-daemon REST
+endpoints fronted by Spring Cloud Gateway (the same Gateway that
+v1.2.0's gRPC track establishes). Enables a future static UI, external
+integrations, and third-party CLI tooling.
+
+Memory reference: [`project_rest_api_gateway`](../../memory/project_rest_api_gateway.md)
+
+### YAML configuration migration
+
+All daemon configs are XML today. YAML is more readable, better-tooled
+in the cloud-native world, and eliminates the `JAXB` → `Jackson XmlMapper`
+bridging currently required. Migrate one daemon at a time, with XML-read
+fallback during the transition.
+
+Memory reference: [`project_yaml_config_migration`](../../memory/project_yaml_config_migration.md)
+
+### Module restructure
+
+Reorganize `core/` into functional subgroups (`daemons/`, `infrastructure/`,
+`flows/`, `model/`) to reflect the logical architecture rather than the
+flat dump that resulted from the Karaf-era inheritance. Mostly mechanical
+but touches every POM; best done in a dedicated release.
+
+Memory reference: [`project_module_restructure`](../../memory/project_module_restructure.md)
+
+### Static UI
+
+The v1.2.0 Spring Cloud Gateway architecture was chosen partly because
+it can front a future static UI (Vue or React) in addition to Minion
+gRPC. Whether/what to build is a separate design conversation. v1.3.0
+scope would be: decide, scaffold, and ship an initial panel for the
+alerting + flow visibility workflows.
+
+## Getting involved
+
+- **Feedback on v1.2.0 scope:** open a discussion issue on the
+  [pbrane/delta-v](https://github.com/pbrane/delta-v) repository.
+- **Design doc review:** PR #205 (observability), #198 (self-contained
+  images + gRPC migration) landed the detailed designs; follow-up PRs
+  will open implementation issues when each track starts.
+- **v1.3.0 scoping:** candidate items above are not yet issue-tracked;
+  that happens after v1.2.0 is mid-flight.
+
+## References
+
+- **Self-contained images design:** `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`
+- **Minion gRPC migration design:** `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`
+- **App observability design:** `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
+- **v1.1.1 release notes (post-release):** TBD

--- a/docs/superpowers/next-session-prompts/2026-04-23-v1.2.0-self-contained-images-implementation.md
+++ b/docs/superpowers/next-session-prompts/2026-04-23-v1.2.0-self-contained-images-implementation.md
@@ -1,0 +1,216 @@
+# Next session: v1.2.0 first track — self-contained images implementation
+
+**Background docs:**
+- Design: `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`
+- Release plan: `docs/plans/2026-04-23-v1.2.0-release-plan.md` (this is the `v1.2.0-alpha1` deliverable per the cadence)
+
+**Background memory:** `project_v1_2_self_contained_images`
+
+**Branch:** `feat/v1.2.0-self-contained-images` off develop.
+
+---
+
+## Why this track first
+
+Smallest v1.2.0 track (~1-2 days of mechanical work), zero architectural
+decisions required, most visible consumer UX improvement. No upstream
+blockers. Landing it:
+
+- Cuts `v1.2.0-alpha1`, proving the v1.2.x release pipeline is healthy.
+- Moves consumers from "git clone + docker compose up" to "curl
+  docker-compose.yml + docker compose up" — the headline v1.2.0 promise.
+- Eliminates the bind-mount-UID-mismatch class of bug that hit us three
+  times in v1.1.1 validation (the `foreign-sources/pending` fix in PR #199
+  was a tactical bandaid for this exact class).
+
+## One-paragraph problem statement
+
+`opennms-container/delta-v/docker-compose.yml` has 20 bind-mounted paths
+pointing at host directories (`./provisiond-overlay/etc`, `./grafana/provisioning`,
+`./clickhouse/init`, etc.). Consumers cannot deploy with just a `docker-compose.yml`
+file — they need a git clone to have those directories available locally. Every
+other mainstream infrastructure stack (Grafana, Prometheus, VictoriaMetrics,
+ClickHouse) ships images with baked-in defaults. v1.1.1 proved that on Linux
+the bind-mount approach also leaks host UIDs into containers, silently breaking
+daemons whose service user doesn't happen to match uid 1000. The structural fix
+is to bake every config into the image that consumes it, so the compose file
+references only published images with no host-filesystem dependencies.
+
+## Scope — 5 workstreams, roughly parallel
+
+### 1. Per-daemon overlay bake-in (10 daemons)
+
+Each daemon currently mounts `./<daemon>-overlay/etc:/opt/deltav/etc:ro`.
+Change `Dockerfile.daemon-per` to `COPY <daemon>-overlay/etc /opt/deltav/etc`
+during image build, then remove the bind mount from docker-compose.yml.
+
+Affected daemons: `pollerd, collectd, discovery, trapd, syslogd,
+eventtranslator, enlinkd, provisiond, perspectivepollerd, telemetryd`.
+Keep `bsmd` and `alarmd` in this set if they have overlay dirs (check).
+
+Shape of the Dockerfile change (parameterized via `DAEMON_NAME` build arg,
+already in the file):
+
+```dockerfile
+# Existing:
+#   ARG DAEMON_NAME
+#   COPY staging/${DAEMON_NAME}/... ...
+# Add:
+COPY ${DAEMON_NAME}-overlay/etc /opt/deltav/etc
+```
+
+Verify the COPY happens AFTER the base daemon layer COPY so overlay wins.
+
+docker-compose.yml: remove the 10 `volumes: - ./<daemon>-overlay/etc:/opt/deltav/etc:ro` lines.
+
+### 2. Custom `deltav/clickhouse` image
+
+New file: `opennms-container/delta-v/Dockerfile.clickhouse`
+
+```dockerfile
+FROM clickhouse/clickhouse-server:25.8
+COPY clickhouse/init                    /docker-entrypoint-initdb.d/
+COPY clickhouse/user-init               /docker-entrypoint-initdb.d/
+COPY clickhouse/config.d                /etc/clickhouse-server/config.d/
+COPY core/flow-enricher/src/main/proto  /opt/clickhouse/format_schemas/
+```
+
+Add a workflow step in `.github/workflows/delta-v-build-images.yml` (model
+after the existing flow-enricher / prometheus-writer steps added in PR #196).
+
+docker-compose.yml: switch `clickhouse` service from `clickhouse/clickhouse-server:25.8`
+to `${IMAGE_PREFIX:-deltav}/clickhouse:${VERSION}`. Remove the 4 bind mounts
+(`./clickhouse/init`, `./clickhouse/user-init`, `./clickhouse/config.d/format-schema-path.xml`,
+and the `core/flow-enricher/src/main/proto` mount).
+
+### 3. Custom `deltav/grafana` image
+
+New file: `opennms-container/delta-v/Dockerfile.grafana`
+
+```dockerfile
+FROM grafana/grafana:11.4.0
+COPY grafana/provisioning /etc/grafana/provisioning
+COPY grafana/dashboards   /var/lib/grafana/dashboards
+```
+
+(Note: PR #204 just merged the symmetrical SNMP Overview dashboard layout
+redesign — the JSON in `grafana/dashboards/snmp-overview.json` is the
+source of truth to bake in.)
+
+Add workflow step. docker-compose.yml: swap image reference, remove 2 bind mounts.
+
+### 4. Init-sidecar bake-in
+
+`provisiond-imports-init` currently: `busybox:1.36` + bind mount `./provisiond-overlay/etc/imports-seed:/seed:ro`.
+Replace with custom `deltav/provisiond-imports-init` image that carries `/seed` internally.
+
+Also `l8opensim-provisioner`: `curlimages/curl:8.10.1` + bind mount `./l8opensim:/seed:ro`.
+Replace with custom `deltav/l8opensim-provisioner` image.
+
+After: remove both bind mounts from docker-compose.yml.
+
+### 5. docker-compose.yml final audit
+
+After workstreams 1-4, walk the compose file and confirm:
+- **Zero bind mounts remain.** Grep for `:/opt/deltav` and `:/etc/grafana`
+  and `:/docker-entrypoint-initdb.d` and `:/delta-v` — each should return
+  zero hits against host paths.
+- Every `image:` reference uses `${IMAGE_PREFIX:-deltav}/<name>:${VERSION}`
+  (already established pattern, extended to new images).
+- Published via `.github/workflows/delta-v-build-images.yml` — add the
+  new images to the build matrix and the image summary output at the end.
+
+## Smoke-test validation (the deliverable)
+
+Repeat the v1.1.1 clean-VM smoke test process documented in the session
+log. Setup:
+
+1. Wipe the VM (already at `192.168.64.2` from v1.1.1 validation, or
+   build a new one) to a clean Ubuntu 24.04 ARM64 state.
+2. Without cloning the repo, run:
+
+```bash
+curl -OL https://raw.githubusercontent.com/pbrane/delta-v/v1.2.0-alpha1/opennms-container/delta-v/docker-compose.yml
+cat > .env <<EOF
+IMAGE_PREFIX=ghcr.io/pbrane
+VERSION=1.2.0-alpha1
+EOF
+docker compose pull
+docker compose up -d
+```
+
+3. Wait 3-5 min for stack settle.
+4. `docker compose ps` should show ~22 healthy services, `curl http://localhost:13000`
+   should hit Grafana, `psql ... -c "SELECT count(*) FROM node"` should show 28.
+
+**No git clone. No chown. No --profile dance except for metrics.**
+
+If that sequence works end-to-end without any host-filesystem prep, this
+track is done.
+
+## Workflow updates
+
+`.github/workflows/delta-v-build-images.yml` needs new steps (mirror the
+PR #196 pattern):
+
+```yaml
+      - name: Build and push deltav/clickhouse image
+        working-directory: opennms-container/delta-v
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -f Dockerfile.clickhouse \
+            -t "${{ env.IMAGE_PREFIX }}/clickhouse:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/clickhouse:latest" \
+            --push \
+            .
+
+      - name: Build and push deltav/grafana image
+        # same pattern, Dockerfile.grafana
+
+      - name: Build and push deltav/provisiond-imports-init image
+      - name: Build and push deltav/l8opensim-provisioner image
+```
+
+Four new steps. Each identical in shape to existing db-init / flow-enricher /
+prometheus-writer steps.
+
+Update the "Images" summary list at the end of the workflow to include the
+four new images (so published tag report is accurate).
+
+Image count after this track: 16 delta-v images + 2 base layers = 18 today,
+becoming **22 images** after this track (adds clickhouse, grafana,
+provisiond-imports-init, l8opensim-provisioner).
+
+## Out of scope for this session
+
+- Minion gRPC migration (v1.2.0-rc1/rc2 track).
+- App observability (v1.2.0-alpha2/beta1 track).
+- Changing compose service names, ports, dependencies, or healthchecks.
+- Moving `foreign-sources/pending` from the PR #199 sidecar workaround
+  into the image — that becomes unnecessary once the whole `/opt/deltav/etc`
+  is baked in (no bind-mount UID mismatch possible), but deleting the
+  sidecar's `pending/` chown logic is a nice-to-have cleanup, not a
+  blocker for alpha1.
+
+## Release cut checklist (end of session)
+
+- [ ] All five workstreams land in one PR against develop.
+- [ ] CI green (build + CodeQL).
+- [ ] Merge.
+- [ ] Tag `v1.2.0-alpha1` at the merge commit.
+- [ ] Image-publish workflow succeeds (22 images).
+- [ ] Clean-VM smoke test passes hands-off (no git clone, no chown).
+- [ ] Update release plan doc with alpha1 cut date.
+- [ ] Announce in the release plan umbrella PR thread (or release notes).
+
+## References
+
+- Design doc: `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`
+- Release plan: `docs/plans/2026-04-23-v1.2.0-release-plan.md`
+- Current bind-mount inventory: `opennms-container/delta-v/docker-compose.yml`
+- Current image-publish workflow: `.github/workflows/delta-v-build-images.yml`
+- v1.1.1 smoke-test process (for the alpha1 validation): session log from 2026-04-22, or reconstruct from PR #199 description.
+- Memory files: `project_v1_2_self_contained_images`, `feedback_deltav_package_namespace` (for image naming), `project_docker_compose_nested_bind_mount_bug` (history of why bind mounts are fragile).


### PR DESCRIPTION
## Summary
Adds a community-facing v1.2.0 release plan that ties together the three design docs filed today / yesterday (self-contained images, Minion gRPC, app observability). Peeks forward to v1.3.0 candidate scope so the direction is visible without being locked in.

README.md gets a matching **Roadmap** section linking to the plan.

Also ships the **next-session implementation prompt** for the first v1.2.0 track (self-contained images → v1.2.0-alpha1), so whichever session picks up implementation has full context.

## Files
- `docs/plans/2026-04-23-v1.2.0-release-plan.md` — umbrella planning doc: three tracks, cadence, v1.3.0 candidates
- `docs/superpowers/next-session-prompts/2026-04-23-v1.2.0-self-contained-images-implementation.md` — implementation kickoff for v1.2.0-alpha1
- `README.md` — new "## Roadmap" section

## v1.2.0 scope shape (three tracks, no junk drawer)
1. **Self-contained images** — eliminate the 20 bind mounts (alpha1)
2. **Minion gRPC + Spring Cloud Gateway** — IPC rewrite, includes ActiveMQ/ServiceMix purge, sink rename, retire Default location as sub-items
3. **App observability parity** — Micrometer domain metrics across 12 daemons (alpha2 Scope A, beta1 Scope B)

Test-harness bugs (#201/#202/#203) are tracked as normal maintenance, not plan scope.
SpringServiceDaemon standardization and cloud-native requisitions moved to v1.3.0 candidates.

## Related
- #205 — app-observability design doc (under review)

## Test plan
- [x] Markdown renders cleanly on GitHub
- [x] Relative links checked against actual files
- [ ] Merge; next session can start v1.2.0-alpha1 from the prompt