### PR TITLE
docs(v1.2.0-rc1): kickoff prompt for Minion gRPC migration

### DIFF
--- a/docs/plans/2026-04-23-v1.2.0-release-plan.md
+++ b/docs/plans/2026-04-23-v1.2.0-release-plan.md
@@ -1,8 +1,10 @@
 # Delta-V v1.2.0 Release Plan
 
 > **Status:** In progress. v1.2.0-alpha1/2/3 cut 2026-04-23; v1.2.0-beta1
-> cut 2026-04-24. Tracks 1 (self-contained images) and 3a
-> (horizon-metric bridging) complete. Two and a half tracks remain.
+> cut 2026-04-24; v1.2.0-beta2 cut 2026-04-25. Tracks 1
+> (self-contained images), 3 (app observability — Scope A bridge + Scope B
+> domain metrics across all 13 daemons), and 4 (Pollerd time-series
+> publishing) complete. Track 2 (Minion gRPC) remains for rc1/rc2.
 
 ## Release theme — "Delta-V runs well on Kubernetes"
 
@@ -108,6 +110,44 @@ Minion metric scrape requires RPC-based federation over Kafka (memory
 PRs [#216](https://github.com/pbrane/delta-v/pull/216),
 [#217](https://github.com/pbrane/delta-v/pull/217).
 
+#### Scope B — per-daemon domain metrics — ✅ DONE (v1.2.0-beta2, 2026-04-25)
+
+Every Boot4 daemon now exposes native delta-v Micrometer counters at
+`/actuator/prometheus` under the `deltav_<daemon>_*` prefix (memory
+[`feedback_meter_naming_horizon_vs_deltav`](../../memory/feedback_meter_naming_horizon_vs_deltav.md)).
+Cardinality is bounded by design: tags use enum values (severity,
+poll-result), Minion locations, RPC module ids, or telemetry protocol
+ids — no per-node/per-IP labels.
+
+Five reusable hook idioms emerged from the per-daemon work
+(memory [`feedback_daemon_instrumentation_patterns`](../../memory/feedback_daemon_instrumentation_patterns.md)):
+
+1. **No-op listener replacement** (alarmd) — replace anonymous no-op
+   `Listener {}` with a named `CountingX` impl. Doubles as a null-op
+   stub fix.
+2. **Lambda wrap inline** (bsmd) — wrap an `@Bean`-returned lambda with
+   `Timer.record()` and counters in the @Bean method itself.
+3. **Subclass horizon class** (eventtranslator, trapd, syslogd, pollerd,
+   discovery) — `extends` horizon class, override entry method,
+   increment counters, call `super`.
+4. **Decorator on a central choke point** (enlinkd, provisiond,
+   discovery, perspectivepollerd) — wrap an interface that 9+
+   implementations all funnel through.
+5. **BeanPostProcessor auto-wrap** (minion-boot) — when the bean set is
+   open-ended (RpcModules: 7 today, more later), wrap via Spring's
+   `BeanPostProcessor` rather than per-config edits.
+
+Phase 1 audit also corrected a beta1 misread: the four "group D"
+daemons (alarmd, bsmd, eventtranslator, trapd) were thought to need
+horizon-bridge wiring; bytecode audit found their horizon classes have
+no Boot4-side `MetricRegistry` to bridge at all. The Scope A bridge is
+therefore truly complete; group D's operator-useful signals come
+entirely from the native `deltav_*` Scope B counters.
+
+PRs [#220](https://github.com/pbrane/delta-v/pull/220),
+[#221](https://github.com/pbrane/delta-v/pull/221),
+[#222](https://github.com/pbrane/delta-v/pull/222).
+
 ### 4. Pollerd + PerspectivePollerd response-time publishing
 
 **Problem:** Only Collectd produces to the `deltav-timeseries` Kafka
@@ -127,6 +167,40 @@ samples (same service, different vantage point, different series).
 **Design doc:** [`2026-04-23-v1.2.0-pollerd-timeseries-design.md`](2026-04-23-v1.2.0-pollerd-timeseries-design.md)
 **Scope:** 1-1.5 weeks. Reuses Collectd's `TimeseriesKafkaPublisher`
 pattern.
+
+#### Pollerd Phase 3 — ✅ DONE (v1.2.0-beta2, 2026-04-25)
+
+`PollResultPublisher` mirrors collectd's `TimeseriesKafkaPublisher`
+shape: same `TimeseriesBatch` protobuf wire format, same
+`publishTimeseries-out-0` Spring Cloud Stream binding, same
+`{location}@{nodeId}` partition key. Each poll completion emits one
+record with a single `Resource`
+(`resource_id="node[N].monitoredService[svc]"`) and a single
+`Attribute` (response time as `ATTRIBUTE_TYPE_GAUGE`),
+`producer=PRODUCER_POLLERD`. Hook is `InstrumentedPollContext extends
+StandalonePollContext`, overriding `trackPoll`/`openOutage`/
+`resolveOutage`. Gated by `deltav.timeseries.enabled` so the publisher
+bean is absent when the flag is off.
+
+Smoke validated end-to-end against ghcr.io/pbrane/*:1.2.0-beta2:
+`opennms_response_time_response{producer="pollerd"}` series appear in
+VictoriaMetrics with full NodeContext labels — both ICMP polls
+(l8opensim lab nodes) and HTTP-equivalent service polls
+(`Google-Search`).
+
+#### PerspectivePollerd Phase 3 — ⏳ DEFERRED
+
+PerspectivePollerd's poll-result callback is a private
+`lambda$execute$0` inside `PerspectivePollJob` (Quartz-scheduled), with
+no public seam equivalent to Pollerd's `PollContext.trackPoll`. Deeper
+hook (likely a wrapping `PersisterFactory`) is required and is tracked
+as post-beta2 follow-up. Phase 2 native `deltav_perspective_*` counters
+ship in beta2 via an `EventForwarder` decorator that catches
+nodeLostService/nodeRegainedService UEIs.
+
+PRs [#220](https://github.com/pbrane/delta-v/pull/220),
+[#221](https://github.com/pbrane/delta-v/pull/221),
+[#222](https://github.com/pbrane/delta-v/pull/222).
 
 ## Release history + remaining cadence
 
@@ -151,19 +225,21 @@ pattern.
    daemons did not expose `/actuator/prometheus` at all in alpha3 because
    `micrometer-registry-prometheus` was missing from `daemon-common`.
    PRs #216, #217.
+5. **`v1.2.0-beta2`** (2026-04-25) — app-observability Scope B
+   (`deltav_<daemon>_*` native domain metrics across all 13 daemons
+   via 5 reusable hook idioms) **plus Pollerd Phase 3** (per-poll
+   response-time samples published to `deltav-timeseries` Kafka topic,
+   landing in VictoriaMetrics as
+   `opennms_response_time_response{producer="pollerd"}` with full
+   NodeContext labels). PerspectivePollerd Phase 3 deferred —
+   no public seam in horizon's Quartz-scheduled `PerspectivePollJob`.
+   Smoke confirmed Pollerd's data-plane pipeline end-to-end against
+   ghcr beta2 images. PRs #220, #221, #222.
 
 ### Remaining
 
 No firm dates. Order based on dependencies, risk, and bundle-ability:
 
-5. **`v1.2.0-beta2`** — app-observability Scope B (per-daemon domain
-   metrics, including the alarmd/bsmd/eventtranslator/trapd registry
-   wiring deferred from beta1) **plus Pollerd + PerspectivePollerd
-   response-time publishing**. Bundle-able because both touch the same
-   two daemons (one edit pass, coordinated metric naming). Native delta-v
-   meters use `deltav_*` prefix (memory
-   [`feedback_meter_naming_horizon_vs_deltav`](../../memory/feedback_meter_naming_horizon_vs_deltav.md))
-   alongside the bridged `opennms_*` meters. ~2–3 weeks.
 6. **`v1.2.0-rc1`** — Minion gRPC migration midpoint: protobuf service
    definitions published, parallel Kafka+gRPC paths running, ActiveMQ
    and ServiceMix bundles purged from minion-boot.
@@ -194,6 +270,19 @@ registries today; beta2 absorbs the remaining 4 daemons as part of
 Scope B's domain-metric retrofit. This is "Option 1" in the next-session
 prompt: ship the bridge module immediately rather than block on a
 per-daemon registry-wiring pass that's better done alongside Scope B.
+
+A third divergence in beta2: the original plan called for both Pollerd
+**and** PerspectivePollerd response-time publishing in the same cut.
+Reality: PerspectivePollerd's poll-result callback is a private lambda
+inside `PerspectivePollJob` (Quartz-scheduled), with no public seam to
+subclass. Pollerd ships Phase 3 in beta2; PerspectivePollerd Phase 3
+is deferred to a dedicated PR that wraps `PersisterFactory` (or
+similar). Beta2 also surfaced a compose-orchestration oversight in
+PR #220 — `DELTAV_TIMESERIES_ENABLED` was added to pollerd's
+`application.yml` but not to its `docker-compose.yml` `environment:`
+block — fixed in PR #222 alongside a documenting comment for
+collectd's vestigial `OPENNMS_TIMESERIES_STRATEGY: inmemory` (memory
+[`project_collectd_inner_persister_inert`](../../memory/project_collectd_inner_persister_inert.md)).
 
 Each beta/RC is smoke-tested on a clean Linux VM following the same
 process established for v1.1.1 and validated on v1.2.0-alpha1/2/3.

--- a/docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md
+++ b/docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md
@@ -1,0 +1,179 @@
+# Next session: v1.2.0-rc1 — Minion gRPC migration kickoff
+
+**This is the kickoff prompt for the largest remaining v1.2.0 track.**
+Beta2 closed out 2026-04-25 (PRs #220, #221, #222, #223; tag
+`v1.2.0-beta2` at `da9a1ba7556`). Track 2 (Minion ↔ Core gRPC) is now
+the only remaining v1.2.0 work, sized 2-4 weeks at the original
+estimate — significantly bigger than any prior cut in this release.
+
+**Read first** — these are not optional preamble:
+- [`docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`](../../plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md) — the design doc has 7 architectural questions (lines 69-95) that need decisions before code.
+- [`docs/plans/2026-04-23-v1.2.0-release-plan.md`](../../plans/2026-04-23-v1.2.0-release-plan.md) — confirms rc1 is midpoint, rc2 is finish, GA is when both land.
+- Memory: `project_v1_2_minion_grpc_migration`, `project_minion_servicemix_activemq_cleanup`, `project_sink_topic_rename`, `project_retire_default_minion`, `project_minion_echo_probes`.
+- Invariants memory (must survive): `feedback_no_local_polling`, `feedback_rpc_timeout_no_outages`, `project_minion_mandatory`.
+
+---
+
+## Where we are
+
+| Track | Status |
+|---|---|
+| 1. Self-contained images | ✅ Done (alpha1/2/3) |
+| 2. **Minion ↔ Core gRPC** | ⏳ rc1 + rc2 (this work) |
+| 3. App observability (Scope A + B) | ✅ Done (beta1, beta2) |
+| 4. Pollerd time-series publishing | ✅ Done (beta2; PerspectivePollerd Phase 3 deferred) |
+
+After rc1 + rc2 ship, v1.2.0 GA. Then v1.3 K8s operator + HPA work begins.
+
+---
+
+## Why this track is different from beta2
+
+**Beta2 was deep but mechanical** — once the 5 hook idioms were named (memory `feedback_daemon_instrumentation_patterns`), the per-daemon work parallelized cleanly. RC1 is the opposite: small surface area code-wise, but lots of upfront design decisions that cascade through the whole implementation. Spending a day on Phase 0 (decisions) is much cheaper than rolling a wrong choice through 3 weeks of code.
+
+The release plan's third divergence-note paragraph (the PerspectivePollerd Phase 3 Quartz-callback issue) is the cautionary tale: what looked like "same shape as Pollerd" was structurally different. Bytecode-audit horizon's RPC and Sink classes carefully before assuming any pattern reuses.
+
+---
+
+## Phase 0 — decide before writing any gRPC code (HIGH PRIORITY)
+
+The design doc's 7 questions split cleanly into "must answer now" vs "can defer." Recommendation: answer the must-answer set in a 1-2 hour design-decision session, write them up as a one-page addendum to the design doc, *then* start coding.
+
+**Must answer now (blocking):**
+
+1. **Per-daemon gRPC services vs. single `minion-api` translator?** (Question 1) — This shapes every protobuf definition that follows. Recommendation lean: per-daemon gRPC, no internal-Kafka translator hop. Each Core daemon already has a Spring Boot HTTP server; adding a gRPC server alongside is small. The "translator daemon" idea reintroduces the Kafka latency we're trying to remove.
+2. **Rolling compatibility — v1.2 Minion against v1.1 Core?** (Question 5) — The answer determines whether Minion ships parallel Kafka + gRPC clients (yes if rolling, no if hard-cut). The design doc recommends parallel for one release. Confirm or override.
+3. **Failure mode when Gateway unreachable.** (Question 3) — Critical because Kafka's durability buffer goes away. Two options: (a) local SQLite/disk queue on Minion with replay-on-reconnect, (b) accept "Gateway down = Minion offline." (a) is more code; (b) is operationally honest. Pick.
+4. **Spring Cloud Gateway gRPC viability for the data path.** (design doc, line 62-67) — Run a load benchmark with realistic Minion telemetry rates (NetFlow + sFlow + IPFIX combined) before committing. If Gateway can't handle it, fall back to Envoy in front of gRPC and Gateway only for HTTP UI.
+
+**Can defer (deployment-layer, doesn't block code):**
+
+5. **Minion identity & auth (mTLS vs JWT)** (Question 2) — Pick "phase 0 = no auth, internal trust, document this" so dev/test deployments don't block on cert plumbing. Real auth lands in a follow-up RC.
+6. **Observability sink (Tempo, Jaeger, ...)** (Question 6) — Decide at deployment time, not code time. OTel SDK in code is sink-agnostic.
+7. **Twin API migration timing** (Question 4) — Decide once Sink + RPC are working. Twin is lower-traffic, simpler shape; can be last.
+
+---
+
+## Suggested phasing (rc1 vs rc2 split)
+
+The release plan slates rc1 as "midpoint" and rc2 as "complete." Concrete suggestion for the split:
+
+### `v1.2.0-rc1` — gRPC parallel to Kafka, Sink path live
+
+Goal: Minion can choose gRPC or Kafka per channel; one channel migrated end-to-end as proof of pattern. Recommendation: **migrate the Heartbeat sink first** (lowest volume, simplest payload, most observable in smoke).
+
+Includes:
+- Protobuf service definitions for **all** sink categories (Heartbeat, Syslog, Telemetry × 5, Trap) — define the shape now even if only Heartbeat is wired.
+- Core-side gRPC service implementation for Heartbeat only.
+- Spring Cloud Gateway deployment + config (or Envoy if Phase 0 #4 went that way).
+- Minion-side gRPC client for Heartbeat, with a feature flag (`MINION_TRANSPORT=grpc|kafka`, default `kafka`).
+- Documented dual-running: Heartbeat on gRPC, everything else on Kafka.
+- E2E test that toggles the flag and validates heartbeat lands on Core via both transports.
+
+### `v1.2.0-rc2` — gRPC complete, Kafka path removed
+
+- All sinks migrated.
+- RPC path migrated (this is the latency-critical one — bidi-streaming).
+- Twin API migrated (server-streaming).
+- ActiveMQ + ServiceMix bundle purge from minion-boot (memory `project_minion_servicemix_activemq_cleanup` — 17+15 bundles to remove).
+- Sink topic renames (`OpenNMS.Sink.*` → `DeltaV.Sink.*`, memory `project_sink_topic_rename`) — only meaningful if any Kafka topics survive into v1.3 (likely not, but check).
+- "Default" Minion location retirement (memory `project_retire_default_minion`).
+- Echo RPC health check replaced (memory `project_minion_echo_probes` — Kafka lag monitor or gRPC liveness probe).
+- Full E2E re-validation; mock-snmp-agent goes away as a side effect of Default-location retirement.
+
+After rc2 → `v1.2.0` GA.
+
+---
+
+## Pre-work to do before phase 0 (these are cheap, do them first)
+
+1. **Bytecode audit horizon's RPC layer.** `javap -p -classpath` against `~/.m2/repository/org/opennms/core/ipc/rpc/org.opennms.core.ipc.rpc.kafka/1.0.13/...jar` and `...rpc.api/1.0.13/...jar`. Identify every public seam where gRPC could substitute for the Kafka transport without rewriting the daemon-side `RpcModule`. Beta2's lesson: the public surface is what you can substitute; private lambdas are what you can't.
+
+2. **Inventory current Minion-side Kafka client code.** Grep `core/daemon-boot-minion/` for every place that calls into `org.opennms.core.ipc.*.kafka.*`. That's the surface that needs a gRPC twin. Goal: a list, not a refactor.
+
+3. **Benchmark current Heartbeat RTT.** Set a baseline before changing anything. Use the existing `delta-v-smoke` UTM VM, capture p50 and p99 RTT for Heartbeat over 10 minutes via `kafka-consumer-groups.sh` lag + a producer timestamp. If gRPC-Heartbeat doesn't beat this, the migration story has a hole.
+
+4. **Read `org.opennms.core.ipc.rpc.kafka.KafkaRpcServerManager` carefully.** Its `bind/unbind` lifecycle and `KafkaConsumerRunner.handleRequest` flow show the pattern any gRPC equivalent needs to match. Beta2 already added `MeteredRpcModule` (memory: 5th idiom) which sits in front of all RpcModules — that wrap survives any transport change, which is useful: gRPC migration doesn't need to redo the metrics work.
+
+---
+
+## Reuse what beta2 built
+
+- **`MeteredRpcModule` + `RpcModuleMetricsPostProcessor`** (in `core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/`) wrap any `RpcModule` regardless of transport. They survive the Kafka → gRPC swap. Don't re-implement metrics during the migration.
+- **`HorizonMetricsBridge`** (from beta1) bridges Dropwizard meters from horizon code. The horizon `KafkaRpcServerManager` has its own `MetricRegistry`; whatever gRPC-equivalent class delta-v ships should similarly expose a `MetricRegistry` so the bridge picks it up automatically.
+- **The smoke procedure** (memory `reference_smoke_test_procedure`) doesn't change. Just bump `GIT_REF` and `IMG_TAG` per cut.
+
+---
+
+## Build / test gotchas (carry-over from beta2)
+
+- `feedback_spring_boot_repackage_needs_clean` — always `./mvnw clean install` after pom changes; plain `install` reuses stale fat jars.
+- `feedback_delta_v_full_reactor_verify` — full reactor build after any horizon version bump; `-pl` misses sibling cascade failures.
+- `feedback_delayed_tag_workflow_trigger` — tag at the **bump-merge** commit, not the feature-merge.
+- `project_v1_2_self_contained_images` — every cut still validates the no-git-clone smoke contract on a clean VM.
+
+---
+
+## RC1 acceptance criteria
+
+- [ ] Phase 0 design decisions written as a one-page addendum to `2026-04-22-v1.2.0-minion-grpc-migration-design.md` (or a sibling `-decisions.md`).
+- [ ] Heartbeat sink migrated end-to-end (Minion gRPC client → Gateway → Core gRPC service).
+- [ ] All other sinks have protobuf service definitions (defined, not implemented).
+- [ ] Spring Cloud Gateway deployment + config in compose.
+- [ ] `MINION_TRANSPORT` feature flag works for Heartbeat.
+- [ ] Existing Kafka path still works for the unmigrated channels.
+- [ ] E2E test validates dual-transport heartbeat.
+- [ ] `v1.2.0-rc1` cut + smoke against ghcr images.
+- [ ] Release-plan doc updated with rc1 results.
+
+---
+
+## RC1 commit shape (anticipated)
+
+| ~ commits | Content |
+|---|---|
+| 1 | Design-decisions addendum doc |
+| 1 | Protobuf service definitions for all sink categories |
+| 2-3 | Core-side Heartbeat gRPC service implementation |
+| 1-2 | Spring Cloud Gateway compose + config |
+| 2-3 | Minion-side gRPC client + transport feature flag |
+| 1 | E2E test for dual-transport heartbeat |
+| 1 | Compose env-var wiring for `MINION_TRANSPORT` |
+| 1 | Reactor-build fixes if any |
+
+Total ~10-12 commits on `feat/v1.2.0-rc1-minion-grpc-heartbeat` (or similar). Plus the standard chore/docs PRs at cut time.
+
+---
+
+## What NOT to do in rc1
+
+- **Don't migrate RPC or Twin in rc1.** Both are higher-risk (RPC is latency-critical; Twin has tricky reconnect semantics). Save for rc2 when the gRPC transport pattern is proven on Heartbeat.
+- **Don't remove ActiveMQ/ServiceMix bundles in rc1.** That work is purely cleanup and rides into rc2.
+- **Don't rename Sink topics in rc1.** `OpenNMS.Sink.*` → `DeltaV.Sink.*` is a separate concern; if rc2 removes Kafka entirely, this becomes moot.
+- **Don't tackle Default-location retirement in rc1.** That's tangled with the test harness rewrite; rc2 territory.
+- **Don't add per-daemon REST host-publishes** in compose for "easier testing." Memory `project_compose_actuator_ports_cleanup` already flags this as a v1.3 cleanup; doesn't belong here.
+
+---
+
+## Open questions for the user at session start
+
+These should be raised explicitly at the top of the rc1 session before any code:
+
+1. Is the Phase 0 split (questions 1-4 blocking, 5-7 deferred) acceptable? Any I should re-prioritize?
+2. Heartbeat-first migration order: yes, or pick a different starting sink?
+3. Spring Cloud Gateway as the data-path ingress, or Envoy? (depends on benchmark in pre-work item 3)
+4. Is parallel Kafka + gRPC the right rolling-upgrade story for rc1, or hard-cut?
+
+Don't start writing protobuf until these are answered.
+
+---
+
+## References
+
+- Design doc: `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`
+- Release plan: `docs/plans/2026-04-23-v1.2.0-release-plan.md`
+- Beta2 continuation prompt (for cadence reference): `docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-beta2-continuation.md`
+- Horizon BOM: pinned at `1.0.13` in root pom.xml (check at session start; may have moved)
+- Smoke procedure: memory `reference_smoke_test_procedure`
+- Hook idioms (carry over): memory `feedback_daemon_instrumentation_patterns`
+- Last cut tag: `v1.2.0-beta2` at `da9a1ba7556`


### PR DESCRIPTION
## Summary

Drafts the next-session prompt for v1.2.0-rc1 / rc2, which is the only remaining v1.2.0 work after the 2026-04-25 beta2 close-out.

The Minion gRPC migration is structurally different from the previous v1.2.0 cuts: small code surface area, but heavy upfront design decisions that cascade through the implementation. The prompt enforces a Phase 0 (decide) → Phase 1 (heartbeat-first migration) → rc2 (the rest) split so we avoid the "wrong decision rolled through 3 weeks of code" failure mode.

## What's captured

- **Status ribbon** showing rc1+rc2 are the only remaining v1.2.0 work
- **7 design-doc questions** (from `2026-04-22-v1.2.0-minion-grpc-migration-design.md`) split into:
  - **Must answer now (blocking)** — 4 questions: per-daemon vs translator architecture, rolling-compat strategy, Gateway-unreachable failure mode, Spring Cloud Gateway gRPC viability benchmark
  - **Can defer (deployment-layer)** — 3 questions: auth pipeline, observability sink, Twin API timing
- **Suggested rc1/rc2 phasing** — heartbeat-first migration in rc1, RPC + Twin + ActiveMQ purge + topic rename + Default-location retirement in rc2
- **Pre-work** that's cheap to do up front (bytecode audit horizon RPC layer, inventory Minion Kafka client surface, baseline Heartbeat RTT, read `KafkaRpcServerManager`)
- **Reuse callouts** from beta1/beta2 — `HorizonMetricsBridge` and `MeteredRpcModule`+`RpcModuleMetricsPostProcessor` wrap any `RpcModule` regardless of transport, so the metrics work survives the Kafka→gRPC swap
- **Build/test gotchas** carried over from beta2 (clean install, full reactor verify, tag at bump-merge, smoke contract)
- **Acceptance criteria** for rc1 cut
- **Explicit "what NOT to do" list** (no RPC/Twin in rc1, no ActiveMQ/ServiceMix purge in rc1, no Sink topic rename in rc1, etc.)
- **4 open questions** to raise at session start before any protobuf

## Pairs with PR #223

PR #223 records the beta2 cut. This PR sets up the rc1 kickoff. Different topic, different review need — kept as separate PRs to keep each review focused.

## Test plan

- [x] Markdown renders cleanly in GitHub preview
- [x] All cross-references to memory entries and design docs resolve
- [x] No code changes — pure documentation
- [ ] CI checks (auto)