### PR TITLE
docs(v1.2.0-rc1): Phase 0 design decisions for Minion gRPC migration

### DIFF
--- a/docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md
+++ b/docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md
@@ -1,0 +1,289 @@
+# v1.2.0 Minion gRPC Migration — Phase 0 Decisions
+
+> **Status:** Phase 0 design decisions captured 2026-04-25 during the v1.2.0-rc1
+> kickoff session. Sibling addendum to
+> [`2026-04-22-v1.2.0-minion-grpc-migration-design.md`](./2026-04-22-v1.2.0-minion-grpc-migration-design.md).
+> Implementation has not started.
+
+This document captures the architectural decisions made during the rc1 kickoff
+session. The kickoff prompt
+([`docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md`](../superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md))
+identified seven architectural questions in the design doc and split them into
+"must answer now" (questions 1-4) and "can defer" (questions 5-7). All four
+blocking questions are now resolved.
+
+---
+
+## Decisions at a glance
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Per-daemon gRPC services vs. translator daemon | **Translator daemon: `minion-gateway`** |
+| 2 | Rolling compatibility (v1.2 Minion ↔ v1.1 Core) | **Hard cut. v1.2.0 is gRPC-only on day one.** |
+| 3 | Failure mode when ingress unreachable | **No buffer; rely on gRPC default reconnect.** |
+| 4 | Spring Cloud Gateway gRPC viability for data path | **Use Envoy, not Spring Cloud Gateway.** |
+| 5 | Minion identity & auth | Deferred. rc1 = no auth, internal trust, documented. |
+| 6 | Observability sink (Tempo / Jaeger / …) | Deferred. rc1 ships sink-agnostic OTel SDK; deploy-time choice. |
+| 7 | Twin API migration timing | Deferred to rc2, after Sink + RPC patterns proven on Heartbeat + RPC. |
+
+Plus two operational decisions captured during the same session:
+
+| Topic | Decision |
+|---|---|
+| Starting channel for rc1 | **Heartbeat sink first.** Lowest payload complexity, one-way client-streaming, most observable in smoke. |
+| New daemon naming | **`minion-gateway`** (rejected: `minion-bridge`, `minion-edge`, `minion-broker`, `minion-api`). |
+
+---
+
+## Decision 1 — Translator daemon (`minion-gateway`)
+
+**Resolution:** A single new daemon, `minion-gateway`, sits between the Envoy
+ingress and the existing internal Kafka topics. It is the only Core-side
+component that accepts inbound network connections from Minions.
+
+**Why this is the only viable option:**
+
+The decision is forced by a stronger reading of `project_minion_mandatory`
+captured during this session. The original wording covered only outbound
+network I/O ("daemons must never touch the network directly"). The user
+clarified the symmetric inbound rule:
+
+> ServiceDaemons must never accept network connections — neither outbound nor
+> inbound — mainly due to not wanting to have listeners that establish
+> sessions and have access to state, file systems, databases, or other
+> internal systems.
+
+This is a **zero-trust security posture**, not just an operational preference.
+ServiceDaemons hold credentials, database connections, filesystem state, and
+internal-system access. Adding a gRPC server to a ServiceDaemon would expose
+all of that surface to the network. The per-daemon gRPC option from design-doc
+Q1 is therefore not on the table.
+
+The bidirectional version of this invariant is now captured in
+`project_minion_mandatory` memory.
+
+**Architectural consequence:**
+
+```
+                                                                         ┌─► Pollerd
+                                                                         ├─► Collectd
+[Minion] ──gRPC/HTTPS─► [Envoy] ──► [minion-gateway] ──► Kafka topics ───┤
+                                                                         ├─► Provisiond
+                                                                         └─► … (12 ServiceDaemons unchanged)
+```
+
+`minion-gateway` is a **pure protocol translator** with no business logic:
+
+- **Outside face (Minion-facing):** ~7-8 long-lived gRPC streams per connected Minion.
+- **Inside face (Core-facing):** Producer for `OpenNMS.Sink.*` topics; consumer
+  for `OpenNMS.<location>.rpc-request`; producer for `OpenNMS.rpc-response`;
+  consumer for `OpenNMS.twin.request`; producer for
+  `OpenNMS.twin.response.<location>`.
+
+ServiceDaemons see zero protocol change. They keep producing and consuming the
+same internal Kafka topics they do today. This is the only ServiceDaemon-level
+property that matters for this migration.
+
+---
+
+## Decision 2 — Hard cut to gRPC in v1.2.0
+
+**Resolution:** v1.2.0 is gRPC-only. No v1.1-Minion-talks-to-v1.2-Core or vice
+versa support path. The `MINION_TRANSPORT` env var exists in rc1 only as an
+emergency rollback flag for smoke-test failures, not as a long-term contract.
+
+**Why hard cut over the prompt's "parallel transports" recommendation:**
+
+The kickoff prompt leaned toward parallel transports for one release as the
+"safer" path. The project's actual adoption profile argues against that:
+
+- The v1.2 deployment story is `curl docker-compose.yml; docker compose up -d`
+  with no git clone (`project_v1_2_self_contained_images`). Adopters pull a
+  fresh stack from a tag, not a long-lived heterogeneous deployment.
+- v1.2.0-beta2 just shipped (2026-04-25). There is no installed base that
+  needs gracefully-rolled upgrades.
+- `feedback_karaf_is_dead` and the entire 12-daemon Karaf removal arc
+  consistently chose "delete the legacy compatibility path" over "carry both
+  for compatibility." Two-transport rc1 would invert that pattern in the same
+  release that is removing ActiveMQ/ServiceMix bundles for being too
+  heavyweight.
+
+Hard cut also halves the Minion client code surface in rc1, eliminates
+dual-running test paths, and lets `minion-gateway` be gRPC-only from day one
+(it never has to read from `OpenNMS.Sink.*` topics — it produces to them).
+
+---
+
+## Decision 3 — Failure mode: no buffer, rely on gRPC reconnect
+
+**Resolution:** Minion does not buffer messages locally during ingress
+unavailability. Steady-state operation uses one long-lived TCP connection per
+Minion with HTTP/2 keepalive; transient outages are handled by the standard
+gRPC `ManagedChannel` reconnect-with-backoff. No SQLite queue, no disk-backed
+durability buffer.
+
+**Why:**
+
+1. **The protocols themselves already tolerate loss.** sFlow is named for
+   sampling. SNMP traps are UDP. Syslog over UDP is best-effort. The Kafka
+   producer-buffer + broker-durability combination was protecting telemetry
+   that the upstream protocols had already designed to be lossy. Adding a
+   Minion-side buffer was overengineering relative to what the data plane
+   actually needs.
+2. **Adding a SQLite queue inverts the project's direction.**
+   `feedback_karaf_is_dead` and a string of "delete the legacy path"
+   decisions argue against introducing a new stateful component. A disk-backed
+   queue on Minion shifts it from "stateless edge" toward "stateful queue
+   endpoint" — additional persistent-volume dependency in K8s, named-volume
+   complexity in Compose, ordering-on-replay semantics, disk-full failure
+   modes, crash-recovery semantics.
+3. **Kafka still protects ServiceDaemon-issued requests.** A Minion outage
+   does not cause RPC-request loss on the Core side — those requests sit in
+   `OpenNMS.<location>.rpc-request` until `minion-gateway` consumes them after
+   the Minion reconnects. Durability is preserved exactly where it matters
+   (server-issued requests), and accepted-loss is limited exactly where the
+   protocols already tolerate it (transient Minion-to-Core telemetry).
+4. **gRPC's connection model has no per-message handshake.** Each Minion
+   maintains a single TCP+TLS connection to Envoy plus ~7-8 long-lived
+   HTTP/2 streams (one per channel). Heartbeats are appended as HTTP/2 DATA
+   frames on an existing stream — microsecond cost, not millisecond. Loss
+   only happens during the gap between TCP-drop-detection (HTTP/2 PING
+   timeout, ~1-30s) and TCP-reconnect (default ~1s initial backoff). For
+   Heartbeat specifically, this is at most one missed heartbeat per network
+   event.
+
+**Per-channel reconsideration knob:** if rc2 production data shows
+Heartbeat false-alarms are an operational pain, add a small in-memory ring
+buffer to the Heartbeat client only. Don't pay the SQLite cost across all
+sinks.
+
+---
+
+## Decision 4 — Envoy as the gRPC ingress
+
+**Resolution:** Envoy is the gRPC ingress in front of `minion-gateway`. Spring
+Cloud Gateway is **not** used for the data path.
+
+**Why commit to Envoy now rather than benchmark Spring Cloud Gateway first:**
+
+The original design doc proposed Spring Cloud Gateway with a benchmark gate
+(if SCG cannot handle telemetry-rate gRPC, fall back to Envoy). The user's
+question "wouldn't it be better to start with the battle-tested Envoy now?"
+holds up under analysis:
+
+- Envoy is the de-facto standard for gRPC proxying — the data plane behind
+  Istio, AWS App Mesh, Google Cloud Service Mesh; in production at Lyft,
+  Uber, Square, Pinterest, Stripe, etc. SCG's gRPC support exists but is
+  comparatively unproven at high-throughput streaming.
+- Skips a benchmark that was likely to send us to Envoy anyway.
+- Avoids carrying SCG gRPC config code that would be deleted in rc2 if the
+  benchmark went the expected way.
+- A delta-v deployment with N remote Minions = N long-lived TCP connections
+  each holding 7-8 streams. Envoy is designed for that connection count;
+  SCG's reactive Java/Netty stack would have struggled.
+
+**The "one ingress for both gRPC + future UI" consolidation argument is
+intentionally abandoned** as part of this decision. Data plane (telemetry,
+RPC, server-to-server, telemetry-heavy) and control plane (browser HTTP, UI,
+low-volume) have different scaling profiles, security postures, and
+audiences. Splitting them — Envoy for data, optionally Spring Cloud Gateway
+later for HTTP UI — is not a compromise; it is good architecture.
+
+---
+
+## Deferred questions (intentional)
+
+The following items from the design doc are not blocking implementation and
+will be revisited later:
+
+- **Auth (mTLS / JWT) — design-doc Q2.** rc1 ships with no auth, internal-trust
+  posture, documented. Real auth lands in a follow-up RC. Deferring this does
+  not block protobuf or wire-format work because auth is an HTTP-header /
+  Envoy-filter concern, not a service-definition concern.
+- **Observability sink — design-doc Q6.** rc1 uses the standard OTel SDK on
+  the Java side and Envoy's native OpenTelemetry support on the proxy side.
+  The collector / backend (Tempo, Jaeger, Grafana Cloud, …) is a deployment-
+  time choice and is not encoded in code.
+- **Twin API migration — design-doc Q4.** Twin migrates last in rc2, after
+  Sink and RPC patterns are proven on Heartbeat and the RPC channel
+  respectively. Twin's reconnect/resubscribe semantics are the trickiest of
+  the three; doing it last benefits from lessons learned on the simpler
+  channels.
+
+**Not deferred — design-doc Q7 (labbox test harness updates) is in scope for
+rc1 and rc2.** `test-perspective-e2e.sh`, `test-enlinkd-e2e.sh`, and any other
+harness that exercises the Kafka RPC path will need to be updated alongside
+the channel migrations. Tracked in the implementation-plan follow-ups below.
+
+---
+
+## rc1 implementation implications
+
+These decisions tighten the rc1 acceptance criteria from the kickoff prompt:
+
+1. **One new daemon to design and ship: `minion-gateway`.** Not 12. Not a
+   per-daemon refactor. The work is concentrated in this one component. Its
+   internal shape is symmetric — gRPC server outside, Kafka producer/consumer
+   inside.
+2. **Protobuf service definitions are gateway-independent.** Defining the
+   wire format for all sink categories in rc1 (Heartbeat, Syslog, Telemetry × 5,
+   Trap) is independent of which ingress proxy fronts them. The same .proto
+   files would work behind SCG, Envoy, nginx, or no proxy at all.
+3. **No SCG config code in this release.** The compose stack adds Envoy. SCG
+   configuration belongs to a future release if and when a delta-v UI is added.
+4. **No Minion-side disk dependency.** Minion stays stateless. No new
+   persistent volume in K8s, no new named volume in Compose.
+5. **No `MINION_TRANSPORT=kafka` runtime path beyond the rc1 emergency
+   rollback flag.** Test code targets gRPC only. CI does not double-run tests
+   in two transports.
+6. **`MeteredRpcModule` and `RpcModuleMetricsPostProcessor` from beta2 carry
+   over unchanged** — they wrap any RpcModule regardless of transport. The
+   `minion-gateway` daemon will get its own `MeteredRpcModule`-equivalent for
+   the gRPC server side, but the existing daemon-side metric wraps survive
+   the migration without modification (memory:
+   `feedback_daemon_instrumentation_patterns`, 5th idiom).
+
+---
+
+## Open follow-ups for the implementation plan
+
+These items remain open and will be addressed when the rc1 implementation plan
+is written (next session, via `superpowers:writing-plans`):
+
+- **Pre-work bytecode audit** of horizon's `org.opennms.core.ipc.rpc.kafka:1.0.13`
+  and `…rpc.api:1.0.13` jars to identify the public seams for gRPC substitution
+  on the daemon side. Beta2's lesson: public surface is substitutable; private
+  lambdas are not.
+- **Inventory** of `core/daemon-boot-minion/` callsites into
+  `org.opennms.core.ipc.*.kafka.*` — produces the list of touchpoints that
+  need a gRPC twin on the Minion side.
+- **Heartbeat RTT baseline** captured on the existing Kafka path (delta-v-smoke
+  UTM VM, p50 + p99 over 10 minutes) so the gRPC-Heartbeat numbers have
+  something to compare against.
+- **Spring Boot 4 gRPC integration choice** — `org.springframework.grpc`
+  vs. `net.devh:grpc-client-spring-boot-starter` vs. raw `io.grpc:grpc-stub`
+  with hand-written `@Configuration` beans. Verify Boot 4 compatibility for
+  whichever wins.
+- **Per-Minion identity attribution in protobuf headers.** `minion-gateway`
+  must route RPC responses back to the right Minion's bidi stream and route
+  Sink messages to the correctly-keyed Kafka topic. Identity-in-headers
+  has to be designed into the .proto from day one even though auth
+  (design-doc Q2) is deferred.
+- **Labbox test harness updates (design-doc Q7).** `test-perspective-e2e.sh`
+  and `test-enlinkd-e2e.sh` exercise the Kafka RPC path today; they will
+  need gRPC-path equivalents in rc2 alongside the RPC channel migration.
+  Heartbeat-channel smoke validation in rc1 is simpler — heartbeats already
+  surface in the Minion-health dashboards.
+
+---
+
+## References
+
+- **Design doc:** [`2026-04-22-v1.2.0-minion-grpc-migration-design.md`](./2026-04-22-v1.2.0-minion-grpc-migration-design.md)
+- **Release plan:** [`2026-04-23-v1.2.0-release-plan.md`](./2026-04-23-v1.2.0-release-plan.md)
+- **Kickoff prompt:** [`docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md`](../superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md)
+- **Invariants:** memory `project_minion_mandatory` (zero-trust, bidirectional);
+  `feedback_no_local_polling`; `feedback_rpc_timeout_no_outages`
+- **Beta2 carry-over patterns:** memory `feedback_daemon_instrumentation_patterns`
+- **Last cut tag:** `v1.2.0-beta2` at `da9a1ba7556`
+- **Horizon BOM in use:** `1.0.13` (root pom.xml `deltav.horizon.version`)


