### PR TITLE
feat(v1.2.0-beta1): horizon-metric-bridge — surface Dropwizard meters at /actuator/prometheus

### DIFF
--- a/core/daemon-boot-alarmd/src/main/resources/application.yml
+++ b/core/daemon-boot-alarmd/src/main/resources/application.yml
@@ -25,7 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       show-details: always

--- a/core/daemon-boot-bsmd/src/main/resources/application.yml
+++ b/core/daemon-boot-bsmd/src/main/resources/application.yml
@@ -25,7 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       show-details: always

--- a/core/daemon-boot-discovery/src/main/resources/application.yml
+++ b/core/daemon-boot-discovery/src/main/resources/application.yml
@@ -15,7 +15,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       show-details: always

--- a/core/daemon-boot-enlinkd/src/main/resources/application.yml
+++ b/core/daemon-boot-enlinkd/src/main/resources/application.yml
@@ -34,3 +34,9 @@ opennms:
 
 server:
   port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus

--- a/core/daemon-boot-eventtranslator/src/main/resources/application.yml
+++ b/core/daemon-boot-eventtranslator/src/main/resources/application.yml
@@ -19,7 +19,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       show-details: always

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcServerConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcServerConfiguration.java
@@ -19,6 +19,7 @@ package org.deltav.minion.common;
 import java.util.Properties;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.core.ipc.rpc.kafka.KafkaRpcServerManager;
 import org.opennms.core.rpc.api.RpcModule;
 import org.opennms.core.tracing.api.TracerRegistry;
@@ -48,18 +49,28 @@ public class KafkaRpcServerConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaRpcServerConfiguration.class);
 
     @Bean
+    public MetricRegistry minionRpcServerMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge minionRpcServerMetricsBridge(MetricRegistry minionRpcServerMetricRegistry) {
+        return new HorizonMetricsBridge(minionRpcServerMetricRegistry, "opennms");
+    }
+
+    @Bean
     public KafkaRpcServerManager kafkaRpcServerManager(
             @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
             MinionIdentity minionIdentity,
-            TracerRegistry tracerRegistry) {
+            TracerRegistry tracerRegistry,
+            MetricRegistry minionRpcServerMetricRegistry) {
 
         Properties kafkaProperties = new Properties();
         kafkaProperties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 
         SpringKafkaConfigProvider configProvider = new SpringKafkaConfigProvider(kafkaProperties);
-        MetricRegistry metricRegistry = new MetricRegistry();
 
-        return new KafkaRpcServerManager(configProvider, minionIdentity, tracerRegistry, metricRegistry);
+        return new KafkaRpcServerManager(configProvider, minionIdentity, tracerRegistry, minionRpcServerMetricRegistry);
     }
 
     @Bean

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaSinkClientConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaSinkClientConfiguration.java
@@ -19,6 +19,7 @@ package org.deltav.minion.common;
 import java.util.Properties;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.core.ipc.sink.kafka.client.KafkaRemoteMessageDispatcherFactory;
 import org.opennms.core.tracing.api.TracerRegistry;
@@ -52,10 +53,21 @@ public class KafkaSinkClientConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSinkClientConfiguration.class);
 
     @Bean
+    public MetricRegistry minionSinkMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge minionSinkMetricsBridge(MetricRegistry minionSinkMetricRegistry) {
+        return new HorizonMetricsBridge(minionSinkMetricRegistry, "opennms");
+    }
+
+    @Bean
     public KafkaRemoteMessageDispatcherFactory kafkaRemoteMessageDispatcherFactory(
             @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
             MinionIdentity minionIdentity,
-            TracerRegistry tracerRegistry) {
+            TracerRegistry tracerRegistry,
+            MetricRegistry minionSinkMetricRegistry) {
 
         Properties kafkaProps = new Properties();
         kafkaProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -65,7 +77,7 @@ public class KafkaSinkClientConfiguration {
         factory.setBundleContext(null);
         factory.setTracerRegistry(tracerRegistry);
         factory.setIdentity(minionIdentity);
-        factory.setMetrics(new MetricRegistry());
+        factory.setMetrics(minionSinkMetricRegistry);
 
         return factory;
     }

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.core.ipc.twin.api.TwinSubscriber;
 import org.opennms.core.ipc.twin.kafka.subscriber.KafkaTwinSubscriber;
 import org.opennms.core.tracing.api.TracerRegistry;
@@ -51,10 +52,21 @@ public class KafkaTwinSubscriberConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaTwinSubscriberConfiguration.class);
 
     @Bean
