### PR TITLE
fix(v1.2.0): 5 smoke-test gaps surfaced by v1.2.0-alpha1 validation

### DIFF
--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -235,10 +235,21 @@
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
 
-        <!-- Jakarta Validation — needed by BSM entity @Size annotations -->
+        <!-- Jakarta Validation — needed by BSM entity @Size annotations.
+             The API-only dep above is insufficient at runtime: Spring Boot
+             autoconfigures a LocalValidatorFactoryBean that probes for a
+             provider via ServiceLoader and fails with NoProviderFoundException
+             when only the API is on the classpath. Hibernate Validator 9.x
+             (managed by Spring Boot 4 BOM) is the reference implementation
+             of jakarta.validation 3.1 and brings no javax/Horizon baggage —
+             just classmate, jboss-logging, and jakarta.el transitively. -->
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
 
         <!-- Jakarta Inject — needed by Hibernate 7 -->

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -237,7 +237,7 @@ services:
       start_period: 15s
 
   pollerd:
-    profiles: [lite, full]
+    profiles: [lite, full, metrics]
     image: ${IMAGE_PREFIX:-deltav}/pollerd:${VERSION}
     container_name: delta-v-pollerd
     hostname: pollerd
@@ -266,7 +266,7 @@ services:
       start_period: 20s
 
   collectd:
-    profiles: [lite, full]
+    profiles: [lite, full, metrics]
     image: ${IMAGE_PREFIX:-deltav}/collectd:${VERSION}
     container_name: delta-v-collectd
     hostname: collectd
@@ -444,7 +444,7 @@ services:
   # itself (baked by Dockerfile.daemon-per's `COPY --chown=opennms:opennms`),
   # so there's no host bind mount to chown here anymore.
   provisiond-imports-init:
-    profiles: [lite, passive, full]
+    profiles: [lite, passive, full, metrics]
     image: ${IMAGE_PREFIX:-deltav}/provisiond-imports-init:${VERSION}
     container_name: delta-v-provisiond-imports-init
     user: "0:0"
@@ -455,16 +455,23 @@ services:
       - -c
       - |
         set -e
-        if [ -z "$$(ls -A /runtime 2>/dev/null)" ]; then
+        # Use a marker file, not the emptiness check: when the named volume
+        # first mounts into the provisiond container, Docker auto-populates
+        # it from provisiond's image content at /opt/deltav/etc/imports
+        # (which contains a baked `.gitkeep`). That write happens before
+        # this sidecar runs, so an emptiness check was fooled into thinking
+        # the volume was already seeded and skipped the actual seed.
+        if [ ! -f /runtime/.seeded ]; then
             echo "[provisiond-imports-init] Seeding /runtime from /seed"
             cp -R /seed/. /runtime/
+            touch /runtime/.seeded
         else
-            echo "[provisiond-imports-init] /runtime already populated — leaving alone"
+            echo "[provisiond-imports-init] /runtime already seeded — leaving alone"
         fi
         chown -R 100:101 /runtime
 
   provisiond:
-    profiles: [lite, passive, full]
+    profiles: [lite, passive, full, metrics]
     image: ${IMAGE_PREFIX:-deltav}/provisiond:${VERSION}
     container_name: delta-v-provisiond
     hostname: provisiond
@@ -514,7 +521,7 @@ services:
     stop_grace_period: 60s
 
   bsmd:
-    profiles: [lite, full]
+    profiles: [lite, full, metrics]
     image: ${IMAGE_PREFIX:-deltav}/bsmd:${VERSION}
     container_name: delta-v-bsmd
     hostname: bsmd
@@ -572,7 +579,7 @@ services:
       start_period: 20s
 
   alarmd:
-    profiles: [lite, passive, full]
+    profiles: [lite, passive, full, metrics]
     image: ${IMAGE_PREFIX:-deltav}/alarmd:${VERSION}
     container_name: delta-v-alarmd
     hostname: alarmd

--- a/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
+++ b/opennms-container/delta-v/pollerd-overlay/etc/poller-configuration.xml
@@ -219,12 +219,6 @@
       <service name="Windows-Task-Scheduler" interval="300000" user-defined="false" status="on">
          <parameter key="service-name" value="${requisition:service-name|detector:service-name|Task Scheduler}" />
       </service>
