### PR TITLE
chore(compose): enable Phase 3 timeseries flag for pollerd; document collectd inmemory strategy

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -258,6 +258,12 @@ services:
       OPENNMS_TSID_NODE_ID: "4"
       OPENNMS_RPC_KAFKA_ENABLED: "true"
       OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      # Phase 3 (delta-v#220, v1.2.0-beta2): publish per-poll response-time
+      # samples to the deltav-timeseries Kafka topic. Without this,
+      # PollerdTimeseriesConfiguration's @ConditionalOnProperty stays inactive
+      # and InstrumentedPollContext sees a null PollResultPublisher (Phase 2
+      # /actuator/prometheus counters still emit; Phase 3 publish is a no-op).
+      DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-true}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 10s
@@ -282,6 +288,14 @@ services:
       SPRING_DATASOURCE_PASSWORD: opennms
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
+      # Vestigial — selects the strategy for horizon's stock TimeseriesPersister
+      # (the "inner" persister inside FanoutPersister). InMemoryStorage is a
+      # black hole in delta-v: nothing reads from it, no Newts, no horizon
+      # webapp. The real TSDB path is the parallel Kafka persister
+      # (TimeseriesKafkaPersister → deltav-timeseries → prometheus-writer →
+      # VictoriaMetrics → Grafana), gated by DELTAV_TIMESERIES_ENABLED below.
+      # Removing this line would let horizon fail-fast on missing strategy
+      # config; documented in memory project_collectd_inner_persister_inert.
       OPENNMS_TIMESERIES_STRATEGY: inmemory
       DELTAV_TIMESERIES_ENABLED: ${DELTAV_TIMESERIES_ENABLED:-true}
     stop_grace_period: 60s


### PR DESCRIPTION
## Summary

Two related compose-orchestration fixes surfaced during the v1.2.0-beta2 smoke.

### 1. Enable `DELTAV_TIMESERIES_ENABLED` for pollerd

Phase 3 in #220 (`PollerdTimeseriesConfiguration`) is a `@ConditionalOnProperty` bean keyed on `deltav.timeseries.enabled=true`. Without the flag, the conditional stays inactive, `PollResultPublisher` is never created, and `InstrumentedPollContext` sees a null publisher. Phase 2 `/actuator/prometheus` counters keep emitting (those are unconditional), but per-poll response-time records never flow to the `deltav-timeseries` Kafka topic.

Smoke validated today: with the flag set, `opennms_response_time_response{producer="pollerd"}` series appear in VictoriaMetrics with full NodeContext labels (`foreign_source`, `node_id`, `location`, `node_label`, `instance`, …). Sample data in VM right now includes:

- ICMP polls against `l8opensim-lab` (lab-01 through lab-NN core/dist routers)
- HTTP polls against `Google-Search` (foreign_source `perspective-test`)

Pattern matches collectd's existing entry on line 286 (PR #170) — same default `true`, same shell-overridable form.

### 2. Document `OPENNMS_TIMESERIES_STRATEGY: inmemory` on collectd

The line is vestigial: it selects the strategy for horizon's stock `TimeseriesPersister` (the "inner" persister inside `FanoutPersister`), which writes to `InMemoryStorage` — a black hole in delta-v. No Newts, no horizon webapp, nothing reads from it. The visible Grafana metrics come exclusively from the parallel Kafka persister path (`TimeseriesKafkaPersister` → `deltav-timeseries` → `prometheus-writer` → VictoriaMetrics).

Removing the line is **not** in this PR — taking it out would let horizon fail-fast on missing strategy config, which is structurally desirable (inner-persister failures would surface louder via the existing `deltav_collectd_persister_inner_failures_total` counters) but warrants a dedicated PR with a careful test cycle. Tracked in memory `project_collectd_inner_persister_inert`. Comment captures the situation so the next reader doesn't assume the inmemory store is what feeds dashboards.

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet` passes
- [x] Smoke against ghcr.io/pbrane/*:1.2.0-beta2 confirmed Phase 3 pipeline lands `producer="pollerd"` series in VM after the flag was enabled inline
- [x] No source code changes — pure compose orchestration + docs
- [ ] CI checks (auto)

## Why no version bump

This is compose-orchestration only; no daemon images change. The flag rides into the next image build whenever it lands; existing 1.2.0-beta2 images already have the conditional bean — they just need the env var to activate it. Smoke against `:1.2.0-beta2` images plus this compose patch validates the full Phase 3 pipeline.