+    public MetricRegistry minionTwinSubscriberMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge minionTwinSubscriberMetricsBridge(MetricRegistry minionTwinSubscriberMetricRegistry) {
+        return new HorizonMetricsBridge(minionTwinSubscriberMetricRegistry, "opennms");
+    }
+
+    @Bean
     public KafkaTwinSubscriber kafkaTwinSubscriber(
             @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
             MinionIdentity minionIdentity,
-            TracerRegistry tracerRegistry) {
+            TracerRegistry tracerRegistry,
+            MetricRegistry minionTwinSubscriberMetricRegistry) {
 
         Properties kafkaProps = new Properties();
         kafkaProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -63,7 +75,7 @@ public class KafkaTwinSubscriberConfiguration {
                 minionIdentity,
                 new SpringKafkaConfigProvider(kafkaProps),
                 tracerRegistry,
-                new MetricRegistry());
+                minionTwinSubscriberMetricRegistry);
     }
 
     /**

--- a/core/daemon-boot-minion/src/main/resources/application.yml
+++ b/core/daemon-boot-minion/src/main/resources/application.yml
@@ -32,7 +32,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,env,detectors,monitors,collectors
+        include: health,info,env,detectors,monitors,collectors,prometheus
   endpoint:
     health:
       show-details: always

--- a/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
@@ -31,3 +31,9 @@ opennms:
     kafka:
       enabled: ${OPENNMS_RPC_KAFKA_ENABLED:true}
       bootstrap-servers: ${OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus

--- a/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdPassiveStatusConfiguration.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 
 import com.codahale.metrics.MetricRegistry;
 
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.core.ipc.twin.common.LocalTwinSubscriberImpl;
 import org.opennms.core.ipc.twin.kafka.publisher.KafkaTwinPublisher;
 import org.opennms.core.tracing.api.TracerRegistry;
@@ -65,11 +66,22 @@ public class PollerdPassiveStatusConfiguration {
         return new LocalTwinSubscriberImpl(twinIdentity);
     }
 
+    @Bean
+    public MetricRegistry pollerdTwinMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge pollerdTwinMetricsBridge(MetricRegistry pollerdTwinMetricRegistry) {
+        return new HorizonMetricsBridge(pollerdTwinMetricRegistry, "opennms");
+    }
+
     @Bean(initMethod = "init", destroyMethod = "close")
     public KafkaTwinPublisher kafkaTwinPublisher(
             LocalTwinSubscriberImpl localTwinSubscriber,
-            TracerRegistry tracerRegistry) {
-        return new KafkaTwinPublisher(localTwinSubscriber, tracerRegistry, new MetricRegistry());
+            TracerRegistry tracerRegistry,
+            MetricRegistry pollerdTwinMetricRegistry) {
+        return new KafkaTwinPublisher(localTwinSubscriber, tracerRegistry, pollerdTwinMetricRegistry);
     }
 
     @Bean(initMethod = "init", destroyMethod = "close")

--- a/core/daemon-boot-pollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-pollerd/src/main/resources/application.yml
@@ -31,3 +31,9 @@ opennms:
     kafka:
       enabled: ${OPENNMS_RPC_KAFKA_ENABLED:true}
       bootstrap-servers: ${OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus

--- a/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/SyslogdConfiguration.java
+++ b/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/SyslogdConfiguration.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import org.deltav.core.daemon.common.JdbcDistPollerDao;
 import org.deltav.core.daemon.common.JdbcInterfaceToNodeCache;
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.netmgt.config.SyslogdConfig;
 import org.opennms.netmgt.config.syslogd.SyslogdConfigurationGroup;
 import org.opennms.netmgt.config.syslogd.HideMatch;
@@ -116,6 +117,11 @@ public class SyslogdConfiguration {
     @Bean
     public MetricRegistry syslogdMetricRegistry() {
         return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge syslogdMetricsBridge(MetricRegistry syslogdMetricRegistry) {
+        return new HorizonMetricsBridge(syslogdMetricRegistry, "opennms");
     }
 
     @Bean

--- a/core/daemon-boot-syslogd/src/main/resources/application.yml
+++ b/core/daemon-boot-syslogd/src/main/resources/application.yml
@@ -15,7 +15,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       show-details: always

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydDaemonConfiguration.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydDaemonConfiguration.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import com.codahale.metrics.MetricRegistry;
 
 import org.deltav.core.daemon.common.NoOpTracerRegistry;
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.core.ipc.sink.api.MessageConsumerManager;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
@@ -107,6 +108,11 @@ public class TelemetrydDaemonConfiguration {
     @Bean
     public MetricRegistry metricRegistry() {
         return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge telemetrydMetricsBridge(MetricRegistry metricRegistry) {
+        return new HorizonMetricsBridge(metricRegistry, "opennms");
     }
 
     /**

--- a/core/daemon-boot-telemetryd/src/main/resources/application.yml
+++ b/core/daemon-boot-telemetryd/src/main/resources/application.yml
@@ -27,3 +27,9 @@ opennms:
     ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-telemetryd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -64,6 +64,16 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Micrometer Prometheus registry — required for Spring Boot Actuator
+             to register the /actuator/prometheus endpoint at all. Without it,
+             enabling 'prometheus' in management.endpoints.web.exposure.include
+             silently 404s. Pulled into daemon-common so every Spring Boot
+             daemon gets the endpoint by default. -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <!-- opennms-config-model — provides eventconf JAXB classes (Event, Events,
              EventMatchers, Partition) used by DaemonEventConfDao for event matching.
              No opennms-model dependency — safe for Spring Boot daemon classpath. -->

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -55,6 +55,15 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
 
+        <!-- Horizon Dropwizard → Micrometer bridge.
+             Surfaces kafkaRpcMetricRegistry meters at /actuator/prometheus
+             for every daemon that imports KafkaRpcClientConfiguration. -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.deltav.horizon-metric-bridge</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- opennms-config-model — provides eventconf JAXB classes (Event, Events,
              EventMatchers, Partition) used by DaemonEventConfDao for event matching.
              No opennms-model dependency — safe for Spring Boot daemon classpath. -->

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/KafkaRpcClientConfiguration.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/KafkaRpcClientConfiguration.java
@@ -18,6 +18,7 @@ package org.deltav.core.daemon.common;
 
 import com.codahale.metrics.MetricRegistry;
 
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.core.ipc.rpc.kafka.KafkaRpcClientFactory;
 import org.opennms.core.rpc.utils.RpcTargetHelper;
 import org.opennms.core.tracing.api.TracerRegistry;
@@ -60,6 +61,11 @@ public class KafkaRpcClientConfiguration {
     @Bean
     public MetricRegistry kafkaRpcMetricRegistry() {
         return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge kafkaRpcMetricsBridge(MetricRegistry kafkaRpcMetricRegistry) {
+        return new HorizonMetricsBridge(kafkaRpcMetricRegistry, "opennms");
     }
 
     @Bean

--- a/core/horizon-metric-bridge/pom.xml
+++ b/core/horizon-metric-bridge/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>1.2.0-alpha3</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>org.deltav.horizon-metric-bridge</artifactId>
+    <name>Delta-V :: Core :: Horizon Metric Bridge</name>
+    <description>Mirrors Dropwizard MetricRegistry meters into Spring Boot's Micrometer registry so that horizon-emitted metrics become scrapable at /actuator/prometheus.</description>
+
+    <dependencies>
+        <!-- Compile: the bridge implements both APIs -->
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/horizon-metric-bridge/src/main/java/org/deltav/horizon/metrics/HorizonMetricsBridge.java
+++ b/core/horizon-metric-bridge/src/main/java/org/deltav/horizon/metrics/HorizonMetricsBridge.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.horizon.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricRegistryListener;
+import com.codahale.metrics.Timer;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * Mirrors every metric in a Dropwizard {@link MetricRegistry} into Spring
+ * Boot's Micrometer {@link MeterRegistry} so that metrics registered via the
+ * Dropwizard API become scrapable at {@code /actuator/prometheus}.
+ *
+ * <p>Horizon code (alarm processing, RPC clients, provisioning, collection,
+ * polling, telemetry parsers, etc.) uses Dropwizard's {@link MetricRegistry}
+ * API directly. Micrometer's built-in {@code DropwizardMeterRegistry} does
+ * <em>not</em> pick those up — it only tracks meters created through the
+ * Micrometer API, using Dropwizard as backing storage. Dropwizard's
+ * {@link MetricRegistry#addListener(MetricRegistryListener)} documents that
+ * "the listener will be notified of all existing metrics when it first
+ * registers," so we attach a listener at {@link #bindTo(MeterRegistry)} time
+ * and create Micrometer mirrors (read-through wrappers) for every existing
+ * and future Dropwizard metric.
+ *
+ * <p>This is implemented as a {@link MeterBinder} so Spring Boot's
+ * {@code MeterRegistryPostProcessor} calls {@link #bindTo(MeterRegistry)}
+ * with the composite {@code MeterRegistry} after all beans (including those
+ * that populate the Dropwizard registry) have been constructed. The
+ * fire-on-attach behavior of {@link MetricRegistry#addListener} then
+ * surfaces every pre-existing metric immediately. Late-arriving meters
+ * (horizon registers many lazily) are surfaced via the same listener.
+ *
+ * <p>Naming: each Dropwizard metric name gets the configured prefix
+ * prepended (e.g. {@code "opennms"} → {@code
+ * opennms.org.opennms.netmgt.collectd.persist}). Micrometer's Prometheus
+ * naming convention flattens dots to underscores and applies snake_case,
+ * producing metric names such as
+ * {@code opennms_org_opennms_netmgt_collectd_persist} at the Prometheus
+ * endpoint.
+ *
+ * <p>Histogram percentile data is intentionally not exposed — only the
+ * count is mirrored as a {@link FunctionCounter}. If a future caller
+ * registers histograms whose distribution is operationally meaningful,
+ * extend {@link MirroringListener#onHistogramAdded} to build a Micrometer
+ * {@code DistributionSummary} via {@code Histogram.getSnapshot()}.
+ *
+ * <p>Bind-once contract: a single bridge instance must not be bound to
+ * multiple {@link MeterRegistry}s. Each Dropwizard registry that needs
+ * surfacing should own one bridge bean.
+ */
+public final class HorizonMetricsBridge implements MeterBinder {
+
+    private final MetricRegistry dropwizardRegistry;
+    private final String prefix;
+
+    /**
+     * @param dropwizardRegistry the Dropwizard registry whose meters should be
+     *     mirrored — must be the same instance horizon code receives
+     * @param prefix dot-separated prefix applied to every mirrored meter name;
+     *     becomes the leading underscore-segment in Prometheus output
+     */
+    public HorizonMetricsBridge(MetricRegistry dropwizardRegistry, String prefix) {
+        this.dropwizardRegistry = dropwizardRegistry;
+        this.prefix = prefix;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        dropwizardRegistry.addListener(new MirroringListener(registry, prefix));
+    }
+
+    private static final class MirroringListener implements MetricRegistryListener {
+
+        private final MeterRegistry registry;
+        private final String prefix;
+
+        MirroringListener(MeterRegistry registry, String prefix) {
+            this.registry = registry;
+            this.prefix = prefix;
+        }
+
+        @Override
+        public void onGaugeAdded(String name, com.codahale.metrics.Gauge<?> gauge) {
+            Gauge.builder(prefixed(name), gauge, MirroringListener::gaugeValue)
+                    .register(registry);
+        }
+
+        @Override
+        public void onCounterAdded(String name, Counter counter) {
+            FunctionCounter.builder(prefixed(name), counter, Counter::getCount)
+                    .register(registry);
+        }
+
+        @Override
+        public void onHistogramAdded(String name, Histogram histogram) {
+            FunctionCounter.builder(prefixed(name) + ".count", histogram, Histogram::getCount)
+                    .register(registry);
+        }
+
+        @Override
+        public void onMeterAdded(String name, com.codahale.metrics.Meter meter) {
+            FunctionCounter.builder(prefixed(name), meter, com.codahale.metrics.Meter::getCount)
+                    .register(registry);
+        }
+
+        @Override
+        public void onTimerAdded(String name, Timer timer) {
+            FunctionTimer.builder(prefixed(name), timer,
+                            Timer::getCount,
+                            t -> t.getSnapshot().getMean(),
+                            TimeUnit.NANOSECONDS)
+                    .register(registry);
+        }
+
+        @Override public void onGaugeRemoved(String name) {}
+        @Override public void onCounterRemoved(String name) {}
+        @Override public void onHistogramRemoved(String name) {}
+        @Override public void onMeterRemoved(String name) {}
+        @Override public void onTimerRemoved(String name) {}
+
+        private String prefixed(String dropwizardName) {
+            return prefix + "." + dropwizardName;
+        }
+
+        private static double gaugeValue(com.codahale.metrics.Gauge<?> gauge) {
+            Object value = gauge.getValue();
+            if (value instanceof Number number) {
+                return number.doubleValue();
+            }
+            return Double.NaN;
+        }
+    }
+}

