### PR TITLE
feat(compose): optional OpenTelemetry tracing overlay

### DIFF
--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -425,6 +425,145 @@ To log in as admin (e.g. to create custom dashboards):
 - Username: `admin`
 - Password: `admin` (override via `GF_ADMIN_PASSWORD` environment variable).
 
+## Distributed tracing (optional)
+
+`docker-compose.tracing.yml` is an opt-in overlay that adds end-to-end
+distributed tracing across the JVM daemons. **No application source changes
+are required**: the OpenTelemetry Java agent attaches at JVM startup via
+`JAVA_TOOL_OPTIONS` and bytecode-instruments Spring Web, JDBC, Kafka clients,
+JAX-RS, and the JDK HTTP client at class-load time. Trace context propagates
+across the Kafka RPC boundary because the agent's `kafka-clients`
+instrumentation injects W3C trace headers into Kafka record headers on the
+producer side and extracts them on the consumer.
+
+### What the overlay adds
+
+- **`tempo`** — Grafana Tempo single-binary, OTLP receivers on `4317` (gRPC)
+  and `4318` (HTTP), local block storage, 1h retention. Exposed on host
+  ports `13200` (HTTP API), `14317`, `14318`.
+- **`otel-agent-init`** — one-shot Alpine container that downloads
+  `opentelemetry-javaagent.jar` into a shared volume on first `up`. Idempotent
+  on subsequent `up`. Override the source URL with `OTEL_AGENT_URL` (e.g. to
+  pin a release tag in CI, or to fetch from an internal mirror in air-gapped
+  environments).
+- **Per-daemon env** — `JAVA_TOOL_OPTIONS=-javaagent:/otel/agent.jar`,
+  `OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317`, `OTEL_SERVICE_NAME=<daemon>`,
+  and a read-only mount of the agent volume at `/otel`.
+- **Grafana datasource** — Tempo provisioned automatically via inlined
+  config; appears under Connections → Data sources without manual setup.
+
+The Tempo config and the Grafana datasource yaml are embedded directly in the
+overlay using Compose top-level `configs:` with inline `content:`, so the
+overlay is a single self-contained file. Requires Compose **v2.23+**.
+
+### Bringing the OpenTelemetry agent in
+
+The `otel-agent-init` service downloads the agent jar at first `up`. By
+default it pulls the latest stable release from GitHub:
+
+```
+https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+```
+
+The jar lands in the named volume `otel-agent`, which the JVM daemons mount
+read-only at `/otel`. Two ways to override the source:
+
+```bash
+# Pin a specific agent version (recommended for CI / reproducibility):
+OTEL_AGENT_URL=https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.27.0/opentelemetry-javaagent.jar \
+  docker compose -f docker-compose.yml -f docker-compose.tracing.yml up -d
+
+# Pre-seed the volume from a local jar (air-gapped):
+docker volume create delta-v_otel-agent
+docker run --rm -v $(pwd)/opentelemetry-javaagent.jar:/src/agent.jar:ro \
+  -v delta-v_otel-agent:/dst alpine:3.20 cp /src/agent.jar /dst/agent.jar
+```
+
+The init container short-circuits with `[ -s /otel/agent.jar ]` if a jar is
+already present, so a pre-seeded volume is never overwritten.
+
+### Usage
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.dev.yml \
+               -f docker-compose.tracing.yml \
+               --profile metrics up -d
+```
+
+Then in Grafana (`http://localhost:13000`): **Explore → Tempo → Search**.
+Anonymous Viewer access is on, so no login is needed to browse traces.
+
+To revert, drop the `-f docker-compose.tracing.yml` from the next `up`. The
+daemons recreate without the agent attached. The `otel-agent` and `tempodata`
+volumes remain until removed (`docker volume rm delta-v_otel-agent
+delta-v_tempodata`).
+
+### Example: a thin wrapper script
+
+A non-destructive wrapper that pulls only the new images, applies the
+overlay, waits for Tempo to report ready, and verifies the agent jar landed.
+Save as `tracing.sh` next to the compose files:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+OVERLAY=(-f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.tracing.yml)
+PROFILE=(--profile metrics)
+
+case "${1:-status}" in
+  up)
+    docker compose "${OVERLAY[@]}" "${PROFILE[@]}" pull tempo otel-agent-init
+    docker compose "${OVERLAY[@]}" "${PROFILE[@]}" up -d
+    for i in $(seq 1 30); do
+      if docker exec delta-v-tempo wget -q -O- http://127.0.0.1:3200/ready 2>/dev/null | grep -q ready; then
+        echo "tempo ready (after ${i}s)"; break
+      fi
+      sleep 1
+    done
+    size=$(docker run --rm -v delta-v_otel-agent:/o alpine:3.20 stat -c %s /o/agent.jar 2>/dev/null || echo 0)
+    [ "$size" -gt 1000000 ] || { echo "FAIL agent jar missing"; exit 1; }
+    echo "agent.jar: ${size} bytes — open http://localhost:13000 → Explore → Tempo"
+    ;;
+  down)
+    docker compose "${OVERLAY[@]}" "${PROFILE[@]}" stop tempo otel-agent-init || true
+    docker compose "${OVERLAY[@]}" "${PROFILE[@]}" rm -f tempo otel-agent-init || true
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml "${PROFILE[@]}" up -d
+    ;;
+  status)
+    docker compose "${OVERLAY[@]}" "${PROFILE[@]}" ps
+    ;;
+  *) echo "usage: $0 {up|down|status}"; exit 1 ;;
+esac
+```
+
+### Caveats
+
+- **100% sampling** by default (`OTEL_TRACES_SAMPLER=parentbased_always_on`)
+  — fine for the smoke profile, dial down with `traceidratio` in production.
+- **Tempo storage is local block** with 1h retention. For longer-lived
+  smoke runs or shared environments, point Tempo at S3 / GCS / Azure Blob.
+- **First `up` requires network egress** for the agent jar (~25 MB) and the
+  tempo image (~80 MB). After that the volume holds the agent.
+- **JVM startup is slower** with the agent attached (typically 5-15s extra
+  for class-load instrumentation).
+
+### Follow-up ideas (not in this overlay)
+
+- **Service map dashboard** — enable Tempo's `metrics-generator` and write
+  RED metrics + service-graph metrics to VictoriaMetrics. Adds the visual
+  node-and-edge graph in Grafana.
+- **Bridge `org.deltav.core.daemon.common.NoOpTracerRegistry`** — replace
+  the no-op with an OTel-shim implementation so the in-tree
+  `io.opentracing` callsites (e.g., telemetryd's
+  `LocalMessageDispatcherFactory`) feed the same trace tree as the
+  agent-instrumented spans.
+- **Migrate off OpenTracing API** — the in-tree `io.opentracing` 0.32.0
+  dependency is archived; eventually it should move to
+  `io.opentelemetry.api.trace.Tracer` directly.
+
 ## Troubleshooting
 
 **Images not found:** Run `./build.sh` to build all images. Verify with `docker images | grep opennms`.

--- a/opennms-container/delta-v/docker-compose.tracing.yml
+++ b/opennms-container/delta-v/docker-compose.tracing.yml
@@ -1,0 +1,255 @@
+---
+# Optional tracing overlay for the Delta-V smoke compose. Adds:
+#   - tempo            : Grafana Tempo (single-binary, OTLP receivers on 4317/4318).
+#   - otel-agent-init  : one-shot job that downloads the OpenTelemetry Java
+#                        agent into a shared volume on first up. Idempotent on
+#                        re-up, and the only step that requires network egress
+#                        beyond what the rest of the stack already needs.
+#   - JAVA_TOOL_OPTIONS / OTEL_* env on every JVM daemon so the agent
+#     auto-instruments Spring Web, JDBC, Kafka clients, JAX-RS, HTTP client
+#     and exports OTLP spans to tempo:4317.
+#   - Tempo datasource provisioning on the existing grafana service so it
+#     appears under Connections → Data sources without manual setup.
+#
+# No application source changes. The agent attaches at JVM startup via the
+# JAVA_TOOL_OPTIONS environment variable and bytecode-instruments classes at
+# load time. Trace context propagates across the Kafka RPC boundary because
+# the agent's kafka-clients instrumentation injects W3C trace headers into
+# Kafka record headers on the producer side and extracts them on the consumer.
+#
+# Usage:
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.dev.yml \
+#                  -f docker-compose.tracing.yml \
+#                  --profile metrics up -d
+#
+# Browse:
+#   Grafana  http://localhost:13000 → Explore → Tempo → Search
+#   Tempo    http://localhost:13200 (HTTP API; for ad-hoc curl)
+#
+# To revert: re-run `docker compose up -d` without `-f docker-compose.tracing.yml`.
+# Volumes (otel-agent, tempodata) persist until removed manually.
+#
+# Requires Compose v2.23+ for top-level `configs:` with inline `content:`.
+
+x-otel-mounts: &otel-mounts
+  volumes:
+    - otel-agent:/otel:ro
+  depends_on:
+    otel-agent-init:
+      condition: service_completed_successfully
+
+x-otel-env: &otel-env
+  JAVA_TOOL_OPTIONS: "-javaagent:/otel/agent.jar"
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+  OTEL_TRACES_EXPORTER: otlp
+  OTEL_METRICS_EXPORTER: none
+  OTEL_LOGS_EXPORTER: none
+  OTEL_TRACES_SAMPLER: parentbased_always_on
+  OTEL_RESOURCE_ATTRIBUTES: deployment.environment=smoke
+
+configs:
+
+  tempo_config:
+    content: |
+      stream_over_http_enabled: true
+      server:
+        http_listen_port: 3200
+        log_level: info
+      distributor:
+        receivers:
+          otlp:
+            protocols:
+              grpc:
+                endpoint: 0.0.0.0:4317
+              http:
+                endpoint: 0.0.0.0:4318
+      ingester:
+        max_block_duration: 5m
+      compactor:
+        compaction:
+          block_retention: 1h
+      storage:
+        trace:
+          backend: local
+          wal:
+            path: /var/tempo/wal
+          local:
+            path: /var/tempo/blocks
+
+  grafana_tempo_datasource:
+    content: |
+      apiVersion: 1
+      datasources:
+        - name: Tempo
+          type: tempo
+          access: proxy
+          uid: tempo
+          url: http://tempo:3200
+          isDefault: false
+          jsonData:
+            httpMethod: GET
+            search:
+              hide: false
+            nodeGraph:
+              enabled: true
+
+services:
+
+  # One-shot: download the OpenTelemetry Java agent into a shared volume.
+  # Subsequent `up` invocations are no-ops thanks to the [ -s ] guard.
+  # The default URL pulls the latest stable release; pin the version for
+  # reproducibility in CI by replacing `latest/download` with a concrete tag,
+  # e.g. .../releases/download/v2.27.0/opentelemetry-javaagent.jar
+  otel-agent-init:
+    image: alpine:3.20
+    container_name: delta-v-otel-agent-init
+    restart: "no"
+    profiles: [lite, full, metrics, metrics-e2e]
+    volumes:
+      - otel-agent:/otel
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        if [ -s /otel/agent.jar ]; then
+          echo "otel-agent-init: agent already present ($(stat -c %s /otel/agent.jar) bytes), skipping"
+          exit 0
+        fi
+        echo "otel-agent-init: downloading opentelemetry-javaagent.jar"
+        wget -q -O /otel/agent.jar \
+          "${OTEL_AGENT_URL:-https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar}"
+        chmod a+r /otel/agent.jar
+        echo "otel-agent-init: done ($(stat -c %s /otel/agent.jar) bytes)"
+
+  tempo:
+    image: grafana/tempo:2.5.0
+    container_name: delta-v-tempo
+    profiles: [metrics, metrics-e2e]
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    configs:
+      - source: tempo_config
+        target: /etc/tempo/tempo.yaml
+    volumes:
+      - tempodata:/var/tempo
+    ports:
+      - "13200:3200"   # Tempo HTTP API
+      - "14317:4317"   # OTLP gRPC (host-side, e.g. for otel-cli testing)
+      - "14318:4318"   # OTLP HTTP
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3200/ready | grep -q ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+
+  # Inject the Tempo datasource into grafana's provisioning dir.
+  # Grafana auto-loads /etc/grafana/provisioning/datasources/*.yaml at boot.
+  grafana:
+    configs:
+      - source: grafana_tempo_datasource
+        target: /etc/grafana/provisioning/datasources/tempo.yaml
+    depends_on:
+      tempo:
+        condition: service_healthy
+
+  # ---- JVM daemons: attach the agent + OTLP env -----------------------------
+  # Each block re-uses the *otel-mounts and *otel-env anchors and only sets the
+  # service-specific OTEL_SERVICE_NAME so spans group correctly in the trace UI.
+  # Daemons gated to non-metrics profiles still receive the override; it has no
+  # effect when the daemon's profile is not active.
+
+  minion:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: minion
+
+  minion-lab:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: minion-lab
+
+  provisiond:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: provisiond
+
+  alarmd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: alarmd
+
+  pollerd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: pollerd
+
+  collectd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: collectd
+
+  discovery:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: discovery
+
+  trapd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: trapd
+
+  syslogd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: syslogd
+
+  eventtranslator:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: eventtranslator
+
+  enlinkd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: enlinkd
+
+  bsmd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: bsmd
+
+  perspectivepollerd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: perspectivepollerd
+
+  telemetryd:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: telemetryd
+
+  flow-enricher:
+    <<: *otel-mounts
+    environment:
+      <<: *otel-env
+      OTEL_SERVICE_NAME: flow-enricher
+
+volumes:
+  otel-agent:
+  tempodata:


### PR DESCRIPTION
## Summary

Adds `docker-compose.tracing.yml` as an **opt-in overlay** that enables end-to-end distributed tracing across the JVM daemons with **no application source changes**.

The OpenTelemetry Java agent attaches at JVM startup via `JAVA_TOOL_OPTIONS` and bytecode-instruments Spring Web, JDBC, Kafka clients, JAX-RS, and the JDK HTTP client at class-load time. Trace context propagates across the Kafka RPC boundary because the agent's `kafka-clients` instrumentation injects W3C trace headers into Kafka record headers on the producer side and extracts them on the consumer — verified locally with cross-service `OpenNMS.twin.request` round-trips appearing as a single 4-span trace tree (minion → pollerd → minion).

## What this PR adds

- **`docker-compose.tracing.yml`** — single self-contained overlay. `tempo.yaml` and the Grafana datasource yaml are inlined via Compose top-level `configs:` with `content:`, so this is the only file to apply.
  - `tempo` service (Grafana Tempo single-binary, OTLP receivers on `4317`/`4318`, local block storage, 1h retention).
  - `otel-agent-init` one-shot Alpine container that downloads `opentelemetry-javaagent.jar` into a shared volume on first `up`. Idempotent.
  - `JAVA_TOOL_OPTIONS` + `OTEL_*` env on every JVM daemon, plus a read-only mount of the agent volume at `/otel`.
  - Tempo datasource provisioned automatically into the existing `grafana` service.
- **README section** — `opennms-container/delta-v/README.md` gains a "Distributed tracing (optional)" section covering usage, the agent-bring-in mechanism, an example `tracing.sh` wrapper, caveats, and follow-up ideas.

## How the OTel agent jar is brought in

The `otel-agent-init` service downloads the agent jar at first `up`, defaulting to the latest stable release from GitHub. Two ways to override:

```bash
# Pin a specific agent version (recommended for CI / reproducibility)
OTEL_AGENT_URL=https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.27.0/opentelemetry-javaagent.jar \
  docker compose -f docker-compose.yml -f docker-compose.tracing.yml up -d

