### PR TITLE
chore: bump version 1.1.1 → 1.2.0-alpha1 + fix cross-repo Maven packages auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
           cache: maven
 
       - name: Configure Maven for GitHub Packages
+        # HORIZON_READ_TOKEN is a PAT with read:packages scope on pbrane/delta-v-horizon.
+        # GITHUB_TOKEN is not sufficient here: it's scoped to this repo's packages, but
+        # the horizon BOM lives on a different repo owned by the same user, and
+        # cross-repo GitHub Packages reads via GITHUB_TOKEN are not granted by default.
         run: |
           mkdir -p ~/.m2
           cat > ~/.m2/settings.xml << SETTINGS
@@ -46,14 +50,14 @@ jobs:
             <servers>
               <server>
                 <id>github-deltav-horizon</id>
-                <username>${GITHUB_ACTOR}</username>
+                <username>${GITHUB_REPOSITORY_OWNER}</username>
                 <password>${PACKAGES_TOKEN}</password>
               </server>
             </servers>
           </settings>
           SETTINGS
         env:
-          PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGES_TOKEN: ${{ secrets.HORIZON_READ_TOKEN }}
 
       - name: Build all modules
         run: ./mvnw -B -DskipTests install

--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -91,6 +91,9 @@ jobs:
           cache: maven
 
       - name: Configure Maven for GitHub Packages
+        # HORIZON_READ_TOKEN is a PAT with read:packages scope on pbrane/delta-v-horizon.
+        # GITHUB_TOKEN is not sufficient here (cross-repo packages access isn't granted
+        # by default, even when the source and target repos have the same owner).
         run: |
           mkdir -p ~/.m2
           cat > ~/.m2/settings.xml << SETTINGS
@@ -98,14 +101,14 @@ jobs:
             <servers>
               <server>
                 <id>github-deltav-horizon</id>
-                <username>${GITHUB_ACTOR}</username>
+                <username>${GITHUB_REPOSITORY_OWNER}</username>
                 <password>${PACKAGES_TOKEN}</password>
               </server>
             </servers>
           </settings>
           SETTINGS
         env:
-          PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGES_TOKEN: ${{ secrets.HORIZON_READ_TOKEN }}
 
       - name: Extract version from POM
         id: version

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-alpha1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>1.1.1</version>
+  <version>1.2.0-alpha1</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>


### PR DESCRIPTION
## Summary

Two changes bundled into one PR:

1. **Version bump**: 25 POMs (root + 24 delta-v modules) via `./mvnw versions:set -DnewVersion=1.2.0-alpha1`. Starts the v1.2.0 release cycle; tag `v1.2.0-alpha1` will be cut at the merge commit, and the image-publish workflow reads `project.version` to tag all 26 images as `:1.2.0-alpha1`.

2. **CI auth fix**: `ci.yml` and `delta-v-build-images.yml` now use `HORIZON_READ_TOKEN` (a pre-existing PAT with `read:packages` scope) instead of `GITHUB_TOKEN` for the horizon Maven BOM on `pbrane/delta-v-horizon`. `GITHUB_TOKEN` is scoped to this repo's packages and can't reach cross-repo packages, even when the source and target repos share an owner. PR #208 passed its CI only because maven cache held the BOM from a prior run — the version bump invalidated that cache key, so fresh downloads were required and they surfaced the latent auth gap.

Why bundled: the CI fix is what makes the version bump actually go green. Splitting them means landing the fix first, rebasing the bump, running CI twice — overhead without benefit.

## Test Plan

- [ ] CI green on updated workflow
- [ ] Merge
- [ ] Tag `v1.2.0-alpha1` at merge commit → `delta-v-build-images.yml` runs with the same auth fix
- [ ] Image-publish workflow succeeds (26 multi-arch images tagged `:1.2.0-alpha1`)