### PR DESCRIPTION
## Summary

- Captures the four blocking architectural decisions for the v1.2.0-rc1 Minion gRPC migration:
  - **`minion-gateway` translator daemon** (zero-trust forces this — ServiceDaemons must never accept network connections)
  - **Hard cut to gRPC** in v1.2.0 (no parallel Kafka+gRPC transports)
  - **No Minion-side buffer** — rely on gRPC `ManagedChannel` reconnect-with-backoff; durability stays where it matters (Kafka, inside Core)
  - **Envoy** as the gRPC ingress (not Spring Cloud Gateway); data-plane / control-plane intentionally split
- Documents deferred questions (auth, observability sink, Twin migration timing) and in-scope-but-not-blocking items (labbox test harness updates)
- Sibling addendum to `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`; sets the stage for the rc1 implementation plan

## Context

Resolves design-doc Q1 (per-daemon vs translator), Q3 (failure mode), Q5 (rolling compat), and the SCG-vs-Envoy decision. Design-doc Q2/Q4/Q6 deferred. Q7 (test harness) in scope for rc1+rc2.

The bidirectional reading of `project_minion_mandatory` (no inbound network either, not just no outbound) is the load-bearing invariant — it makes Decision 1 (translator daemon) the only viable option rather than a preference.

## Validation

- [ ] Doc renders cleanly on GitHub (tables, ASCII diagram, links)
- [ ] All cross-references resolve (design doc, release plan, kickoff prompt)
- [ ] Decision rationales match the kickoff-session discussion
- [ ] No placeholder text
- [ ] Sibling memory updates noted (`project_minion_mandatory` bidirectional invariant, `project_v1_2_minion_grpc_migration` architecture)

## Next session

`superpowers:writing-plans` to turn the open follow-ups (bytecode audit, Minion Kafka surface inventory, Heartbeat RTT baseline, Spring Boot 4 gRPC integration choice, identity-in-headers, labbox harness updates) into the rc1 implementation plan. Implementation branch will be `feat/v1.2.0-rc1-minion-grpc-heartbeat`.