### PR TITLE
docs(v1.2.0): add Pollerd + PerspectivePollerd response-time publishing track

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,12 @@ cd opennms-container/delta-v
 
 **Current release: v1.1.1** — clean Linux consumer flow. Pull the 18 images from GHCR, `docker compose up`, stack comes up hands-off with 28 seed nodes imported. Full 12-test E2E suite passes in isolation.
 
-**Next release: v1.2.0** — "Delta-V runs well on Kubernetes." Three parallel tracks:
+**Next release: v1.2.0** — "Delta-V runs well on Kubernetes." Four parallel tracks:
 
 - **Container hygiene** — self-contained images (eliminate the remaining bind mounts in `docker-compose.yml` so consumers don't need a git clone). [Design](docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md).
 - **Transport modernization** — Minion Kafka IPC → gRPC via Spring Cloud Gateway (lower latency, lighter dependency, same Gateway will front any future static UI). [Design](docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md).
 - **Operational observability** — Micrometer domain metrics across all 12 daemons so a future K8s operator can autoscale on application-aware signals (backlog depth, throughput, operation latency) instead of CPU/memory. [Design](docs/plans/2026-04-23-v1.2.0-app-observability-design.md).
+- **Historical observability** — Pollerd + PerspectivePollerd publish per-poll response-time samples to the `deltav-timeseries` Kafka topic so service latency lands in VictoriaMetrics alongside SNMP metrics (Kafka Time Series Phase 3). [Design](docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md).
 
 See the [v1.2.0 release plan](docs/plans/2026-04-23-v1.2.0-release-plan.md) for the full scope and forward look at **v1.3.0 candidates** (K8s operator, Nephron analytics replacement, REST API gateway, YAML config migration, SpringServiceDaemon standardization, cloud-native requisitions, static UI).
 

--- a/docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md
+++ b/docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md
@@ -1,0 +1,239 @@
+# v1.2.0: Pollerd + PerspectivePollerd Response-Time Publishing to `deltav-timeseries`
+
+> **Status:** Design / roadmap. No implementation started. Scope captured 2026-04-23 during v1.2.0 planning.
+
+## Goal
+
+Every service poll executed by Pollerd or PerspectivePollerd publishes its
+response-time sample (and availability bit) to the `deltav-timeseries`
+Kafka topic. The existing `prometheus-writer` consumer then forwards those
+samples to VictoriaMetrics with no changes required on the consumer side.
+
+After this lands, Grafana dashboards can plot **service response time**
+per node/service/location — the same way they plot SNMP metrics today —
+and a future thresholder can alert on latency degradation.
+
+## Context
+
+Delta-V's Kafka Time Series pipeline has three phases already shipped:
+
+| Phase | Producer | Status |
+|---|---|---|
+| Phase 0 | Collectd publishes CollectionSets | Done (PR #169–175) |
+| Phase 1 | Provisiond publishes node-context deltas | Done (PR #180) |
+| Phase 2 | prometheus-writer remote-writes to VictoriaMetrics | Done (PR #181) |
+
+Pollerd and PerspectivePollerd were left out of Phase 0 because the focus
+at that time was SNMP collection. But poll response time is:
+
+- **The primary SLA metric** for reachability monitoring. "Is the service
+  up?" is useful; "how long does it take to respond?" tracks degradation
+  before it becomes an outage.
+- **The whole point of perspective polling.** Running the same poll from
+  multiple vantage points (edge, core, regional) produces a family of
+  latency series that reveal where a problem lives. That signal is
+  currently invisible in dashboards because it never reaches VictoriaMetrics.
+- **A prerequisite for the future thresholder** ([`project_thresholder_brainstorm`](../../memory/project_thresholder_brainstorm.md)).
+  The thresholder design assumes all latency-bearing signals are on a
+  single Kafka topic.
+
+Closing this gap is **Phase 3** of the Kafka Time Series pipeline.
+
+## Target pattern
+
+### Where the sample originates
+
+**Pollerd:** every service poll completes in `ServiceMonitor.poll(...)`
+returning a `PollStatus`. `PollStatus` already carries
+`getResponseTime()` (double, milliseconds) and `getStatusCode()` (up,
+down, unresponsive). Today Pollerd uses that value to update the
+in-memory availability state and (historically) to write RRD files;
+delta-v's Pollerd does not persist latency anywhere.
+
+**PerspectivePollerd:** same `ServiceMonitor.poll` contract, but poll
+results arrive via Kafka RPC responses from Minions at different
+locations. The `perspective-outages` enrichment step is where poll
+results are assembled.
+
+### Publisher
+
+Introduce `org.deltav.pollerd.timeseries.ResponseTimePublisher` (or
+`org.deltav.netmgt.poller.timeseries.ResponseTimeKafkaPublisher` —
+package shape TBD during implementation) that:
+
+1. Accepts a `ResponseTimeSample` record per poll completion.
+2. Batches samples in-memory (same shape as
+   `org.deltav.collectd.timeseries.TimeseriesKafkaPublisher`).
+3. Serializes as protobuf using the existing `deltav-kafka-contracts`
+   format (or a new message type if the existing format isn't a fit —
+   see "architectural questions" below).
+4. Publishes to `deltav-timeseries` Kafka topic, reusing the same
+   `KafkaTemplate` configuration as Collectd's publisher.
+
+The Collectd publisher is the reference implementation:
+- `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java`
+- `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java`
+
+Batching / back-pressure semantics:
+- Batch size: probably 100 samples or 500ms whichever first (match Collectd).
+- Flush on shutdown.
+- If Kafka unreachable → pause the batch emission with a counter
+  (`deltav_pollerd_timeseries_batches_failed_total`), do not lose samples
+  — same pattern as prometheus-writer's auto-pause when VictoriaMetrics
+  is unreachable.
+
+### Metric shape
+
+Starting point (subject to naming-convention discussion — see question 4):
+
+```
+# Response time (histogram or gauge — TBD):
+deltav_service_response_time_seconds{node_id, foreign_source, service, location, perspective, status}
+
+# Availability (0 or 1):
+deltav_service_available{node_id, foreign_source, service, location, perspective}
+```
+
+Perspective is distinguished from location:
+- `location` = the Minion location that ran the poll (e.g., `mhuot-labs`).
+  Always present (even for direct Pollerd).
+- `perspective` = empty for direct Pollerd; set to the perspective-path
+  identifier (e.g., `edge`, `core`) for PerspectivePollerd.
+
+### Consumer-side changes
+
+**None.** prometheus-writer already subscribes to `deltav-timeseries`
+and forwards to VictoriaMetrics. As long as the new samples conform to
+the existing protobuf envelope, prometheus-writer will route them
+through without source code changes.
+
+This is a key feature of the pipeline design: Phase 3 is producer-only.
+
+## Architectural questions to answer before implementation
+
+1. **Protobuf message reuse vs. new type.** Collectd's publisher emits
+   `CollectionSet` protobufs (heavy — groups of attributes per resource).
+   Pollerd emits one sample per poll (simple: timestamp + metric name +
+   value + labels). Either (a) reuse `CollectionSet` with a single-attribute
+   wrapper (works, but wasteful in bytes), or (b) add a new
+   `ResponseTimeSample` message type to `core/deltav-kafka-contracts`.
+   Lean toward (b) — ~30 lines of protobuf, no downstream compatibility
+   impact because prometheus-writer already dispatches by message type.
+
+2. **Histogram vs. gauge.** Individual poll latencies could be emitted as
+   gauge samples (one value per poll) or pre-aggregated client-side into
+   histograms with buckets. Gauge is simpler and preserves per-poll
+   detail (matches what you'd want in forensic-detail Grafana panels).
+   Histogram is lower-volume and better for SLO alerts. Probably **both**:
+   emit gauge samples plus a local histogram for in-process `/actuator/prometheus`
+   (that overlaps with the app-observability track — worth coordinating).
+
+3. **Label cardinality.** `node_id` is unbounded on large deployments.
+   For a 10,000-node installation, a single gauge family with `node_id`
+   labels produces 10,000 series per service-type. VictoriaMetrics
+   handles this but it's not free. Decision options:
+   - **Emit node_id by default**, document a knob to strip it under
+     `DELTAV_POLLERD_TIMESERIES_LABEL_NODE_ID=false`.
+   - **Don't emit node_id**, aggregate by `foreign_source + service`;
+     consumers who need per-node join with node-context topic downstream.
+
+   Defer the call to implementation-time; the gauge-vs-aggregate choice
+   in #2 affects the answer.
+
+4. **Metric name convention.** Align with the app-observability track's
+   naming convention (`deltav_<daemon>_<noun>_<unit>`). Candidate names:
+   - `deltav_pollerd_response_time_seconds` + `deltav_pollerd_service_available`
+   - `deltav_perspective_response_time_seconds` + `deltav_perspective_service_available`
+   - Or unified: `deltav_service_response_time_seconds{source=pollerd|perspective, ...}`
+
+   Unified is easier to query; per-daemon is easier to filter. Lean
+   unified, with `source` label.
+
+5. **Publishing failure handling.** When Kafka is unreachable, Pollerd
+   must never block the poll scheduler. Two options:
+   - Non-blocking queue with bounded capacity; drop-newest on full +
+     increment `deltav_pollerd_timeseries_samples_dropped_total`.
+   - Persistent disk buffer (e.g., Chronicle Queue) that tolerates
+     multi-minute Kafka outages.
+
+   Recommendation: non-blocking bounded queue, same as Collectd today.
+   Persistent buffer is a v1.3+ resilience feature if operators ask for it.
+
+6. **Test-harness coverage.** `test-timeseries-e2e.sh` currently asserts
+   Collectd produces to `deltav-timeseries`. Extend the assertion to
+   also look for response-time samples after a poll cycle. Extend
+   `test-perspective-e2e.sh` similarly for perspective samples.
+
+## Scope estimate
+
+**1-1.5 weeks of focused work** — roughly:
+
+- Define protobuf message (question 1): 0.5 day
+- Implement `ResponseTimePublisher` for Pollerd (copy + adapt Collectd publisher): 1-2 days
+- Wire into Pollerd's poll-completion callback: 1 day
+- Same for PerspectivePollerd: 2-3 days (perspective enrichment path is more complex than direct poll)
+- E2E test extensions (questions 6): 1 day
+- Grafana dashboard additions (response-time panels on Flows / SNMP / new "Service Latency" dashboard): 1 day
+
+Smaller than the other three v1.2.0 tracks, but not trivially small —
+enough that it deserves its own design doc rather than being buried in
+another track's scope.
+
+## Non-goals
+
+- **Thresholder / alerting on response time.** That's v1.3.0 scope
+  ([`project_thresholder_brainstorm`](../../memory/project_thresholder_brainstorm.md)).
+  This track makes the metric available; the alerting consumer comes later.
+- **Replacing RRD.** Delta-V never adopted RRD; there's nothing to replace.
+- **Histogrammed SLO dashboards.** Graph existing latency samples first;
+  the SLO dashboard work (percentile panels, error budgets) is a
+  follow-up.
+- **Collectd changes.** Collectd already publishes and is unaffected.
+
+## Dependencies and ordering
+
+Independent of the other three v1.2.0 tracks. Specifically:
+
+- **Self-contained images** — no coupling. Publisher code is in the
+  daemon JARs, not in config.
+- **Minion gRPC** — no coupling on the PerspectivePollerd side either:
+  PerspectivePollerd receives RPC responses in either transport; the
+  publisher only cares about what comes out.
+- **App observability** — light overlap (both touch Micrometer on
+  Pollerd). Coordinate naming conventions (question 4) but implementation
+  is separable.
+
+**Suggested slot in cadence:** parallel with app-observability Scope B in
+`v1.2.0-beta1`. Both touch Pollerd + PerspectivePollerd, so they could
+even be bundled into the same per-daemon PR to avoid two edit passes on
+the same file.
+
+## Invariants that must survive
+
+- **`feedback_no_local_polling`** — response-time samples describe polls
+  already happening via Minion; no new polling paths.
+- **`feedback_rpc_timeout_no_outages`** — a timed-out poll is reported
+  as `status=timeout`, NOT as a synthesized outage. Same semantic as
+  today; the change only adds observability, not behavior.
+- **`project_minion_mandatory`** — producer code runs in Pollerd /
+  PerspectivePollerd containers, not on Minion. Minion is unaffected.
+
+## References
+
+- **Kafka Time Series pipeline history:**
+  `docs/plans/` prefixes `2026-04-16-kafka-ts-*`, `2026-04-17-kafka-ts-*`,
+  `2026-04-18-kafka-ts-*`
+- **Reference producer:**
+  `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java`
+  (and its `Configuration` counterpart)
+- **Consumer (unchanged):** `core/prometheus-writer`
+- **Memory cross-refs:**
+  - `project_kafka_timeseries_pipeline`
+  - `project_thresholder_brainstorm`
+  - `project_thresholding_e2e_followup`
+  - `project_collectd_scheduler_publisher_split` (scheduler-vs-publisher concern also applies to Pollerd; worth noting during implementation)
+- **Sibling v1.2.0 tracks:**
+  - `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`
+  - `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`
+  - `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
+  - `docs/plans/2026-04-23-v1.2.0-release-plan.md` (umbrella)

--- a/docs/plans/2026-04-23-v1.2.0-release-plan.md
+++ b/docs/plans/2026-04-23-v1.2.0-release-plan.md
@@ -9,12 +9,13 @@ v1.0.x through v1.1.x made Delta-V *run*: Karaf removed, all daemons on
 Spring Boot 4, flow pipeline and time-series pipeline fully validated,
 clean-VM consumer deploy working hands-off.
 
-v1.2.0 makes it *run well on Kubernetes*. Three tracks, each with its
+v1.2.0 makes it *run well on Kubernetes*. Four tracks, each with its
 own design document, all parallel-izable:
 
 - **Container hygiene** — self-contained images (eliminate bind mounts)
 - **Transport modernization** — Minion Kafka IPC → gRPC via Spring Cloud Gateway
 - **Operational observability** — application-aware metrics across all daemons
+- **Historical observability** — Pollerd + PerspectivePollerd response-time publishing (Kafka Time Series Phase 3)
 
 ## Tracks (each has its own design document)
 
@@ -80,6 +81,26 @@ for HPA v2 autoscaling. Two-part scope: horizon-metric bridging
 **Design doc:** [`2026-04-23-v1.2.0-app-observability-design.md`](2026-04-23-v1.2.0-app-observability-design.md)
 **Scope:** 2-3 weeks total, pipeline-able per daemon.
 
+### 4. Pollerd + PerspectivePollerd response-time publishing
+
+**Problem:** Only Collectd produces to the `deltav-timeseries` Kafka
+topic today. Pollerd and PerspectivePollerd measure service response
+time on every poll (ICMP roundtrip, HTTP response, SNMP detection
+latency, etc.) and that signal never reaches VictoriaMetrics. Operators
+can chart SNMP metrics but not poll latency, and the future thresholder
+has no single topic to consume from.
+
+**Target:** Both Pollerd and PerspectivePollerd publish response-time
+samples (and availability bits) to `deltav-timeseries` on every poll
+completion. prometheus-writer consumes unchanged — Phase 3 of the Kafka
+Time Series pipeline is producer-only. PerspectivePollerd samples carry
+a `perspective` label that distinguishes them from direct Pollerd
+samples (same service, different vantage point, different series).
+
+**Design doc:** [`2026-04-23-v1.2.0-pollerd-timeseries-design.md`](2026-04-23-v1.2.0-pollerd-timeseries-design.md)
+**Scope:** 1-1.5 weeks. Reuses Collectd's `TimeseriesKafkaPublisher`
+pattern.
+
 ## Tentative sequence and cadence
 
 No firm dates. Suggested order based on dependencies and risk:
@@ -89,7 +110,9 @@ No firm dates. Suggested order based on dependencies and risk:
 2. **`v1.2.0-alpha2`** — app-observability Scope A (horizon-metric
    bridging across all daemons). Mechanical, low-risk.
 3. **`v1.2.0-beta1`** — app-observability Scope B (per-daemon domain
-   metrics). Pipelined as one PR per daemon.
+   metrics) **plus Pollerd + PerspectivePollerd response-time
+   publishing**. Bundle-able because both touch the same two daemons
+   (one edit pass, coordinated metric naming).
 4. **`v1.2.0-rc1`** — Minion gRPC migration midpoint: protobuf service
    definitions published, parallel Kafka+gRPC paths running, ActiveMQ
    and ServiceMix bundles purged from minion-boot.


### PR DESCRIPTION
## Summary
Fourth v1.2.0 track. Closes the Phase 3 gap in the Kafka Time Series pipeline — Pollerd + PerspectivePollerd measure per-poll response time today but never publish it to \`deltav-timeseries\`, so service latency isn't in VictoriaMetrics for Grafana dashboards and the future thresholder has no single topic to consume latency from.

## Why this is distinct from the app-observability track (#205)

Two separate observability pipelines in delta-v:

| Pipeline | Consumer | Purpose |
|---|---|---|
| \`/actuator/prometheus\` endpoint | Operator scrape | Autoscaling decisions (#205 covers this) |
| Kafka \`deltav-timeseries\` topic | prometheus-writer → VictoriaMetrics | **Dashboards + historical + thresholder** (this track covers this for Pollerd/PerspectivePollerd) |

Different publish mechanisms, different consumers, different signal shapes. Both are "delta-v tells the world its signals" but they're not the same pipeline.

## Files
- \`docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md\` — new design doc (239 lines)
- \`docs/plans/2026-04-23-v1.2.0-release-plan.md\` — add Track 4, update cadence for \`v1.2.0-beta1\` (bundle-able with app-observability Scope B since both touch the same two daemons)
- \`README.md\` — Roadmap section grows from 3 bullets to 4

## Design highlights
- **Producer-only work.** prometheus-writer subscribes to \`deltav-timeseries\` today; no consumer changes needed.
- Reuses Collectd's \`org.deltav.collectd.timeseries.TimeseriesKafkaPublisher\` pattern as reference.
- PerspectivePollerd samples carry a \`perspective\` label distinguishing them from direct Pollerd samples — the whole point of perspective polling becomes visible in dashboards.
- Architectural questions reserved for implementation time (protobuf message reuse, gauge vs histogram, label cardinality, naming convention, failure handling, E2E test coverage).

## Scope & cadence
- **Effort:** 1-1.5 weeks
- **Cadence slot:** \`v1.2.0-beta1\` alongside app-observability Scope B
- **Downstream:** enables the thresholder work captured in \`project_thresholder_brainstorm\` (v1.3.0 track)

## Related
- #205 — app-observability design
- #206 — v1.2.0 release plan + README Roadmap
- Memory: \`project_v1_2_pollerd_timeseries\` (captured tonight)

## Test plan
- [x] Markdown renders cleanly on GitHub
- [x] Relative links verified
- [ ] Merge; v1.2.0 scope now captures the four tracks completely