### PR TITLE
docs(v1.2.0): next-session prompt for beta2 — domain metrics + Pollerd TS

### DIFF
--- a/docs/superpowers/next-session-prompts/2026-05-08-v1.2.0-beta2-domain-metrics-pollerd-ts.md
+++ b/docs/superpowers/next-session-prompts/2026-05-08-v1.2.0-beta2-domain-metrics-pollerd-ts.md
@@ -1,0 +1,296 @@
+# Next session: v1.2.0-beta2 — domain-metric retrofit + Pollerd response-time publishing
+
+**Background docs:**
+- App-obs design: `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
+- Pollerd TS design: `docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md`
+- Release plan: `docs/plans/2026-04-23-v1.2.0-release-plan.md` (this is the `v1.2.0-beta2` deliverable per the refreshed cadence)
+- Reference TS publisher impl: `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java` + `TimeseriesKafkaPublisherConfiguration.java`
+- Reference horizon-metric bridge: `core/horizon-metric-bridge/` (PR #216, beta1)
+
+**Background memory:**
+- `project_v1_2_app_observability` — priority + why
+- `project_v1_2_pollerd_timeseries` — Pollerd/PerspectivePollerd TS design
+- `feedback_meter_naming_horizon_vs_deltav` — `opennms_*` for bridged, `deltav_*` for native (set in beta1)
+- `project_kafka_timeseries_pipeline` — overall pipeline design (Collectd → prometheus-writer → VictoriaMetrics)
+- `project_collectd_publisher_inert_investigation` — Collectd publisher's gotchas, worth re-reading before mirroring the pattern
+- `feedback_spring_boot_repackage_needs_clean` — clean install needed when shared deps change (cost beta1 ~30 min)
+- `feedback_delta_v_full_reactor_verify` — full reactor verify before pushing
+- `feedback_delayed_tag_workflow_trigger` — ghost-run gotcha
+- `feedback_user_confusion_is_a_signal` — when in doubt about a design, re-verify against actual code, don't reassure from memory
+
+**Branch:** `feat/v1.2.0-beta2-domain-metrics-pollerd-ts` off develop
+
+**Current develop HEAD at prompt authorship (2026-04-24):** `ce85619bc35` — `docs(v1.2.0): record beta1 cut + Option 1 scope divergence (#218)`
+
+---
+
+## Why this track next
+
+v1.2.0-beta1 shipped (PRs #216, #217, tag `v1.2.0-beta1`, 2026-04-24).
+The reusable `core/horizon-metric-bridge` module surfaces `opennms_*`
+horizon meters at `/actuator/prometheus` across 9 daemons + Minion.
+**Two known gaps were explicitly deferred to beta2:**
+
+1. **Group D daemons** (alarmd, bsmd, eventtranslator, trapd) emit zero
+   horizon meters because no `MetricRegistry` is wired into their horizon
+   classes today. Verified during beta1 audit: horizon classes inside
+   them accept `(String, MetricRegistry)` constructors but receive
+   nothing.
+2. **No native domain metrics anywhere.** The bridge surfaces what
+   horizon already emits (RPC counters, ring-buffer state, etc.) but
+   the operator-useful business signals — polls dispatched, alarms
+   created, scans completed, traps received per second, etc. — aren't
+   instrumented. The future K8s operator / HPA work in v1.3 needs these
+   to make scaling decisions.
+
+Bundled with **Pollerd + PerspectivePollerd TS publishing** because both
+touch the same two daemons (one edit pass, coordinated metric naming),
+and TS publishing is itself a form of domain-metric instrumentation.
+
+## One-paragraph problem statement
+
+After beta1 an operator looking at `/actuator/prometheus` sees `opennms_*`
+meters from bridged horizon code (RPC counters, ring buffers) but no
+first-class delta-v signals. They can chart RPC roundtrip counts but
+not "how many polls per second did Pollerd dispatch", "how many alarms
+were created in the last hour", or "what's the p99 trap-to-event
+processing latency". This session adds those signals across all 12
+daemons + Minion via Micrometer (`deltav_*` prefix), wires the 4 group
+D daemons to also bridge their existing horizon meters (closes the
+beta1 gap), and ships Pollerd/PerspectivePollerd response-time samples
+to the `deltav-timeseries` Kafka topic so they appear in
+VictoriaMetrics alongside Collectd samples.
+
+## Scope — three phases
+
+### Phase 1 — Group D registry wiring (closes beta1 gap)
+
+For each of alarmd, bsmd, eventtranslator, trapd:
+
+1. Audit which horizon classes the daemon constructs as @Beans that
+   accept `(String, MetricRegistry)` or similar registry constructors.
+   Use `javap -p` on the relevant horizon JARs in `~/.m2/repository/org/opennms/`
+   to find the signatures (the technique that worked for the beta1
+   audit — see `feedback_jakarta_port_audit_bytecode`).
+2. Add a `@Bean MetricRegistry <daemon>MetricRegistry()` and a paired
+   `@Bean HorizonMetricsBridge <daemon>MetricsBridge(MetricRegistry)`
+   in the daemon's @Configuration. Pattern is identical to syslogd /
+   telemetryd from PR #216.
+3. Refactor the horizon-class @Bean methods to take the registry as a
+   constructor param.
+
+Validation per daemon: `opennms_*` meters now appear at
+`/actuator/prometheus` (idle stack should produce at least the
+init-time meters; activity will populate the rest).
+
+### Phase 2 — Native domain metrics (Micrometer, `deltav_*` prefix)
+
+Per-daemon brainstorm of operationally useful signals. Naming convention
+is **strict** — see `feedback_meter_naming_horizon_vs_deltav`. All
+native meters use `deltav_<daemon>_<metric>` (e.g.
+`deltav_pollerd_polls_dispatched_total`,
+`deltav_alarmd_alarms_created_total{severity="major"}`).
+
+**Suggested per-daemon sketch — refine during the session by reading
+each daemon's horizon source for what's already counted internally so
+you don't duplicate:**
+
+| Daemon | Suggested counters/timers |
+|---|---|
+| alarmd | `alarms_created_total{severity}`, `alarms_cleared_total`, `alarms_escalated_total`, `alarm_processing_duration_seconds` |
+| bsmd | `bsm_evaluations_total{result}`, `bsm_evaluation_duration_seconds`, `business_services_count` (gauge) |
+| collectd | `polls_dispatched_total{location, package}`, `persist_duration_seconds`, `ring_buffer_utilization` (gauge) |
+| discovery | `pings_dispatched_total{location}`, `range_scan_duration_seconds`, `nodes_discovered_total` |
+| enlinkd | `snmp_walks_total{source}`, `links_inserted_total`, `topology_node_count` (gauge) |
+| eventtranslator | `events_translated_total{rule}`, `translation_duration_seconds` |
+| perspectivepollerd | `perspective_polls_total{perspective}`, `perspective_poll_duration_seconds` |
+| pollerd | `polls_dispatched_total{location, monitor}`, `poll_outcome_total{result}`, `poll_duration_seconds` |
+| provisiond | `requisitions_imported_total`, `scan_duration_seconds`, `nodes_provisioned_total` |
+| syslogd | `syslogs_received_total{source}`, `syslogs_dropped_total`, `syslog_to_event_duration_seconds` |
+| telemetryd | `telemetry_packets_total{protocol, source}`, `packets_dropped_total` |
+| trapd | `traps_received_total{source}`, `trap_to_event_duration_seconds` |
+
+**Cardinality discipline:**
+- No per-node labels. Use location/package/protocol/severity — bounded sets only.
+- If a label could explode (e.g., per-IP), drop it; charts are aggregate.
+- For each label, document the bounded value set in the daemon's docstring.
+
+**Implementation pattern:**
+- Inject `MeterRegistry` via constructor into the relevant service class.
+- Register meters lazily on first use (Micrometer convention) rather than at startup.
+- Use `Counter`, `Timer`, `Gauge` directly (skip `DistributionSummary` unless histograms are operator-relevant).
+
+### Phase 3 — Pollerd + PerspectivePollerd TS publishing
+
+Mirror the Collectd pattern. Reference impl:
+`core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java`.
+
+For each daemon:
+1. Add a `PollResultPublisher` (analogous to `TimeseriesKafkaPublisher`)
+   that consumes poll-completion events and produces samples to the
+   `deltav-timeseries` Kafka topic.
+2. Sample shape: `{node, service, location, value=responseTimeMs, timestamp}`
+   for response-time; `{node, service, location, value=0|1, timestamp}` for
+   availability.
+3. PerspectivePollerd samples carry an additional `perspective` label
+   distinguishing them from direct Pollerd samples (same service,
+   different vantage point, different series in VictoriaMetrics).
+4. prometheus-writer consumes unchanged — Phase 3 is producer-only.
+
+**Don't double-count:** the new native `deltav_pollerd_poll_duration_seconds`
+Micrometer timer (Phase 2) and the TS-published response-time (Phase 3)
+measure the same thing but differ in *aggregation*: Phase 2 is per-poll
+locally aggregated by Pollerd, Phase 3 is per-poll *raw* on a
+time-series for cross-vantage analysis. Both are correct; document the
+distinction in code comments.
+
+## Recommended commit shape
+
+| Phase | Commits | Why |
+|---|---|---|
+| 1 | One per daemon (4 commits) | Each group D daemon's wiring is independent; clean bisect |
+| 2 | One per daemon (12 commits) | Per-daemon Micrometer addition; per-PR review possible if you want |
+| 3 | One commit (Pollerd) + one (PerspectivePollerd) | Pattern is identical; small files |
+
+Total ~18 commits. A single bundled PR is acceptable; per-phase PRs
+also fine if review wants tighter scope.
+
+## Validation
+
+**Phase 1 — group D bridge:**
+```bash
+for d in alarmd bsmd eventtranslator trapd; do
+  count=$(docker exec "delta-v-$d" curl -sf localhost:8080/actuator/prometheus 2>/dev/null | grep -cE '^opennms_')
+  printf "%-22s %d opennms meters (was 0 in beta1)\n" "$d" "$count"
+done
+```
+Expected: all four > 0.
+
+**Phase 2 — native deltav metrics:**
+```bash
+for d in alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd; do
+  count=$(docker exec "delta-v-$d" curl -sf localhost:8080/actuator/prometheus 2>/dev/null | grep -cE '^deltav_')
+  printf "%-22s %d deltav meters\n" "$d" "$count"
+done
+echo "--- minion ---"
+docker exec delta-v-minion curl -sf localhost:8080/actuator/prometheus 2>/dev/null | grep -cE '^deltav_'
+```
+Expected: every daemon > 0.
+
+**Phase 3 — Pollerd TS publishing:**
+- Trigger a poll (any node/service in the test stack)
+- Query VictoriaMetrics: `pollerd_response_time_seconds{service="ICMP"}` returns recent samples
+- Query: `perspectivepollerd_response_time_seconds{perspective="..."}` for a perspective-tagged sample
+- Confirm both flow through the same `deltav-timeseries` Kafka topic (kcat -t deltav-timeseries -C -o end -e | jq)
+
+## Out of scope
+
+- **Minion RPC-based metric scrape** (v1.3 — see `project_v1_3_minion_rpc_metric_scrape`)
+- **K8s operator / HPA policies** (v1.3)
+- **Grafana dashboards beyond what's needed to validate Phase 3** — full operator dashboard is v1.3 polish
+- **Legacy XML-config touch** (`project_yaml_config_migration` is v1.3+)
+- **Minion gRPC migration** (rc1/rc2)
+- **Removing/changing existing `opennms_*` bridged meters** — lineage matters per `feedback_meter_naming_horizon_vs_deltav`
+- **JDK 25 upgrade** (post-v1.3)
+
+## Release-cut checklist
+
+- [ ] Phase 1 group D wiring landed and validated (all 4 daemons emit `opennms_*` > 0)
+- [ ] Phase 2 native domain metrics landed across 12 daemons + Minion (all emit `deltav_*` > 0)
+- [ ] Phase 3 Pollerd + PerspectivePollerd TS publishing landed; samples visible in VictoriaMetrics
+- [ ] Full reactor `./mvnw clean install` green (NOT `install` — see `feedback_spring_boot_repackage_needs_clean`)
+- [ ] CI green (Build and Analyze + CodeQL — retry CodeQL once if it flakes on horizon Packages, see ci.yml gotcha from PR #216)
+- [ ] Validation recipes pass on local stack with `--profile full` (NOT `--profile metrics` — see beta1 lesson)
+- [ ] Open feature PR `--repo pbrane/delta-v --base develop`
+- [ ] After merge, second chore PR: `1.2.0-beta1` → `1.2.0-beta2` via `./mvnw versions:set -DnewVersion=1.2.0-beta2 -DgenerateBackupPoms=false`
+- [ ] After bump merges, tag `v1.2.0-beta2` at the **bump-merge commit** (not the feature-merge commit)
+- [ ] Image-publish workflow succeeds — 26+ images at `:1.2.0-beta2`
+- [ ] Smoke against `ghcr.io/pbrane/*:1.2.0-beta2` images: re-run validation recipes; expect parity with local validation
+- [ ] Release plan doc update: `docs(v1.2.0): record beta2 cut` (PR pattern matches #214 / #218)
+
+**Tag carefully** per the 2026-04-23 ghost-run gotcha. If anything fires
+against the wrong SHA, `gh run cancel <run-id>` immediately rather than
+trusting `git push --delete`. PR #217's tag at `ef771d00a99` (beta1)
+ran clean — match that pattern.
+
+## Lessons from beta1 worth carrying forward
+
+1. **Audit before assuming wiring shape.** The beta1 prompt assumed
+   *"every daemon emits Dropwizard meters; just bridge them."* Reality:
+   only 8/12 daemons had a registry exposed at all, and even those
+   varied by pattern (shared bean vs local bean vs inline `new`).
+   **Audit first, scope second.** For beta2 Phase 1, the audit step is
+   already done (group D = 4 daemons need wiring). For Phase 2, do a
+   per-daemon read of the horizon code FIRST to see what's already
+   counted internally before duplicating it natively.
+
+2. **Latent bugs surface during validation — budget for them.** Beta1
+   found that 9/12 daemons didn't even expose `/actuator/prometheus`
+   because `micrometer-registry-prometheus` was missing from
+   `daemon-common`. Beta2 may surface analogous "this never worked"
+   issues — particularly around Pollerd's existing event hooks for the
+   TS publisher. Don't be surprised; document and fix.
+
+3. **`./mvnw clean install`** when shared-module deps change. Plain
+   `install` silently re-uses the cached fat jar. See
+   `feedback_spring_boot_repackage_needs_clean`.
+
+4. **Profile-naming gotcha.** `docker compose --profile metrics` only
+   brings up 5 daemons. For full-daemon validation use `--profile full`.
+   The validation recipes above already correct for this.
+
+5. **CI flakes on horizon Packages.** CodeQL hit a transient missing
+   parent-POM error during PR #216; rerun cleared it. Same may happen
+   here — the `codeql-analysis.yml` workflow uses `GITHUB_TOKEN` which
+   doesn't reliably resolve cross-repo GH Packages, while `ci.yml` uses
+   `HORIZON_READ_TOKEN`. Worth a separate followup PR to swap the token
+   in codeql-analysis.yml; not blocking on beta2.
+
+## Solo-driver note
+
+(Added because the human is the primary core-code reviewer right now.)
+This prompt is more directive than the beta1 one because there's no
+peer review catching wrong-shaped scope. **Resist scope creep into
+v1.3 items.** If a "while I'm here" thought is for the K8s operator,
+RPC-based scrape, gRPC migration, YAML config, or new dashboards —
+write it down as a memory entry and stay on track. Beta2 is bounded
+by Phase 1 + Phase 2 + Phase 3. Done is better than expansive.
+
+## References
+
+- **App-obs design:** `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
+- **Pollerd TS design:** `docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md`
+- **Release plan (refreshed 2026-04-24 with beta1 cut):** `docs/plans/2026-04-23-v1.2.0-release-plan.md`
+- **Bridge module (beta1 reference):** `core/horizon-metric-bridge/` (PR #216)
+- **Reference TS publisher impl:** `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java`
+- **Current horizon BOM:** `opennms:pom:1.0.13` (in root pom.xml)
+- **Current develop HEAD:** `ce85619bc35` (beta1 cut record, 2026-04-24)
+- **Last published images:** `ghcr.io/pbrane/*:1.2.0-beta1` + `:latest`
+- **Smoke-test recipe (corrected — uses `--profile full`):**
+  ```bash
+  GIT_REF=v1.2.0-beta2
+  IMG_TAG=1.2.0-beta2
+  BASE=https://raw.githubusercontent.com/pbrane/delta-v/$GIT_REF/opennms-container/delta-v
+  curl -OL $BASE/docker-compose.yml
+  curl -OL $BASE/docker-compose.dev.yml
+  cat > .env <<EOF
+  IMAGE_PREFIX=ghcr.io/pbrane
+  VERSION=$IMG_TAG
+  EOF
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile full up -d
+  ```
+
+## After beta2 lands
+
+Next track is **rc1** — Minion gRPC migration midpoint. Largest single
+track in v1.2.0 (2-4 weeks of focused work). Bundles three things into
+one IPC-stack rewrite:
+
+- ActiveMQ + ServiceMix bundle purge from minion-boot (17 + 15 bundles)
+- Sink topic rename `OpenNMS.Sink.*` → `DeltaV.Sink.*`
+- "Default" Minion location retirement (named locations only)
+
+Design doc: `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`.
+This is also when the v1.3 K8s operator track becomes unblocked, since
+the Spring Cloud Gateway from rc1 is the same Gateway the operator's
+HTTP API will sit behind.


### PR DESCRIPTION
## Summary

Drafts the v1.2.0-beta2 next-session prompt while beta1 context is still fresh. Same pattern as PR #215 (which drafted the beta1 prompt).

Three phases scoped:
1. **Group D registry wiring** — closes the deferred beta1 gap (alarmd, bsmd, eventtranslator, trapd → emit `opennms_*` via the bridge)
2. **Native domain metrics** — Micrometer with `deltav_*` prefix across 12 daemons + Minion (per the meter-naming convention memory)
3. **Pollerd + PerspectivePollerd response-time TS publishing** — mirrors Collectd's `TimeseriesKafkaPublisher` pattern; PerspectivePollerd carries a `perspective` label

## Embedded lessons from beta1

The prompt deliberately bakes in self-correction for the things that cost time today:
- Audit before assuming wiring shape (Option 1 came from active pushback during the beta1 session; the original prompt was wrong-shaped)
- `--profile metrics` ≠ `--profile full` (only 5 daemons in metrics; the prompt's earlier validation recipe couldn't actually validate all 12)
- `./mvnw clean install` when shared-module deps change (caches stale fat jars otherwise; cost ~30 min in beta1)
- Ghost-run tag-safety reminder
- CodeQL flake pattern on horizon GH Packages — retry once before debugging

## "Solo-driver note"

A new section explicitly acknowledges the human is the primary core-code reviewer right now and counsels against scope creep into v1.3 items (K8s operator, RPC-scrape, gRPC migration, YAML config, dashboards). When peer review isn't catching wrong-shaped scope, the prompt itself has to.

## Filename + date

`2026-05-08-v1.2.0-beta2-domain-metrics-pollerd-ts.md` — date is a soft anchor (~2 weeks from beta1 cut) following the beta1 prompt's convention. Rename when actually started.

## Test plan

- [x] All referenced docs/files exist (verified before writing)
- [x] Memory references resolve to existing entries
- [x] PR refs (#216, #217, #218) verified valid
- [x] Validation recipes use `--profile full` (corrected from beta1's mistake)
- [ ] Reviewer (you): does the per-daemon metric sketch in Phase 2 match what you'd want, or refine before this gets used?