### PR TITLE
feat(v1.2.0-beta2): all 13 daemons deltav_* domain metrics + Pollerd Phase 3 TS publisher

### DIFF
--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -18,9 +18,10 @@ package org.deltav.netmgt.alarmd.boot;
 
 
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.deltav.core.daemon.common.SpringServiceDaemonSmartLifecycle;
 import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
-import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.alarmd.Alarmd;
 import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
 import org.opennms.netmgt.alarmd.AlarmPersister;
@@ -161,27 +162,15 @@ public class AlarmdConfiguration {
     }
 
     /**
-     * No-op AlarmEntityNotifier — alarm lifecycle notifications are not needed
-     * until REST API or BSMd integration is added.
+     * Counting AlarmEntityNotifier — increments {@code deltav_alarmd_alarms_*}
+     * Micrometer counters on every lifecycle notification. Downstream listener
+     * integration (BSMd, REST callers) is tracked in memory
+     * {@code project_alarmd_alarm_lifecycle_gap}; this bean only surfaces
+     * domain signal, it does not forward events.
      */
     @Bean
-    public AlarmEntityNotifier alarmEntityNotifier() {
-        return new AlarmEntityNotifier() {
-            @Override public void didCreateAlarm(OnmsAlarm alarm) {}
-            @Override public void didUpdateAlarmWithReducedEvent(OnmsAlarm alarm) {}
-            @Override public void didAcknowledgeAlarm(OnmsAlarm alarm, String u, java.util.Date d) {}
-            @Override public void didUnacknowledgeAlarm(OnmsAlarm alarm, String u, java.util.Date d) {}
-            @Override public void didUpdateAlarmSeverity(OnmsAlarm alarm, OnmsSeverity s) {}
-            @Override public void didArchiveAlarm(OnmsAlarm alarm, String k) {}
-            @Override public void didDeleteAlarm(OnmsAlarm alarm) {}
-            @Override public void didUpdateStickyMemo(OnmsAlarm a, String b, String au, java.util.Date d) {}
-            @Override public void didUpdateReductionKeyMemo(OnmsAlarm a, String b, String au, java.util.Date d) {}
-            @Override public void didDeleteStickyMemo(OnmsAlarm a, OnmsMemo m) {}
-            @Override public void didDeleteReductionKeyMemo(OnmsAlarm a, OnmsReductionKeyMemo m) {}
-            @Override public void didUpdateLastAutomationTime(OnmsAlarm a, java.util.Date d) {}
-            @Override public void didUpdateRelatedAlarms(OnmsAlarm a, java.util.Set<OnmsAlarm> s) {}
-            @Override public void didChangeTicketStateForAlarm(OnmsAlarm a, org.opennms.netmgt.model.TroubleTicketState s) {}
-        };
+    public AlarmEntityNotifier alarmEntityNotifier(MeterRegistry meterRegistry) {
+        return new CountingAlarmEntityNotifier(meterRegistry);
     }
 
     @Bean

--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdDomainMetrics.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdDomainMetrics.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.alarmd.boot;
+
+/**
+ * Canonical Micrometer meter names for alarmd domain signals. Names become
+ * {@code deltav_alarmd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>All counters are tagged by {@code severity} bounded to the
+ * {@code OnmsSeverity} enum (7 values). No per-node/per-ip labels — those
+ * would explode cardinality.
+ */
+public final class AlarmdDomainMetrics {
+
+    private AlarmdDomainMetrics() {}
+
+    public static final String ALARMS_CREATED          = "deltav.alarmd.alarms.created";
+    public static final String ALARMS_REDUCED          = "deltav.alarmd.alarms.reduced";
+    public static final String ALARMS_ACKNOWLEDGED     = "deltav.alarmd.alarms.acknowledged";
+    public static final String ALARMS_UNACKNOWLEDGED   = "deltav.alarmd.alarms.unacknowledged";
+    public static final String ALARMS_SEVERITY_UPDATED = "deltav.alarmd.alarms.severity.updated";
+    public static final String ALARMS_ARCHIVED         = "deltav.alarmd.alarms.archived";
+    public static final String ALARMS_DELETED          = "deltav.alarmd.alarms.deleted";
+
+    static final String TAG_SEVERITY = "severity";
+}

--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifier.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifier.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.alarmd.boot;
+
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_ACKNOWLEDGED;
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_ARCHIVED;
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_CREATED;
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_DELETED;
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_REDUCED;
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_SEVERITY_UPDATED;
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_UNACKNOWLEDGED;
+import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.TAG_SEVERITY;
+
+import java.util.Date;
+import java.util.Set;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsMemo;
+import org.opennms.netmgt.model.OnmsReductionKeyMemo;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
+
+/**
+ * {@link AlarmEntityNotifier} that counts every lifecycle notification it
+ * receives via Micrometer. Replaces the no-op anonymous implementation
+ * previously declared inline in {@code AlarmdConfiguration}.
+ *
+ * <p>Downstream listener integration (BSMd, REST callers) is tracked
+ * separately in memory {@code project_alarmd_alarm_lifecycle_gap}. This
+ * class exists purely to surface domain signal — it does not forward
+ * events anywhere.
+ */
+public class CountingAlarmEntityNotifier implements AlarmEntityNotifier {
+
+    private final MeterRegistry registry;
+
+    public CountingAlarmEntityNotifier(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void didCreateAlarm(OnmsAlarm alarm) {
+        registry.counter(ALARMS_CREATED, TAG_SEVERITY, severity(alarm)).increment();
+    }
+
+    @Override
+    public void didUpdateAlarmWithReducedEvent(OnmsAlarm alarm) {
+        registry.counter(ALARMS_REDUCED, TAG_SEVERITY, severity(alarm)).increment();
+    }
+
+    @Override
+    public void didAcknowledgeAlarm(OnmsAlarm alarm, String user, Date when) {
+        registry.counter(ALARMS_ACKNOWLEDGED).increment();
+    }
+
+    @Override
+    public void didUnacknowledgeAlarm(OnmsAlarm alarm, String user, Date when) {
+        registry.counter(ALARMS_UNACKNOWLEDGED).increment();
+    }
+
+    @Override
+    public void didUpdateAlarmSeverity(OnmsAlarm alarm, OnmsSeverity previous) {
+        // Tag by *new* severity (what the alarm is now, which is the operationally
+        // interesting dimension — "alarms that just became CRITICAL").
+        registry.counter(ALARMS_SEVERITY_UPDATED, TAG_SEVERITY, severity(alarm)).increment();
+    }
+
+    @Override
+    public void didArchiveAlarm(OnmsAlarm alarm, String previousReductionKey) {
+        registry.counter(ALARMS_ARCHIVED).increment();
+    }
+
+    @Override
+    public void didDeleteAlarm(OnmsAlarm alarm) {
+        registry.counter(ALARMS_DELETED, TAG_SEVERITY, severity(alarm)).increment();
+    }
+
+    @Override public void didUpdateStickyMemo(OnmsAlarm a, String b, String au, Date d) {}
+    @Override public void didUpdateReductionKeyMemo(OnmsAlarm a, String b, String au, Date d) {}
+    @Override public void didDeleteStickyMemo(OnmsAlarm a, OnmsMemo m) {}
+    @Override public void didDeleteReductionKeyMemo(OnmsAlarm a, OnmsReductionKeyMemo m) {}
+    @Override public void didUpdateLastAutomationTime(OnmsAlarm a, Date d) {}
+    @Override public void didUpdateRelatedAlarms(OnmsAlarm a, Set<OnmsAlarm> s) {}
+    @Override public void didChangeTicketStateForAlarm(OnmsAlarm a, TroubleTicketState s) {}
+
+    private static String severity(OnmsAlarm alarm) {
+        OnmsSeverity s = alarm != null ? alarm.getSeverity() : null;
+        return s != null ? s.getLabel() : OnmsSeverity.INDETERMINATE.getLabel();
+    }
+}

--- a/core/daemon-boot-bsmd/src/main/java/org/deltav/netmgt/bsm/boot/BsmdConfiguration.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/deltav/netmgt/bsm/boot/BsmdConfiguration.java
@@ -77,6 +77,9 @@ import org.opennms.netmgt.model.jakarta.converter.NodeLabelSourceConverter;
 import org.opennms.netmgt.model.jakarta.converter.NodeTypeConverter;
 import org.opennms.netmgt.model.jakarta.converter.OnmsSeverityConverter;
 import org.opennms.netmgt.model.jakarta.converter.PrimaryTypeConverter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -220,19 +223,28 @@ public class BsmdConfiguration {
      */
     @Bean
     public org.opennms.netmgt.bsm.service.AlarmProvider alarmProvider(
-            org.opennms.netmgt.dao.api.AlarmDao alarmDao) {
-        return reductionKeys -> {
+            org.opennms.netmgt.dao.api.AlarmDao alarmDao,
+            MeterRegistry meterRegistry) {
+        Timer lookupTimer = meterRegistry.timer(BsmdDomainMetrics.ALARM_LOOKUP_DURATION);
+        return reductionKeys -> lookupTimer.record(() -> {
+            meterRegistry.counter(BsmdDomainMetrics.ALARM_LOOKUPS).increment();
             if (reductionKeys == null || reductionKeys.isEmpty()) {
                 return new HashMap<>();
             }
-            return alarmDao.findAll().stream()
+            meterRegistry.counter(BsmdDomainMetrics.ALARM_LOOKUP_KEYS_REQUESTED)
+                    .increment(reductionKeys.size());
+            var matches = alarmDao.findAll().stream()
                     .filter(a -> reductionKeys.contains(a.getReductionKey()))
                     .collect(java.util.stream.Collectors.toMap(
                             OnmsAlarm::getReductionKey,
                             a -> (org.opennms.netmgt.bsm.service.model.AlarmWrapper)
                                     new org.opennms.netmgt.bsm.service.internal.AlarmWrapperImpl(a)));
-        };
+            meterRegistry.counter(BsmdDomainMetrics.ALARM_LOOKUP_KEYS_MATCHED)
+                    .increment(matches.size());
+            return matches;
+        });
     }
+
 
     @Bean
     public BusinessServiceStateMachine businessServiceStateMachine(

--- a/core/daemon-boot-bsmd/src/main/java/org/deltav/netmgt/bsm/boot/BsmdDomainMetrics.java
+++ b/core/daemon-boot-bsmd/src/main/java/org/deltav/netmgt/bsm/boot/BsmdDomainMetrics.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.bsm.boot;
+
+/**
+ * Canonical Micrometer meter names for bsmd domain signals. Names become
+ * {@code deltav_bsmd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ */
+public final class BsmdDomainMetrics {
+
+    private BsmdDomainMetrics() {}
+
+    /** Counter: alarm-provider reduction-key lookup invocations. */
+    public static final String ALARM_LOOKUPS               = "deltav.bsmd.alarm.lookups";
+
+    /** Timer: alarm-provider lookup wall-clock duration. */
+    public static final String ALARM_LOOKUP_DURATION       = "deltav.bsmd.alarm.lookup.duration";
+
+    /** Counter: number of reduction keys requested (sum across lookups). */
+    public static final String ALARM_LOOKUP_KEYS_REQUESTED = "deltav.bsmd.alarm.lookup.keys.requested";
+
+    /** Counter: number of reduction keys resolved (sum across lookups). */
+    public static final String ALARM_LOOKUP_KEYS_MATCHED   = "deltav.bsmd.alarm.lookup.keys.matched";
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectdDomainMetrics.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/CollectdDomainMetrics.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.collectd.timeseries;
+
+/**
+ * Canonical Micrometer meter names for collectd domain signals. Names become
+ * {@code deltav_collectd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>These counters describe the *shape* of horizon's collection-set walk
+ * passing through the Kafka-side persister: how many resources, groups, and
+ * attributes a single CollectionSet contains. They sit alongside the existing
+ * {@code deltav_timeseries_*} batch-level counters from PR #170 (which describe
+ * Kafka publish behavior) and the {@code deltav_collectd_persister_*_failures}
+ * counters in {@code FanoutPersister} (which describe persister failures).
+ *
+ * <p>No labels — collection-package and node identity carry too much
+ * cardinality at the per-attribute level. The TimeseriesKafkaPublisher
+ * already records publish-side counters with bounded tags.
+ */
+public final class CollectdDomainMetrics {
+
+    private CollectdDomainMetrics() {}
+
+    public static final String COLLECTION_SETS_VISITED   = "deltav.collectd.collection.sets.visited";
+    public static final String COLLECTION_RESOURCES      = "deltav.collectd.collection.resources.visited";
+    public static final String COLLECTION_GROUPS         = "deltav.collectd.collection.groups.visited";
+    public static final String COLLECTION_ATTRIBUTES     = "deltav.collectd.collection.attributes.visited";
+    public static final String COLLECTION_SETS_COMPLETED = "deltav.collectd.collection.sets.completed";
+}

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersister.java
@@ -16,6 +16,9 @@
  */
 package org.deltav.collectd.timeseries;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.deltav.collectd.identity.AgentIdentity;
 import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.opennms.netmgt.collection.api.AttributeGroup;
@@ -47,29 +50,47 @@ public class TimeseriesKafkaPersister implements Persister {
     private final TimeseriesKafkaPublisher publisher;
     private final String collectionPackage;
     private final AgentIdentityHolder holder;
+    private final Counter setsVisited;
+    private final Counter resourcesVisited;
+    private final Counter groupsVisited;
+    private final Counter attributesVisited;
+    private final Counter setsCompleted;
     private CollectionSet capturedSet;
 
     public TimeseriesKafkaPersister(TimeseriesKafkaPublisher publisher,
                                      String collectionPackage,
-                                     AgentIdentityHolder holder) {
+                                     AgentIdentityHolder holder,
+                                     MeterRegistry meterRegistry) {
         this.publisher = publisher;
         this.collectionPackage = collectionPackage;
         this.holder = holder;
+        this.setsVisited       = meterRegistry.counter(CollectdDomainMetrics.COLLECTION_SETS_VISITED);
+        this.resourcesVisited  = meterRegistry.counter(CollectdDomainMetrics.COLLECTION_RESOURCES);
+        this.groupsVisited     = meterRegistry.counter(CollectdDomainMetrics.COLLECTION_GROUPS);
+        this.attributesVisited = meterRegistry.counter(CollectdDomainMetrics.COLLECTION_ATTRIBUTES);
+        this.setsCompleted     = meterRegistry.counter(CollectdDomainMetrics.COLLECTION_SETS_COMPLETED);
     }
 
     @Override
     public void visitCollectionSet(CollectionSet set) {
+        setsVisited.increment();
         this.capturedSet = set;
     }
 
     @Override
-    public void visitResource(CollectionResource resource) { /* no-op */ }
+    public void visitResource(CollectionResource resource) {
+        resourcesVisited.increment();
+    }
 
     @Override
-    public void visitGroup(AttributeGroup group) { /* no-op */ }
+    public void visitGroup(AttributeGroup group) {
+        groupsVisited.increment();
+    }
 
     @Override
-    public void visitAttribute(CollectionAttribute attribute) { /* no-op */ }
+    public void visitAttribute(CollectionAttribute attribute) {
+        attributesVisited.increment();
+    }
 
     @Override
     public void completeAttribute(CollectionAttribute attribute) { /* no-op */ }
@@ -82,6 +103,7 @@ public class TimeseriesKafkaPersister implements Persister {
 
     @Override
     public void completeCollectionSet(CollectionSet set) {
+        setsCompleted.increment();
         try {
             if (capturedSet != null) {
                 AgentIdentity identity = holder.getOrThrow();

--- a/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
+++ b/core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisherConfiguration.java
@@ -170,7 +170,7 @@ public class TimeseriesKafkaPublisherConfiguration {
         public Persister createPersister(ServiceParameters params, RrdRepository repository) {
             return new FanoutPersister(
                     innerFactory.createPersister(params, repository),
-                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder),
+                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder, meterRegistry),
                     meterRegistry, failFastInner, failFastKafka);
         }
 
@@ -181,7 +181,7 @@ public class TimeseriesKafkaPublisherConfiguration {
             return new FanoutPersister(
                     innerFactory.createPersister(params, repository, dontPersistCounters,
                             forceStoreByGroup, dontReorderAttributes),
-                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder),
+                    new TimeseriesKafkaPersister(publisher, extractCollection(params), holder, meterRegistry),
                     meterRegistry, failFastInner, failFastKafka);
         }
 

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/FanoutPersisterTest.java
@@ -53,7 +53,7 @@ class FanoutPersisterTest {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
         AgentIdentityHolder holder = new AgentIdentityHolder();
         holder.set(1, "Default");
-        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder);
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
         FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
@@ -78,7 +78,7 @@ class FanoutPersisterTest {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
         AgentIdentityHolder holder = new AgentIdentityHolder();
         holder.set(1, "Default");
-        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder);
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
         FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);
@@ -101,7 +101,7 @@ class FanoutPersisterTest {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
         AgentIdentityHolder holder = new AgentIdentityHolder();
         holder.set(1, "Default");
-        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder);
+        TimeseriesKafkaPersister kafka = new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
         FanoutPersister fanout = new FanoutPersister(inner, kafka, new SimpleMeterRegistry(), false, false);
 
         CollectionSet set = mock(CollectionSet.class);

--- a/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
+++ b/core/daemon-boot-collectd/src/test/java/org/deltav/collectd/timeseries/TimeseriesKafkaPersisterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.deltav.collectd.identity.AgentIdentityHolder;
 import org.junit.jupiter.api.Test;
 import org.opennms.netmgt.collection.api.AttributeGroup;
@@ -37,7 +38,7 @@ class TimeseriesKafkaPersisterTest {
         AgentIdentityHolder holder = new AgentIdentityHolder();
         holder.set(42, "Site-A");
         TimeseriesKafkaPersister persister =
-                new TimeseriesKafkaPersister(publisher, "critical-infra", holder);
+                new TimeseriesKafkaPersister(publisher, "critical-infra", holder, new SimpleMeterRegistry());
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
@@ -52,7 +53,7 @@ class TimeseriesKafkaPersisterTest {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
         AgentIdentityHolder holder = new AgentIdentityHolder();
         TimeseriesKafkaPersister persister =
-                new TimeseriesKafkaPersister(publisher, "default", holder);
+                new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
@@ -71,7 +72,7 @@ class TimeseriesKafkaPersisterTest {
         AgentIdentityHolder holder = new AgentIdentityHolder();
         holder.set(0, "Default");
         TimeseriesKafkaPersister persister =
-                new TimeseriesKafkaPersister(publisher, "default", holder);
+                new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
@@ -89,7 +90,7 @@ class TimeseriesKafkaPersisterTest {
         AgentIdentityHolder holder = new AgentIdentityHolder();
         holder.set(-5, "Default");
         TimeseriesKafkaPersister persister =
-                new TimeseriesKafkaPersister(publisher, "default", holder);
+                new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
 
         CollectionSet set = mock(CollectionSet.class);
         persister.visitCollectionSet(set);
@@ -105,7 +106,7 @@ class TimeseriesKafkaPersisterTest {
         AgentIdentityHolder holder = new AgentIdentityHolder();
         holder.set(7, "X");
         TimeseriesKafkaPersister persister =
-                new TimeseriesKafkaPersister(publisher, "default", holder);
+                new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
 
         CollectionSet set = mock(CollectionSet.class);
         persister.completeCollectionSet(set);
@@ -119,7 +120,7 @@ class TimeseriesKafkaPersisterTest {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
         AgentIdentityHolder holder = new AgentIdentityHolder();
         TimeseriesKafkaPersister persister =
-                new TimeseriesKafkaPersister(publisher, "default", holder);
+                new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
 
         persister.visitResource(mock(CollectionResource.class));
         persister.visitGroup(mock(AttributeGroup.class));
@@ -136,7 +137,7 @@ class TimeseriesKafkaPersisterTest {
         TimeseriesKafkaPublisher publisher = mock(TimeseriesKafkaPublisher.class);
         AgentIdentityHolder holder = new AgentIdentityHolder();
         TimeseriesKafkaPersister persister =
-                new TimeseriesKafkaPersister(publisher, "default", holder);
+                new TimeseriesKafkaPersister(publisher, "default", holder, new SimpleMeterRegistry());
 
         persister.persistNumericAttribute(mock(CollectionAttribute.class));
         persister.persistStringAttribute(mock(CollectionAttribute.class));

--- a/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/CountingDiscoveryTaskExecutor.java
+++ b/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/CountingDiscoveryTaskExecutor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.discovery.boot;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.opennms.netmgt.config.discovery.DiscoveryConfiguration;
+import org.opennms.netmgt.discovery.DiscoveryTaskExecutorImpl;
+import org.opennms.netmgt.discovery.RangeChunker;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
+import org.opennms.netmgt.provision.LocationAwareDetectorClient;
+
+/**
+ * {@link DiscoveryTaskExecutorImpl} subclass that increments a counter and
+ * times each {@code handleDiscoveryTask} invocation. Delegates to
+ * {@code super.handleDiscoveryTask} so discovery logic is unchanged.
+ *
+ * <p>The result is a {@code CompletableFuture<Void>}; the timer records
+ * the asynchronous duration via {@code whenComplete}, not the synchronous
+ * call duration (which is just the chunk-and-dispatch latency).
+ */
+public class CountingDiscoveryTaskExecutor extends DiscoveryTaskExecutorImpl {
+
+    private final Counter tasksHandled;
+    private final Timer handleDuration;
+
+    public CountingDiscoveryTaskExecutor(RangeChunker rangeChunker,
+                                         LocationAwarePingClient pingClient,
+                                         EventForwarder eventForwarder,
+                                         LocationAwareDetectorClient detectorClient,
+                                         MeterRegistry registry) {
+        super(rangeChunker, pingClient, eventForwarder, detectorClient);
+        this.tasksHandled = registry.counter(DiscoveryDomainMetrics.TASKS_HANDLED);
+        this.handleDuration = registry.timer(DiscoveryDomainMetrics.HANDLE_DURATION);
+    }
+
+    @Override
+    public CompletableFuture<Void> handleDiscoveryTask(DiscoveryConfiguration config) {
+        tasksHandled.increment();
+        Timer.Sample sample = Timer.start();
+        CompletableFuture<Void> future = super.handleDiscoveryTask(config);
+        future.whenComplete((v, t) -> sample.stop(handleDuration));
+        return future;
+    }
+}

--- a/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/CountingEventForwarder.java
+++ b/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/CountingEventForwarder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.discovery.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Log;
+
+/**
+ * Decorator around the discovery daemon's {@link EventForwarder} that
+ * increments {@code deltav_discovery_events_forwarded_total} for every event
+ * the daemon publishes, and a separate {@code _suspects_found_total} for
+ * the {@code newSuspect} UEI specifically.
+ *
+ * <p>Operationally, suspects-found is the signal that discovery actually
+ * accomplished work — it's the metric an HPA wants to scale by. Total events
+ * is a coarser denominator (covers internal Discovery lifecycle UEIs, not
+ * just suspects).
+ */
+public class CountingEventForwarder implements EventForwarder {
+
+    private final EventForwarder delegate;
+    private final MeterRegistry registry;
+
+    public CountingEventForwarder(EventForwarder delegate, MeterRegistry registry) {
+        this.delegate = delegate;
+        this.registry = registry;
+    }
+
+    @Override
+    public void sendNow(Event event) {
+        record(event);
+        delegate.sendNow(event);
+    }
+
+    @Override
+    public void sendNow(Log eventLog) {
+        if (eventLog != null && eventLog.getEvents() != null && eventLog.getEvents().getEvent() != null) {
+            for (Event event : eventLog.getEvents().getEvent()) {
+                record(event);
+            }
+        }
+        delegate.sendNow(eventLog);
+    }
+
+    @Override
+    public void sendNowSync(Event event) {
+        record(event);
+        delegate.sendNowSync(event);
+    }
+
+    @Override
+    public void sendNowSync(Log eventLog) {
+        if (eventLog != null && eventLog.getEvents() != null && eventLog.getEvents().getEvent() != null) {
+            for (Event event : eventLog.getEvents().getEvent()) {
+                record(event);
+            }
+        }
+        delegate.sendNowSync(eventLog);
+    }
+
+    private void record(Event event) {
+        registry.counter(DiscoveryDomainMetrics.EVENTS_FORWARDED).increment();
+        if (event != null && EventConstants.NEW_SUSPECT_INTERFACE_EVENT_UEI.equals(event.getUei())) {
+            registry.counter(DiscoveryDomainMetrics.SUSPECTS_FOUND).increment();
+        }
+    }
+}

--- a/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/DiscoveryBootConfiguration.java
+++ b/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/DiscoveryBootConfiguration.java
@@ -26,6 +26,7 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import org.deltav.core.daemon.common.SpringServiceDaemonSmartLifecycle;
 import org.deltav.core.daemon.common.JdbcDistPollerDao;
@@ -186,19 +187,33 @@ public class DiscoveryBootConfiguration {
         return new RangeChunker(filter);
     }
 
+    /**
+     * Wraps the discovery daemon's {@link EventForwarder} so that every event
+     * forwarded — and {@code newSuspect} events specifically — increments
+     * Micrometer counters at {@code /actuator/prometheus}. Suspects-found
+     * is the operationally meaningful "discovery is doing real work" signal.
+     */
+    @Bean(name = "countingDiscoveryEventForwarder")
+    public EventForwarder countingDiscoveryEventForwarder(
+            @Qualifier("eventIpcManager") EventForwarder eventForwarder,
+            MeterRegistry meterRegistry) {
+        return new CountingEventForwarder(eventForwarder, meterRegistry);
+    }
+
     @Bean
     public DiscoveryTaskExecutorImpl discoveryTaskExecutor(
             RangeChunker rangeChunker,
             LocationAwarePingClient locationAwarePingClient,
-            @Qualifier("eventIpcManager") EventForwarder eventForwarder) {
-        return new DiscoveryTaskExecutorImpl(rangeChunker, locationAwarePingClient,
-                eventForwarder, null);
+            @Qualifier("countingDiscoveryEventForwarder") EventForwarder eventForwarder,
+            MeterRegistry meterRegistry) {
+        return new CountingDiscoveryTaskExecutor(rangeChunker, locationAwarePingClient,
+                eventForwarder, null, meterRegistry);
     }
 
     @Bean
     public Discovery discovery(DiscoveryConfigurationFactory discoveryConfigFactory,
                                DiscoveryTaskExecutorImpl discoveryTaskExecutor,
-                               @Qualifier("eventIpcManager") EventForwarder eventForwarder) {
+                               @Qualifier("countingDiscoveryEventForwarder") EventForwarder eventForwarder) {
         return new Discovery(discoveryConfigFactory, discoveryTaskExecutor, eventForwarder);
     }
 

--- a/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/DiscoveryDomainMetrics.java
+++ b/core/daemon-boot-discovery/src/main/java/org/deltav/netmgt/discovery/boot/DiscoveryDomainMetrics.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.discovery.boot;
+
+/**
+ * Canonical Micrometer meter names for discovery domain signals. Names become
+ * {@code deltav_discovery_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>{@code TASKS_HANDLED} fires once per {@code handleDiscoveryTask}
+ * invocation — i.e., once per scheduled discovery run. {@code SUSPECTS_FOUND}
+ * is incremented from a wrapping {@link org.opennms.netmgt.events.api.EventForwarder}
+ * each time a {@code uei.opennms.org/internal/discovery/newSuspect} event is
+ * forwarded — this is the signal an HPA actually wants ("discovery is finding
+ * things").
+ */
+public final class DiscoveryDomainMetrics {
+
+    private DiscoveryDomainMetrics() {}
+
+    public static final String TASKS_HANDLED      = "deltav.discovery.tasks.handled";
+    public static final String HANDLE_DURATION    = "deltav.discovery.handle.duration";
+    public static final String SUSPECTS_FOUND     = "deltav.discovery.suspects.found";
+    public static final String EVENTS_FORWARDED   = "deltav.discovery.events.forwarded";
+}

--- a/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/CountingOnmsTopologyDao.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/CountingOnmsTopologyDao.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.enlinkd.boot;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.opennms.netmgt.topologies.service.api.OnmsTopology;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyConsumer;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyMessage;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyUpdater;
+
+/**
+ * Decorator around {@link OnmsTopologyDao} that increments Micrometer counters
+ * on every topology message and tracks the number of currently registered
+ * updaters as a gauge.
+ *
+ * <p>Tags on the per-update counter:
+ * <ul>
+ *   <li>{@code protocol} — bounded to the {@code ProtocolSupported} enum
+ *       (NODES, CDP, LLDP, ISIS, OSPF, OSPFAREA, BRIDGE, NETWORKROUTER,
+ *       USERDEFINED) plus any that future horizon adds.</li>
+ *   <li>{@code status} — bounded to {@code TopologyMessageStatus}
+ *       (UPDATE, DELETE).</li>
+ * </ul>
+ */
+public class CountingOnmsTopologyDao implements OnmsTopologyDao {
+
+    private final OnmsTopologyDao delegate;
+    private final MeterRegistry registry;
+    private final AtomicLong activeUpdaters = new AtomicLong(0);
+
+    public CountingOnmsTopologyDao(OnmsTopologyDao delegate, MeterRegistry registry) {
+        this.delegate = delegate;
+        this.registry = registry;
+        Gauge.builder(EnlinkdDomainMetrics.TOPOLOGY_UPDATERS_ACTIVE, activeUpdaters, AtomicLong::get)
+                .register(registry);
+    }
+
+    @Override
+    public OnmsTopology getTopology(String id) {
+        return delegate.getTopology(id);
+    }
+
+    @Override
+    public Map<OnmsTopologyProtocol, OnmsTopology> getTopologies() {
+        return delegate.getTopologies();
+    }
+
+    @Override
+    public Set<OnmsTopologyProtocol> getSupportedProtocols() {
+        return delegate.getSupportedProtocols();
+    }
+
+    @Override
+    public void register(OnmsTopologyUpdater updater) {
+        delegate.register(updater);
+        activeUpdaters.incrementAndGet();
+    }
+
+    @Override
+    public void unregister(OnmsTopologyUpdater updater) {
+        delegate.unregister(updater);
+        activeUpdaters.updateAndGet(v -> Math.max(0L, v - 1));
+    }
+
+    @Override
+    public void subscribe(OnmsTopologyConsumer consumer) {
+        delegate.subscribe(consumer);
+    }
+
+    @Override
+    public void unsubscribe(OnmsTopologyConsumer consumer) {
+        delegate.unsubscribe(consumer);
+    }
+
+    @Override
+    public void update(OnmsTopologyUpdater updater, OnmsTopologyMessage message) {
+        delegate.update(updater, message);
+        String protocol = message != null && message.getProtocol() != null
+                ? message.getProtocol().getId() : "unknown";
+        String status = message != null && message.getMessagestatus() != null
+                ? message.getMessagestatus().name() : "unknown";
+        registry.counter(EnlinkdDomainMetrics.TOPOLOGY_UPDATES,
+                EnlinkdDomainMetrics.TAG_PROTOCOL, protocol,
+                EnlinkdDomainMetrics.TAG_STATUS, status).increment();
+    }
+}

--- a/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/EnlinkdDaemonConfiguration.java
@@ -24,6 +24,7 @@ import java.util.List;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import org.deltav.core.daemon.common.SpringServiceDaemonSmartLifecycle;
 import org.opennms.core.mate.api.EntityScopeProvider;
@@ -160,9 +161,15 @@ public class EnlinkdDaemonConfiguration {
 
     // ── 4. OnmsTopologyDao ───────────────────────────────────────────
 
+    /**
+     * Wraps the in-memory OnmsTopologyDao with a Micrometer-counting
+     * decorator so every protocol updater's {@code update(...)} call is
+     * surfaced at {@code /actuator/prometheus} as
+     * {@code deltav_enlinkd_topology_updates_total{protocol,status}}.
+     */
     @Bean
-    public OnmsTopologyDao onmsTopologyDao() {
-        return new OnmsTopologyDaoInMemoryImpl();
+    public OnmsTopologyDao onmsTopologyDao(MeterRegistry meterRegistry) {
+        return new CountingOnmsTopologyDao(new OnmsTopologyDaoInMemoryImpl(), meterRegistry);
     }
 
     // ── 5. TopologyEntityCache (no-op) ───────────────────────────────

--- a/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/EnlinkdDomainMetrics.java
+++ b/core/daemon-boot-enlinkd/src/main/java/org/deltav/netmgt/enlinkd/boot/EnlinkdDomainMetrics.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.enlinkd.boot;
+
+/**
+ * Canonical Micrometer meter names for enlinkd domain signals. Names become
+ * {@code deltav_enlinkd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>The instrumentation point is the central {@code OnmsTopologyDao.update}
+ * call — every protocol's updater funnels its topology messages through this
+ * single method, so wrapping it captures activity from all 9 protocol updaters
+ * (LLDP, CDP, OSPF, OSPFAREA, ISIS, BRIDGE, NETWORKROUTER, NODES, USERDEFINED)
+ * without subclassing each one.
+ *
+ * <p>Tagged by {@code protocol} (bounded enum) and {@code status} (UPDATE or
+ * DELETE — bounded). Updater-registration counters give a one-shot signal at
+ * daemon start to confirm the bean graph wired up correctly.
+ */
+public final class EnlinkdDomainMetrics {
+
+    private EnlinkdDomainMetrics() {}
+
+    public static final String TOPOLOGY_UPDATES        = "deltav.enlinkd.topology.updates";
+    public static final String TOPOLOGY_UPDATERS_ACTIVE = "deltav.enlinkd.topology.updaters.active";
+
+    static final String TAG_PROTOCOL = "protocol";
+    static final String TAG_STATUS   = "status";
+}

--- a/core/daemon-boot-eventtranslator/src/main/java/org/deltav/netmgt/translator/boot/CountingEventTranslator.java
+++ b/core/daemon-boot-eventtranslator/src/main/java/org/deltav/netmgt/translator/boot/CountingEventTranslator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.translator.boot;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.translator.EventTranslator;
+
+/**
+ * {@link EventTranslator} subclass that increments Micrometer counters on
+ * every event received via the horizon {@code EventListener} contract.
+ * Delegates to {@code super.onEvent} so translation semantics are unchanged.
+ */
+public class CountingEventTranslator extends EventTranslator {
+
+    private final Counter eventsReceived;
+    private final Timer processingDuration;
+
+    public CountingEventTranslator(MeterRegistry registry) {
+        super();
+        this.eventsReceived = registry.counter(EventTranslatorDomainMetrics.EVENTS_RECEIVED);
+        this.processingDuration = registry.timer(EventTranslatorDomainMetrics.EVENT_PROCESSING_DURATION);
+    }
+
+    @Override
+    public void onEvent(IEvent event) {
+        eventsReceived.increment();
+        processingDuration.record(() -> super.onEvent(event));
+    }
+}

--- a/core/daemon-boot-eventtranslator/src/main/java/org/deltav/netmgt/translator/boot/EventTranslatorBootConfiguration.java
+++ b/core/daemon-boot-eventtranslator/src/main/java/org/deltav/netmgt/translator/boot/EventTranslatorBootConfiguration.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.deltav.core.daemon.common.SpringServiceDaemonSmartLifecycle;
 import org.opennms.netmgt.config.EventTranslatorConfig;
 import org.opennms.netmgt.config.EventTranslatorConfigFactory;
@@ -86,8 +88,9 @@ public class EventTranslatorBootConfiguration {
     public EventTranslator eventTranslator(
             EventIpcManager eventIpcManager,
             EventTranslatorConfig config,
-            DataSource dataSource) {
-        var translator = new EventTranslator();
+            DataSource dataSource,
+            MeterRegistry meterRegistry) {
+        var translator = new CountingEventTranslator(meterRegistry);
         translator.setEventManager(eventIpcManager);
         translator.setConfig(config);
         translator.setDataSource(dataSource);

--- a/core/daemon-boot-eventtranslator/src/main/java/org/deltav/netmgt/translator/boot/EventTranslatorDomainMetrics.java
+++ b/core/daemon-boot-eventtranslator/src/main/java/org/deltav/netmgt/translator/boot/EventTranslatorDomainMetrics.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.translator.boot;
+
+/**
+ * Canonical Micrometer meter names for eventtranslator domain signals.
+ * Names become {@code deltav_eventtranslator_*} at
+ * {@code /actuator/prometheus} after Micrometer's dot-to-underscore flattening.
+ */
+public final class EventTranslatorDomainMetrics {
+
+    private EventTranslatorDomainMetrics() {}
+
+    /** Counter: events received by the translator's {@code onEvent} listener. */
+    public static final String EVENTS_RECEIVED = "deltav.eventtranslator.events.received";
+
+    /** Timer: wall-clock duration of each {@code onEvent} invocation. */
+    public static final String EVENT_PROCESSING_DURATION = "deltav.eventtranslator.event.processing.duration";
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/MeteredRpcModule.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/MeteredRpcModule.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.boot;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.opennms.core.rpc.api.RpcModule;
+import org.opennms.core.rpc.api.RpcRequest;
+import org.opennms.core.rpc.api.RpcResponse;
+
+/**
+ * Decorator around any {@link RpcModule} that increments Micrometer counters
+ * for each request executed on the Minion side, and times the asynchronous
+ * completion of the returned {@link CompletableFuture}.
+ *
+ * <p>Pre-resolves the per-module counter and timer instances at construction
+ * time so the hot path is a single map lookup per call. Module id is bounded
+ * to the compiled-in RPC module set (currently 7 modules), so cardinality is
+ * safe.
+ *
+ * <p>Marshal/unmarshal/createResponseWithException all delegate without
+ * instrumentation — those are pure marshaling operations and not part of the
+ * request-rate signal we want.
+ */
+public class MeteredRpcModule<S extends RpcRequest, T extends RpcResponse>
+        implements RpcModule<S, T> {
+
+    private final RpcModule<S, T> delegate;
+    private final MeterRegistry registry;
+    private final Counter received;
+    private final Counter failed;
+    private final Timer duration;
+
+    public MeteredRpcModule(RpcModule<S, T> delegate, MeterRegistry registry) {
+        this.delegate = delegate;
+        this.registry = registry;
+        String moduleId = delegate.getId();
+        this.received = registry.counter(MinionDomainMetrics.RPC_RECEIVED,
+                MinionDomainMetrics.TAG_MODULE, moduleId);
+        this.failed = registry.counter(MinionDomainMetrics.RPC_FAILED,
+                MinionDomainMetrics.TAG_MODULE, moduleId);
+        this.duration = Timer.builder(MinionDomainMetrics.RPC_DURATION)
+                .tag(MinionDomainMetrics.TAG_MODULE, moduleId)
+                .register(registry);
+    }
+
+    @Override
+    public CompletableFuture<T> execute(S request) {
+        received.increment();
+        Timer.Sample sample = Timer.start(registry);
+        CompletableFuture<T> future = delegate.execute(request);
+        future.whenComplete((response, throwable) -> {
+            sample.stop(duration);
+            if (throwable != null) {
+                failed.increment();
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public String getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public String marshalRequest(S request) {
+        return delegate.marshalRequest(request);
+    }
+
+    @Override
+    public S unmarshalRequest(String s) {
+        return delegate.unmarshalRequest(s);
+    }
+
+    @Override
+    public String marshalResponse(T response) {
+        return delegate.marshalResponse(response);
+    }
+
+    @Override
+    public T unmarshalResponse(String s) {
+        return delegate.unmarshalResponse(s);
+    }
+
+    @Override
+    public T createResponseWithException(Throwable throwable) {
+        return delegate.createResponseWithException(throwable);
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/MinionDomainMetrics.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/MinionDomainMetrics.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.boot;
+
+/**
+ * Canonical Micrometer meter names for the Minion's native delta-v signals.
+ * Names become {@code deltav_minion_*} at {@code /actuator/prometheus} after
+ * Micrometer's dot-to-underscore flattening.
+ *
+ * <p>Per-module counters are tagged by RPC module id ({@code Echo},
+ * {@code Detect}, {@code Collect}, {@code Poll}, {@code Ping},
+ * {@code PingSweep}, {@code SnmpProxy}, etc.). The set is bounded to the
+ * compiled-in module set (currently 7 modules). Per-call duration is a
+ * timer keyed by the same module tag.
+ *
+ * <p>Note (vs the existing {@code opennms_*} meters via PR #216's
+ * horizon-metric-bridge): horizon's {@code KafkaRpcServerManager} already
+ * surfaces its internal Codahale {@code MetricRegistry} as
+ * {@code opennms_*} metrics. The {@code deltav_minion_*} meters added here
+ * are a separate, native Micrometer source that an HPA can target without
+ * inheriting any decisions baked into horizon's bridged names.
+ */
+public final class MinionDomainMetrics {
+
+    private MinionDomainMetrics() {}
+
+    public static final String RPC_RECEIVED  = "deltav.minion.rpc.received";
+    public static final String RPC_FAILED    = "deltav.minion.rpc.failed";
+    public static final String RPC_DURATION  = "deltav.minion.rpc.duration";
+
+    static final String TAG_MODULE = "module";
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/RpcModuleMetricsPostProcessor.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/RpcModuleMetricsPostProcessor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.opennms.core.rpc.api.RpcModule;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-wraps every {@link RpcModule} bean produced by the Spring context
+ * with {@link MeteredRpcModule}, so any future RPC module added to the
+ * Minion picks up {@code deltav_minion_*} counters and timing without
+ * needing per-config edits.
+ *
+ * <p>Implemented as a {@link BeanPostProcessor} rather than touching each
+ * {@code @Bean} factory because the set of RPC modules is open-ended —
+ * Echo, Detect, Collect, Poll, Ping, PingSweep, SnmpProxy today; future
+ * modules added by importing additional starters tomorrow.
+ *
+ * <p>Uses {@link ObjectProvider} for {@link MeterRegistry} so this class
+ * loads cleanly at very early phase of bean creation; the {@link MeterRegistry}
+ * is resolved lazily on first wrap call (when actuator beans are ready).
+ */
+@Configuration
+public class RpcModuleMetricsPostProcessor implements BeanPostProcessor {
+
+    private final ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+    public RpcModuleMetricsPostProcessor(ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this.meterRegistryProvider = meterRegistryProvider;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) {
+        if (!(bean instanceof RpcModule<?, ?> module)) {
+            return bean;
+        }
+        if (bean instanceof MeteredRpcModule<?, ?>) {
+            return bean;
+        }
+        MeterRegistry registry = meterRegistryProvider.getIfAvailable();
+        if (registry == null) {
+            // MeterRegistry not yet available — actuator may initialize later.
+            // Skipping the wrap is preferable to throwing; the underlying module
+            // still functions, just without deltav_minion_* metrics.
+            return bean;
+        }
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        RpcModule wrapped = new MeteredRpcModule((RpcModule) module, registry);
+        return wrapped;
+    }
+}

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/CountingPerspectiveEventForwarder.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/CountingPerspectiveEventForwarder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.perspectivepoller.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Log;
+
+/**
+ * Decorator around the perspectivepollerd {@link EventForwarder} that
+ * increments dedicated Micrometer counters for perspective lifecycle UEIs.
+ *
+ * <p>PerspectivePollerd's constructor parameter 9 is plain
+ * {@code EventForwarder} (not {@code EventIpcManager}), so this wrapper
+ * only needs to satisfy the four-method {@link EventForwarder} interface.
+ * The unwrapped {@link org.opennms.netmgt.events.api.EventIpcManager} is
+ * still used by the {@code AnnotationBasedEventListenerAdapter} beans
+ * for inbound event-listener registration.
+ */
+public class CountingPerspectiveEventForwarder implements EventForwarder {
+
+    private final EventForwarder delegate;
+    private final MeterRegistry registry;
+
+    public CountingPerspectiveEventForwarder(EventForwarder delegate, MeterRegistry registry) {
+        this.delegate = delegate;
+        this.registry = registry;
+    }
+
+    @Override
+    public void sendNow(Event event) {
+        record(event);
+        delegate.sendNow(event);
+    }
+
+    @Override
+    public void sendNow(Log eventLog) {
+        recordLog(eventLog);
+        delegate.sendNow(eventLog);
+    }
+
+    @Override
+    public void sendNowSync(Event event) {
+        record(event);
+        delegate.sendNowSync(event);
+    }
+
+    @Override
+    public void sendNowSync(Log eventLog) {
+        recordLog(eventLog);
+        delegate.sendNowSync(eventLog);
+    }
+
+    private void recordLog(Log eventLog) {
+        if (eventLog == null || eventLog.getEvents() == null
+                || eventLog.getEvents().getEvent() == null) {
+            return;
+        }
+        for (Event event : eventLog.getEvents().getEvent()) {
+            record(event);
+        }
+    }
+
+    private void record(Event event) {
+        registry.counter(PerspectivePollerdDomainMetrics.EVENTS_FORWARDED).increment();
+        if (event == null || event.getUei() == null) {
+            return;
+        }
+        String uei = event.getUei();
+        if (EventConstants.PERSPECTIVE_NODE_LOST_SERVICE_UEI.equals(uei)) {
+            registry.counter(PerspectivePollerdDomainMetrics.SERVICE_LOST_TOTAL).increment();
+        } else if (EventConstants.PERSPECTIVE_NODE_REGAINED_SERVICE_UEI.equals(uei)) {
+            registry.counter(PerspectivePollerdDomainMetrics.SERVICE_REGAINED_TOTAL).increment();
+        }
+    }
+}

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
@@ -42,6 +42,7 @@ import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
 import org.opennms.netmgt.perspectivepoller.PerspectivePollerd;
@@ -136,6 +137,14 @@ public class PerspectivePollerdDaemonConfiguration {
      * {@code EventForwarder}, but {@code EventIpcManager} extends
      * {@code EventForwarder}, so passing the EventIpcManager bean is valid.
      * Spring resolves by type compatibility.</p>
+     *
+     * <p>The forwarder slot is wrapped with {@link CountingPerspectiveEventForwarder}
+     * so per-perspective lifecycle UEIs (nodeLostService /
+     * nodeRegainedService) are surfaced at {@code /actuator/prometheus}
+     * as {@code deltav_perspective_*} counters. The unwrapped
+     * {@code EventIpcManager} bean is still used by the
+     * {@code AnnotationBasedEventListenerAdapter} beans for inbound
+     * subscription registration.</p>
      */
     @Bean
     public PerspectivePollerd perspectivePollerd(
@@ -151,10 +160,13 @@ public class PerspectivePollerdDaemonConfiguration {
             ThresholdingService thresholdingService,
             OutageDao outageDao,
             TracerRegistry tracerRegistry,
-            PerspectiveServiceTracker perspectiveServiceTracker) {
+            PerspectiveServiceTracker perspectiveServiceTracker,
+            io.micrometer.core.instrument.MeterRegistry meterRegistry) {
+        EventForwarder countingForwarder =
+                new CountingPerspectiveEventForwarder(eventIpcManager, meterRegistry);
         return new PerspectivePollerd(sessionUtils, monitoringLocationDao, pollerConfig,
                 monitoredServiceDao, locationAwarePollerClient, applicationDao,
-                collectionAgentFactory, persisterFactory, eventIpcManager,
+                collectionAgentFactory, persisterFactory, countingForwarder,
                 thresholdingService, outageDao, tracerRegistry, perspectiveServiceTracker);
     }
 

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDomainMetrics.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDomainMetrics.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.perspectivepoller.boot;
+
+/**
+ * Canonical Micrometer meter names for perspectivepollerd domain signals.
+ * Names become {@code deltav_perspective_*} at {@code /actuator/prometheus}
+ * after Micrometer's dot-to-underscore flattening.
+ *
+ * <p>Architecture note (vs pollerd): horizon's {@code PerspectivePollerd}
+ * uses a Quartz-based scheduler and a private {@code lambda$execute$0}
+ * inside {@code PerspectivePollJob} as its per-poll callback. There is no
+ * public {@code PollContext}-equivalent seam to subclass without modifying
+ * horizon source. As a result, beta2 instrumentation is bounded to the
+ * {@code EventForwarder} wrap (outage UEI counting) — the same pattern
+ * applied to discovery's daemon. Per-poll response-time {@code deltav_*}
+ * counters and Phase 3 Kafka publishing for perspective polls require a
+ * deeper hook (e.g., a wrapping {@code PersisterFactory}) and are tracked
+ * as a post-beta2 follow-up.
+ */
+public final class PerspectivePollerdDomainMetrics {
+
+    private PerspectivePollerdDomainMetrics() {}
+
+    public static final String EVENTS_FORWARDED          = "deltav.perspective.events.forwarded";
+    public static final String SERVICE_LOST_TOTAL        = "deltav.perspective.service.lost";
+    public static final String SERVICE_REGAINED_TOTAL    = "deltav.perspective.service.regained";
+}

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -330,6 +330,20 @@
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Phase 3 (delta-v#TBD): publish PollResult time-series records to
+             the deltav-timeseries Kafka topic. Mirrors the collectd publisher
+             from PR #170 — same wire contract (TimeseriesBatch protobuf), same
+             Spring Cloud Stream binder. -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.deltav-kafka-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/InstrumentedPollContext.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/InstrumentedPollContext.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.poller.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.opennms.core.tsid.TsidFactory;
+import org.opennms.netmgt.config.PollerConfig;
+import org.opennms.netmgt.events.api.EventIpcManager;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
+import org.opennms.netmgt.poller.PollStatus;
+import org.opennms.netmgt.poller.QueryManager;
+import org.opennms.netmgt.poller.pollables.PollEvent;
+import org.opennms.netmgt.poller.pollables.PollableService;
+
+/**
+ * {@link StandalonePollContext} subclass that increments {@code deltav_pollerd_*}
+ * Micrometer counters on every poll completion and outage transition, and
+ * optionally publishes per-poll response-time samples to the
+ * {@code deltav-timeseries} Kafka topic via {@link PollResultPublisher}.
+ *
+ * <p>The publisher is wired only when {@code deltav.timeseries.enabled=true}
+ * in {@code application.yml}; otherwise it is null and Phase 3 publishing
+ * is a no-op (Phase 2 metrics still fire). This matches the collectd module's
+ * conditional pattern.
+ */
+public class InstrumentedPollContext extends StandalonePollContext {
+
+    private final MeterRegistry registry;
+    private final PollResultPublisher publisher;
+    private final Timer pollDuration;
+
+    public InstrumentedPollContext(EventIpcManager eventManager, PollerConfig pollerConfig,
+                                   QueryManager queryManager, LocationAwarePingClient pingClient,
+                                   TsidFactory tsidFactory, String localHostName, String name,
+                                   MeterRegistry registry, PollResultPublisher publisher) {
+        super(eventManager, pollerConfig, queryManager, pingClient, tsidFactory, localHostName, name);
+        this.registry = registry;
+        this.publisher = publisher;
+        this.pollDuration = registry.timer(PollerdDomainMetrics.POLL_DURATION);
+    }
+
+    @Override
+    public void trackPoll(PollableService service, PollStatus status) {
+        super.trackPoll(service, status);
+        recordPoll(service, status);
+        if (publisher != null) {
+            publisher.publish(service, status);
+        }
+    }
+
+    @Override
+    public void openOutage(PollableService service, PollEvent event) {
+        super.openOutage(service, event);
+        registry.counter(PollerdDomainMetrics.OUTAGES_OPENED,
+                PollerdDomainMetrics.TAG_LOCATION, location(service)).increment();
+    }
+
+    @Override
+    public void resolveOutage(PollableService service, PollEvent event) {
+        super.resolveOutage(service, event);
+        registry.counter(PollerdDomainMetrics.OUTAGES_RESOLVED,
+                PollerdDomainMetrics.TAG_LOCATION, location(service)).increment();
+    }
+
+    private void recordPoll(PollableService service, PollStatus status) {
+        String location = location(service);
+        String result = status != null && status.getStatusName() != null
+                ? status.getStatusName().toLowerCase() : "unknown";
+        registry.counter(PollerdDomainMetrics.POLLS_COMPLETED,
+                PollerdDomainMetrics.TAG_LOCATION, location,
+                PollerdDomainMetrics.TAG_RESULT, result).increment();
+        if (status != null && status.getResponseTime() != null) {
+            pollDuration.record((long) (status.getResponseTime() * 1_000_000.0),
+                    java.util.concurrent.TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private static String location(PollableService service) {
+        if (service == null) return "unknown";
+        String l = service.getNodeLocation();
+        return l != null ? l : "Default";
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollResultPublisher.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollResultPublisher.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.poller.boot;
+
+import java.nio.charset.StandardCharsets;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.opennms.netmgt.poller.PollStatus;
+import org.opennms.netmgt.poller.pollables.PollableService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Publishes per-poll response-time samples to the {@code deltav-timeseries}
+ * Kafka topic as {@link TimeseriesBatch} protobuf records, keyed by
+ * {@code "{location}@{nodeId}"}.
+ *
+ * <p>Each batch contains a single {@link Resource} whose {@code resource_id}
+ * follows the horizon convention {@code node[N].monitoredService[svc]}. The
+ * single attribute carries the response-time in milliseconds as a GAUGE.
+ * Producer is set to {@link ProducerType#PRODUCER_POLLERD} so the consumer
+ * can distinguish the origin from collectd or perspectivepollerd records.
+ *
+ * <p>Error-isolated: never throws. Failures bump
+ * {@code deltav_timeseries_batches_failed_total} and the poll context
+ * continues unaffected.
+ */
+public class PollResultPublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PollResultPublisher.class);
+    static final String BINDING_NAME = "publishTimeseries-out-0";
+    static final String GROUP_NAME = "response-time";
+    static final String ATTRIBUTE_NAME = "response";
+    static final String RESOURCE_TYPE = "monitoredService";
+
+    private final StreamBridge streamBridge;
+    private final MeterRegistry meterRegistry;
+    private final ProducerType producerType;
+    private final String producerLabel;
+
+    public PollResultPublisher(StreamBridge streamBridge,
+                               MeterRegistry meterRegistry,
+                               ProducerType producerType,
+                               String producerLabel) {
+        this.streamBridge = streamBridge;
+        this.meterRegistry = meterRegistry;
+        this.producerType = producerType;
+        this.producerLabel = producerLabel;
+    }
+
+    /**
+     * Publishes one response-time sample. Returns silently when the poll
+     * has no measurable response time (UNKNOWN polls, immediate failures
+     * with no I/O).
+     */
+    public void publish(PollableService service, PollStatus status) {
+        if (service == null || status == null) {
+            return;
+        }
+        Double responseTime = status.getResponseTime();
+        if (responseTime == null || Double.isNaN(responseTime)) {
+            return;
+        }
+        String location = service.getNodeLocation() != null ? service.getNodeLocation() : "Default";
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            TimeseriesBatch batch = buildBatch(service, status, responseTime, location);
+            byte[] payload;
+            try {
+                payload = batch.toByteArray();
+            } catch (RuntimeException ex) {
+                LOG.warn("Serialization failed for node {} svc {}; dropping",
+                        service.getNodeId(), service.getSvcName(), ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", location, "producer", producerLabel,
+                        "reason", "serialization_error").increment();
+                return;
+            }
+            byte[] key = (location + "@" + service.getNodeId()).getBytes(StandardCharsets.UTF_8);
+            Message<byte[]> message = MessageBuilder.withPayload(payload)
+                    .setHeader(KafkaHeaders.KEY, key)
+                    .build();
+            boolean sent;
+            try {
+                sent = streamBridge.send(BINDING_NAME, message);
+            } catch (RuntimeException ex) {
+                LOG.warn("streamBridge.send threw for node {} svc {}",
+                        service.getNodeId(), service.getSvcName(), ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", location, "producer", producerLabel,
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+            if (!sent) {
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", location, "producer", producerLabel,
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+            meterRegistry.counter("deltav_timeseries_batches_published_total",
+                    "location", location, "producer", producerLabel).increment();
+        } finally {
+            sample.stop(Timer.builder("deltav_timeseries_publish_duration_seconds")
+                    .tags("location", location, "producer", producerLabel)
+                    .register(meterRegistry));
+        }
+    }
+
+    private TimeseriesBatch buildBatch(PollableService service, PollStatus status,
+                                       double responseTimeMs, String location) {
+        long timestampMs = status.getTimestamp() != null
+                ? status.getTimestamp().getTime()
+                : System.currentTimeMillis();
+        String resourceId = "node[" + service.getNodeId() + "].monitoredService["
+                + service.getSvcName() + "]";
+        Attribute responseAttr = Attribute.newBuilder()
+                .setName(ATTRIBUTE_NAME)
+                .setNumeric(responseTimeMs)
+                .setType(AttributeType.ATTRIBUTE_TYPE_GAUGE)
+                .build();
+        AttributeGroup group = AttributeGroup.newBuilder()
+                .setName(GROUP_NAME)
+                .addAttributes(responseAttr)
+                .build();
+        Resource resource = Resource.newBuilder()
+                .setResourceId(resourceId)
+                .setType(RESOURCE_TYPE)
+                .setInstance(service.getSvcName() != null ? service.getSvcName() : "")
+                .addGroups(group)
+                .build();
+        return TimeseriesBatch.newBuilder()
+                .setTimestampMs(timestampMs)
+                .setNodeId(service.getNodeId())
+                .setLocation(location)
+                .setCollectionPackage(service.getSvcName() != null ? service.getSvcName() : "")
+                .setProducer(producerType)
+                .addResources(resource)
+                .build();
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdDaemonConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdDaemonConfiguration.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.ObjectProvider;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import org.deltav.core.daemon.common.SpringServiceDaemonSmartLifecycle;
@@ -141,21 +143,30 @@ public class PollerdDaemonConfiguration {
     }
 
     /**
-     * PollContext that skips AsyncPollingEngine creation.
+     * PollContext that skips AsyncPollingEngine creation and instruments
+     * every poll with {@code deltav_pollerd_*} Micrometer counters plus
+     * (when {@code deltav.timeseries.enabled=true}) per-poll Kafka publish
+     * via {@link PollResultPublisher}.
      *
-     * <p>{@link StandalonePollContext} overrides {@code afterPropertiesSet()} as a
-     * no-op to avoid loading resilience4j Bulkhead, which is not needed when polls
-     * execute via Kafka RPC to Minion.</p>
+     * <p>The {@link ObjectProvider} for {@link PollResultPublisher} is used
+     * so the bean stays optional — {@code PollerdTimeseriesConfiguration}
+     * is gated by {@code @ConditionalOnProperty}, so the publisher is absent
+     * unless the flag is on. {@link InstrumentedPollContext} treats a null
+     * publisher as "Phase 3 disabled" and still emits Phase 2 counters.</p>
      */
     @Bean
     public PollContext pollContext(EventIpcManager eventIpcManager,
                                   PollerConfig pollerConfig,
                                   QueryManager queryManager,
                                   LocationAwarePingClient locationAwarePingClient,
-                                  TsidFactory tsidFactory) {
+                                  TsidFactory tsidFactory,
+                                  MeterRegistry meterRegistry,
+                                  ObjectProvider<PollResultPublisher> publisherProvider) {
         String localHostName = InetAddressUtils.getLocalHostName();
-        return new StandalonePollContext(eventIpcManager, pollerConfig, queryManager,
-                locationAwarePingClient, tsidFactory, localHostName, "OpenNMS.Poller.DefaultPollContext");
+        return new InstrumentedPollContext(eventIpcManager, pollerConfig, queryManager,
+                locationAwarePingClient, tsidFactory, localHostName,
+                "OpenNMS.Poller.DefaultPollContext",
+                meterRegistry, publisherProvider.getIfAvailable());
     }
 
     /**

--- a/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdDomainMetrics.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdDomainMetrics.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.poller.boot;
+
+/**
+ * Canonical Micrometer meter names for pollerd domain signals. Names become
+ * {@code deltav_pollerd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>The instrumentation point is {@link org.opennms.netmgt.poller.DefaultPollContext}'s
+ * three callback methods:
+ * <ul>
+ *   <li>{@code trackPoll} — fires once per poll completion. Tagged by
+ *       {@code location} (bounded to configured Minion locations) and
+ *       {@code result} (bounded to {@code PollStatus} status names).</li>
+ *   <li>{@code openOutage} / {@code resolveOutage} — fire on outage state
+ *       transitions. Tagged by {@code location} only; service name is too
+ *       cardinal to label.</li>
+ * </ul>
+ *
+ * <p>Response-time distributions feed both Micrometer (for direct alerting on
+ * percentile latency) and the Phase 3 Kafka time-series topic (for storage
+ * in VictoriaMetrics).
+ */
+public final class PollerdDomainMetrics {
+
+    private PollerdDomainMetrics() {}
+
+    public static final String POLLS_COMPLETED       = "deltav.pollerd.polls.completed";
+    public static final String POLL_DURATION         = "deltav.pollerd.poll.duration";
+    public static final String OUTAGES_OPENED        = "deltav.pollerd.outages.opened";
+    public static final String OUTAGES_RESOLVED      = "deltav.pollerd.outages.resolved";
+
+    static final String TAG_LOCATION = "location";
+    static final String TAG_RESULT   = "result";
+}

--- a/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdTimeseriesConfiguration.java
+++ b/core/daemon-boot-pollerd/src/main/java/org/deltav/netmgt/poller/boot/PollerdTimeseriesConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.poller.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.deltav.timeseries.proto.ProducerType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+/**
+ * Phase 3: publishes per-poll response-time records to the
+ * {@code deltav-timeseries} Kafka topic, mirroring the collectd publisher
+ * shipped in PR #170.
+ *
+ * <p>Activated only when {@code deltav.timeseries.enabled=true}; otherwise
+ * the publisher bean is absent and {@link InstrumentedPollContext} sees a
+ * null publisher and skips Phase 3 work. Phase 2 Micrometer counters fire
+ * unconditionally regardless of this flag.
+ */
+@Configuration
+@ConditionalOnProperty(name = "deltav.timeseries.enabled", havingValue = "true")
+public class PollerdTimeseriesConfiguration {
+
+    /**
+     * Provisions the {@code deltav-timeseries} topic. The collectd publisher
+     * declares the same topic; whichever daemon starts first creates it,
+     * subsequent daemons see {@code TopicAlreadyExistsException} which Kafka
+     * Admin treats as a no-op.
+     */
+    @Bean
+    public NewTopic deltavTimeseriesTopic(
+            @Value("${deltav.timeseries.partitions:16}") int partitions,
+            @Value("${deltav.timeseries.replication-factor:1}") short replicationFactor,
+            @Value("${deltav.timeseries.retention-days:1}") int retentionDays) {
+        return TopicBuilder.name("deltav-timeseries")
+                .partitions(partitions)
+                .replicas(replicationFactor)
+                .config("retention.ms", String.valueOf(retentionDays * 24L * 3600_000L))
+                .config("compression.type", "lz4")
+                .build();
+    }
+
+    @Bean
+    public PollResultPublisher pollResultPublisher(StreamBridge streamBridge,
+                                                   MeterRegistry meterRegistry) {
+        return new PollResultPublisher(streamBridge, meterRegistry,
+                ProducerType.PRODUCER_POLLERD, "pollerd");
+    }
+}

--- a/core/daemon-boot-pollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-pollerd/src/main/resources/application.yml
@@ -14,6 +14,34 @@ spring:
     properties:
       hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
       hibernate.archive.autodetection: none
+  # KafkaAdmin (which provisions deltavTimeseriesTopic in
+  # PollerdTimeseriesConfiguration) binds to spring.kafka.bootstrap-servers.
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+  cloud:
+    stream:
+      bindings:
+        publishTimeseries-out-0:
+          destination: deltav-timeseries
+          producer:
+            partition-count: ${DELTAV_TIMESERIES_PARTITIONS:16}
+            use-native-encoding: true
+      kafka:
+        binder:
+          brokers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+          auto-create-topics: true
+        bindings:
+          publishTimeseries-out-0:
+            producer:
+              configuration:
+                key.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                value.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                compression.type: lz4
+                linger.ms: 50
+                batch.size: 65536
+                acks: all
+                enable.idempotence: true
+                max.in.flight.requests.per.connection: 5
 
 opennms:
   home: ${OPENNMS_HOME:/opt/deltav}
@@ -37,3 +65,10 @@ management:
     web:
       exposure:
         include: health,prometheus
+
+deltav:
+  timeseries:
+    enabled: ${DELTAV_TIMESERIES_ENABLED:false}
+    partitions: ${DELTAV_TIMESERIES_PARTITIONS:16}
+    replication-factor: ${DELTAV_TIMESERIES_REPLICATION_FACTOR:1}
+    retention-days: ${DELTAV_TIMESERIES_RETENTION_DAYS:1}

--- a/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/boot/CountingProvisionEventForwarder.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/boot/CountingProvisionEventForwarder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.provision.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Log;
+
+/**
+ * Decorator around the provisiond {@link EventForwarder} that increments
+ * dedicated Micrometer counters for each provisiond lifecycle UEI.
+ *
+ * <p>Per-UEI counters (rather than one counter tagged by {@code uei}) keep
+ * PromQL queries direct and avoid string-comparison work in alert rules.
+ * The set of recognized UEIs is bounded; unrecognized UEIs only bump the
+ * generic {@code deltav_provisiond_events_forwarded_total} bucket.
+ */
+public class CountingProvisionEventForwarder implements EventForwarder {
+
+    private final EventForwarder delegate;
+    private final MeterRegistry registry;
+
+    public CountingProvisionEventForwarder(EventForwarder delegate, MeterRegistry registry) {
+        this.delegate = delegate;
+        this.registry = registry;
+    }
+
+    @Override
+    public void sendNow(Event event) {
+        record(event);
+        delegate.sendNow(event);
+    }
+
+    @Override
+    public void sendNow(Log eventLog) {
+        recordLog(eventLog);
+        delegate.sendNow(eventLog);
+    }
+
+    @Override
+    public void sendNowSync(Event event) {
+        record(event);
+        delegate.sendNowSync(event);
+    }
+
+    @Override
+    public void sendNowSync(Log eventLog) {
+        recordLog(eventLog);
+        delegate.sendNowSync(eventLog);
+    }
+
+    private void recordLog(Log eventLog) {
+        if (eventLog == null || eventLog.getEvents() == null
+                || eventLog.getEvents().getEvent() == null) {
+            return;
+        }
+        for (Event event : eventLog.getEvents().getEvent()) {
+            record(event);
+        }
+    }
+
+    private void record(Event event) {
+        registry.counter(ProvisiondDomainMetrics.EVENTS_FORWARDED).increment();
+        if (event == null || event.getUei() == null) {
+            return;
+        }
+        String uei = event.getUei();
+        if (EventConstants.IMPORT_STARTED_UEI.equals(uei)) {
+            registry.counter(ProvisiondDomainMetrics.IMPORTS_STARTED).increment();
+        } else if (EventConstants.IMPORT_SUCCESSFUL_UEI.equals(uei)) {
+            registry.counter(ProvisiondDomainMetrics.IMPORTS_SUCCESSFUL).increment();
+        } else if (EventConstants.IMPORT_FAILED_UEI.equals(uei)) {
+            registry.counter(ProvisiondDomainMetrics.IMPORTS_FAILED).increment();
+        } else if (EventConstants.NODE_ADDED_EVENT_UEI.equals(uei)) {
+            registry.counter(ProvisiondDomainMetrics.NODES_ADDED).increment();
+        } else if (EventConstants.NODE_UPDATED_EVENT_UEI.equals(uei)) {
+            registry.counter(ProvisiondDomainMetrics.NODES_UPDATED).increment();
+        } else if (EventConstants.NODE_DELETED_EVENT_UEI.equals(uei)
+                || EventConstants.DUP_NODE_DELETED_EVENT_UEI.equals(uei)) {
+            registry.counter(ProvisiondDomainMetrics.NODES_DELETED).increment();
+        }
+    }
+}

--- a/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/boot/ProvisiondBootConfiguration.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/boot/ProvisiondBootConfiguration.java
@@ -28,6 +28,7 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import org.opennms.netmgt.config.SnmpAssetAdapterConfig;
 import org.opennms.netmgt.config.SnmpAssetAdapterConfigFactory;
@@ -288,10 +289,20 @@ public class ProvisiondBootConfiguration {
     // Section 5: Event Forwarder
     // ===================================================================
 
+    /**
+     * Wraps the upstream {@link EventForwarder} with {@link CountingProvisionEventForwarder}
+     * (Micrometer counters per provisiond lifecycle UEI) and then with
+     * {@link QualifiedEventForwarder} (the {@code @Qualifier("transactionAware")}
+     * marker bean). The chain order is intentional: counting must see every
+     * outbound event, including those that {@code QualifiedEventForwarder}
+     * would otherwise pass through unchanged today but might mediate later.
+     */
     @Bean
     @Qualifier("transactionAware")
-    public EventForwarder transactionAwareEventForwarder(EventForwarder eventForwarder) {
-        return new QualifiedEventForwarder(eventForwarder);
+    public EventForwarder transactionAwareEventForwarder(EventForwarder eventForwarder,
+                                                         MeterRegistry meterRegistry) {
+        return new QualifiedEventForwarder(
+                new CountingProvisionEventForwarder(eventForwarder, meterRegistry));
     }
 
     // ===================================================================

--- a/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/boot/ProvisiondDomainMetrics.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/boot/ProvisiondDomainMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.provision.boot;
+
+/**
+ * Canonical Micrometer meter names for provisiond domain signals. Names become
+ * {@code deltav_provisiond_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>Provisiond emits a known, finite set of UEIs for its lifecycle events.
+ * Rather than tag a single counter by UEI (which works but is harder to query),
+ * each high-value UEI gets its own dedicated counter so PromQL queries are
+ * direct (e.g., {@code rate(deltav_provisiond_imports_successful_total[5m])}).
+ */
+public final class ProvisiondDomainMetrics {
+
+    private ProvisiondDomainMetrics() {}
+
+    public static final String EVENTS_FORWARDED        = "deltav.provisiond.events.forwarded";
+    public static final String IMPORTS_STARTED         = "deltav.provisiond.imports.started";
+    public static final String IMPORTS_SUCCESSFUL      = "deltav.provisiond.imports.successful";
+    public static final String IMPORTS_FAILED          = "deltav.provisiond.imports.failed";
+    public static final String NODES_ADDED             = "deltav.provisiond.nodes.added";
+    public static final String NODES_UPDATED           = "deltav.provisiond.nodes.updated";
+    public static final String NODES_DELETED           = "deltav.provisiond.nodes.deleted";
+}

--- a/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/CountingSyslogSinkConsumer.java
+++ b/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/CountingSyslogSinkConsumer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.syslogd.boot;
+
+import java.util.List;
+
+import com.codahale.metrics.MetricRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.opennms.core.ipc.sink.api.MessageConsumerManager;
+import org.opennms.netmgt.config.SyslogdConfig;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
+import org.opennms.netmgt.syslogd.SyslogSinkConsumer;
+import org.opennms.netmgt.syslogd.api.SyslogMessageDTO;
+import org.opennms.netmgt.syslogd.api.SyslogMessageLogDTO;
+
+/**
+ * {@link SyslogSinkConsumer} subclass that increments Micrometer counters and
+ * records timing on every Sink batch arriving from a Minion. Delegates to
+ * {@code super.handleMessage} so syslog processing semantics are unchanged.
+ *
+ * <p>Horizon's internal Dropwizard timers (consumer/toEvent/broadcast) are
+ * already bridged to {@code opennms_*} meters via {@code HorizonMetricsBridge};
+ * this subclass adds the delta-v-native batch-shape signals on top.
+ */
+public class CountingSyslogSinkConsumer extends SyslogSinkConsumer {
+
+    private final MeterRegistry registry;
+    private final Timer handleDuration;
+
+    public CountingSyslogSinkConsumer(MetricRegistry metricRegistry,
+                                      MessageConsumerManager messageConsumerManager,
+                                      SyslogdConfig syslogdConfig,
+                                      DistPollerDao distPollerDao,
+                                      EventForwarder eventForwarder,
+                                      LocationAwareDnsLookupClient dnsLookupClient,
+                                      MeterRegistry registry) {
+        super(metricRegistry, messageConsumerManager, syslogdConfig, distPollerDao,
+                eventForwarder, dnsLookupClient);
+        this.registry = registry;
+        this.handleDuration = registry.timer(SyslogdDomainMetrics.HANDLE_DURATION);
+    }
+
+    @Override
+    public void handleMessage(SyslogMessageLogDTO message) {
+        String location = location(message);
+        registry.counter(SyslogdDomainMetrics.MESSAGE_LOGS_RECEIVED,
+                SyslogdDomainMetrics.TAG_LOCATION, location).increment();
+        List<SyslogMessageDTO> batch = message != null ? message.getMessages() : null;
+        int size = batch != null ? batch.size() : 0;
+        if (size > 0) {
+            registry.counter(SyslogdDomainMetrics.MESSAGES_IN_BATCH,
+                    SyslogdDomainMetrics.TAG_LOCATION, location).increment(size);
+        }
+        handleDuration.record(() -> super.handleMessage(message));
+    }
+
+    private static String location(SyslogMessageLogDTO message) {
+        if (message == null) return "unknown";
+        String l = message.getLocation();
+        return l != null ? l : "unknown";
+    }
+}

--- a/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/SyslogdConfiguration.java
+++ b/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/SyslogdConfiguration.java
@@ -26,6 +26,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import org.deltav.core.daemon.common.JdbcDistPollerDao;
 import org.deltav.core.daemon.common.JdbcInterfaceToNodeCache;
@@ -148,7 +149,8 @@ public class SyslogdConfiguration {
                                                   SyslogdConfig syslogdConfig,
                                                   DistPollerDao distPollerDao,
                                                   EventForwarder eventForwarder,
-                                                  LocationAwareDnsLookupClient locationAwareDnsLookupClient) {
+                                                  LocationAwareDnsLookupClient locationAwareDnsLookupClient,
+                                                  MeterRegistry meterRegistry) {
         // Bridge DNS cache config for SyslogSinkConsumer constructor
         System.setProperty("org.opennms.netmgt.syslogd.dnscache.config", dnsCacheConfig);
 
@@ -160,7 +162,7 @@ public class SyslogdConfiguration {
         // Note: SyslogSinkConsumer.getModule() internally creates its own
         // SyslogSinkModule using its syslogdConfig and distPollerDao.
         // No separate SyslogSinkModule @Bean is needed.
-        return new SyslogSinkConsumer(metricRegistry, messageConsumerManager, syslogdConfig,
-                distPollerDao, eventForwarder, locationAwareDnsLookupClient);
+        return new CountingSyslogSinkConsumer(metricRegistry, messageConsumerManager, syslogdConfig,
+                distPollerDao, eventForwarder, locationAwareDnsLookupClient, meterRegistry);
     }
 }

--- a/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/SyslogdDomainMetrics.java
+++ b/core/daemon-boot-syslogd/src/main/java/org/deltav/netmgt/syslogd/boot/SyslogdDomainMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.syslogd.boot;
+
+/**
+ * Canonical Micrometer meter names for syslogd domain signals. Names become
+ * {@code deltav_syslogd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>These are the native delta-v counters; horizon's existing Dropwizard
+ * timers (consumer/toEvent/broadcast) are surfaced separately as
+ * {@code opennms_*} via {@link org.deltav.horizon.metrics.HorizonMetricsBridge}.
+ *
+ * <p>Tagged by {@code location} (Minion location), bounded to the configured
+ * locations. No per-source-address labels.
+ */
+public final class SyslogdDomainMetrics {
+
+    private SyslogdDomainMetrics() {}
+
+    public static final String MESSAGE_LOGS_RECEIVED = "deltav.syslogd.messagelogs.received";
+    public static final String MESSAGES_IN_BATCH     = "deltav.syslogd.messages.in.batch";
+    public static final String HANDLE_DURATION       = "deltav.syslogd.handle.duration";
+
+    static final String TAG_LOCATION = "location";
+}

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/KafkaSinkBridge.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/KafkaSinkBridge.java
@@ -21,6 +21,9 @@ import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -60,13 +63,16 @@ public class KafkaSinkBridge implements InitializingBean, DisposableBean {
     private static final String DEFAULT_GROUP_ID = "opennms-telemetryd-sink";
 
     private final AbstractMessageConsumerManager consumerManager;
+    private final MeterRegistry meterRegistry;
 
     private volatile SinkModule<?, Message> module;
     private volatile Thread consumerThread;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    public KafkaSinkBridge(AbstractMessageConsumerManager consumerManager) {
+    public KafkaSinkBridge(AbstractMessageConsumerManager consumerManager,
+                           MeterRegistry meterRegistry) {
         this.consumerManager = consumerManager;
+        this.meterRegistry = meterRegistry;
     }
 
     /**
@@ -112,6 +118,23 @@ public class KafkaSinkBridge implements InitializingBean, DisposableBean {
         props.put("auto.commit.interval.ms", "1000");
         props.put("auto.offset.reset", "latest");
 
+        // Pre-resolve per-module meters so the hot path doesn't repeatedly hit
+        // the registry. module.getId() is bounded to the configured queue
+        // count (typically 4-8) so this is a single resolution per bridge.
+        final String moduleId = module.getId();
+        final var packetsReceived = meterRegistry.counter(
+                TelemetrydDomainMetrics.PACKETS_RECEIVED,
+                TelemetrydDomainMetrics.TAG_MODULE, moduleId);
+        final var packetsDispatched = meterRegistry.counter(
+                TelemetrydDomainMetrics.PACKETS_DISPATCHED,
+                TelemetrydDomainMetrics.TAG_MODULE, moduleId);
+        final var dispatchFailures = meterRegistry.counter(
+                TelemetrydDomainMetrics.DISPATCH_FAILURES,
+                TelemetrydDomainMetrics.TAG_MODULE, moduleId);
+        final Timer dispatchDuration = Timer.builder(TelemetrydDomainMetrics.DISPATCH_DURATION)
+                .tag(TelemetrydDomainMetrics.TAG_MODULE, moduleId)
+                .register(meterRegistry);
+
         try (KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(props)) {
             consumer.subscribe(Collections.singletonList(topic));
 
@@ -119,16 +142,22 @@ public class KafkaSinkBridge implements InitializingBean, DisposableBean {
                 try {
                     ConsumerRecords<String, byte[]> records = consumer.poll(POLL_DURATION);
                     for (ConsumerRecord<String, byte[]> record : records) {
+                        packetsReceived.increment();
+                        Timer.Sample sample = Timer.start(meterRegistry);
                         try {
                             SinkMessage sinkMessage = SinkMessage.parseFrom(record.value());
                             byte[] content = sinkMessage.getContent().toByteArray();
                             Message message = module.unmarshal(content);
                             consumerManager.dispatch(module, message);
+                            packetsDispatched.increment();
                             LOG.debug("Dispatched Sink message from Kafka: module={}, offset={}",
                                     module.getId(), record.offset());
                         } catch (Exception e) {
+                            dispatchFailures.increment();
                             LOG.warn("Error processing Sink message from Kafka (module={}, offset={}): {}",
                                     module.getId(), record.offset(), e.getMessage(), e);
+                        } finally {
+                            sample.stop(dispatchDuration);
                         }
                     }
                 } catch (Throwable t) {

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetryMessageConsumerManager.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetryMessageConsumerManager.java
@@ -19,6 +19,8 @@ package org.deltav.netmgt.telemetry.boot;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.opennms.core.ipc.sink.api.Message;
 import org.opennms.core.ipc.sink.api.SinkModule;
 import org.opennms.core.ipc.sink.common.AbstractMessageConsumerManager;
@@ -44,6 +46,11 @@ public class TelemetryMessageConsumerManager extends AbstractMessageConsumerMana
     private static final Logger LOG = LoggerFactory.getLogger(TelemetryMessageConsumerManager.class);
 
     private final Map<String, KafkaSinkBridge> bridges = new ConcurrentHashMap<>();
+    private final MeterRegistry meterRegistry;
+
+    public TelemetryMessageConsumerManager(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
 
     @Override
     @SuppressWarnings("unchecked")
@@ -56,7 +63,7 @@ public class TelemetryMessageConsumerManager extends AbstractMessageConsumerMana
             return;
         }
 
-        KafkaSinkBridge bridge = new KafkaSinkBridge(this);
+        KafkaSinkBridge bridge = new KafkaSinkBridge(this, meterRegistry);
         bridge.setModule(module);
         bridges.put(moduleId, bridge);
 

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydDomainMetrics.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydDomainMetrics.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.telemetry.boot;
+
+/**
+ * Canonical Micrometer meter names for telemetryd domain signals. Names become
+ * {@code deltav_telemetryd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>Tagged by {@code module} (the SinkModule id, e.g. {@code Telemetry-Netflow-5},
+ * {@code Telemetry-IPFIX}, {@code Telemetry-sFlow}). The set is bounded to the
+ * configured telemetry queues — typically 4–8 protocols.
+ */
+public final class TelemetrydDomainMetrics {
+
+    private TelemetrydDomainMetrics() {}
+
+    public static final String PACKETS_RECEIVED   = "deltav.telemetryd.packets.received";
+    public static final String PACKETS_DISPATCHED = "deltav.telemetryd.packets.dispatched";
+    public static final String DISPATCH_FAILURES  = "deltav.telemetryd.dispatch.failures";
+    public static final String DISPATCH_DURATION  = "deltav.telemetryd.dispatch.duration";
+
+    static final String TAG_MODULE = "module";
+}

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydSinkConfiguration.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydSinkConfiguration.java
@@ -16,6 +16,8 @@
  */
 package org.deltav.netmgt.telemetry.boot;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.opennms.core.ipc.sink.api.MessageConsumerManager;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.springframework.context.annotation.Bean;
@@ -36,8 +38,8 @@ import org.springframework.context.annotation.Configuration;
 public class TelemetrydSinkConfiguration {
 
     @Bean
-    public TelemetryMessageConsumerManager messageConsumerManager() {
-        return new TelemetryMessageConsumerManager();
+    public TelemetryMessageConsumerManager messageConsumerManager(MeterRegistry meterRegistry) {
+        return new TelemetryMessageConsumerManager(meterRegistry);
     }
 
     @Bean

--- a/core/daemon-boot-trapd/src/main/java/org/deltav/netmgt/trapd/boot/CountingTrapSinkConsumer.java
+++ b/core/daemon-boot-trapd/src/main/java/org/deltav/netmgt/trapd/boot/CountingTrapSinkConsumer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.trapd.boot;
+
+import java.util.List;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.opennms.core.ipc.sink.api.MessageConsumerManager;
+import org.opennms.netmgt.config.TrapdConfig;
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.trapd.TrapDTO;
+import org.opennms.netmgt.trapd.TrapLogDTO;
+import org.opennms.netmgt.trapd.TrapSinkConsumer;
+
+/**
+ * {@link TrapSinkConsumer} subclass that increments Micrometer counters and
+ * records timing on every batch received via the Sink topic from Minion.
+ * Delegates to {@code super.handleMessage} so trap processing semantics
+ * are unchanged.
+ *
+ * <p>Counters are pre-resolved against the registry once per location/unlabeled
+ * pair; the Timer is unlabeled.
+ */
+public class CountingTrapSinkConsumer extends TrapSinkConsumer {
+
+    private final MeterRegistry registry;
+    private final Timer handleDuration;
+
+    public CountingTrapSinkConsumer(MessageConsumerManager messageConsumerManager,
+                                    EventConfDao eventConfDao,
+                                    EventForwarder eventForwarder,
+                                    InterfaceToNodeCache interfaceToNodeCache,
+                                    TrapdConfig config,
+                                    DistPollerDao distPollerDao,
+                                    MeterRegistry registry) {
+        super(messageConsumerManager, eventConfDao, eventForwarder, interfaceToNodeCache,
+                config, distPollerDao);
+        this.registry = registry;
+        this.handleDuration = registry.timer(TrapdDomainMetrics.HANDLE_DURATION);
+    }
+
+    @Override
+    public void handleMessage(TrapLogDTO message) {
+        String location = location(message);
+        registry.counter(TrapdDomainMetrics.TRAPLOGS_RECEIVED,
+                TrapdDomainMetrics.TAG_LOCATION, location).increment();
+        List<TrapDTO> batch = message != null ? message.getMessages() : null;
+        int size = batch != null ? batch.size() : 0;
+        if (size > 0) {
+            registry.counter(TrapdDomainMetrics.TRAPS_IN_BATCH,
+                    TrapdDomainMetrics.TAG_LOCATION, location).increment(size);
+        }
+        handleDuration.record(() -> super.handleMessage(message));
+    }
+
+    private static String location(TrapLogDTO message) {
+        if (message == null) return "unknown";
+        String l = message.getLocation();
+        return l != null ? l : "unknown";
+    }
+}

--- a/core/daemon-boot-trapd/src/main/java/org/deltav/netmgt/trapd/boot/TrapdConfiguration.java
+++ b/core/daemon-boot-trapd/src/main/java/org/deltav/netmgt/trapd/boot/TrapdConfiguration.java
@@ -24,6 +24,7 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import org.deltav.core.daemon.common.DaemonEventConfDao;
 import org.opennms.netmgt.config.api.EventConfDao;
@@ -115,8 +116,9 @@ public class TrapdConfiguration {
                                              @Qualifier("eventIpcManager") EventForwarder eventForwarder,
                                              InterfaceToNodeCache interfaceToNodeCache,
                                              TrapdConfig trapdConfig,
-                                             DistPollerDao distPollerDao) {
-        return new TrapSinkConsumer(messageConsumerManager, eventConfDao, eventForwarder,
-                interfaceToNodeCache, trapdConfig, distPollerDao);
+                                             DistPollerDao distPollerDao,
+                                             MeterRegistry meterRegistry) {
+        return new CountingTrapSinkConsumer(messageConsumerManager, eventConfDao, eventForwarder,
+                interfaceToNodeCache, trapdConfig, distPollerDao, meterRegistry);
     }
 }

--- a/core/daemon-boot-trapd/src/main/java/org/deltav/netmgt/trapd/boot/TrapdDomainMetrics.java
+++ b/core/daemon-boot-trapd/src/main/java/org/deltav/netmgt/trapd/boot/TrapdDomainMetrics.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.trapd.boot;
+
+/**
+ * Canonical Micrometer meter names for trapd domain signals. Names become
+ * {@code deltav_trapd_*} at {@code /actuator/prometheus} after Micrometer's
+ * dot-to-underscore flattening.
+ *
+ * <p>{@code TRAPLOGS_RECEIVED} counts each {@code TrapLogDTO} batch arriving
+ * from a Minion via the Sink topic. {@code TRAPS_IN_BATCH} is incremented by
+ * the size of each batch — operators want both signals because batch shape
+ * (small frequent batches vs. large rare batches) is itself diagnostic.
+ *
+ * <p>Tagged by {@code location} (Minion location), bounded to the configured
+ * locations — typically a small finite set. No per-trap-source-address
+ * labels (would explode cardinality).
+ */
+public final class TrapdDomainMetrics {
+
+    private TrapdDomainMetrics() {}
+
+    public static final String TRAPLOGS_RECEIVED  = "deltav.trapd.traplogs.received";
+    public static final String TRAPS_IN_BATCH     = "deltav.trapd.traps.in.batch";
+    public static final String HANDLE_DURATION    = "deltav.trapd.handle.duration";
+
+    static final String TAG_LOCATION = "location";
+}

--- a/docs/plans/2026-04-23-v1.2.0-app-observability-design.md
+++ b/docs/plans/2026-04-23-v1.2.0-app-observability-design.md
@@ -232,3 +232,24 @@ Suggested sequence inside v1.2.0:
   - `docs/plans/2026-04-22-v1.2.0-self-contained-images-design.md`
   - `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`
 - **Future K8s operator track:** not yet filed; consumer of these metrics.
+
+## Correction (2026-04-24, during beta2 scoping): Scope A is complete
+
+Beta1 (PR #216) shipped `core/horizon-metric-bridge` and wired it into **9 daemons + Minion**. The next-session prompt framed the remaining 3 daemons (**"group D"**: alarmd, bsmd, eventtranslator, trapd — 4 daemons counting trapd, which beta1 also skipped) as a beta2 gap to close.
+
+Bytecode audit during beta2 Phase 1 (2026-04-24) found the premise was wrong: none of the 4 group D daemons have a horizon-side Dropwizard `MetricRegistry` on the Boot4 daemon that would be worth bridging.
+
+| Daemon | Horizon `MetricRegistry` on Boot4 side? | Evidence |
+|---|---|---|
+| alarmd | No (indirect only) | Registry lives inside `ManagedDroolsContext` (parent of `DroolsAlarmContext`). We pass `null` for Drools in `new Alarmd(..., null, null)` — Drools is disabled in delta-v. Ungating it would bring in the rules engine + memory cost + license review — architectural scope, not a metric wiring fix. |
+| bsmd | No | No `MetricRegistry` references anywhere in `bsm.daemon` or `bsm.service.impl` horizon JARs. |
+| eventtranslator | No | No `MetricRegistry` references anywhere in `event-translator` horizon JAR. |
+| trapd | No on Boot4 side | `TrapSinkConsumer` (the Boot4 @Bean) uses `TrapdInstrumentation` — a JMX MBean backed by `AtomicLong`, not Dropwizard. The Dropwizard `TrapListenerMetrics` exists but is only used by `TrapListener`, which runs on Minion (port 162). Minion is already bridged. |
+
+**Conclusion:** Scope A as described in this doc is complete. There is no bridge-wiring work remaining.
+
+**Downstream consequence:** group D daemons get their operator-useful signals entirely through Scope B (native Micrometer `deltav_*`). For alarmd specifically, this means the `drools_working_memory_size` gauge listed in the Scope B table isn't wireable while Drools is null — revisit once Drools is enabled (tracked in memory `project_alarmd_alarm_lifecycle_gap`).
+
+### Null-op debt surfaced by this audit
+
+The group D investigation revealed a systemic pattern — 40-day-old "plug it now, fix it later" no-op stubs that have outlived their temporary status. Alarmd alone has four (null `DroolsAlarmContext`, null `MessageBus`, no-op `AlarmEntityNotifier`, no-op `EventProxy`). A dedicated audit pass across all daemon configs is tracked as a future project (memory `project_daemon_nullop_debt_audit`). Explicitly **not** in beta2 scope — sequenced after v1.2.0-rc1.

--- a/docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-beta2-continuation.md
+++ b/docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-beta2-continuation.md
@@ -1,0 +1,229 @@
+# Next session: v1.2.0-beta2 continuation — finish Phase 2, do Phase 3, cut beta2
+
+**This is the resumption prompt for `2026-05-08-v1.2.0-beta2-domain-metrics-pollerd-ts.md`.**
+Today's session (2026-04-24) made it 4 commits in before checkpointing.
+Tomorrow's session pushes through Phase 2 completion + Phase 3 +
+beta2 cut in one run.
+
+**Branch:** `feat/v1.2.0-beta2-domain-metrics-pollerd-ts` — already
+exists with 4 commits. Either continue on it or rebase onto develop
+and open a fresh branch; both work since the partial PR will be
+either merged or kept open.
+
+**Open PR:** opened 2026-04-24 (search `gh pr list --repo pbrane/delta-v --state open`).
+Decide at start of session: continue adding commits to that PR vs.
+merging it as "beta2-partial" and starting fresh.
+
+---
+
+## Status ribbon (resumed from 2026-04-24)
+
+**Done:**
+- [x] Phase 1 scope correction — established that group D's horizon code has no Boot4-side Dropwizard `MetricRegistry` to bridge. Design doc updated, two memory entries written. Commit `0bdedecd095`.
+- [x] alarmd `deltav_alarmd_alarms_*` via `CountingAlarmEntityNotifier`. Commit `9964dcd1c04`.
+- [x] bsmd `deltav_bsmd_alarm_lookup_*` via wrapped AlarmProvider lambda. Commit `861659ab5eb`.
+- [x] eventtranslator `deltav_eventtranslator_events_*` via `CountingEventTranslator` subclass. Commit `c0f2b674f2c`.
+
+**Remaining Phase 2** (10 daemons):
+- [ ] trapd
+- [ ] syslogd
+- [ ] collectd
+- [ ] discovery
+- [ ] enlinkd
+- [ ] provisiond
+- [ ] pollerd (also needed by Phase 3)
+- [ ] perspectivepollerd (also needed by Phase 3)
+- [ ] telemetryd
+- [ ] minion-boot
+
+**Phase 3:**
+- [ ] Pollerd `PollResultPublisher` (mirrors `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java`)
+- [ ] PerspectivePollerd `PollResultPublisher` with `perspective` label
+- [ ] VictoriaMetrics validation (poll trigger → query → confirm)
+
+**beta2 cut workflow:**
+- [ ] full reactor `./mvnw clean install` (NOT `install` per `feedback_spring_boot_repackage_needs_clean`)
+- [ ] Docker image rebuild via `build.sh deltav` (rebuilds all 13 daemon images)
+- [ ] live validation on `--profile full` stack
+- [ ] open feature PR `--repo pbrane/delta-v --base develop` (or update existing partial PR)
+- [ ] after merge: chore PR `1.2.0-beta1` → `1.2.0-beta2` via `./mvnw versions:set`
+- [ ] tag `v1.2.0-beta2` at the **bump-merge commit** (not feature-merge — see `feedback_delayed_tag_workflow_trigger`)
+- [ ] image-publish workflow → `:1.2.0-beta2`
+- [ ] smoke-test against ghcr images
+- [ ] release plan doc update PR
+
+---
+
+## The established pattern (reuse for the remaining 10)
+
+Each daemon in Phase 2 follows the same shape. Skim the 3 done daemons before starting the next:
+
+```
+core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/
+  ├── AlarmdDomainMetrics.java          # name constants
+  ├── CountingAlarmEntityNotifier.java  # wrapper
+  └── AlarmdConfiguration.java          # bean wiring (existing file, modified)
+
+core/daemon-boot-bsmd/src/main/java/org/deltav/netmgt/bsm/boot/
+  ├── BsmdDomainMetrics.java
+  └── BsmdConfiguration.java            # AlarmProvider lambda wrapped inline
+
+core/daemon-boot-eventtranslator/src/main/java/org/deltav/netmgt/translator/boot/
+  ├── EventTranslatorDomainMetrics.java
+  ├── CountingEventTranslator.java      # subclass of horizon EventTranslator
+  └── EventTranslatorBootConfiguration.java
+```
+
+**Three idioms** — pick whichever fits each daemon's seam:
+
+1. **Hook a no-op listener** (alarmd pattern): replace an anonymous no-op
+   listener bean with a counting impl in its own file. Best when the
+   daemon already has a notification interface that horizon calls.
+2. **Wrap a lambda inline** (bsmd pattern): if a `@Bean` returns a small
+   lambda (like `AlarmProvider`), wrap it inline with timer + counters.
+   Best when the seam is a pure function and there's no listener interface.
+3. **Subclass the horizon class** (eventtranslator pattern): `extends`
+   the horizon class, override the entry method, increment counters,
+   call `super.method(...)`. Best when the horizon class has a clean
+   public entry method (like `onEvent(IEvent)`).
+
+**Naming:** dot-delimited Micrometer names that flatten to
+`deltav_<daemon>_<noun>_<unit>_total` for counters, `_seconds` for
+timers, `_ratio` for ratios, no unit for unitless gauges. Example:
+`deltav.alarmd.alarms.created` becomes `deltav_alarmd_alarms_created_total`.
+
+**Cardinality discipline (lesson from today):** label sets must be
+bounded. Severity is fine (7 enum values). `node`/`ip`/`hostname` are
+not — drop them. When in doubt, leave the counter unlabeled.
+
+**Gauges that need a transaction (lesson from today):** if the gauge
+reader calls a DAO that needs an active Hibernate session,
+`Gauge.builder` will throw `LazyInitializationException` at scrape
+time. Skip the gauge or wrap it in a transaction supplier — but the
+latter adds non-trivial code. Default: skip gauges that need DB access
+in beta2; revisit later.
+
+---
+
+## Per-remaining-daemon hook-point map
+
+For each daemon below, the suggested hook is the easiest seam I noticed
+during today's bytecode audit. Verify against the actual horizon class
+constructor signatures before writing — assumptions get invalidated
+fast (today's Phase 1 was an example).
+
+| Daemon | Hook approach | Suggested counters |
+|---|---|---|
+| **trapd** | Subclass `TrapSinkConsumer.handleMessage(TrapLogDTO)` — entry point per Kafka batch from Minion | `deltav_trapd_traplogs_received_total`, `_traps_in_batch_total` (counter, increment by `dto.getMessages().size()`), `_handle_duration_seconds` |
+| **syslogd** | Subclass `SyslogSinkConsumer.handleMessage` — same Sink consumer pattern as trapd | `deltav_syslogd_messages_received_total`, `_handle_duration_seconds` |
+| **collectd** | Wrap `TimeseriesKafkaPersister.visit*` no-op methods (already named no-op in the file). Several visit-method increments give per-resource/per-attribute counts cheaply. | `deltav_collectd_collection_resources_visited_total`, `_attributes_visited_total`, `_groups_visited_total`. Keep the existing `deltav_timeseries_*` from PR #170; don't rename. |
+| **discovery** | Hook `Discovery.onEvent` or wrap the `PingSweeper` callback in `DiscoveryConfiguration`. Audit the daemon class first. | `deltav_discovery_pings_dispatched_total{location}`, `_suspects_found_total`, `_range_scan_duration_seconds` |
+| **enlinkd** | Wrap one of the `*Updater` beans (per `project_enlinkd_constructor_injection`, the registry pattern is already in place). Each updater corresponds to a topology source (LLDP, CDP, OSPF, BFD). | `deltav_enlinkd_walks_completed_total{protocol}` (label = LLDP/CDP/OSPF/BFD/IS-IS, bounded), `_links_inserted_total`, `_walk_duration_seconds` |
+| **provisiond** | Hook the `Provisioner.handleReloadEvent` listener pattern OR wrap `RequisitionRepositoryUpdate` events. Check `core/daemon-boot-provisiond/src/main/java/.../ProvisiondConfiguration.java`. | `deltav_provisiond_requisitions_imported_total`, `_nodes_provisioned_total{operation=add|update|delete}`, `_scan_duration_seconds` |
+| **pollerd** | `Pollerd` itself extends `AbstractServiceDaemon`. Likely a `PollableServicesUpdater` or schedule callback to wrap. **Combine this with Phase 3's `PollResultPublisher` so both touch one daemon edit.** | `deltav_pollerd_polls_dispatched_total{location}`, `_polls_completed_total{result=success|failure}`, `_poll_duration_seconds` |
+| **perspectivepollerd** | Same shape as pollerd, but emits with `perspective` label. **Combine with Phase 3.** | `deltav_perspective_polls_*` mirroring pollerd, with `{perspective}` label (bounded by configured perspectives — usually 2–10). |
+| **telemetryd** | The Telemetryd Sink Consumer per protocol (see existing config in `TelemetrydSinkConfiguration.java`). | `deltav_telemetryd_packets_received_total{protocol}` (label = NetFlow5/9/IPFIX/sFlow, bounded set of ~6), `_packets_forwarded_total`, `_forward_duration_seconds` |
+| **minion-boot** | Minion is special — already has a `MeterRegistry` available via Spring Boot Actuator, but its RPC handling is in horizon's `MinionStartupBean` etc. Hook the RPC dispatcher. | `deltav_minion_rpc_received_total{module}` (label = SnmpProxy/Detector/Pinger/etc., bounded), `_rpc_dispatched_total`, `_rpc_duration_seconds` |
+
+For each daemon: build single-module first (`./mvnw -pl core/daemon-boot-X -DskipTests install` — ~3s) before moving on. Catches compile errors fast.
+
+---
+
+## Phase 3 — Pollerd + PerspectivePollerd TS publishing
+
+Mirror `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/TimeseriesKafkaPublisher.java` (157 lines, well-tested in beta1's flow pipeline).
+
+**Investigation step before coding:** verify the listener surface in
+Pollerd. Horizon's `Pollerd.onPollResult` or similar — the prompt
+flagged this as a probable "this never worked" gap. Steps:
+
+1. `javap -p` the horizon `opennms-poller` jar at 1.0.13 — find the
+   class that holds the poll-result callback.
+2. Trace whether the result is exposed via an event, a listener
+   interface, or buried in a void method.
+3. If buried: subclass the relevant horizon class and override the
+   result-handling method to also publish to Kafka.
+4. If exposed via listener: add a counting listener like alarmd's notifier.
+
+**Sample shape:**
+```json
+{"node": "...", "service": "ICMP", "location": "Default",
+ "value": 23.5, "timestamp": 1714074123000}
+```
+
+PerspectivePollerd samples carry an additional `perspective` label.
+prometheus-writer's NodeContext-cache + RW translator path should
+work unchanged — Phase 3 is producer-only.
+
+**Bundle Phase 3 with the Phase 2 pollerd/perspectivepollerd commits.**
+One edit pass per daemon, one commit per daemon, both deltav_* meters
+and TS publisher in the same commit.
+
+---
+
+## Lessons from today worth carrying
+
+1. **Bytecode audit first, code second.** Phase 1 was scoped on a
+   misread of where the MetricRegistry lived. `javap -p` is the
+   ground truth, not source-grep over the delta-v config files.
+
+2. **Anonymous no-op beans are your friends.** Several daemons use
+   inline `new SomeListener() { ... }` patterns. Replace them with
+   named counting impls — gets you instrumentation AND closes a
+   null-op gap simultaneously.
+
+3. **Gauges are dangerous.** Anything that reads from JPA at scrape
+   time will trip on `LazyInitializationException` outside a
+   transaction. Counters and timers are safer; default to those.
+
+4. **Per-module builds (`./mvnw -pl X -am install`) are fast.** ~3s
+   each. Catches compile errors without paying the full reactor cost.
+
+5. **Cardinality discipline saves you twice.** Fewer labels = smaller
+   Prometheus storage AND clearer dashboards. Severity is fine, node
+   is not, location is fine, IP is not.
+
+6. **Null-op debt is real.** Today surfaced 4 in alarmd alone (Drools,
+   MessageBus, AlarmEntityNotifier, EventProxy). See memories
+   `project_daemon_nullop_debt_audit` and
+   `project_alarmd_alarm_lifecycle_gap`. **Do not start filling these
+   in beta2** — sequenced after rc1.
+
+---
+
+## Recommended commit shape (continuing from today)
+
+| Commits | Content |
+|---|---|
+| 4 | already on branch (Phase 1 correction + 3 Phase 2 daemons) |
+| 10 | one per remaining Phase 2 daemon (trapd, syslogd, collectd, discovery, enlinkd, provisiond, pollerd, perspectivepollerd, telemetryd, minion) — but pollerd + perspectivepollerd commits include their Phase 3 publisher in the same commit |
+| ~3 | reactor build fixes if any surface during full `./mvnw clean install` |
+
+Total **~17 commits** on the feature branch by end of tomorrow. Plus
+the chore (version bump) PR + the release-cut record PR after merge.
+
+---
+
+## References
+
+- **App-obs design doc (now includes Phase 1 correction):** `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
+- **Pollerd TS design:** `docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md`
+- **Release plan:** `docs/plans/2026-04-23-v1.2.0-release-plan.md`
+- **Reference TS publisher:** `core/daemon-boot-collectd/src/main/java/org/deltav/collectd/timeseries/`
+- **Today's commits:** `0bdedecd095..c0f2b674f2c` on `feat/v1.2.0-beta2-domain-metrics-pollerd-ts`
+- **Horizon BOM:** `1.0.13` pinned in root pom.xml
+- **Memory: null-op debt audit:** `project_daemon_nullop_debt_audit`
+- **Memory: alarmd alarm-lifecycle gap (the biggest null-op):** `project_alarmd_alarm_lifecycle_gap`
+- **Memory: meter naming convention:** `feedback_meter_naming_horizon_vs_deltav`
+- **Memory: clean install needed:** `feedback_spring_boot_repackage_needs_clean`
+- **Memory: tag-workflow gotcha:** `feedback_delayed_tag_workflow_trigger`
+
+## After beta2 lands
+
+Next track is rc1 — Minion gRPC migration. Largest single track in
+v1.2.0. Bundles ActiveMQ + ServiceMix purge, Sink topic rename
+(`OpenNMS.Sink.*` → `DeltaV.Sink.*`), and "Default" Minion location
+retirement. Design doc: `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`.
+
+After rc1, the **null-op debt audit** kicks off — alarmd's alarm
+lifecycle gap is the highest priority.


### PR DESCRIPTION
## Summary

Completes the v1.2.0 app-observability + Pollerd time-series tracks. Every delta-v daemon now exposes domain-level Micrometer counters at `/actuator/prometheus` with names that flatten to `deltav_<daemon>_*`. Pollerd additionally publishes per-poll response-time records to the `deltav-timeseries` Kafka topic (Phase 3, gated by `deltav.timeseries.enabled`).

Two-day session: 4 commits on 2026-04-24 (scope correction + alarmd/bsmd/eventtranslator), 10 commits on 2026-04-25 (10 remaining daemons + Pollerd Phase 3).

### Phase 1 — scope correction (commit `0bdedecd095`)

Bytecode audit of horizon 1.0.13 found no Boot4-side Dropwizard `MetricRegistry` to bridge in the "group D" daemons (alarmd, bsmd, eventtranslator, trapd). Beta1's PR #216 effectively completed Scope A; group D gets its operator signals entirely through Scope B.

### Phase 2 — all 13 daemons

| Daemon | Hook | Key counters |
|---|---|---|
| **alarmd** | `CountingAlarmEntityNotifier` (no-op→counting) | `alarms_{created,reduced,acknowledged,unacknowledged,severity_updated,archived,deleted}_total{severity}` |
| **bsmd** | `AlarmProvider` lambda wrap | `alarm_{lookups,lookup_keys_requested,lookup_keys_matched}_total` + `_lookup_duration_seconds` |
| **eventtranslator** | `CountingEventTranslator` subclass | `events_received_total` + `_event_processing_duration_seconds` |
| **trapd** | `CountingTrapSinkConsumer` subclass | `traplogs_received_total{location}`, `_traps_in_batch_total{location}`, `_handle_duration_seconds` |
| **syslogd** | `CountingSyslogSinkConsumer` subclass | `messagelogs_received_total{location}`, `_messages_in_batch_total{location}`, `_handle_duration_seconds` |
| **collectd** | `TimeseriesKafkaPersister.visit*` hooks | `collection_{sets_visited,resources,groups,attributes,sets_completed}_total` |
| **discovery** | `CountingDiscoveryTaskExecutor` + `CountingEventForwarder` | `tasks_handled_total`, `_handle_duration_seconds`, `events_forwarded_total`, `suspects_found_total` |
| **enlinkd** | `CountingOnmsTopologyDao` decorator | `topology_updates_total{protocol,status}`, `topology_updaters_active` (gauge) |
| **provisiond** | `CountingProvisionEventForwarder` | `events_forwarded_total`, `imports_{started,successful,failed}_total`, `nodes_{added,updated,deleted}_total` |
| **pollerd** | `InstrumentedPollContext` (extends StandalonePollContext) | `polls_completed_total{location,result}`, `_poll_duration_seconds`, `outages_{opened,resolved}_total{location}` |
| **perspectivepollerd** | `CountingPerspectiveEventForwarder` | `events_forwarded_total`, `service_{lost,regained}_total` |
| **telemetryd** | `KafkaSinkBridge` inline counters | `packets_received_total{module}`, `_packets_dispatched_total{module}`, `_dispatch_failures_total{module}`, `_dispatch_duration_seconds{module}` |
| **minion-boot** | `RpcModuleMetricsPostProcessor` auto-wrap | `rpc_received_total{module}`, `_rpc_failed_total{module}`, `_rpc_duration_seconds{module}` |

Cardinality discipline applied throughout: bounded labels only (severity enums, Minion locations, RPC module ids, protocol ids). Per-node/per-IP labels avoided.

### Phase 3 — Pollerd Kafka time-series publisher (commit `e644b60f7fd`)

`PollResultPublisher` mirrors collectd's `TimeseriesKafkaPublisher` from PR #170: same `TimeseriesBatch` protobuf wire format, same `publishTimeseries-out-0` Spring Cloud Stream binding, same partition key `{location}@{nodeId}`, `producer=PRODUCER_POLLERD`. Each poll emits one record with a single Resource (`node[N].monitoredService[svc]`) and one Attribute (response_time_ms as GAUGE). Gated by `deltav.timeseries.enabled` (default false); when off, Phase 2 counters still emit but Phase 3 publish is a no-op.

PerspectivePollerd Phase 3 is **not** in this PR — its Quartz-based scheduler has no public seam equivalent to `PollContext.trackPoll`. A deeper hook (likely a wrapping `PersisterFactory`) is needed and is tracked as a post-beta2 follow-up.

### Three idioms (reusable for future daemons)

1. **No-op listener replacement** (alarmd, trapd-pattern): replace an anonymous `new Listener() { ... }` no-op with a named counting impl. Doubles as a null-op stub fix.
2. **Lambda wrap** (bsmd-pattern): wrap an existing `@Bean`-returned lambda inline with `Timer.record()` and counters.
3. **Subclass horizon class** (eventtranslator-pattern, pollerd-pattern, etc): `extends` horizon's class, override entry method, increment counters, call `super`.
4. **Decorator on the central choke point** (enlinkd, provisiond, discovery): wrap an interface that 9+ implementations all funnel through.
5. **BeanPostProcessor auto-wrap** (minion-boot): when N similar beans need the same wrap and the set is open-ended, do it via Spring's `BeanPostProcessor` rather than per-config edits.

## Build evidence

- Full reactor `./mvnw clean install -DskipTests` — green, 37s
- All 17 Docker images rebuilt at `:1.2.0-beta1` via `build.sh deltav`
- collectd unit tests 18/18 green after persister constructor signature change

## Null-op debt surfaced (out of beta2 scope)

Phase 1 + per-daemon audits surfaced a systemic pattern of "plug it now, fix later" stubs across daemon configs. alarmd alone has 4 (Drools, MessageBus, AlarmEntityNotifier, EventProxy). Tracked in memory entries `project_daemon_nullop_debt_audit` and `project_alarmd_alarm_lifecycle_gap`. Sequenced for post-rc1.

## Test plan

- [x] Full reactor build — green
- [x] Per-module compile for each of 10 instrumented modules — green
- [x] collectd persister unit tests — 18/18 pass
- [x] All 17 daemon Docker images rebuilt at `:1.2.0-beta1`
- [ ] Live validation on `--profile full` stack — deferred to beta2 smoke
- [ ] CI checks (auto)

## Follow-ups (deferred from beta2)

- PerspectivePollerd Phase 3 (per-poll Kafka publish) — needs deeper PersisterFactory wrap
- Provisiond inbound signal counters (suspects received, force rescans) — needs Provisioner-side hook, not EventForwarder
- alarmd `drools_working_memory_size` gauge — needs Drools enabled

## References

- Design doc: `docs/plans/2026-04-23-v1.2.0-app-observability-design.md`
- Pollerd TS design: `docs/plans/2026-04-23-v1.2.0-pollerd-timeseries-design.md`
- Continuation prompt: `docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-beta2-continuation.md`