### PR TITLE
docs(v1.2.0): record beta2 cut + Scope B / Pollerd Phase 3 completion

### DIFF
--- a/docs/plans/2026-04-23-v1.2.0-release-plan.md
+++ b/docs/plans/2026-04-23-v1.2.0-release-plan.md
@@ -1,8 +1,10 @@
 # Delta-V v1.2.0 Release Plan
 
 > **Status:** In progress. v1.2.0-alpha1/2/3 cut 2026-04-23; v1.2.0-beta1
-> cut 2026-04-24. Tracks 1 (self-contained images) and 3a
-> (horizon-metric bridging) complete. Two and a half tracks remain.
+> cut 2026-04-24; v1.2.0-beta2 cut 2026-04-25. Tracks 1
+> (self-contained images), 3 (app observability — Scope A bridge + Scope B
+> domain metrics across all 13 daemons), and 4 (Pollerd time-series
+> publishing) complete. Track 2 (Minion gRPC) remains for rc1/rc2.
 
 ## Release theme — "Delta-V runs well on Kubernetes"
 
@@ -108,6 +110,44 @@ Minion metric scrape requires RPC-based federation over Kafka (memory
 PRs [#216](https://github.com/pbrane/delta-v/pull/216),
 [#217](https://github.com/pbrane/delta-v/pull/217).
 
+#### Scope B — per-daemon domain metrics — ✅ DONE (v1.2.0-beta2, 2026-04-25)
+
+Every Boot4 daemon now exposes native delta-v Micrometer counters at
+`/actuator/prometheus` under the `deltav_<daemon>_*` prefix (memory
+[`feedback_meter_naming_horizon_vs_deltav`](../../memory/feedback_meter_naming_horizon_vs_deltav.md)).
+Cardinality is bounded by design: tags use enum values (severity,
+poll-result), Minion locations, RPC module ids, or telemetry protocol
+ids — no per-node/per-IP labels.
+
+Five reusable hook idioms emerged from the per-daemon work
+(memory [`feedback_daemon_instrumentation_patterns`](../../memory/feedback_daemon_instrumentation_patterns.md)):
+
+1. **No-op listener replacement** (alarmd) — replace anonymous no-op
+   `Listener {}` with a named `CountingX` impl. Doubles as a null-op
+   stub fix.
+2. **Lambda wrap inline** (bsmd) — wrap an `@Bean`-returned lambda with
+   `Timer.record()` and counters in the @Bean method itself.
+3. **Subclass horizon class** (eventtranslator, trapd, syslogd, pollerd,
+   discovery) — `extends` horizon class, override entry method,
+   increment counters, call `super`.
+4. **Decorator on a central choke point** (enlinkd, provisiond,
+   discovery, perspectivepollerd) — wrap an interface that 9+
+   implementations all funnel through.
+5. **BeanPostProcessor auto-wrap** (minion-boot) — when the bean set is
+   open-ended (RpcModules: 7 today, more later), wrap via Spring's
+   `BeanPostProcessor` rather than per-config edits.
+
+Phase 1 audit also corrected a beta1 misread: the four "group D"
+daemons (alarmd, bsmd, eventtranslator, trapd) were thought to need
+horizon-bridge wiring; bytecode audit found their horizon classes have
+no Boot4-side `MetricRegistry` to bridge at all. The Scope A bridge is
+therefore truly complete; group D's operator-useful signals come
+entirely from the native `deltav_*` Scope B counters.
+
+PRs [#220](https://github.com/pbrane/delta-v/pull/220),
+[#221](https://github.com/pbrane/delta-v/pull/221),
+[#222](https://github.com/pbrane/delta-v/pull/222).
+
 ### 4. Pollerd + PerspectivePollerd response-time publishing
 
 **Problem:** Only Collectd produces to the `deltav-timeseries` Kafka
@@ -127,6 +167,40 @@ samples (same service, different vantage point, different series).
 **Design doc:** [`2026-04-23-v1.2.0-pollerd-timeseries-design.md`](2026-04-23-v1.2.0-pollerd-timeseries-design.md)
 **Scope:** 1-1.5 weeks. Reuses Collectd's `TimeseriesKafkaPublisher`
 pattern.
+
+#### Pollerd Phase 3 — ✅ DONE (v1.2.0-beta2, 2026-04-25)
+
+`PollResultPublisher` mirrors collectd's `TimeseriesKafkaPublisher`
+shape: same `TimeseriesBatch` protobuf wire format, same
+`publishTimeseries-out-0` Spring Cloud Stream binding, same
+`{location}@{nodeId}` partition key. Each poll completion emits one
+record with a single `Resource`
+(`resource_id="node[N].monitoredService[svc]"`) and a single
+`Attribute` (response time as `ATTRIBUTE_TYPE_GAUGE`),
+`producer=PRODUCER_POLLERD`. Hook is `InstrumentedPollContext extends
+StandalonePollContext`, overriding `trackPoll`/`openOutage`/
+`resolveOutage`. Gated by `deltav.timeseries.enabled` so the publisher
+bean is absent when the flag is off.
+
+Smoke validated end-to-end against ghcr.io/pbrane/*:1.2.0-beta2:
+`opennms_response_time_response{producer="pollerd"}` series appear in
+VictoriaMetrics with full NodeContext labels — both ICMP polls
+(l8opensim lab nodes) and HTTP-equivalent service polls
+(`Google-Search`).
+
+#### PerspectivePollerd Phase 3 — ⏳ DEFERRED
+
+PerspectivePollerd's poll-result callback is a private
+`lambda$execute$0` inside `PerspectivePollJob` (Quartz-scheduled), with
+no public seam equivalent to Pollerd's `PollContext.trackPoll`. Deeper
+hook (likely a wrapping `PersisterFactory`) is required and is tracked
+as post-beta2 follow-up. Phase 2 native `deltav_perspective_*` counters
+ship in beta2 via an `EventForwarder` decorator that catches
+nodeLostService/nodeRegainedService UEIs.
+
+PRs [#220](https://github.com/pbrane/delta-v/pull/220),
+[#221](https://github.com/pbrane/delta-v/pull/221),
+[#222](https://github.com/pbrane/delta-v/pull/222).
 
 ## Release history + remaining cadence
 
@@ -151,19 +225,21 @@ pattern.
    daemons did not expose `/actuator/prometheus` at all in alpha3 because
    `micrometer-registry-prometheus` was missing from `daemon-common`.
    PRs #216, #217.
+5. **`v1.2.0-beta2`** (2026-04-25) — app-observability Scope B
+   (`deltav_<daemon>_*` native domain metrics across all 13 daemons
+   via 5 reusable hook idioms) **plus Pollerd Phase 3** (per-poll
+   response-time samples published to `deltav-timeseries` Kafka topic,
+   landing in VictoriaMetrics as
+   `opennms_response_time_response{producer="pollerd"}` with full
+   NodeContext labels). PerspectivePollerd Phase 3 deferred —
+   no public seam in horizon's Quartz-scheduled `PerspectivePollJob`.
+   Smoke confirmed Pollerd's data-plane pipeline end-to-end against
+   ghcr beta2 images. PRs #220, #221, #222.
 
 ### Remaining
 
 No firm dates. Order based on dependencies, risk, and bundle-ability:
 
-5. **`v1.2.0-beta2`** — app-observability Scope B (per-daemon domain
-   metrics, including the alarmd/bsmd/eventtranslator/trapd registry
-   wiring deferred from beta1) **plus Pollerd + PerspectivePollerd
-   response-time publishing**. Bundle-able because both touch the same
-   two daemons (one edit pass, coordinated metric naming). Native delta-v
-   meters use `deltav_*` prefix (memory
-   [`feedback_meter_naming_horizon_vs_deltav`](../../memory/feedback_meter_naming_horizon_vs_deltav.md))
-   alongside the bridged `opennms_*` meters. ~2–3 weeks.
 6. **`v1.2.0-rc1`** — Minion gRPC migration midpoint: protobuf service
    definitions published, parallel Kafka+gRPC paths running, ActiveMQ
    and ServiceMix bundles purged from minion-boot.
@@ -194,6 +270,19 @@ registries today; beta2 absorbs the remaining 4 daemons as part of
 Scope B's domain-metric retrofit. This is "Option 1" in the next-session
 prompt: ship the bridge module immediately rather than block on a
 per-daemon registry-wiring pass that's better done alongside Scope B.
+
+A third divergence in beta2: the original plan called for both Pollerd
+**and** PerspectivePollerd response-time publishing in the same cut.
+Reality: PerspectivePollerd's poll-result callback is a private lambda
+inside `PerspectivePollJob` (Quartz-scheduled), with no public seam to
+subclass. Pollerd ships Phase 3 in beta2; PerspectivePollerd Phase 3
+is deferred to a dedicated PR that wraps `PersisterFactory` (or
+similar). Beta2 also surfaced a compose-orchestration oversight in
+PR #220 — `DELTAV_TIMESERIES_ENABLED` was added to pollerd's
+`application.yml` but not to its `docker-compose.yml` `environment:`
+block — fixed in PR #222 alongside a documenting comment for
+collectd's vestigial `OPENNMS_TIMESERIES_STRATEGY: inmemory` (memory
+[`project_collectd_inner_persister_inert`](../../memory/project_collectd_inner_persister_inert.md)).
 
 Each beta/RC is smoke-tested on a clean Linux VM following the same
 process established for v1.1.1 and validated on v1.2.0-alpha1/2/3.


### PR DESCRIPTION
## Summary

Updates `docs/plans/2026-04-23-v1.2.0-release-plan.md` to reflect the v1.2.0-beta2 cut on 2026-04-25. Tracks 3 (app observability) and 4 (Pollerd time-series publishing) are now ✅ DONE; only Track 2 (Minion gRPC) remains for rc1/rc2.

## What's recorded

### Track 3 — Scope B section added

Every Boot4 daemon now exposes native `deltav_<daemon>_*` Micrometer counters at `/actuator/prometheus`. Five reusable hook idioms emerged across the 13 daemons:

1. **No-op listener replacement** (alarmd) — replace anonymous no-op `Listener {}` with named `CountingX` impl
2. **Lambda wrap inline** (bsmd) — wrap an `@Bean`-returned lambda with `Timer.record()` and counters
3. **Subclass horizon class** (eventtranslator, trapd, syslogd, pollerd, discovery) — `extends` + override entry method + `super` call
4. **Decorator on a central choke point** (enlinkd, provisiond, discovery, perspectivepollerd) — wrap an interface that 9+ implementations all funnel through
5. **BeanPostProcessor auto-wrap** (minion-boot) — for open-ended bean sets

Phase 1 audit also corrected the beta1 misread: the four "group D" daemons (alarmd, bsmd, eventtranslator, trapd) have no Boot4-side `MetricRegistry` to bridge — Scope A is truly complete; group D's signals come entirely from Scope B's native counters.

### Track 4 — Pollerd Phase 3 done, PerspectivePollerd deferred

- **Pollerd Phase 3 ✅ DONE** — `PollResultPublisher` mirrors collectd's `TimeseriesKafkaPublisher`. Each poll completion emits one `TimeseriesBatch` protobuf record with single Resource (`node[N].monitoredService[svc]`), single Attribute (response time as GAUGE), `producer=PRODUCER_POLLERD`. Hook is `InstrumentedPollContext` overriding `trackPoll`/`openOutage`/`resolveOutage`. Smoke confirmed `opennms_response_time_response{producer="pollerd"}` series in VictoriaMetrics with full NodeContext labels.
- **PerspectivePollerd Phase 3 ⏳ DEFERRED** — horizon's `PerspectivePollJob` is Quartz-scheduled with a private `lambda$execute$0` poll-result callback; no public seam. Tracked as post-beta2 follow-up that will likely wrap `PersisterFactory`. Phase 2 native counters via `EventForwarder` decorator do ship in beta2.

### Divergence note expanded

Third paragraph captures:
- PerspectivePollerd Phase 3 deferral
- The compose-orchestration oversight in PR #220 (`DELTAV_TIMESERIES_ENABLED` was added to `application.yml` but not to `docker-compose.yml`'s pollerd `environment:` block) and its fix in PR #222
- The accompanying documenting comment for collectd's vestigial `OPENNMS_TIMESERIES_STRATEGY: inmemory`

## Test plan

- [x] Diff confirms 99 additions, 10 deletions to a single doc file — no code changes, no version bump needed
- [x] References to PRs #216, #217 (beta1) preserved; PRs #220, #221, #222 (beta2) added
- [ ] CI checks (auto)

## Validation evidence

The validation cited in the doc — `opennms_response_time_response{producer="pollerd"}` series in VictoriaMetrics with full NodeContext labels — was confirmed during the live smoke against `ghcr.io/pbrane/*:1.2.0-beta2` on 2026-04-25 (UTM VM, `~/delta-v-smoke`).