-      <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
-         <parameter key="port" value="${requisition:port|detector:port|18980}" />
-         <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />
-         <parameter key="timeout" value="${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}" />
-         <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      </service>
       <service name="JMX-Kafka" interval="300000" user-defined="false" status="on">
          <parameter key="port" value="${requisition:port|detector:port|9999}" />
          <parameter key="retry" value="${requisition:poller-retry|requisition:retry|detector:retry|2}" />

--- a/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/delta-v.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/delta-v.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Foreign source for the delta-v requisition. Only ICMP and SNMP detectors;
+  prevents scans from invoking detector classes (e.g. WsManDetector) that
+  aren't on the provisiond image's classpath.
+-->
+<foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="delta-v">
+    <scan-interval>1d</scan-interval>
+    <detectors>
+        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+        <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector"/>
+    </detectors>
+    <policies/>
+</foreign-source>

--- a/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/l8opensim-lab.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/l8opensim-lab.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Foreign source for l8opensim-lab — simulated network devices emitting flow
+  traffic on a shared netns. Only ICMP and SNMP detectors; prevents scans
+  from invoking detector classes (e.g. WsManDetector) that aren't on the
+  provisiond image's classpath.
+-->
+<foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="l8opensim-lab">
+    <scan-interval>1d</scan-interval>
+    <detectors>
+        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+        <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector"/>
+    </detectors>
+    <policies/>
+</foreign-source>


### PR DESCRIPTION
## Summary

Fixes five gaps caught by the clean-VM smoke test of `v1.2.0-alpha1` — one blocker (volume seed race) and four cosmetic/UX issues. The alpha1 functional gate was met despite these (28 nodes imported, grafana healthy, collectd persisting SNMP data); this PR cleans them up so `v1.2.0-alpha2` can ship a cleaner single-command deploy.

## Changes

1. **Sidecar volume-seed race** (`docker-compose.yml`) — BLOCKER. The provisiond-imports-init sidecar's emptiness check on `/runtime` was fooled by Docker's auto-populate from provisiond's baked `imports/.gitkeep`. Replaced with a `.seeded` marker file. Without this, the smoke test required a manual `docker run` seed step.

2. **Profile UX for `--profile metrics`** (`docker-compose.yml`). prometheus-writer's `depends_on: provisiond` crossed profile boundaries, rejecting the single-profile compose project. Added `metrics` to provisiond-imports-init / provisiond / collectd / pollerd / alarmd / bsmd. `docker compose --profile metrics up -d` now works standalone.

3. **Pollerd legacy self-poll** (`pollerd-overlay/etc/poller-configuration.xml`). Removed the `OpenNMS-JVM @ 127.0.0.1` monitor — holdover from monolithic OpenNMS; doesn't apply to the microservice split and threw `NoSuchElementException` every 30s.

4. **WS-Man detector on fallback foreign sources** (new: `provisiond-overlay/etc/foreign-sources/{delta-v,l8opensim-lab}.xml`). These requisitions had no explicit foreign-source so provisiond fell through to a built-in default that invokes `WsManDetector` — a class not in delta-v's provisiond image. Added explicit ICMP+SNMP-only foreign-sources to skip the WS-Man scan path.

5. **Bsmd missing jakarta.validation provider** (`core/daemon-boot-bsmd/pom.xml`). Spring Boot 4 autoconfigures `LocalValidatorFactoryBean` and needs a provider on the classpath. Added `hibernate-validator` — Spring Boot 4 BOM resolves 9.0.1.Final, clean Jakarta 3.1 implementation. No Hibernate ORM, no javax, no horizon baggage.

## Test Plan

Manual clean-VM smoke test of v1.2.0-alpha1 validated the root causes of #1 and #2 and surfaced the log noise categorized in #3–#5. After this PR merges and a v1.2.0-alpha2 tag is cut:

- [ ] CI green
- [ ] Merge
- [ ] Bump `1.2.0-alpha1` → `1.2.0-alpha2` (separate chore PR)
- [ ] Tag `v1.2.0-alpha2` at the bump commit
- [ ] Image-publish workflow succeeds (26 images at `:1.2.0-alpha2`)
- [ ] Smoke test: `curl docker-compose.yml; docker compose --profile metrics up -d` on a wiped VM, without any manual volume-seed workaround, imports 28 nodes