### PR TITLE
docs(v1.2.0-rc1): next-session prompt for Minion gRPC implementation plan

### DIFF
--- a/docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-implementation-plan-kickoff.md
+++ b/docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-implementation-plan-kickoff.md
@@ -1,0 +1,239 @@
+# Next session: v1.2.0-rc1 — Minion gRPC migration implementation plan
+
+**This is the implementation-plan kickoff prompt for v1.2.0-rc1.**
+Phase 0 closed out 2026-04-25 (PR #226 at `bf45c3bfbe5`). All four
+blocking design questions are resolved (see addendum). Pre-work is the
+last gate before drafting the rc1 implementation plan via
+`superpowers:writing-plans`.
+
+This session is sized at one focused working session — pre-work + plan
+write-up. Implementation work itself is the next session after this one.
+
+**Read first** — these are not optional preamble:
+- [`docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md`](../../plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md) — the Phase 0 addendum that locks in minion-gateway / hard-cut / no-buffer / Envoy.
+- [`docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`](../../plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md) — original design doc; Q1/Q3/Q5 + SCG-viability are now resolved by the addendum.
+- [`docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md`](./2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md) — the prior session's kickoff for context on the rc1/rc2 split and acceptance criteria.
+- Memory: `project_v1_2_minion_grpc_migration` (updated with Phase 0 outcomes), `project_minion_mandatory` (updated with bidirectional zero-trust rule), `feedback_daemon_instrumentation_patterns` (5 hook idioms — MeteredRpcModule survives the transport swap), `reference_smoke_test_procedure`.
+- Invariants memory (must survive): `feedback_no_local_polling`, `feedback_rpc_timeout_no_outages`, `project_minion_mandatory`.
+
+---
+
+## Where we are
+
+| Track | Status |
+|---|---|
+| 1. Self-contained images | ✅ Done (alpha1/2/3) |
+| 2a. **Minion ↔ Core gRPC — Phase 0 design decisions** | ✅ Done (PR #226) |
+| 2b. **Minion ↔ Core gRPC — rc1 implementation plan** | ⏳ This session |
+| 2c. Minion ↔ Core gRPC — rc1 implementation | Next session |
+| 2d. Minion ↔ Core gRPC — rc2 (full migration) | Future sessions |
+| 3. App observability (Scope A + B) | ✅ Done (beta1, beta2) |
+| 4. Pollerd time-series publishing | ✅ Done (beta2) |
+
+---
+
+## What's locked from Phase 0 — do not relitigate
+
+- **`minion-gateway`** — single new daemon, gRPC↔Kafka translator. ServiceDaemons unchanged.
+- **Hard cut to gRPC in v1.2.0.** No parallel transports. `MINION_TRANSPORT=kafka` exists in rc1 only as an emergency rollback flag.
+- **No Minion-side buffer.** Rely on gRPC `ManagedChannel` reconnect-with-backoff. Per-channel buffer reconsideration is a *post-rc2 production data* decision, not a rc1 design choice.
+- **Envoy as the gRPC ingress.** Spring Cloud Gateway is not in the compose stack for this work.
+- **Heartbeat sink is the rc1 proof-of-pattern channel.** Other sinks get protobuf definitions but not implementations.
+- **Auth deferred** — rc1 is no-auth-internal-trust, documented.
+- **Observability sink choice deferred** — sink-agnostic OTel SDK in code; collector chosen at deploy time.
+- **Twin migration deferred to rc2.** RPC also rc2.
+
+If this session finds a reason to revisit any of the above, treat it as a
+red flag — the Phase 0 addendum was deliberate, and a "let me just" change
+to a locked decision means re-running the kickoff brainstorm. Surface the
+concern explicitly to the user before changing course.
+
+---
+
+## Pre-work — do these BEFORE invoking `superpowers:writing-plans`
+
+These four items came out of the Phase 0 addendum's "Open follow-ups for
+the implementation plan" section. They are reading-and-reporting tasks,
+not implementation. The plan can't be honest without them.
+
+### 1. Bytecode-audit horizon's RPC layer
+
+```bash
+# horizon BOM is pinned at 1.0.13 in root pom.xml
+ls ~/.m2/repository/org/opennms/core/ipc/rpc/org.opennms.core.ipc.rpc.kafka/1.0.13/
+ls ~/.m2/repository/org/opennms/core/ipc/rpc/org.opennms.core.ipc.rpc.api/1.0.13/
+
+# javap each public class — focus on the seams where gRPC could substitute
+# without rewriting the daemon-side RpcModule
+javap -p ... | less
+```
+
+**Goal:** identify the public surface where transport substitution is
+viable. Beta2's lesson (memory `feedback_daemon_instrumentation_patterns`):
+public surface is substitutable; private lambdas are not. Specifically
+study `KafkaRpcServerManager` (its `bind`/`unbind` lifecycle and
+`KafkaConsumerRunner.handleRequest` flow show the pattern any gRPC
+equivalent must match). The MeteredRpcModule wrap from beta2 sits in
+front of all RpcModules and survives any transport swap — confirm this
+in code, don't assume it.
+
+**Report:** a short list of the public classes and methods on the seam,
+plus any private surfaces that would need refactor to be substitutable.
+
+### 2. Inventory Minion-side Kafka client surface
+
+```bash
+# Find every callsite into horizon's Kafka IPC from the Minion module
+grep -rn 'org.opennms.core.ipc' core/daemon-boot-minion/src/main/java/ | \
+  grep -i kafka
+
+# Also check the common boot
+grep -rn 'org.opennms.core.ipc' core/daemon-boot-minion-common/src/main/java/ 2>/dev/null | \
+  grep -i kafka
+```
+
+**Goal:** produce the list of touchpoints that need a gRPC twin. List,
+not refactor. Note the call shape (constructor injection? service
+lookup? @Bean method?) for each callsite — informs the Spring Boot 4
+gRPC integration choice.
+
+**Report:** a numbered list of files with the relevant import + line
+number, plus a one-sentence description of what each callsite does
+(producer, consumer, lifecycle binder, etc.).
+
+### 3. Heartbeat RTT baseline on the existing Kafka path
+
+Use the existing `delta-v-smoke` UTM VM (memory
+`reference_smoke_test_procedure`). Capture **p50 and p99 round-trip
+latency** for Heartbeat over 10 minutes via:
+
+- `kafka-consumer-groups.sh` lag on `OpenNMS.Sink.Heartbeat` consumer
+- Producer-side timestamp embedded in heartbeat payload (already there;
+  check `HeartbeatModule`)
+
+**Goal:** baseline number to validate the gRPC migration story. If
+gRPC-Heartbeat doesn't beat this, the migration is doing harm to the
+metric we care about most.
+
+**Report:** p50 + p99 numbers, the conditions (Minion location, broker
+count, network conditions), and the raw command used.
+
+### 4. Spring Boot 4 gRPC integration choice
+
+Three candidates, in order of preference:
+
+1. **`org.springframework.grpc:spring-grpc-spring-boot-starter`** — Spring's
+   own gRPC project. Ideal alignment if Boot 4 is supported.
+2. **`net.devh:grpc-client-spring-boot-starter`** — community standard,
+   battle-tested on Boot 3.x. Verify Boot 4 compatibility.
+3. **Raw `io.grpc:grpc-stub` + hand-written `@Configuration` beans** —
+   skips the integration layer entirely. Always works; loses some
+   ergonomics (`@GrpcClient`, `@GrpcService` annotations).
+
+**Verify:** Boot 4 + Java 17 + Spring Cloud BOM compatibility for
+candidates 1 and 2. Check Maven Central + the candidate's own release
+notes for Boot 4 mention.
+
+**Report:** decision with reasoning. If neither (1) nor (2) supports
+Boot 4 cleanly, fall back to (3) and note the ergonomic loss.
+
+---
+
+## After pre-work — invoke `superpowers:writing-plans`
+
+The implementation plan should produce a step-by-step roadmap for the
+rc1 commit shape (~10-12 commits; see kickoff prompt). Hand the
+following structure to `writing-plans`:
+
+### rc1 commit shape (refined from kickoff prompt)
+
+| ~ commits | Content |
+|---|---|
+| 1 | Protobuf service definitions for ALL sink categories (defined, not implemented) — Heartbeat, Syslog, Telemetry × 5, Trap. RPC + Twin schemas can be sketched but not finalized. Identity-in-headers must be in the .proto from day one. |
+| 1 | New module: `core/minion-gateway/` — daemon scaffolding, Spring Boot 4, gRPC server libraries, MeteredRpcModule-equivalent for the gRPC server side, MetricRegistry exposed for HorizonMetricsBridge. |
+| 2 | minion-gateway: Heartbeat gRPC service implementation + Kafka producer to `OpenNMS.Sink.Heartbeat`. |
+| 1-2 | Envoy compose addition — listener config, gRPC route to minion-gateway, Prometheus stats endpoint for the new ingress. |
+| 2-3 | Minion-side gRPC client for Heartbeat, behind the `MINION_TRANSPORT` flag. Default `grpc` (per Decision 2 hard-cut); `kafka` only as emergency rollback. |
+| 1 | E2E test that validates Heartbeat lands on Core via the gRPC path. (No dual-transport test — hard-cut.) |
+| 1 | Compose env-var wiring for `MINION_TRANSPORT`. |
+| 1 | Reactor-build fixes if any (memory `feedback_delta_v_full_reactor_verify` — full reactor build after horizon-version-bump-style changes). |
+
+### Implementation-phase open questions to resolve in the plan
+
+These are NOT Phase 0 questions (those are locked). They are
+implementation-plan questions — they need answers, but the answers
+inform code structure, not architecture.
+
+1. **Per-Minion identity attribution in protobuf headers.** Where does
+   identity live? gRPC metadata header? In-message field? Both? The
+   minion-gateway must route RPC responses to the right Minion's open
+   bidi stream and key Sink-Kafka publishes to the right partition.
+   Identity-in-headers has to be designed into the .proto from day one
+   even though auth (design-doc Q2) is deferred.
+2. **minion-gateway internal architecture.** Singleton process, or
+   sharded? Threading model — one thread per open Minion stream, or
+   shared event-loop? gRPC's default Netty event-loop probably handles
+   this for free, but confirm in the plan.
+3. **Envoy compose-stack placement.** New service in `compose.yml`? New
+   compose file? What's the listener port (443? something else?)? Where
+   do TLS certs live in compose (no auth in rc1, but TLS is still
+   wanted for the HTTPS deployment story)?
+4. **Heartbeat protobuf shape.** Message fields, streaming RPC method
+   signature (`rpc publish (stream Heartbeat) returns (HeartbeatAck)` or
+   similar). Match the existing Java HeartbeatModule's payload as
+   closely as possible to minimize translation logic.
+5. **Test harness structure.** New script under
+   `tests/e2e/test-grpc-heartbeat-e2e.sh`? Or extension of an existing
+   script? `test-perspective-e2e.sh` and `test-enlinkd-e2e.sh` will
+   need gRPC-path equivalents in rc2 alongside the RPC channel
+   migration (design-doc Q7 — in scope, not deferred).
+
+---
+
+## RC1 acceptance criteria (carried over from kickoff prompt, updated)
+
+- [ ] All Phase 0 pre-work items above completed and reported.
+- [ ] Heartbeat sink migrated end-to-end (Minion gRPC client → Envoy → minion-gateway → Kafka → existing Heartbeat consumer).
+- [ ] All other sinks have protobuf service definitions (defined, not implemented).
+- [ ] Envoy deployment + config in compose.
+- [ ] `minion-gateway` daemon shipping with MeteredRpcModule-equivalent metrics, MetricRegistry exposed for HorizonMetricsBridge.
+- [ ] `MINION_TRANSPORT` feature flag works as emergency rollback (default `grpc`; flip to `kafka` documented).
+- [ ] E2E test validates Heartbeat on the gRPC path (single transport — no dual-transport test per Decision 2).
+- [ ] `v1.2.0-rc1` cut + smoke against ghcr images.
+- [ ] Release-plan doc updated with rc1 results.
+
+---
+
+## What NOT to do in this session
+
+- **Don't write protobuf code, daemon code, or Envoy config in this session.** This session ends at the implementation plan. Code goes to the *next* session, scoped to the plan.
+- **Don't relitigate Phase 0 decisions.** If something feels wrong about translator/hard-cut/no-buffer/Envoy, surface it explicitly to the user before changing direction. The addendum was deliberate.
+- **Don't extend rc1 scope.** RPC and Twin are explicitly rc2. Adding "while we're at it, let's also..." doubles the rc1 surface and breaks the proof-of-pattern intent.
+- **Don't replace MeteredRpcModule.** Beta2's metrics infrastructure survives the transport swap by design (memory `feedback_daemon_instrumentation_patterns`, 5th idiom). Use it.
+- **Don't commit anything beyond the plan doc itself.** Pre-work findings can go in a session-notes doc if useful, but the plan doc is the deliverable.
+
+---
+
+## Open questions for the user at session start
+
+These should be raised at the top of the implementation-plan session
+before invoking `writing-plans`:
+
+1. Are the four pre-work items the right scope, or is there a fifth I should add?
+2. Plan doc location: `docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md` (matches the addendum / design-doc cadence in `docs/plans/`)?
+3. Should the plan include the RPC + Twin migration as separate (deferred) sections, or treat them as entirely out-of-scope and pick up in a separate rc2 plan doc?
+4. Branch naming for the implementation work: `feat/v1.2.0-rc1-minion-grpc-heartbeat` (per the kickoff prompt) or different?
+
+---
+
+## References
+
+- **Phase 0 addendum:** [`docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md`](../../plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md)
+- **Original design doc:** [`docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`](../../plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md)
+- **Prior kickoff prompt:** [`docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md`](./2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md)
+- **Release plan:** [`docs/plans/2026-04-23-v1.2.0-release-plan.md`](../../plans/2026-04-23-v1.2.0-release-plan.md)
+- **Horizon BOM:** `1.0.13` (verify at session start in root pom.xml `deltav.horizon.version`)
+- **Last cut tag:** `v1.2.0-beta2` at `da9a1ba7556`
+- **Phase 0 merge:** PR #226 at `bf45c3bfbe5`
+- **Smoke procedure:** memory `reference_smoke_test_procedure`
+- **Hook idioms (carry over):** memory `feedback_daemon_instrumentation_patterns`


### PR DESCRIPTION
## Summary

- Hands off the v1.2.0-rc1 implementation-plan work to a fresh session
- Lists four pre-work items (bytecode audit, Minion Kafka inventory, Heartbeat RTT baseline, Spring Boot 4 gRPC integration choice) that gate invocation of \`superpowers:writing-plans\`
- Carries forward Phase 0 locked decisions explicitly so the next session does not relitigate (minion-gateway translator / hard-cut / no-buffer / Envoy ingress / Heartbeat-first)
- Lists implementation-plan open questions: identity-in-headers, minion-gateway internals, Envoy compose placement, Heartbeat protobuf shape, test harness structure

## Context

Sibling to \`docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-minion-grpc-kickoff.md\` (PR #224, Phase 0 kickoff). References \`docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md\` (PR #226, Phase 0 addendum) as the load-bearing prior-art.

The next session ends at the implementation-plan deliverable; code goes to the session after that.

## Validation

- [ ] Doc renders cleanly on GitHub
- [ ] All cross-references resolve (Phase 0 addendum, design doc, prior kickoff prompt, release plan)
- [ ] Pre-work items are concrete enough to execute without further clarification
- [ ] Open questions are scoped to implementation-plan concerns, not Phase 0 decisions

## Next session

After this merges, a fresh session can read this prompt verbatim and (1) execute pre-work, (2) invoke \`superpowers:writing-plans\` to draft the rc1 implementation plan. Implementation work itself comes after that.