# Pre-seed the volume from a local jar (air-gapped)
docker volume create delta-v_otel-agent
docker run --rm -v $(pwd)/opentelemetry-javaagent.jar:/src/agent.jar:ro \
  -v delta-v_otel-agent:/dst alpine:3.20 cp /src/agent.jar /dst/agent.jar
```

The init container short-circuits with `[ -s /otel/agent.jar ]` if a jar is already present, so a pre-seeded volume is never overwritten.

## Try it

```bash
docker compose -f docker-compose.yml \
               -f docker-compose.dev.yml \
               -f docker-compose.tracing.yml \
               --profile metrics up -d
```

Then `http://localhost:13000` → Explore → Tempo → Search. Anonymous Viewer access is on, so no login is required to browse traces.

To revert: drop the `-f docker-compose.tracing.yml` flag from the next `up`. Volumes (`otel-agent`, `tempodata`) persist until removed manually.

## Caveats

- Requires Compose **v2.23+** for inline `configs:` content.
- 100% sampling by default (`OTEL_TRACES_SAMPLER=parentbased_always_on`) — fine for the smoke profile, dial down with `traceidratio` in production.
- First `up` requires network egress for the agent jar (~25 MB) and the tempo image (~80 MB).
- JVM startup is ~5-15s slower with the agent attached (class-load instrumentation).