--- a/core/horizon-metric-bridge/src/test/java/org/deltav/horizon/metrics/HorizonMetricsBridgeTest.java
+++ b/core/horizon-metric-bridge/src/test/java/org/deltav/horizon/metrics/HorizonMetricsBridgeTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.horizon.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.jupiter.api.Test;
+
+class HorizonMetricsBridgeTest {
+
+    private static final String PREFIX = "opennms";
+
+    @Test
+    void mirrorsMetersThatExistedBeforeBind() {
+        MetricRegistry dropwizard = new MetricRegistry();
+        Counter sourceCounter = dropwizard.counter("alarmd.events.received");
+        sourceCounter.inc(7);
+
+        SimpleMeterRegistry micrometer = new SimpleMeterRegistry();
+        new HorizonMetricsBridge(dropwizard, PREFIX).bindTo(micrometer);
+
+        assertThat(micrometer.find("opennms.alarmd.events.received").functionCounter())
+                .isNotNull()
+                .extracting(fc -> fc.count())
+                .isEqualTo(7.0);
+    }
+
+    @Test
+    void mirrorsMetersAddedAfterBind() {
+        MetricRegistry dropwizard = new MetricRegistry();
+        SimpleMeterRegistry micrometer = new SimpleMeterRegistry();
+        new HorizonMetricsBridge(dropwizard, PREFIX).bindTo(micrometer);
+
+        Counter lateCounter = dropwizard.counter("provisiond.nodes.scanned");
+        lateCounter.inc(42);
+
+        assertThat(micrometer.find("opennms.provisiond.nodes.scanned").functionCounter())
+                .isNotNull()
+                .extracting(fc -> fc.count())
+                .isEqualTo(42.0);
+    }
+
+    @Test
+    void counterMirrorIsReadThrough() {
+        MetricRegistry dropwizard = new MetricRegistry();
+        Counter source = dropwizard.counter("collectd.persists");
+        SimpleMeterRegistry micrometer = new SimpleMeterRegistry();
+        new HorizonMetricsBridge(dropwizard, PREFIX).bindTo(micrometer);
+
+        source.inc(3);
+        assertThat(micrometer.find("opennms.collectd.persists").functionCounter().count()).isEqualTo(3.0);
+
+        source.inc(5);
+        assertThat(micrometer.find("opennms.collectd.persists").functionCounter().count()).isEqualTo(8.0);
+    }
+
+    @Test
+    void mirrorsAllFiveDropwizardMeterTypes() {
+        MetricRegistry dropwizard = new MetricRegistry();
+        dropwizard.gauge("kafka.lag", () -> () -> 12L);
+        dropwizard.counter("rpc.requests");
+        dropwizard.histogram("rpc.payloadBytes");
+        dropwizard.meter("rpc.errors");
+        dropwizard.timer("rpc.latency");
+
+        SimpleMeterRegistry micrometer = new SimpleMeterRegistry();
+        new HorizonMetricsBridge(dropwizard, PREFIX).bindTo(micrometer);
+
+        assertThat(micrometer.find("opennms.kafka.lag").gauge()).isNotNull();
+        assertThat(micrometer.find("opennms.rpc.requests").functionCounter()).isNotNull();
+        assertThat(micrometer.find("opennms.rpc.payloadBytes.count").functionCounter()).isNotNull();
+        assertThat(micrometer.find("opennms.rpc.errors").functionCounter()).isNotNull();
+        assertThat(micrometer.find("opennms.rpc.latency").functionTimer()).isNotNull();
+    }
+
+    @Test
+    void timerMirrorReportsCount() {
+        MetricRegistry dropwizard = new MetricRegistry();
+        Timer timer = dropwizard.timer("provisiond.scanDuration");
+        SimpleMeterRegistry micrometer = new SimpleMeterRegistry();
+        new HorizonMetricsBridge(dropwizard, PREFIX).bindTo(micrometer);
+
+        timer.update(java.time.Duration.ofMillis(50));
+        timer.update(java.time.Duration.ofMillis(75));
+
+        assertThat(micrometer.find("opennms.provisiond.scanDuration").functionTimer().count()).isEqualTo(2L);
+    }
+
+    @Test
+    void appliesPrefixToEveryMeter() {
+        MetricRegistry dropwizard = new MetricRegistry();
+        dropwizard.counter("a");
+        dropwizard.counter("b.c");
+
+        SimpleMeterRegistry micrometer = new SimpleMeterRegistry();
+        new HorizonMetricsBridge(dropwizard, "minion").bindTo(micrometer);
+
+        assertThat(micrometer.find("minion.a").functionCounter()).isNotNull();
+        assertThat(micrometer.find("minion.b.c").functionCounter()).isNotNull();
+        assertThat(micrometer.find("a").functionCounter()).isNull();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <module>core/dao-jpa-support</module>
     <module>core/deltav-kafka-contracts</module>
     <module>core/event-forwarder-kafka</module>
+    <module>core/horizon-metric-bridge</module>
     <module>core/opennms-model-jakarta</module>
 
     <!-- Daemon boots (Spring Boot fat JARs) -->


### PR DESCRIPTION
## Summary

Ships v1.2.0-beta1's app-observability Scope A per the [next-session prompt](docs/superpowers/next-session-prompts/2026-04-24-v1.2.0-beta1-horizon-metric-bridge.md): a reusable `HorizonMetricsBridge` that mirrors Dropwizard `MetricRegistry` meters into Spring Boot's Micrometer registry, plus the per-daemon wiring + actuator-exposure fixes needed to make those meters scrapable at `/actuator/prometheus`.

## What's in the bridge module

`core/horizon-metric-bridge/` — a focused, reusable module that exposes `HorizonMetricsBridge`: a `MeterBinder` + nested `MetricRegistryListener` that mirrors all five Dropwizard meter types (Gauge, Counter, Histogram, Meter, Timer) using `FunctionCounter`/`FunctionTimer` for read-through values. Lifts the recipe from PR #161 (flow-enricher) into a standalone module so all consumers can pick it up via a single dep.

6 unit tests cover: existing meters, late-arriving meters (lazy registration), read-through value, all five meter types, timer count, prefix isolation.

## Per-daemon wiring (Option 1 scope)

Audited each daemon's `MetricRegistry` source before wiring. Three patterns existed:

| Group | Daemons | Action |
|---|---|---|
| **(A)** Already exposes a `MetricRegistry` @Bean | syslogd, telemetryd | Add bridge bean alongside |
| **(B)** Pulls one in via `daemon-common`'s `KafkaRpcClientConfiguration` | discovery, pollerd, collectd, enlinkd, perspectivepollerd, provisiond | Bridge added to `daemon-common` — cascades to all 6 transitively |
| **(C)** Inline `new MetricRegistry()` (invisible to bridge) | minion-common (3 sites), pollerd-passive | Promoted to named @Beans + added bridges |
| **(D)** No registry at all | alarmd, bsmd, eventtranslator, trapd | **Out of scope for beta1** — needs registry-wiring pass. Documented in commit + memory. |

## Latent bug fixed: `/actuator/prometheus` exposure

During validation we discovered that `alpha3` only exposed `/actuator/prometheus` on 3/12 daemons. The bridge would have silently emitted nothing on the rest because:
1. Their `application.yml` didn't include `prometheus` in `management.endpoints.web.exposure.include`
2. `daemon-common` didn't pull in `micrometer-registry-prometheus` — without that artifact, the actuator endpoint silently 404s even when listed in exposure config

Both are fixed in this PR. After fixes, every daemon serves `/actuator/prometheus` with 100+ Spring/JVM meters, and the daemons with bridges add horizon-emitted meters on top.

## Validation result (local stack, alpha3 base + this PR)

```
alarmd                    0 horizon meters / 120 total      (group D — future)
bsmd                      0 horizon meters / 117 total      (group D — future)
collectd                 10 horizon meters / 133 total
discovery                 5 horizon meters / 128 total
enlinkd                  10 horizon meters / 130 total
eventtranslator           0 horizon meters / 117 total      (group D — future)
perspectivepollerd        0 horizon meters / 110 total      (bridge wired, idle stack — no RPC traffic yet)
pollerd                  12 horizon meters / 122 total
provisiond               30 horizon meters / 305 total
syslogd                   8 horizon meters / 138 total
telemetryd                1 horizon meters / 118 total
trapd                     0 horizon meters / 136 total      (group D — future)
minion                   29 horizon meters / 123 total
```

8 daemons + minion emit horizon meters. Eyeballed collectd: real domain signal (`opennms_l8opensim_lab_SNMP_*` RPC counters, `opennms_ring_buffer_*`, `opennms_samples_write_ts_seconds_*`).

## Naming convention

All bridged meters use prefix `opennms` → results in `opennms_*` Prometheus output. Preserves the upstream `org.opennms.*` namespace literally so anyone cross-referencing horizon source/issues sees identical names. Native Micrometer meters added in delta-v code (Scope B / beta2) should use `deltav_*` to assert provenance — the two namespaces will coexist cleanly.

## Known scope limits — documented for follow-up

1. **Group D daemons** (alarmd, bsmd, eventtranslator, trapd) emit zero horizon meters because no `MetricRegistry` is wired into their horizon classes today. Verified via JAR inspection that horizon classes inside them accept `(String, MetricRegistry)` constructors but receive nothing. Wiring requires identifying which horizon classes should receive a registry per daemon — a focused per-daemon pass best done alongside beta2's domain-metric retrofit.
2. **Remote/NAT'd Minions** can't be scraped via standard Prometheus pull because Minions only originate outbound connections (Kafka). Bridge-on-Minion is correct for local compose; production multi-Minion observability needs RPC-based federation over Kafka. Tracked as a v1.3 design item, coupled to the K8s operator work.

## Test plan

- [x] Unit tests: `./mvnw -pl core/horizon-metric-bridge test` — 6/6 pass
- [x] Full reactor build: `./mvnw clean install -DskipTests` — 26/26 modules green
- [x] Local stack validation: 13 daemons reach `(healthy)`; 9 of 13 emit horizon meters as expected; 4 are documented zero-emitters
- [ ] Reviewer: confirm Option 1 scope split is acceptable (group D as future work, not a beta1 blocker)
- [ ] Reviewer: confirm `opennms_*` / `deltav_*` namespace plan is acceptable for the future Scope B work

## Refs

- Reference impl: PR #161 (flow-enricher Dropwizard → Micrometer bridge)
- Design doc: `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
- Release plan: `docs/plans/2026-04-23-v1.2.0-release-plan.md`
- Next-session prompt: `docs/superpowers/next-session-prompts/2026-04-24-v1.2.0-beta1-horizon-metric-bridge.md`