### PR TITLE
docs(v1.2.0): next-session prompt for beta1 horizon-metric bridge

### DIFF
--- a/docs/superpowers/next-session-prompts/2026-04-24-v1.2.0-beta1-horizon-metric-bridge.md
+++ b/docs/superpowers/next-session-prompts/2026-04-24-v1.2.0-beta1-horizon-metric-bridge.md
@@ -1,0 +1,223 @@
+# Next session: v1.2.0-beta1 — horizon-metric bridging across all daemons
+
+**Background docs:**
+- Design: `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
+- Release plan: `docs/plans/2026-04-23-v1.2.0-release-plan.md` (this is the `v1.2.0-beta1` deliverable per the refreshed cadence)
+- Reference implementation: PR #161 (flow-enricher Dropwizard → Micrometer bridge)
+
+**Background memory:**
+- `project_v1_2_app_observability` — priority + why
+- `project_dropwizard_prometheus_bridge_pattern` — the reusable MeterBinder + MetricRegistryListener recipe; THE key memory for this track
+- `feedback_delayed_tag_workflow_trigger` — the ghost-run gotcha from 2026-04-23; tag carefully
+- `feedback_named_volume_autopopulate` — unrelated to this track but a fresh cautionary tale worth re-reading before next sidecar work
+
+**Branch:** `feat/v1.2.0-beta1-horizon-metric-bridge` off develop
+
+**Current develop HEAD at session start (2026-04-23 end-of-day):** `91c0d8716ae` — docs(v1.2.0): record alpha1/2/3 cuts and refresh cadence (#214)
+
+---
+
+## Why this track next
+
+v1.2.0-alpha1/2/3 shipped on 2026-04-23: self-contained images + smoke-test
+fixes + dev/test JVM override. Track 1 done. Three tracks remain. App-obs
+Scope A (horizon-metric bridging) is picked next because it's the smallest
+remaining increment (~1–2 days), the lowest risk (no behavioral changes
+beyond exposing metrics that already exist in-process), and unlocks the
+v1.3 K8s operator / HPA v2 work that needs a discovery surface.
+
+Scope B (per-daemon domain metrics) and Pollerd TS publishing are bundled
+into `beta2` because they both touch the same two daemons; keeping `beta1`
+focused on the mechanical bridge port lets us ship fast and iterate.
+
+## One-paragraph problem statement
+
+Every daemon runs horizon jars that emit `com.codahale.metrics` (Dropwizard)
+meters throughout provisioning, collection, polling, RPC, and event
+processing code paths. Spring Boot's `/actuator/prometheus` endpoint sees
+none of them because Dropwizard and Micrometer are separate metric
+registries. Operators and future K8s controllers can observe JVM + Spring
+Boot boilerplate on each daemon but essentially zero domain signal.
+flow-enricher already bridges its Dropwizard registry to Micrometer via
+the recipe from PR #161; this session ports that recipe to the other 11
+daemons (and verifies that `org.opennms.*` meters emerge at
+`/actuator/prometheus`).
+
+## Scope — horizon-metric bridging only
+
+### Target daemons (12)
+
+All `core/daemon-boot-*` modules. flow-enricher already has it (the
+reference implementation) so it's **out** of this pass.
+
+Daemons to wire up:
+
+```
+alarmd          enlinkd              pollerd       telemetryd
+bsmd            eventtranslator      provisiond    trapd
+collectd        perspectivepollerd   syslogd       discovery
+```
+
+Plus — decide whether **minion** (`daemon-boot-minion`) gets the bridge
+too. Minion runs horizon code with its own Dropwizard registry (IPC
+metrics, sink throughput, RPC invocation counters). These are genuinely
+operator-useful for HPA on the Minion pool in v1.3. Recommend yes;
+confirm early in the session.
+
+### Shape of the work — two phases
+
+**Phase 1 — extract the reusable bridge into a shared module.**
+
+The flow-enricher implementation was a one-off; for 12+ consumers we need
+a library. Options:
+
+- **A.** Add to `core/daemon-common` — already shared by all 12 daemons.
+  Cleanest for daemon-boot-* consumers. Minion would need its own copy
+  unless we also link daemon-common into daemon-boot-minion (worth
+  evaluating).
+- **B.** New module `core/horizon-metric-bridge` — explicit dependency,
+  more discoverable, no risk of polluting daemon-common's surface.
+  Consumers opt in via a POM dep.
+
+Recommend **B** — explicit is better than implicit, and it keeps
+daemon-common focused on pure Spring plumbing.
+
+The module should expose:
+
+```java
+// Implements Micrometer's MeterBinder + Dropwizard's MetricRegistryListener
+public final class HorizonMetricsBridge implements MeterBinder, MetricRegistryListener {
+    private final MetricRegistry dropwizardRegistry;
+    // ... register existing meters up-front, plus listen for new ones
+    //     added at runtime (horizon creates meters lazily in a lot of places)
+}
+
+// Spring Boot auto-configuration: if a bean of MetricRegistry exists,
+// auto-register the bridge. Otherwise no-op.
+@AutoConfiguration
+public class HorizonMetricsBridgeAutoConfiguration { ... }
+```
+
+The auto-config is what makes consumer adoption zero-work — add the
+dep, done.
+
+**Phase 2 — wire each daemon.**
+
+For each of the 12 (or 13) daemons:
+
+1. Add the new module as a POM dep in `core/daemon-boot-<name>/pom.xml`.
+2. Start the daemon in the running alpha3 stack, curl
+   `/actuator/prometheus`, count meters before vs. after.
+3. Confirm `org_opennms_*` or similar horizon-namespace meters appear.
+
+Per-daemon commits are ~3–5 POM lines each. A single "wire all daemons"
+commit is fine since the change is identical across 12 files.
+
+### docker-compose.yml — probably no change
+
+Each daemon's actuator port is already exposed to the compose network.
+bsmd is the only one with a host-mapped actuator (`8180→8080`); the
+rest are internal-only. That's fine — consumers inspecting metrics use
+`docker compose exec <daemon> curl localhost:8080/actuator/prometheus`.
+
+If you want host-mapped actuators for every daemon during development
+(convenient for scraping from a host-side Prometheus), that's a
+separate cosmetic PR — not part of this track.
+
+## Validation
+
+For each daemon, run the stack on a laptop (alpha3 images, dev JVM
+override, since the daemon count is now 12+ and RSS matters):
+
+```bash
+cd ~/delta-v-smoke
+# assume alpha3 stack already running per the README recipe
+
+for d in alarmd bsmd collectd discovery enlinkd eventtranslator \
+         perspectivepollerd pollerd provisiond syslogd telemetryd trapd; do
+  count=$(docker compose exec -T "delta-v-$d" \
+          curl -sf http://localhost:8080/actuator/prometheus 2>/dev/null \
+          | grep -cE '^org_opennms|^opennms_' || echo 0)
+  printf "%-22s %d horizon meters\n" "$d" "$count"
+done
+```
+
+Expected: non-zero for every daemon, rising into the hundreds for the
+big ones (collectd, provisiond, pollerd).
+
+Before shipping beta1, eyeball at least one daemon's metrics in detail
+— pick collectd — and confirm meaningful families are present (e.g.
+`org_opennms_netmgt_collectd_*` counters for scheduling, persist rate,
+datacollection group timings).
+
+## Out of scope for this session
+
+- **No new domain metrics** (that's Scope B / beta2). We only bridge
+  the metrics horizon already exposes via Dropwizard.
+- **No Grafana dashboards** built on these metrics. Consumers get that
+  in v1.3 with the K8s operator / HPA work.
+- **No metric renaming** — preserve the `org.opennms.*` namespace as it
+  is in horizon's jars. Consistency with upstream matters for anyone
+  cross-referencing.
+- **No JDK 25 upgrade** — already queued for post-v1.3 per
+  `project_jdk_25_upgrade`.
+- **Pollerd TS publishing** — belongs in beta2 alongside Scope B, not
+  here.
+
+## Release-cut checklist (end of session)
+
+- [ ] `core/horizon-metric-bridge` module landed (new) — OR in daemon-common
+      if that path wins (document why either way)
+- [ ] All 12 daemon-boot-* modules take the dep; optionally minion-boot
+- [ ] CI green (build + CodeQL)
+- [ ] Merge fix PR into develop
+- [ ] Bump `1.2.0-alpha3` → `1.2.0-beta1` in a second chore PR
+- [ ] Merge the bump
+- [ ] Tag `v1.2.0-beta1` at the bump merge commit
+- [ ] Image-publish workflow succeeds (26 images at `:1.2.0-beta1`)
+- [ ] Clean-VM smoke test passes, then re-run the metric-count validation
+      against beta1 images. Confirm every daemon emits > 0 horizon meters
+- [ ] Update release plan doc with beta1 cut date (same pattern as PR #214)
+
+**Tag carefully** — remember the 2026-04-23 ghost-run incident where a
+tag pushed at the wrong commit then deleted still fired a delayed
+workflow that overwrote v1.1.1 GA images. Always push the tag at the
+POST-bump merge commit; if anything goes sideways, `gh run cancel <id>`
+immediately rather than trusting `git push --delete` to cancel the
+queued workflow trigger.
+
+## References
+
+- **App-obs design:** `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
+- **Release plan (refreshed 2026-04-23):** `docs/plans/2026-04-23-v1.2.0-release-plan.md`
+- **Reference implementation (flow-enricher):** PR #161. Look at:
+  - `core/flow-enricher/src/main/java/.../metrics/` — the bridge classes
+  - `core/flow-enricher/src/main/resources/META-INF/spring.factories` or
+    `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` — auto-config wiring
+- **Current horizon BOM:** `opennms:pom:1.0.13` (in root pom.xml)
+- **Current develop HEAD:** `91c0d8716ae` (plan doc refresh, 2026-04-23)
+- **Last published images:** `ghcr.io/pbrane/*:1.2.0-alpha3` + `:latest`
+- **Smoke-test recipe (reference):**
+  ```bash
+  GIT_REF=v1.2.0-alpha3
+  IMG_TAG=1.2.0-alpha3
+  BASE=https://raw.githubusercontent.com/pbrane/delta-v/$GIT_REF/opennms-container/delta-v
+  curl -OL $BASE/docker-compose.yml
+  curl -OL $BASE/docker-compose.dev.yml
+  cat > .env <<EOF
+  IMAGE_PREFIX=ghcr.io/pbrane
+  VERSION=$IMG_TAG
+  EOF
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile metrics up -d
+  ```
+
+## After beta1 lands
+
+Next track is **beta2** — app-obs Scope B (per-daemon domain metrics)
+bundled with Pollerd + PerspectivePollerd response-time publishing to
+`deltav-timeseries`. Both touch the same two daemons; one coordinated
+edit pass, one alpha cut. Estimate ~2–3 weeks.
+
+Then **rc1/rc2** are the Minion gRPC migration — the largest single
+track in v1.2.0, bundled with the ActiveMQ/ServiceMix purge, sink topic
+rename, and "Default" location retirement.


### PR DESCRIPTION
Docs-only. Captures end-of-2026-04-23 state and scopes the app-obs Scope A track for the next session (beta1). Sibling of the alpha1 session prompt already in docs/superpowers/next-session-prompts/.