### PR TITLE
docs(v1.2.0): record alpha1/2/3 cuts and refresh cadence

### DIFF
--- a/docs/plans/2026-04-23-v1.2.0-release-plan.md
+++ b/docs/plans/2026-04-23-v1.2.0-release-plan.md
@@ -1,7 +1,7 @@
 # Delta-V v1.2.0 Release Plan
 
-> **Status:** Planning. v1.1.1 ships now; v1.2.0 scope captured 2026-04-23.
-> No implementation has started on the v1.2.0 tracks yet.
+> **Status:** In progress. v1.2.0-alpha1/2/3 cut 2026-04-23; track 1
+> (self-contained images) complete. Three tracks remain.
 
 ## Release theme — "Delta-V runs well on Kubernetes"
 
@@ -19,7 +19,7 @@ own design document, all parallel-izable:
 
 ## Tracks (each has its own design document)
 
-### 1. Self-contained images
+### 1. Self-contained images — ✅ DONE (v1.2.0-alpha1, 2026-04-23)
 
 **Problem:** v1.1.x's `docker-compose.yml` has 20 bind mounts. Consumers
 can't deploy with just `curl docker-compose.yml && docker compose up -d`
@@ -31,7 +31,18 @@ format schemas + dashboards. Consumer deploy is one curl + one
 `docker compose up`.
 
 **Design doc:** [`2026-04-22-v1.2.0-self-contained-images-design.md`](2026-04-22-v1.2.0-self-contained-images-design.md)
-**Scope:** ~1-2 days of mechanical work.
+
+**Outcome:** Clean-VM smoke test passes end-to-end — `curl docker-compose.yml
+&& docker compose up -d` on a wiped Ubuntu 24.04 ARM64 VM imports 28 nodes,
+Grafana reachable, all 19 services healthy, zero host filesystem prep.
+Implementation ended up slightly wider than the original scope (26 images
+published instead of 22) to cover test-infra containers that had `build:`
+directives (`mock-snmp-agent`, `flow-exporter`, `sflow-exporter`).
+Shipped across three alpha cuts:
+
+- **v1.2.0-alpha1** — core self-contained-images refactor ([PR #208](https://github.com/pbrane/delta-v/pull/208), [PR #209](https://github.com/pbrane/delta-v/pull/209))
+- **v1.2.0-alpha2** — five smoke-test-gap fixes surfaced by alpha1 validation ([PR #210](https://github.com/pbrane/delta-v/pull/210), [PR #211](https://github.com/pbrane/delta-v/pull/211))
+- **v1.2.0-alpha3** — `docker-compose.dev.yml` lean-JVM override for resource-constrained lab VMs ([PR #212](https://github.com/pbrane/delta-v/pull/212), [PR #213](https://github.com/pbrane/delta-v/pull/213))
 
 ### 2. Minion Kafka IPC → gRPC via Spring Cloud Gateway
 
@@ -101,28 +112,54 @@ samples (same service, different vantage point, different series).
 **Scope:** 1-1.5 weeks. Reuses Collectd's `TimeseriesKafkaPublisher`
 pattern.
 
-## Tentative sequence and cadence
+## Release history + remaining cadence
 
-No firm dates. Suggested order based on dependencies and risk:
+### Shipped
 
-1. **`v1.2.0-alpha1`** — self-contained images. Smallest, least risky;
-   proves the consumer UX improvement.
-2. **`v1.2.0-alpha2`** — app-observability Scope A (horizon-metric
-   bridging across all daemons). Mechanical, low-risk.
-3. **`v1.2.0-beta1`** — app-observability Scope B (per-daemon domain
+1. **`v1.2.0-alpha1`** (2026-04-23) — self-contained images, core refactor.
+   PRs #208, #209.
+2. **`v1.2.0-alpha2`** (2026-04-23) — five smoke-test-gap fixes surfaced
+   during alpha1 clean-VM validation: sidecar volume-seed race (marker
+   file instead of emptiness check), `--profile metrics` single-flag UX,
+   pollerd legacy self-poll removed, WS-Man detector fallback stripped,
+   Hibernate Validator for bsmd Jakarta Validation provider. PRs #210, #211.
+3. **`v1.2.0-alpha3`** (2026-04-23) — `docker-compose.dev.yml` lean-JVM
+   override file for resource-constrained lab VMs (~2 GB stack-wide RSS
+   saving, empirically validated). PRs #212, #213.
+
+### Remaining
+
+No firm dates. Order based on dependencies, risk, and bundle-ability:
+
+4. **`v1.2.0-beta1`** — app-observability Scope A (horizon-metric
+   bridging across all daemons). Mechanical, low-risk (~1–2 days).
+   Dropwizard → Micrometer adapter pattern already proven in flow-enricher
+   (PR #161); apply to the other 11 daemons.
+5. **`v1.2.0-beta2`** — app-observability Scope B (per-daemon domain
    metrics) **plus Pollerd + PerspectivePollerd response-time
    publishing**. Bundle-able because both touch the same two daemons
-   (one edit pass, coordinated metric naming).
-4. **`v1.2.0-rc1`** — Minion gRPC migration midpoint: protobuf service
+   (one edit pass, coordinated metric naming). ~2–3 weeks.
+6. **`v1.2.0-rc1`** — Minion gRPC migration midpoint: protobuf service
    definitions published, parallel Kafka+gRPC paths running, ActiveMQ
    and ServiceMix bundles purged from minion-boot.
-5. **`v1.2.0-rc2`** — Minion gRPC migration complete: Kafka IPC path
+7. **`v1.2.0-rc2`** — Minion gRPC migration complete: Kafka IPC path
    removed, sink topics renamed, "Default" location retired, full
    E2E validation.
-6. **`v1.2.0`** — GA.
+8. **`v1.2.0`** — GA.
 
-Each RC is smoke-tested on a clean Linux VM following the same process
-established for v1.1.1.
+### Divergence note
+
+The original plan intended `alpha2` to be app-observability Scope A and
+`beta1` to be Scope B + Pollerd TS. Reality diverged: alpha1 validation
+surfaced five smoke-test gaps that were worth fixing immediately
+(`alpha2`), and empirical heap-usage data from the clean-VM smoke test
+motivated the dev/test JVM override (`alpha3`) before moving on to new
+feature tracks. Net effect: one extra alpha cut, track 1 shipped more
+polished than originally scoped, remaining tracks pushed one tag
+forward (beta1 = Scope A, beta2 = Scope B + Pollerd TS).
+
+Each beta/RC is smoke-tested on a clean Linux VM following the same
+process established for v1.1.1 and validated on v1.2.0-alpha1/2/3.
 
 Test-harness bugs found during v1.1.1 validation
 ([#201](https://github.com/pbrane/delta-v/issues/201),


### PR DESCRIPTION
## Summary

Brings the v1.2.0 release plan doc in sync with reality after the three alpha cuts on 2026-04-23. Pure documentation — no code, no POMs, no image implications.

- Status header flipped from "Planning" to "In progress"
- Track 1 (self-contained images) marked DONE, with outcome summary and PR links (#208–#213)
- "Tentative sequence and cadence" split into "Shipped" and "Remaining" sections
- Divergence note explaining why alpha2/alpha3 are what they are (instead of the originally-planned app-obs Scope A)
- Tracks 2–4 untouched (not started)

## Test Plan

- [x] Doc renders cleanly locally (markdown preview)
- [ ] CI green
- [ ] Merge — no version bump, no tag; this is pure housekeeping