## Not addressed (follow-ups)

- Tempo `metrics-generator` → VictoriaMetrics (already in the stack) for the service-map dashboard.
- Replacing `org.deltav.core.daemon.common.NoOpTracerRegistry` with an OTel-shim implementation so the in-tree `io.opentracing` callsites (e.g., telemetryd's `LocalMessageDispatcherFactory`) feed the same trace tree as the agent-instrumented spans.
- Migrating off `io.opentracing` 0.32.0 (archived) to `io.opentelemetry.api.trace.Tracer` directly.

## Test plan

- [ ] Apply the overlay against a fresh smoke stack and confirm `docker compose ps` shows tempo healthy and otel-agent-init exited 0.
- [ ] Confirm `agent.jar` lands in the `otel-agent` volume (size > 1 MB).
- [ ] Open Grafana Explore, pick Tempo, search by service name (e.g., `provisiond`), open a trace and verify the waterfall renders.
- [ ] Confirm a Kafka cross-service trace links spans from at least two services (e.g., a `OpenNMS.twin.request` round-trip between minion and a daemon).
- [ ] Drop the `-f docker-compose.tracing.yml` flag from `up` and confirm daemons recreate cleanly without the agent attached.
- [ ] Verify `OTEL_AGENT_URL` override works for pinning a specific release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)