### PR TITLE
docs(v1.2.0-rc1): implementation plan for Minion Heartbeat gRPC migration

### DIFF
--- a/docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md
+++ b/docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Minion sends Heartbeat over a long-lived gRPC bidi stream → Envoy ingress (h2c plaintext, no auth, internal-trust) → new `minion-gateway` translator daemon → existing Kafka topic `OpenNMS.Sink.Heartbeat` → existing Heartbeat consumer in horizon. ServiceDaemons are unchanged. Per-Minion identity flows in gRPC metadata (not payload) so `minion-gateway` can key Kafka publishes correctly without parsing the message body. The hard-cut to gRPC for v1.2.0 happens at the GA boundary; within rc1, Heartbeat is gRPC-only and other channels are Kafka-only — no parallel transport for the same channel.
 
-**Tech Stack:** Java 17, Spring Boot 4.0.3, Spring gRPC 1.0.3 (`org.springframework.grpc:spring-grpc-spring-boot-starter`), gRPC-Java 1.75.0 with Netty, protobuf-java 3.25.5 generated via `org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1`, Envoy 1.30+ (h2c → upstream gRPC), Apache Kafka 3.6.2 (existing internal topic), Maven via `./mvnw`, Docker Compose, JUnit 5 + Mockito + Testcontainers.
+**Tech Stack:** Java 21, Spring Boot 4.0.3, Spring gRPC 1.0.3 (`org.springframework.grpc:spring-grpc-spring-boot-starter`), gRPC-Java 1.75.0 with Netty, protobuf-java 3.25.5 generated via `org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1`, Envoy 1.30+ (h2c → upstream gRPC), Apache Kafka 3.6.2 (existing internal topic), Maven via `./mvnw`, Docker Compose, JUnit 5 + Mockito + Testcontainers.
 
 **Phase 0 locked decisions** (see `docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md` — do not relitigate):
 - Translator daemon `minion-gateway`, not per-daemon gRPC. Forced by zero-trust bidirectional `project_minion_mandatory`.
@@ -233,7 +233,7 @@ mkdir -p core/minion-grpc-contracts/src/main/proto
         Heartbeat is implemented in v1.2.0-rc1; other sinks defined-only (rc2 implementations).</description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <protoc.version>3.25.5</protoc.version>
         <grpc.version>1.75.0</grpc.version>
     </properties>
@@ -500,7 +500,7 @@ In `<dependencyManagement>`, **after** the `spring-boot-dependencies` import (BO
         connections from Minions per project_minion_mandatory zero-trust posture.</description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>

--- a/docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md
+++ b/docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md
@@ -1,0 +1,2429 @@
+# v1.2.0-rc1 Minion Heartbeat gRPC Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the Minion Heartbeat sink from Kafka to gRPC end-to-end as proof-of-pattern for the v1.2.0 Minion ↔ Core gRPC transition. All other sinks, RPC, and Twin remain on Kafka in rc1; their migration is rc2 work.
+
+**Architecture:** Minion sends Heartbeat over a long-lived gRPC bidi stream → Envoy ingress (h2c plaintext, no auth, internal-trust) → new `minion-gateway` translator daemon → existing Kafka topic `OpenNMS.Sink.Heartbeat` → existing Heartbeat consumer in horizon. ServiceDaemons are unchanged. Per-Minion identity flows in gRPC metadata (not payload) so `minion-gateway` can key Kafka publishes correctly without parsing the message body. The hard-cut to gRPC for v1.2.0 happens at the GA boundary; within rc1, Heartbeat is gRPC-only and other channels are Kafka-only — no parallel transport for the same channel.
+
+**Tech Stack:** Java 17, Spring Boot 4.0.3, Spring gRPC 1.0.3 (`org.springframework.grpc:spring-grpc-spring-boot-starter`), gRPC-Java 1.75.0 with Netty, protobuf-java 3.25.5 generated via `org.xolstice.maven.plugins:protobuf-maven-plugin:0.6.1`, Envoy 1.30+ (h2c → upstream gRPC), Apache Kafka 3.6.2 (existing internal topic), Maven via `./mvnw`, Docker Compose, JUnit 5 + Mockito + Testcontainers.
+
+**Phase 0 locked decisions** (see `docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md` — do not relitigate):
+- Translator daemon `minion-gateway`, not per-daemon gRPC. Forced by zero-trust bidirectional `project_minion_mandatory`.
+- Hard cut at v1.2.0 GA boundary; `MINION_TRANSPORT=kafka` is rc1 emergency rollback only.
+- No Minion-side buffer; gRPC `ManagedChannel` reconnect-with-backoff handles transient outages.
+- Envoy ingress, not Spring Cloud Gateway.
+- Heartbeat sink first; other sinks get `.proto` definitions but no implementations in rc1.
+
+**Invariants** (must survive every commit):
+- `feedback_no_local_polling` — daemons never poll directly; all I/O through Minion.
+- `feedback_rpc_timeout_no_outages` — RPC timeouts must never create outages or fault events.
+- `project_minion_mandatory` — bidirectional zero-trust; ServiceDaemons never accept inbound network connections.
+- `feedback_e2e_continuous_validation_grpc_migration` — full E2E suite (`tests/e2e/test-*.sh`) must pass after every commit; Heartbeat-only migration in rc1 means non-Heartbeat E2E tests are the regression detector for non-migrated channels.
+
+**Pre-work findings carried into this plan** (from session notes 2026-04-26, four parallel agent reports):
+- RPC seam clean at `org.opennms.core.ipc.rpc.api.{RpcModule,RpcClient,RpcClientFactory}` interfaces. `KafkaRpcServerManager` has no public interface above it but is directly constructed in delta-v's `KafkaRpcServerConfiguration` — replace the @Configuration class, not horizon. (Not exercised in rc1; relevant for rc2.)
+- Sink seam clean at `org.opennms.core.ipc.sink.api.{SinkModule,MessageDispatcherFactory,MessageConsumerManager}`. `HeartbeatModule.getRoutingKey()` returns `Optional.empty()` today — identity (id, location, timestamp, version) flows in `MinionIdentityDTO` payload (XML-serialized via `AbstractXmlSinkModule`). For rc1 gRPC, identity moves to gRPC metadata; minion-gateway extracts metadata and uses it as the Kafka message key.
+- Minion-side Kafka touchpoints: 22 callsites, all centralized in three @Configuration classes in `core/daemon-boot-minion-common/` (`KafkaRpcServerConfiguration`, `KafkaSinkClientConfiguration`, `KafkaTwinSubscriberConfiguration`) plus 4 listener configs in `core/daemon-boot-minion/` that consume only the abstract `MessageDispatcherFactory` interface. **Listener configs do not change in rc1** — only `HeartbeatConfiguration` adds a `@Qualifier` on its `MessageDispatcherFactory` injection to pick the gRPC-backed bean.
+- `MeteredRpcModule` from beta2 wraps any `RpcModule` regardless of transport; transport swap does not break wrapping. Spring gRPC 1.0.3 emits native Micrometer meters at `/actuator/prometheus` (no Dropwizard bridge needed for the new gRPC surface). `HorizonMetricsBridge` is still needed in `minion-gateway` for the Kafka **producer** side (republishing into the internal Kafka topic uses horizon's Kafka producer with Dropwizard meters).
+
+---
+
+## File Structure
+
+**New files:**
+
+| Path | Responsibility |
+|---|---|
+| `core/minion-grpc-contracts/pom.xml` | Maven module: protobuf-only, builds `minion-grpc-contracts-1.2.0-rc1.jar` for both client and server. |
+| `core/minion-grpc-contracts/src/main/proto/heartbeat.proto` | Heartbeat service: `rpc Publish(stream Heartbeat) returns (stream HeartbeatAck)`. **Implemented in rc1.** |
+| `core/minion-grpc-contracts/src/main/proto/syslog.proto` | Syslog service shape (defined, not implemented). rc2 implementation. |
+| `core/minion-grpc-contracts/src/main/proto/telemetry.proto` | Telemetry services for IPFIX, Netflow5, Netflow9, sFlow (defined, not implemented). rc2. |
+| `core/minion-grpc-contracts/src/main/proto/trap.proto` | Trap service shape (defined, not implemented). rc2. |
+| `core/minion-gateway/pom.xml` | New Spring Boot 4 daemon module. |
+| `core/minion-gateway/src/main/java/org/deltav/gateway/MinionGatewayApplication.java` | Spring Boot main. |
+| `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/HeartbeatGrpcService.java` | Server-side `HeartbeatService` impl: receives gRPC bidi stream, republishes to Kafka. |
+| `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/MinionIdentityServerInterceptor.java` | Extracts `x-minion-id` / `x-minion-location` metadata into `Context` for handlers. |
+| `core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatKafkaProducer.java` | Wraps horizon's `KafkaProducer` for `OpenNMS.Sink.Heartbeat` topic. |
+| `core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatTranslator.java` | Pure function: gRPC `Heartbeat` + identity metadata → horizon Sink wire format (`MinionIdentityDTO` XML bytes). |
+| (no new bridge file) | Use the shared `core/horizon-metric-bridge/` module (`org.deltav.core:org.deltav.horizon-metric-bridge`) — wire one `@Bean HorizonMetricsBridge(metricRegistry, "opennms")` in `MinionGatewayApplication` per the syslogd pattern. |
+| `core/minion-gateway/src/main/resources/application.yml` | Spring config: gRPC port, Kafka bootstrap, actuator endpoints. |
+| `core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceTest.java` | Unit test using in-process gRPC server. |
+| `core/minion-gateway/src/test/java/org/deltav/gateway/kafka/HeartbeatTranslatorTest.java` | Pure-function translator unit test. |
+| `core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceIT.java` | Integration test with `KafkaContainer`. |
+| `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcHeartbeatDispatcherConfiguration.java` | Minion-side: produces `heartbeatDispatcherFactory` bean (gRPC variant). Conditional on `minion.transport=grpc`. |
+| `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/HeartbeatKafkaFallbackConfiguration.java` | Minion-side: produces `heartbeatDispatcherFactory` bean (alias to primary Kafka factory). Conditional on `minion.transport=kafka`. |
+| `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/GrpcMessageDispatcherFactory.java` | Minion-side: implements horizon's `MessageDispatcherFactory`; backed by gRPC stub. |
+| `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionIdentityClientInterceptor.java` | Minion-side: attaches `x-minion-id` / `x-minion-location` metadata on every gRPC call. |
+| `opennms-container/delta-v/minion-gateway/Dockerfile` | minion-gateway container image. |
+| `opennms-container/delta-v/envoy/envoy.yaml` | Envoy listener + gRPC route to minion-gateway. |
+| `opennms-container/delta-v/envoy/Dockerfile` | Pinned-version Envoy with config volume-mounted. |
+| `tests/e2e/test-grpc-heartbeat-e2e.sh` | Validates Heartbeat lands on Core via gRPC path; asserts `MINION_TRANSPORT=grpc` was used; captures gRPC-Heartbeat p99. |
+| `docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md` | Session-notes doc: bytecode audit reports, dispatcher-routing rationale, baseline command spec. |
+
+**Modified files:**
+
+| Path | Modification |
+|---|---|
+| `pom.xml` (root) | Add `core/minion-grpc-contracts` and `core/minion-gateway` to `<modules>`. Add Spring Boot 4 + Spring gRPC BOM imports under `<dependencyManagement>` (Boot first, Spring gRPC second per `feedback_bom_import_precedence`). |
+| `core/daemon-boot-minion-common/pom.xml` | Add `spring-grpc-spring-boot-starter` (Netty variant), `core/minion-grpc-contracts` dependency. |
+| `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/MinionProperties.java` | Add `transport` field (`grpc` or `kafka`), default `grpc`; add `gateway.host` and `gateway.port`. |
+| `core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/HeartbeatConfiguration.java` | Add `@Qualifier("heartbeatDispatcherFactory")` to `MessageDispatcherFactory` constructor parameter. **Single-line change.** |
+| `opennms-container/delta-v/docker-compose.yml` | Add `minion-gateway` service, add `envoy` service, expose Envoy listener port 8443 to Minion. Add `MINION_TRANSPORT=grpc` to minion service env block; document `MINION_TRANSPORT=kafka` rollback. |
+| `tests/e2e/run-all.sh` (or equivalent runner) | Append `test-grpc-heartbeat-e2e.sh` to the suite list. |
+
+---
+
+## Task 1: Heartbeat RTT baseline measurement
+
+**Files:**
+- Create: `docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md`
+
+**Why first:** Capturing the baseline against the pre-gRPC build of the same rc1 codebase is the apples-to-apples gate for the post-gRPC measurement in Task 8. If gRPC-Heartbeat p99 doesn't beat Kafka-Heartbeat p99 (or come within an explicit, documented threshold), the migration isn't earning its keep. Run on Mac dev env (per memory `feedback_smoke_vm_release_only` — smoke VM is release-validation only).
+
+- [ ] **Step 1: Bring up local stack on current `develop` HEAD with Heartbeat enabled**
+
+```bash
+cd ~/beta1-smoke   # the existing local compose dir per the dev env
+# update VERSION to whatever's freshly built off develop (or use 1.2.0-beta2 if not building locally)
+sed -i.bak 's/^VERSION=.*/VERSION=1.2.0-beta2/' .env
+docker compose pull
+docker compose up -d
+docker compose ps  # wait until minion + kafka + heartbeat consumer (alarmd or whichever owns Sink.Heartbeat) are all healthy
+```
+
+Expected: all services in `Up (healthy)` state. Wait ~2 min for Minion warm-up and first Heartbeat publish.
+
+- [ ] **Step 2: Confirm Heartbeat is flowing on the Kafka path**
+
+```bash
+docker exec -it kafka-1 /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 \
+  --topic OpenNMS.Sink.Heartbeat \
+  --from-beginning --max-messages 3
+```
+
+Expected: 3 XML-serialized `MinionIdentityDTO` records visible (one per Minion if multiple). Confirms baseline traffic is real.
+
+- [ ] **Step 3: Capture p50 + p99 RTT over a 10-minute window**
+
+The horizon `HeartbeatModule` payload includes a `timestamp` field set on send (via `MinionIdentityDTO.setTimestamp(new Date())` at `core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/HeartbeatConfiguration.java:66`). The Kafka record's `CreateTime` (broker-ingest time) gives the receive side. RTT = `CreateTime` minus payload timestamp.
+
+```bash
+mkdir -p /tmp/rc1-baseline
+docker exec kafka-1 /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 \
+  --topic OpenNMS.Sink.Heartbeat \
+  --property print.timestamp=true \
+  --property print.value=true \
+  --timeout-ms 600000 \
+  > /tmp/rc1-baseline/heartbeats.raw 2>&1 &
+PID=$!
+sleep 605  # 10 min + 5 sec settle
+kill -INT $PID 2>/dev/null || true
+wait $PID 2>/dev/null
+echo "Captured $(grep -c '^CreateTime:' /tmp/rc1-baseline/heartbeats.raw) records"
+```
+
+Expected: ~20 records per Minion over 10 min (one per 30 s).
+
+- [ ] **Step 4: Compute p50 + p99 from the captured records**
+
+```bash
+python3 - <<'PY'
+import re, statistics, xml.etree.ElementTree as ET
+from datetime import datetime
+deltas = []
+with open('/tmp/rc1-baseline/heartbeats.raw') as f:
+    text = f.read()
+# Each record is "CreateTime:<ms>\t<XML payload on next line(s)>"
+for m in re.finditer(r'CreateTime:(\d+)\s*\n(<MinionIdentityDTO[^>]*>.*?</MinionIdentityDTO>)', text, re.DOTALL):
+    create_ms = int(m.group(1))
+    root = ET.fromstring(m.group(2))
+    ts = root.findtext('timestamp')
+    sent_ms = int(datetime.fromisoformat(ts.replace('Z', '+00:00')).timestamp() * 1000)
+    deltas.append(create_ms - sent_ms)
+deltas.sort()
+n = len(deltas)
+print(f"samples={n}")
+print(f"p50={deltas[n//2]} ms")
+print(f"p99={deltas[int(n*0.99)]} ms")
+print(f"min={min(deltas)} ms  max={max(deltas)} ms  mean={statistics.mean(deltas):.1f} ms")
+PY
+```
+
+Expected output (illustrative): `samples=20  p50=15 ms  p99=42 ms`. Numbers vary by stack state; record whatever the local env shows.
+
+- [ ] **Step 5: Write findings doc and commit**
+
+```bash
+cat > docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md <<'EOF'
+# v1.2.0-rc1 Implementation Plan — Pre-Work Findings
+
+> Session notes captured 2026-04-26 in support of `2026-04-26-v1.2.0-rc1-implementation-plan.md`.
+> Carried forward as commit 1 of the rc1 implementation work (Heartbeat RTT baseline).
+
+## Heartbeat RTT baseline (Kafka path, dev env)
+
+**Measured on:** <hostname>, <date>, local docker compose stack on v1.2.0-beta2 images
+**Method:** producer-side timestamp from MinionIdentityDTO.timestamp; receive-side from Kafka CreateTime.
+**Window:** 10 minutes. **Samples:** <n>.
+
+| Metric | Value |
+|---|---|
+| p50 | <X> ms |
+| p99 | <Y> ms |
+| min / max | <a> / <b> ms |
+| mean | <m> ms |
+
+**Release gate for rc1 (Task 8):** `gRPC-Heartbeat p99 ≤ Kafka-Heartbeat p99 + 10 ms`. Threshold accepts measurement noise on a small sample but rejects regressions large enough to change the migration story.
+
+## Pre-work bytecode + inventory findings
+
+(Carried over from agent reports 2026-04-26; see implementation plan for the substitution-seam summary.)
+
+EOF
+# fill in <X>, <Y>, <a>, <b>, <m>, <n> from Step 4 output before committing
+git add docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc1): Heartbeat RTT baseline (Kafka path) for migration release gate"
+```
+
+Expected: one commit on `docs/v1.2.0-rc1-implementation-plan` branch.
+
+---
+
+## Task 2: Protobuf service definitions module
+
+**Files:**
+- Create: `core/minion-grpc-contracts/pom.xml`
+- Create: `core/minion-grpc-contracts/src/main/proto/heartbeat.proto`
+- Create: `core/minion-grpc-contracts/src/main/proto/syslog.proto`
+- Create: `core/minion-grpc-contracts/src/main/proto/telemetry.proto`
+- Create: `core/minion-grpc-contracts/src/main/proto/trap.proto`
+- Modify: `pom.xml` (root) — add `<module>core/minion-grpc-contracts</module>`
+
+Pattern after `core/deltav-kafka-contracts/pom.xml` (existing protobuf-only module in this repo).
+
+- [ ] **Step 1: Create the module pom**
+
+```bash
+mkdir -p core/minion-grpc-contracts/src/main/proto
+```
+
+```xml
+<!-- core/minion-grpc-contracts/pom.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>1.2.0-beta2</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>org.opennms.core.minion-grpc-contracts</artifactId>
+    <name>OpenNMS :: Core :: Minion gRPC Contracts</name>
+    <description>Shared protobuf service definitions for Minion ↔ Core gRPC.
+        Heartbeat is implemented in v1.2.0-rc1; other sinks defined-only (rc2 implementations).</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <protoc.version>3.25.5</protoc.version>
+        <grpc.version>1.75.0</grpc.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+- [ ] **Step 2: Write `heartbeat.proto` (the only one implemented in rc1)**
+
+```protobuf
+// core/minion-grpc-contracts/src/main/proto/heartbeat.proto
+syntax = "proto3";
+
+package org.deltav.minion.grpc.v1;
+
+option java_package = "org.deltav.minion.grpc.v1";
+option java_multiple_files = true;
+option java_outer_classname = "HeartbeatProto";
+
+import "google/protobuf/timestamp.proto";
+
+// Heartbeat carries Minion identity + version. Sent every 30s from Minion to
+// minion-gateway over a long-lived bidi gRPC stream. Identity is also in
+// gRPC metadata (x-minion-id, x-minion-location); the duplication in the
+// payload is intentional — keeps the message self-describing if logged out
+// of band, but minion-gateway routes Kafka publishes from the metadata only.
+message Heartbeat {
+  string minion_id = 1;
+  string location = 2;
+  google.protobuf.Timestamp sent_at = 3;
+  string version = 4;
+}
+
+// Server acks each heartbeat. Client treats ack stream as a liveness signal;
+// missing acks for >2 heartbeat intervals trigger a stream reset (gRPC
+// ManagedChannel handles reconnect via default backoff per Phase 0 Decision 3).
+message HeartbeatAck {
+  string minion_id = 1;
+  google.protobuf.Timestamp received_at = 2;
+}
+
+service HeartbeatService {
+  rpc Publish(stream Heartbeat) returns (stream HeartbeatAck);
+}
+```
+
+- [ ] **Step 3: Write `syslog.proto`, `telemetry.proto`, `trap.proto` (defined-only)**
+
+```protobuf
+// core/minion-grpc-contracts/src/main/proto/syslog.proto
+syntax = "proto3";
+package org.deltav.minion.grpc.v1;
+option java_package = "org.deltav.minion.grpc.v1";
+option java_multiple_files = true;
+option java_outer_classname = "SyslogProto";
+
+import "google/protobuf/timestamp.proto";
+
+message SyslogMessage {
+  bytes raw = 1;                        // exact UDP datagram bytes
+  string source_address = 2;
+  int32 source_port = 3;
+  google.protobuf.Timestamp received_at = 4;
+}
+
+message SyslogAck {
+  google.protobuf.Timestamp received_at = 1;
+}
+
+// rc2 implementation; rc1 ships definition only so the wire format is stable
+// before any client/server code lands.
+service SyslogService {
+  rpc Publish(stream SyslogMessage) returns (stream SyslogAck);
+}
+```
+
+```protobuf
+// core/minion-grpc-contracts/src/main/proto/telemetry.proto
+syntax = "proto3";
+package org.deltav.minion.grpc.v1;
+option java_package = "org.deltav.minion.grpc.v1";
+option java_multiple_files = true;
+option java_outer_classname = "TelemetryProto";
+
+import "google/protobuf/timestamp.proto";
+
+message TelemetryDatagram {
+  bytes raw = 1;                        // protocol-specific bytes (IPFIX, NetflowN, sFlow)
+  string source_address = 2;
+  int32 source_port = 3;
+  google.protobuf.Timestamp received_at = 4;
+}
+
+message TelemetryAck {
+  google.protobuf.Timestamp received_at = 1;
+}
+
+// rc2: separate methods per protocol so minion-gateway can route to the
+// right OpenNMS.Sink.Telemetry-* topic without inspecting payload.
+service TelemetryService {
+  rpc PublishIpfix(stream TelemetryDatagram) returns (stream TelemetryAck);
+  rpc PublishNetflow5(stream TelemetryDatagram) returns (stream TelemetryAck);
+  rpc PublishNetflow9(stream TelemetryDatagram) returns (stream TelemetryAck);
+  rpc PublishSflow(stream TelemetryDatagram) returns (stream TelemetryAck);
+}
+```
+
+```protobuf
+// core/minion-grpc-contracts/src/main/proto/trap.proto
+syntax = "proto3";
+package org.deltav.minion.grpc.v1;
+option java_package = "org.deltav.minion.grpc.v1";
+option java_multiple_files = true;
+option java_outer_classname = "TrapProto";
+
+import "google/protobuf/timestamp.proto";
+
+message SnmpTrap {
+  bytes raw = 1;                        // raw SNMP PDU
+  string source_address = 2;
+  int32 source_port = 3;
+  google.protobuf.Timestamp received_at = 4;
+}
+
+message TrapAck {
+  google.protobuf.Timestamp received_at = 1;
+}
+
+// rc2 implementation; rc1 ships definition only.
+service TrapService {
+  rpc Publish(stream SnmpTrap) returns (stream TrapAck);
+}
+```
+
+- [ ] **Step 4: Add module to root reactor**
+
+Edit `pom.xml` (root) — find the `<modules>` block and add `<module>core/minion-grpc-contracts</module>` in alphabetical order with the other `core/...` entries.
+
+- [ ] **Step 5: Build the module to verify protoc generation**
+
+```bash
+./mvnw -pl core/minion-grpc-contracts -am clean install
+```
+
+Expected: BUILD SUCCESS. Generated sources visible at `core/minion-grpc-contracts/target/generated-sources/protobuf/java/org/deltav/minion/grpc/v1/Heartbeat.java` and `…/grpc-java/org/deltav/minion/grpc/v1/HeartbeatServiceGrpc.java`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/minion-grpc-contracts/ pom.xml
+git commit -m "feat(v1.2.0-rc1): protobuf service definitions for Minion gRPC sinks
+
+Defines Heartbeat (implemented rc1), Syslog, Telemetry × 4, Trap (rc2).
+All services use bidi streaming for long-lived per-channel connections
+per Phase 0 Decision 3. Identity flows in gRPC metadata; payload duplicate
+is intentional for self-describing log lines."
+```
+
+---
+
+## Task 3: minion-gateway daemon scaffolding
+
+**Files:**
+- Create: `core/minion-gateway/pom.xml`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/MinionGatewayApplication.java`
+- Create: `core/minion-gateway/src/main/resources/application.yml`
+- Create: `core/minion-gateway/src/main/resources/banner.txt` (optional aesthetic; matches other daemon-boot-* modules)
+- Modify: `pom.xml` (root) — add `<module>core/minion-gateway</module>` and Spring gRPC BOM import
+
+Goal: a minimal Spring Boot 4 daemon that starts cleanly with no gRPC services registered yet. Validates BOM ordering (`feedback_bom_import_precedence`), Spring gRPC starter discovery, actuator availability.
+
+- [ ] **Step 1: Add Spring gRPC BOM import to root `pom.xml`**
+
+In `<dependencyManagement>`, **after** the `spring-boot-dependencies` import (BOM precedence rule per `feedback_bom_import_precedence`):
+
+```xml
+<dependency>
+    <groupId>org.springframework.grpc</groupId>
+    <artifactId>spring-grpc-dependencies</artifactId>
+    <version>1.0.3</version>
+    <type>pom</type>
+    <scope>import</scope>
+</dependency>
+```
+
+- [ ] **Step 2: Create the module pom**
+
+```xml
+<!-- core/minion-gateway/pom.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>1.2.0-beta2</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>org.opennms.core.minion-gateway</artifactId>
+    <name>OpenNMS :: Core :: Minion Gateway</name>
+    <description>gRPC ↔ Kafka translator daemon. Sole Core-side component that accepts inbound
+        connections from Minions per project_minion_mandatory zero-trust posture.</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.minion-grpc-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.grpc</groupId>
+            <artifactId>spring-grpc-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.deltav.horizon-metric-bridge</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Boot 4 BOM pins commons-io 2.15.0; Testcontainers needs ≥2.16
+             per feedback_boot4_testcontainers_commons_io -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals><goal>repackage</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+Note: the `commons-io 2.16.1` test override is required per `feedback_boot4_testcontainers_commons_io`; without it `Testcontainers KafkaContainer` hangs at start under Boot 4 because the BOM-pinned 2.15.0 is too old.
+
+- [ ] **Step 3: Create the Spring Boot main class**
+
+```java
+// core/minion-gateway/src/main/java/org/deltav/gateway/MinionGatewayApplication.java
+package org.deltav.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MinionGatewayApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MinionGatewayApplication.class, args);
+    }
+}
+```
+
+Suffix `Application` rather than naming the @Configuration class anything that could collide with @Bean names (per `feedback_configuration_class_bean_name_collision`).
+
+- [ ] **Step 4: Create application.yml**
+
+```yaml
+# core/minion-gateway/src/main/resources/application.yml
+spring:
+  application:
+    name: minion-gateway
+  grpc:
+    server:
+      port: 50051            # h2c plaintext within compose network; TLS terminated at Envoy in front
+      address: 0.0.0.0
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+
+server:
+  port: 8080                 # actuator http port
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: when_authorized
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
+logging:
+  level:
+    org.deltav.gateway: INFO
+    io.grpc: INFO
+    org.apache.kafka: WARN
+```
+
+- [ ] **Step 5: Add module to root reactor**
+
+Edit `pom.xml` (root) — add `<module>core/minion-gateway</module>` to `<modules>`.
+
+- [ ] **Step 6: Verify clean build**
+
+```bash
+./mvnw -pl core/minion-gateway -am clean install
+```
+
+Expected: BUILD SUCCESS. Repackaged fat jar at `core/minion-gateway/target/org.opennms.core.minion-gateway-1.2.0-beta2.jar`.
+
+- [ ] **Step 7: Smoke-run the binary locally**
+
+```bash
+java -jar core/minion-gateway/target/org.opennms.core.minion-gateway-1.2.0-beta2.jar &
+PID=$!
+sleep 8
+curl -s http://localhost:8080/actuator/health
+echo
+curl -s http://localhost:8080/actuator/prometheus | head -20
+kill $PID
+```
+
+Expected: `/actuator/health` returns `{"status":"UP"}`. `/actuator/prometheus` shows JVM + Spring meters; no `grpc_server_*` meters yet (no service registered).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/minion-gateway/ pom.xml
+git commit -m "feat(v1.2.0-rc1): minion-gateway daemon scaffolding
+
+New Spring Boot 4 daemon (Boot 4.0.3 + Spring gRPC 1.0.3 + Netty).
+Sole Core-side component accepting inbound network connections from Minions
+per project_minion_mandatory bidirectional zero-trust rule. No services
+registered yet — that lands in the Heartbeat impl commit."
+```
+
+---
+
+## Task 4: minion-gateway HeartbeatService gRPC + Kafka producer
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/HeartbeatGrpcService.java`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/MinionIdentityServerInterceptor.java`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatKafkaProducer.java`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatTranslator.java`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/metrics/HorizonMetricsBridge.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/kafka/HeartbeatTranslatorTest.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceTest.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceIT.java`
+
+The gRPC server is the interesting half of the rc1 system. TDD discipline: translator tests first (pure), then in-process gRPC server tests (mocked Kafka), then full integration test (real Kafka via Testcontainers).
+
+- [ ] **Step 1: Write the failing translator unit test**
+
+```java
+// core/minion-gateway/src/test/java/org/deltav/gateway/kafka/HeartbeatTranslatorTest.java
+package org.deltav.gateway.kafka;
+
+import com.google.protobuf.Timestamp;
+import org.deltav.minion.grpc.v1.Heartbeat;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HeartbeatTranslatorTest {
+
+    @Test
+    void translate_keysKafkaRecordByLocationAndId() {
+        Heartbeat hb = Heartbeat.newBuilder()
+            .setMinionId("minion-A")
+            .setLocation("loc-DC1")
+            .setSentAt(Timestamp.newBuilder().setSeconds(1745625600L).build())
+            .setVersion("1.2.0-rc1")
+            .build();
+
+        var record = HeartbeatTranslator.toKafkaRecord(hb, "minion-A", "loc-DC1");
+
+        assertThat(record.topic()).isEqualTo("OpenNMS.Sink.Heartbeat");
+        assertThat(record.key()).isEqualTo("loc-DC1@minion-A");
+    }
+
+    @Test
+    void translate_emitsXmlPayloadCompatibleWithExistingConsumer() {
+        Heartbeat hb = Heartbeat.newBuilder()
+            .setMinionId("minion-A")
+            .setLocation("loc-DC1")
+            .setSentAt(Timestamp.newBuilder().setSeconds(1745625600L).build())
+            .setVersion("1.2.0-rc1")
+            .build();
+
+        var record = HeartbeatTranslator.toKafkaRecord(hb, "minion-A", "loc-DC1");
+
+        String payload = new String(record.value());
+        // Match horizon's MinionIdentityDTO XML shape exactly so the existing
+        // Heartbeat consumer in horizon's alarmd needs no change.
+        assertThat(payload).contains("<MinionIdentityDTO>");
+        assertThat(payload).contains("<id>minion-A</id>");
+        assertThat(payload).contains("<location>loc-DC1</location>");
+        assertThat(payload).contains("<version>1.2.0-rc1</version>");
+        assertThat(payload).contains("<timestamp>2025-04-25T22:40:00");  // first 19 chars of ISO timestamp
+    }
+
+    @Test
+    void translate_metadataIdentityWinsOverPayloadIdentity() {
+        // Defensive: payload identity is duplicate-for-logging; the metadata
+        // is authoritative for routing. If they disagree, metadata wins.
+        Heartbeat hb = Heartbeat.newBuilder()
+            .setMinionId("payload-id")
+            .setLocation("payload-loc")
+            .setSentAt(Timestamp.newBuilder().setSeconds(1745625600L).build())
+            .setVersion("1.2.0-rc1")
+            .build();
+
+        var record = HeartbeatTranslator.toKafkaRecord(hb, "metadata-id", "metadata-loc");
+
+        assertThat(record.key()).isEqualTo("metadata-loc@metadata-id");
+        // Payload still echoes what the Minion sent; downstream tools may use it
+        assertThat(new String(record.value())).contains("<id>payload-id</id>");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (class doesn't exist yet)**
+
+```bash
+./mvnw -pl core/minion-gateway test -Dtest=HeartbeatTranslatorTest
+```
+
+Expected: COMPILATION ERROR — `HeartbeatTranslator` not found.
+
+- [ ] **Step 3: Implement `HeartbeatTranslator`**
+
+```java
+// core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatTranslator.java
+package org.deltav.gateway.kafka;
+
+import com.google.protobuf.Timestamp;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.deltav.minion.grpc.v1.Heartbeat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Pure translator from gRPC {@link Heartbeat} to a Kafka {@link ProducerRecord}
+ * carrying horizon's MinionIdentityDTO XML payload. Identity passed in as
+ * separate parameters is the authoritative routing source — payload identity
+ * is duplicate-for-logging only.
+ */
+public final class HeartbeatTranslator {
+
+    public static final String TOPIC = "OpenNMS.Sink.Heartbeat";
+
+    private static final DateTimeFormatter ISO =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC);
+
+    private HeartbeatTranslator() {}
+
+    public static ProducerRecord<String, byte[]> toKafkaRecord(
+            Heartbeat hb, String minionId, String location) {
+        String key = location + "@" + minionId;
+        String xml = renderXml(hb);
+        return new ProducerRecord<>(TOPIC, key, xml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String renderXml(Heartbeat hb) {
+        Instant sent = toInstant(hb.getSentAt());
+        // Match horizon's AbstractXmlSinkModule output for MinionIdentityDTO.
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<MinionIdentityDTO>"
+            + "<id>" + escape(hb.getMinionId()) + "</id>"
+            + "<location>" + escape(hb.getLocation()) + "</location>"
+            + "<timestamp>" + ISO.format(sent) + "</timestamp>"
+            + "<version>" + escape(hb.getVersion()) + "</version>"
+            + "</MinionIdentityDTO>";
+    }
+
+    private static Instant toInstant(Timestamp ts) {
+        return Instant.ofEpochSecond(ts.getSeconds(), ts.getNanos());
+    }
+
+    private static String escape(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+}
+```
+
+- [ ] **Step 4: Run translator test to verify it passes**
+
+```bash
+./mvnw -pl core/minion-gateway test -Dtest=HeartbeatTranslatorTest
+```
+
+Expected: 3 tests, 3 passing.
+
+- [ ] **Step 5: Write the metadata-extraction interceptor**
+
+```java
+// core/minion-gateway/src/main/java/org/deltav/gateway/grpc/MinionIdentityServerInterceptor.java
+package org.deltav.gateway.grpc;
+
+import io.grpc.*;
+import org.springframework.stereotype.Component;
+
+/**
+ * Server-side interceptor that pulls Minion identity out of gRPC metadata
+ * (x-minion-id, x-minion-location) and stashes it in the gRPC Context so
+ * service handlers can read it without seeing the metadata layer.
+ */
+@Component
+public class MinionIdentityServerInterceptor implements ServerInterceptor {
+
+    public static final Metadata.Key<String> MINION_ID_HEADER =
+        Metadata.Key.of("x-minion-id", Metadata.ASCII_STRING_MARSHALLER);
+    public static final Metadata.Key<String> MINION_LOCATION_HEADER =
+        Metadata.Key.of("x-minion-location", Metadata.ASCII_STRING_MARSHALLER);
+
+    public static final Context.Key<String> MINION_ID_CTX = Context.key("minion-id");
+    public static final Context.Key<String> MINION_LOCATION_CTX = Context.key("minion-location");
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        String id = headers.get(MINION_ID_HEADER);
+        String location = headers.get(MINION_LOCATION_HEADER);
+
+        if (id == null || id.isBlank() || location == null || location.isBlank()) {
+            call.close(Status.UNAUTHENTICATED.withDescription(
+                "x-minion-id and x-minion-location metadata required"), new Metadata());
+            return new ServerCall.Listener<>() {};
+        }
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, id)
+            .withValue(MINION_LOCATION_CTX, location);
+        return Contexts.interceptCall(ctx, call, headers, next);
+    }
+}
+```
+
+- [ ] **Step 6: Write the Kafka producer wrapper**
+
+```java
+// core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatKafkaProducer.java
+package org.deltav.gateway.kafka;
+
+import com.codahale.metrics.MetricRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class HeartbeatKafkaProducer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeartbeatKafkaProducer.class);
+
+    private final String bootstrapServers;
+    private final MetricRegistry metricRegistry;
+    private KafkaProducer<String, byte[]> producer;
+
+    public HeartbeatKafkaProducer(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers,
+            MetricRegistry metricRegistry) {
+        this.bootstrapServers = bootstrapServers;
+        this.metricRegistry = metricRegistry;
+    }
+
+    @PostConstruct
+    public void start() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "minion-gateway-heartbeat");
+        props.put(ProducerConfig.ACKS_CONFIG, "1");
+        props.put(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, "");  // Dropwizard meters via bridge
+        producer = new KafkaProducer<>(props);
+        LOG.info("HeartbeatKafkaProducer started; bootstrap={}", bootstrapServers);
+    }
+
+    @PreDestroy
+    public void stop() {
+        if (producer != null) {
+            producer.close();
+            LOG.info("HeartbeatKafkaProducer stopped");
+        }
+    }
+
+    public CompletableFuture<Void> send(ProducerRecord<String, byte[]> record) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        producer.send(record, (metadata, exception) -> {
+            if (exception != null) {
+                metricRegistry.counter("minion_gateway_heartbeat_kafka_publish_failures").inc();
+                result.completeExceptionally(exception);
+            } else {
+                metricRegistry.counter("minion_gateway_heartbeat_kafka_publish_total").inc();
+                result.complete(null);
+            }
+        });
+        return result;
+    }
+}
+```
+
+- [ ] **Step 7: Write the gRPC service implementation**
+
+```java
+// core/minion-gateway/src/main/java/org/deltav/gateway/grpc/HeartbeatGrpcService.java
+package org.deltav.gateway.grpc;
+
+import com.google.protobuf.Timestamp;
+import io.grpc.stub.StreamObserver;
+import org.deltav.gateway.kafka.HeartbeatKafkaProducer;
+import org.deltav.gateway.kafka.HeartbeatTranslator;
+import org.deltav.minion.grpc.v1.Heartbeat;
+import org.deltav.minion.grpc.v1.HeartbeatAck;
+import org.deltav.minion.grpc.v1.HeartbeatServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.grpc.server.service.GrpcService;
+
+import java.time.Instant;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+
+@GrpcService
+public class HeartbeatGrpcService extends HeartbeatServiceGrpc.HeartbeatServiceImplBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeartbeatGrpcService.class);
+
+    private final HeartbeatKafkaProducer kafkaProducer;
+
+    public HeartbeatGrpcService(HeartbeatKafkaProducer kafkaProducer) {
+        this.kafkaProducer = kafkaProducer;
+    }
+
+    @Override
+    public StreamObserver<Heartbeat> publish(StreamObserver<HeartbeatAck> responseObserver) {
+        // Capture identity at stream open; gRPC Context is per-stream here.
+        String minionId = MINION_ID_CTX.get();
+        String location = MINION_LOCATION_CTX.get();
+        LOG.info("Heartbeat stream opened for minion={} location={}", minionId, location);
+
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(Heartbeat hb) {
+                kafkaProducer.send(HeartbeatTranslator.toKafkaRecord(hb, minionId, location))
+                    .thenAccept(v -> responseObserver.onNext(buildAck(minionId)))
+                    .exceptionally(t -> {
+                        LOG.warn("Heartbeat publish failed for minion={}", minionId, t);
+                        // Don't tear down the stream — Phase 0 Decision 3 says
+                        // gRPC reconnect handles transient outages. Skip the ack;
+                        // Minion will continue sending heartbeats on the same stream.
+                        return null;
+                    });
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Heartbeat stream error for minion={}: {}", minionId, t.toString());
+            }
+
+            @Override
+            public void onCompleted() {
+                LOG.info("Heartbeat stream closed for minion={}", minionId);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    private HeartbeatAck buildAck(String minionId) {
+        Instant now = Instant.now();
+        return HeartbeatAck.newBuilder()
+            .setMinionId(minionId)
+            .setReceivedAt(Timestamp.newBuilder()
+                .setSeconds(now.getEpochSecond())
+                .setNanos(now.getNano()).build())
+            .build();
+    }
+}
+```
+
+- [ ] **Step 8: Wire the shared HorizonMetricsBridge as a @Bean in MinionGatewayApplication**
+
+The bridge already exists at `core/horizon-metric-bridge/` (used by syslogd, telemetryd, pollerd, etc.). Don't reimplement — depend on it (added in Step 2's pom) and add two beans to `MinionGatewayApplication.java`:
+
+```java
+// edit core/minion-gateway/src/main/java/org/deltav/gateway/MinionGatewayApplication.java
+package org.deltav.gateway;
+
+import com.codahale.metrics.MetricRegistry;
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class MinionGatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MinionGatewayApplication.class, args);
+    }
+
+    @Bean
+    public MetricRegistry horizonMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    /**
+     * Bridges horizon's Dropwizard MetricRegistry (used by the Kafka producer
+     * republishing to OpenNMS.Sink.Heartbeat) into Micrometer so meters appear
+     * at /actuator/prometheus under the "opennms_" prefix per
+     * feedback_meter_naming_horizon_vs_deltav. Spring gRPC's native
+     * Micrometer meters (grpc.server.*) are emitted directly without
+     * needing this bridge.
+     */
+    @Bean
+    public HorizonMetricsBridge horizonMetricsBridge(MetricRegistry horizonMetricRegistry) {
+        return new HorizonMetricsBridge(horizonMetricRegistry, "opennms");
+    }
+}
+```
+
+Naming convention enforced: `opennms_*` for the bridged Kafka-producer meters, `grpc_server_*` (Spring gRPC native) for the gRPC ingress, `deltav_*` reserved for any new native Micrometer meters added in this module's own code.
+
+- [ ] **Step 9: Write the in-process gRPC server unit test**
+
+```java
+// core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceTest.java
+package org.deltav.gateway.grpc;
+
+import com.google.protobuf.Timestamp;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.ServerInterceptors;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.MetadataUtils;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.deltav.gateway.kafka.HeartbeatKafkaProducer;
+import org.deltav.minion.grpc.v1.Heartbeat;
+import org.deltav.minion.grpc.v1.HeartbeatAck;
+import org.deltav.minion.grpc.v1.HeartbeatServiceGrpc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HeartbeatGrpcServiceTest {
+
+    private HeartbeatKafkaProducer mockProducer;
+    private ManagedChannel channel;
+    private String serverName;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockProducer = mock(HeartbeatKafkaProducer.class);
+        when(mockProducer.send(any())).thenReturn(CompletableFuture.completedFuture(null));
+
+        serverName = InProcessServerBuilder.generateName();
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(ServerInterceptors.intercept(
+                new HeartbeatGrpcService(mockProducer),
+                new MinionIdentityServerInterceptor()))
+            .build()
+            .start();
+
+        channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+    }
+
+    @Test
+    void publishStream_routesEachMessageToKafka_andAcksClient() throws Exception {
+        Metadata headers = new Metadata();
+        headers.put(MinionIdentityServerInterceptor.MINION_ID_HEADER, "minion-A");
+        headers.put(MinionIdentityServerInterceptor.MINION_LOCATION_HEADER, "loc-DC1");
+
+        var stub = HeartbeatServiceGrpc.newStub(channel)
+            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers));
+
+        CountDownLatch ackLatch = new CountDownLatch(1);
+        StreamObserver<HeartbeatAck> ackObserver = new StreamObserver<>() {
+            HeartbeatAck last;
+            public void onNext(HeartbeatAck ack) { last = ack; ackLatch.countDown(); }
+            public void onError(Throwable t) { throw new AssertionError(t); }
+            public void onCompleted() {}
+        };
+
+        StreamObserver<Heartbeat> sender = stub.publish(ackObserver);
+        sender.onNext(Heartbeat.newBuilder()
+            .setMinionId("minion-A")
+            .setLocation("loc-DC1")
+            .setSentAt(Timestamp.newBuilder().setSeconds(1745625600L).build())
+            .setVersion("1.2.0-rc1").build());
+
+        assertThat(ackLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        ArgumentCaptor<ProducerRecord<String, byte[]>> captor = ArgumentCaptor.forClass(ProducerRecord.class);
+        org.mockito.Mockito.verify(mockProducer).send(captor.capture());
+        assertThat(captor.getValue().topic()).isEqualTo("OpenNMS.Sink.Heartbeat");
+        assertThat(captor.getValue().key()).isEqualTo("loc-DC1@minion-A");
+
+        sender.onCompleted();
+    }
+
+    @Test
+    void publishStream_rejectsCallWithoutIdentityMetadata() {
+        var stub = HeartbeatServiceGrpc.newStub(channel);
+
+        CountDownLatch errorLatch = new CountDownLatch(1);
+        StreamObserver<HeartbeatAck> observer = new StreamObserver<>() {
+            public void onNext(HeartbeatAck ack) {}
+            public void onError(Throwable t) {
+                assertThat(t.getMessage()).contains("UNAUTHENTICATED");
+                errorLatch.countDown();
+            }
+            public void onCompleted() {}
+        };
+
+        var sender = stub.publish(observer);
+        sender.onNext(Heartbeat.newBuilder().setMinionId("x").build());
+
+        try { assertThat(errorLatch.await(5, TimeUnit.SECONDS)).isTrue(); }
+        catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+}
+```
+
+- [ ] **Step 10: Run unit tests to verify they pass**
+
+```bash
+./mvnw -pl core/minion-gateway test -Dtest='HeartbeatTranslatorTest,HeartbeatGrpcServiceTest'
+```
+
+Expected: 5 tests, 5 passing.
+
+- [ ] **Step 11: Write the integration test with real Kafka**
+
+```java
+// core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceIT.java
+package org.deltav.gateway.grpc;
+
+import com.google.protobuf.Timestamp;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.MetadataUtils;
+import io.grpc.stub.StreamObserver;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.deltav.minion.grpc.v1.Heartbeat;
+import org.deltav.minion.grpc.v1.HeartbeatAck;
+import org.deltav.minion.grpc.v1.HeartbeatServiceGrpc;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+class HeartbeatGrpcServiceIT {
+
+    @Container
+    static KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"));
+
+    @DynamicPropertySource
+    static void kafkaBootstrap(DynamicPropertyRegistry r) {
+        r.add("spring.kafka.bootstrap-servers", KAFKA::getBootstrapServers);
+        r.add("spring.grpc.server.port", () -> 0);  // ephemeral
+    }
+
+    @Value("${spring.grpc.server.port}")
+    int grpcPort;
+
+    @Test
+    void heartbeatPublishedViaGrpc_landsOnKafkaTopic() throws Exception {
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcPort).usePlaintext().build();
+        Metadata headers = new Metadata();
+        headers.put(MinionIdentityServerInterceptor.MINION_ID_HEADER, "minion-IT");
+        headers.put(MinionIdentityServerInterceptor.MINION_LOCATION_HEADER, "loc-IT");
+
+        var stub = HeartbeatServiceGrpc.newStub(channel)
+            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers));
+
+        CountDownLatch ackLatch = new CountDownLatch(1);
+        StreamObserver<HeartbeatAck> obs = new StreamObserver<>() {
+            public void onNext(HeartbeatAck a) { ackLatch.countDown(); }
+            public void onError(Throwable t) {}
+            public void onCompleted() {}
+        };
+        StreamObserver<Heartbeat> sender = stub.publish(obs);
+        sender.onNext(Heartbeat.newBuilder()
+            .setMinionId("minion-IT").setLocation("loc-IT")
+            .setSentAt(Timestamp.newBuilder().setSeconds(1745625600L).build())
+            .setVersion("1.2.0-rc1").build());
+
+        assertThat(ackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        // Consume from Kafka and assert payload
+        Properties cp = new Properties();
+        cp.put("bootstrap.servers", KAFKA.getBootstrapServers());
+        cp.put("group.id", "it-consumer");
+        cp.put("auto.offset.reset", "earliest");
+        cp.put("key.deserializer", StringDeserializer.class);
+        cp.put("value.deserializer", ByteArrayDeserializer.class);
+
+        try (KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(cp)) {
+            consumer.subscribe(Collections.singletonList("OpenNMS.Sink.Heartbeat"));
+            List<ConsumerRecord<String, byte[]>> all = new java.util.ArrayList<>();
+            long deadline = System.nanoTime() + Duration.ofSeconds(20).toNanos();
+            while (all.isEmpty() && System.nanoTime() < deadline) {
+                consumer.poll(Duration.ofMillis(500)).forEach(all::add);
+            }
+            assertThat(all).hasSize(1);
+            assertThat(all.get(0).key()).isEqualTo("loc-IT@minion-IT");
+            assertThat(new String(all.get(0).value())).contains("<id>minion-IT</id>");
+        }
+
+        sender.onCompleted();
+        channel.shutdown();
+    }
+}
+```
+
+- [ ] **Step 12: Run integration test**
+
+```bash
+./mvnw -pl core/minion-gateway verify -Dit.test=HeartbeatGrpcServiceIT
+```
+
+Expected: BUILD SUCCESS. KafkaContainer starts, gRPC server starts on ephemeral port, message round-trips.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add core/minion-gateway/
+git commit -m "feat(v1.2.0-rc1): minion-gateway HeartbeatService gRPC + Kafka producer
+
+- HeartbeatGrpcService: bidi streaming, ack per message, identity from
+  gRPC Context (set by MinionIdentityServerInterceptor from x-minion-id
+  / x-minion-location headers).
+- HeartbeatKafkaProducer: republishes to OpenNMS.Sink.Heartbeat with
+  identity-derived key (location@id) so existing consumer keys correctly.
+- HeartbeatTranslator: pure function, gRPC Heartbeat → MinionIdentityDTO
+  XML matching horizon's AbstractXmlSinkModule output. 3 unit tests.
+- HeartbeatGrpcServiceIT: end-to-end with KafkaContainer.
+- HorizonMetricsBridge: Dropwizard → Micrometer for Kafka-producer meters
+  alongside Spring gRPC's native grpc.server.* meters."
+```
+
+---
+
+## Task 5: Envoy compose service
+
+**Files:**
+- Create: `opennms-container/delta-v/envoy/Dockerfile`
+- Create: `opennms-container/delta-v/envoy/envoy.yaml`
+- Create: `opennms-container/delta-v/minion-gateway/Dockerfile`
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+
+rc1 ships Envoy with **h2c plaintext** between Minion → Envoy → minion-gateway (no TLS, no auth — internal-trust posture per Phase 0 Decision 5). TLS termination is documented as a pre-GA add when remote-Minion deployments are validated. Envoy gives us the right ingress shape today and a stats endpoint for `/actuator/prometheus` parity.
+
+- [ ] **Step 1: Build the minion-gateway Dockerfile**
+
+```dockerfile
+# opennms-container/delta-v/minion-gateway/Dockerfile
+ARG JRE_BASE=delta-v-jre:latest
+FROM ${JRE_BASE}
+
+LABEL org.opennms.image.role="minion-gateway"
+LABEL org.opennms.image.responsibility="gRPC ↔ Kafka translator for Minion-facing surface"
+
+ENV APP_HOME=/opt/deltav/minion-gateway
+ENV KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+
+WORKDIR ${APP_HOME}
+
+COPY target/org.opennms.core.minion-gateway-*.jar ${APP_HOME}/minion-gateway.jar
+
+EXPOSE 50051 8080
+
+ENTRYPOINT ["java", "-jar", "/opt/deltav/minion-gateway/minion-gateway.jar"]
+```
+
+- [ ] **Step 2: Build the Envoy Dockerfile**
+
+```dockerfile
+# opennms-container/delta-v/envoy/Dockerfile
+FROM envoyproxy/envoy:v1.30.4
+
+COPY envoy.yaml /etc/envoy/envoy.yaml
+
+EXPOSE 8443 9901
+
+CMD ["/usr/local/bin/envoy", "-c", "/etc/envoy/envoy.yaml", "--service-cluster", "minion-edge"]
+```
+
+- [ ] **Step 3: Write the Envoy listener + route config**
+
+```yaml
+# opennms-container/delta-v/envoy/envoy.yaml
+admin:
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: minion_grpc_listener
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 8443 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: HTTP2
+          stat_prefix: minion_grpc
+          stream_idle_timeout: 0s        # long-lived streams, no idle timeout
+          route_config:
+            name: minion_grpc_routes
+            virtual_hosts:
+            - name: minion_grpc
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/org.deltav.minion.grpc.v1.HeartbeatService/"
+                  grpc: {}
+                route:
+                  cluster: minion_gateway
+                  timeout: 0s            # streaming RPCs, no per-call timeout
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+  - name: minion_gateway
+    connect_timeout: 5s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}            # h2c upstream
+    load_assignment:
+      cluster_name: minion_gateway
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address: { address: minion-gateway, port_value: 50051 }
+```
+
+- [ ] **Step 4: Add `minion-gateway` and `envoy` services to docker-compose.yml**
+
+In `opennms-container/delta-v/docker-compose.yml`, add (placement: after `kafka`, before `minion`):
+
+```yaml
+  minion-gateway:
+    image: ${IMAGE_PREFIX:-pbrane}/minion-gateway:${VERSION:-1.2.0-rc1}
+    container_name: delta-v-minion-gateway
+    depends_on:
+      kafka:
+        condition: service_healthy
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      JAVA_OPTS: "-Xms256m -Xmx512m"
+    networks: [deltav]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health | grep -q UP"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 30s
+
+  envoy:
+    image: ${IMAGE_PREFIX:-pbrane}/envoy:${VERSION:-1.2.0-rc1}
+    container_name: delta-v-envoy
+    depends_on:
+      minion-gateway:
+        condition: service_healthy
+    ports:
+      # 8443 published so Minions running outside the compose network can reach it.
+      # Internal-stack Minion uses the in-network DNS name and skips host-port.
+      - "8443:8443"
+    networks: [deltav]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9901/ready | grep -q LIVE"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+```
+
+In the `minion` service env block, add:
+
+```yaml
+    environment:
+      MINION_TRANSPORT: ${MINION_TRANSPORT:-grpc}    # rc1 default; set to 'kafka' as emergency rollback
+      MINION_GATEWAY_HOST: envoy
+      MINION_GATEWAY_PORT: 8443
+      # ... existing env entries unchanged
+```
+
+And in the `minion` `depends_on:` block, add:
+
+```yaml
+      envoy:
+        condition: service_healthy
+```
+
+- [ ] **Step 5: Build the two new images**
+
+```bash
+./mvnw -pl core/minion-gateway -am clean install -DskipTests
+docker build -t pbrane/minion-gateway:1.2.0-rc1 \
+  -f opennms-container/delta-v/minion-gateway/Dockerfile \
+  core/minion-gateway/
+docker build -t pbrane/envoy:1.2.0-rc1 \
+  opennms-container/delta-v/envoy/
+```
+
+Expected: both images build. Verify `docker images | grep -E '(minion-gateway|envoy)'`.
+
+- [ ] **Step 6: Smoke-bring-up the stack with the new services**
+
+```bash
+cd opennms-container/delta-v/
+docker compose up -d minion-gateway envoy
+sleep 15
+docker compose ps minion-gateway envoy
+curl -s http://localhost:9901/stats/prometheus | grep envoy_cluster_minion_gateway | head -5
+curl -s http://localhost:8080/actuator/health 2>/dev/null \
+  || docker exec delta-v-minion-gateway wget -qO- http://localhost:8080/actuator/health
+```
+
+Expected: both containers healthy. Envoy stats endpoint shows `envoy_cluster_minion_gateway_*` counters at zero. minion-gateway `/actuator/health` returns UP.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add opennms-container/delta-v/minion-gateway/ \
+       opennms-container/delta-v/envoy/ \
+       opennms-container/delta-v/docker-compose.yml
+git commit -m "feat(v1.2.0-rc1): Envoy ingress + minion-gateway compose services
+
+- Envoy 1.30.4 with HTTP/2 listener on 8443 (h2c, no TLS in rc1 per
+  Phase 0 internal-trust posture; TLS termination added pre-GA).
+- gRPC route for HeartbeatService → minion-gateway:50051 upstream.
+- Stream timeouts disabled per Phase 0 Decision 3 (long-lived per-channel
+  bidi streams).
+- minion service depends_on envoy; MINION_TRANSPORT default 'grpc' with
+  'kafka' rollback path documented inline."
+```
+
+---
+
+## Task 6: Minion-side gRPC client + dispatcher factory
+
+**Files:**
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/GrpcMessageDispatcherFactory.java`
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionIdentityClientInterceptor.java`
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcHeartbeatDispatcherConfiguration.java`
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/HeartbeatKafkaFallbackConfiguration.java`
+- Create: `core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/GrpcMessageDispatcherFactoryTest.java`
+- Modify: `core/daemon-boot-minion-common/pom.xml`
+- Modify: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/MinionProperties.java`
+
+The Minion-side gRPC client implements horizon's `MessageDispatcherFactory` so the existing `HeartbeatConfiguration` keeps using a `MessageDispatcherFactory` interface — only the bean qualifier changes.
+
+- [ ] **Step 1: Add deps to `daemon-boot-minion-common/pom.xml`**
+
+In `<dependencies>`:
+
+```xml
+<dependency>
+    <groupId>org.deltav.core</groupId>
+    <artifactId>org.opennms.core.minion-grpc-contracts</artifactId>
+    <version>${project.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.grpc</groupId>
+    <artifactId>spring-grpc-spring-boot-starter</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.grpc</groupId>
+    <artifactId>grpc-netty-shaded</artifactId>
+</dependency>
+```
+
+- [ ] **Step 2: Extend MinionProperties**
+
+In `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/MinionProperties.java`, add fields under `@ConfigurationProperties(prefix = "minion")`:
+
+```java
+private String transport = "grpc";              // grpc | kafka
+
+private final Gateway gateway = new Gateway();
+
+public String getTransport() { return transport; }
+public void setTransport(String transport) { this.transport = transport; }
+public Gateway getGateway() { return gateway; }
+
+public static class Gateway {
+    private String host = "envoy";
+    private int port = 8443;
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+    public int getPort() { return port; }
+    public void setPort(int port) { this.port = port; }
+}
+```
+
+- [ ] **Step 3: Write the client-side identity interceptor**
+
+```java
+// core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionIdentityClientInterceptor.java
+package org.deltav.minion.common.grpc;
+
+import io.grpc.*;
+
+public class MinionIdentityClientInterceptor implements ClientInterceptor {
+
+    public static final Metadata.Key<String> MINION_ID_HEADER =
+        Metadata.Key.of("x-minion-id", Metadata.ASCII_STRING_MARSHALLER);
+    public static final Metadata.Key<String> MINION_LOCATION_HEADER =
+        Metadata.Key.of("x-minion-location", Metadata.ASCII_STRING_MARSHALLER);
+
+    private final String minionId;
+    private final String location;
+
+    public MinionIdentityClientInterceptor(String minionId, String location) {
+        this.minionId = minionId;
+        this.location = location;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                headers.put(MINION_ID_HEADER, minionId);
+                headers.put(MINION_LOCATION_HEADER, location);
+                super.start(responseListener, headers);
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Write the gRPC-backed `MessageDispatcherFactory`**
+
+```java
+// core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/GrpcMessageDispatcherFactory.java
+package org.deltav.minion.common.grpc;
+
+import com.google.protobuf.Timestamp;
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.Heartbeat;
+import org.deltav.minion.grpc.v1.HeartbeatAck;
+import org.deltav.minion.grpc.v1.HeartbeatServiceGrpc;
+import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.ipc.sink.api.SinkModule;
+import org.opennms.core.ipc.sink.api.SyncDispatcher;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.opennms.minion.heartbeat.common.MinionIdentityDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * gRPC-backed {@link MessageDispatcherFactory}. rc1 implements only Heartbeat;
+ * any other module-id requested throws UnsupportedOperationException so a
+ * misconfigured listener can't silently fall back. Keeps the rc1 surface
+ * channel-isolated per feedback_e2e_continuous_validation_grpc_migration.
+ *
+ * <p>Identity headers are attached at the stub level via
+ * MinionIdentityClientInterceptor so every Publish call carries
+ * x-minion-id / x-minion-location metadata for minion-gateway routing.
+ */
+public class GrpcMessageDispatcherFactory implements MessageDispatcherFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GrpcMessageDispatcherFactory.class);
+
+    private final ManagedChannel channel;
+    private final HeartbeatServiceGrpc.HeartbeatServiceStub heartbeatStub;
+    private final AtomicReference<StreamObserver<Heartbeat>> heartbeatStream = new AtomicReference<>();
+
+    public GrpcMessageDispatcherFactory(ManagedChannel channel, MinionIdentity identity) {
+        this.channel = channel;
+        this.heartbeatStub = HeartbeatServiceGrpc.newStub(channel)
+            .withInterceptors(new MinionIdentityClientInterceptor(
+                identity.getId(), identity.getLocation()));
+    }
+
+    @Override
+    public <S, T> SyncDispatcher<S> createSyncDispatcher(SinkModule<S, T> module) {
+        if ("Heartbeat".equals(module.getId())) {
+            @SuppressWarnings("unchecked")
+            SyncDispatcher<S> typed = (SyncDispatcher<S>) heartbeatSyncDispatcher();
+            return typed;
+        }
+        throw new UnsupportedOperationException(
+            "GrpcMessageDispatcherFactory rc1 supports module 'Heartbeat' only; "
+            + "got '" + module.getId() + "'. Other sinks remain on Kafka in rc1 — "
+            + "verify HeartbeatConfiguration is the only @Qualifier consumer.");
+    }
+
+    @Override
+    public <S, T> AsyncDispatcher<S> createAsyncDispatcher(SinkModule<S, T> module) {
+        throw new UnsupportedOperationException(
+            "GrpcMessageDispatcherFactory rc1 supports sync dispatch only "
+            + "(Heartbeat is sync); async sinks remain on Kafka.");
+    }
+
+    private SyncDispatcher<MinionIdentityDTO> heartbeatSyncDispatcher() {
+        return new SyncDispatcher<>() {
+            @Override
+            public void send(MinionIdentityDTO identity) {
+                StreamObserver<Heartbeat> stream = heartbeatStream.updateAndGet(s -> s != null ? s : openStream());
+                Instant now = identity.getTimestamp() != null
+                    ? identity.getTimestamp().toInstant() : Instant.now();
+                Heartbeat hb = Heartbeat.newBuilder()
+                    .setMinionId(identity.getId())
+                    .setLocation(identity.getLocation())
+                    .setSentAt(Timestamp.newBuilder()
+                        .setSeconds(now.getEpochSecond())
+                        .setNanos(now.getNano()).build())
+                    .setVersion(identity.getVersion() != null ? identity.getVersion() : "")
+                    .build();
+                try {
+                    stream.onNext(hb);
+                    LOG.debug("Sent heartbeat via gRPC for minion={} location={}",
+                        identity.getId(), identity.getLocation());
+                } catch (RuntimeException e) {
+                    LOG.warn("Heartbeat stream send failed; resetting stream", e);
+                    heartbeatStream.set(null);   // next send will reopen
+                    throw e;
+                }
+            }
+
+            @Override
+            public void close() {
+                StreamObserver<Heartbeat> s = heartbeatStream.getAndSet(null);
+                if (s != null) s.onCompleted();
+                channel.shutdown();
+            }
+        };
+    }
+
+    private StreamObserver<Heartbeat> openStream() {
+        StreamObserver<HeartbeatAck> ackObserver = new StreamObserver<>() {
+            public void onNext(HeartbeatAck ack) {
+                LOG.debug("Received ack for minion={}", ack.getMinionId());
+            }
+            public void onError(Throwable t) {
+                LOG.warn("Heartbeat ack stream error; channel will reconnect on next send", t);
+                heartbeatStream.set(null);
+            }
+            public void onCompleted() {
+                heartbeatStream.set(null);
+            }
+        };
+        return heartbeatStub.publish(ackObserver);
+    }
+}
+```
+
+- [ ] **Step 5: Write the conditional @Configuration classes**
+
+The `GrpcMessageDispatcherFactory` shown in Step 4 takes `(ManagedChannel channel, MinionIdentity identity)` and builds the stub with `MinionIdentityClientInterceptor` attached at stub level. The @Configuration just wires the channel and constructs the factory:
+
+```java
+// core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcHeartbeatDispatcherConfiguration.java
+package org.deltav.minion.common;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PreDestroy;
+import org.deltav.minion.common.grpc.GrpcMessageDispatcherFactory;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@ConditionalOnProperty(name = "minion.transport", havingValue = "grpc", matchIfMissing = true)
+public class GrpcHeartbeatDispatcherConfiguration {
+
+    private ManagedChannel channel;
+
+    @Bean
+    public ManagedChannel minionGatewayChannel(MinionProperties props) {
+        this.channel = NettyChannelBuilder
+            .forAddress(props.getGateway().getHost(), props.getGateway().getPort())
+            .usePlaintext()                                    // h2c — Envoy fronts; rc1 has no TLS
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
+        return channel;
+    }
+
+    @Bean(name = "heartbeatDispatcherFactory")
+    public MessageDispatcherFactory heartbeatDispatcherFactory(
+            ManagedChannel minionGatewayChannel, MinionIdentity identity) {
+        return new GrpcMessageDispatcherFactory(minionGatewayChannel, identity);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (channel != null) {
+            channel.shutdown();
+        }
+    }
+}
+```
+
+```java
+// core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/HeartbeatKafkaFallbackConfiguration.java
+package org.deltav.minion.common;
+
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * MINION_TRANSPORT=kafka rollback path: aliases the primary Kafka
+ * MessageDispatcherFactory under the "heartbeatDispatcherFactory" bean name
+ * so HeartbeatConfiguration's @Qualifier injection still resolves.
+ */
+@Configuration
+@ConditionalOnProperty(name = "minion.transport", havingValue = "kafka")
+public class HeartbeatKafkaFallbackConfiguration {
+
+    @Bean(name = "heartbeatDispatcherFactory")
+    public MessageDispatcherFactory heartbeatDispatcherFactory(
+            MessageDispatcherFactory kafkaPrimary) {
+        return kafkaPrimary;
+    }
+}
+```
+
+- [ ] **Step 6: Sanity-build the module to catch any wiring errors**
+
+```bash
+./mvnw -pl core/daemon-boot-minion-common -am clean install -DskipTests
+```
+
+Expected: BUILD SUCCESS. Compilation surfaces any `@Qualifier` / bean-name mismatches before the test step.
+
+- [ ] **Step 7: Write the dispatcher factory unit test**
+
+```java
+// core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/GrpcMessageDispatcherFactoryTest.java
+package org.deltav.minion.common.grpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.Heartbeat;
+import org.deltav.minion.grpc.v1.HeartbeatAck;
+import org.deltav.minion.grpc.v1.HeartbeatServiceGrpc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.api.SinkModule;
+import org.opennms.core.ipc.sink.api.SyncDispatcher;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.opennms.minion.heartbeat.common.HeartbeatModule;
+import org.opennms.minion.heartbeat.common.MinionIdentityDTO;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GrpcMessageDispatcherFactoryTest {
+
+    private ManagedChannel clientChannel;
+    private CountDownLatch heartbeatReceived;
+    private Heartbeat lastReceived;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        heartbeatReceived = new CountDownLatch(1);
+        String name = InProcessServerBuilder.generateName();
+
+        InProcessServerBuilder.forName(name).directExecutor()
+            .addService(new HeartbeatServiceGrpc.HeartbeatServiceImplBase() {
+                @Override
+                public StreamObserver<Heartbeat> publish(StreamObserver<HeartbeatAck> ack) {
+                    return new StreamObserver<>() {
+                        public void onNext(Heartbeat hb) {
+                            lastReceived = hb;
+                            heartbeatReceived.countDown();
+                            ack.onNext(HeartbeatAck.newBuilder().setMinionId(hb.getMinionId()).build());
+                        }
+                        public void onError(Throwable t) {}
+                        public void onCompleted() { ack.onCompleted(); }
+                    };
+                }
+            })
+            .build().start();
+
+        clientChannel = InProcessChannelBuilder.forName(name).directExecutor().build();
+    }
+
+    @Test
+    void send_translatesAndStreamsHeartbeatPayload() throws Exception {
+        MinionIdentity id = Mockito.mock(MinionIdentity.class);
+        Mockito.when(id.getId()).thenReturn("minion-A");
+        Mockito.when(id.getLocation()).thenReturn("loc-DC1");
+
+        var factory = new GrpcMessageDispatcherFactory(clientChannel, id);
+        SyncDispatcher<MinionIdentityDTO> dispatcher = factory.createSyncDispatcher(new HeartbeatModule());
+
+        MinionIdentityDTO dto = new MinionIdentityDTO();
+        dto.setId("minion-A");
+        dto.setLocation("loc-DC1");
+        dto.setVersion("1.2.0-rc1");
+        dto.setTimestamp(new Date(1745625600000L));
+
+        dispatcher.send(dto);
+
+        assertThat(heartbeatReceived.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(lastReceived.getMinionId()).isEqualTo("minion-A");
+        assertThat(lastReceived.getLocation()).isEqualTo("loc-DC1");
+        assertThat(lastReceived.getVersion()).isEqualTo("1.2.0-rc1");
+
+        dispatcher.close();
+    }
+
+    @Test
+    void createSyncDispatcher_rejectsNonHeartbeatModules() {
+        MinionIdentity id = Mockito.mock(MinionIdentity.class);
+        Mockito.when(id.getId()).thenReturn("m");
+        Mockito.when(id.getLocation()).thenReturn("l");
+
+        var factory = new GrpcMessageDispatcherFactory(clientChannel, id);
+        SinkModule<?, ?> fakeSyslog = Mockito.mock(SinkModule.class);
+        Mockito.when(fakeSyslog.getId()).thenReturn("Syslog");
+
+        assertThatThrownBy(() -> factory.createSyncDispatcher(fakeSyslog))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("Heartbeat")
+            .hasMessageContaining("Syslog");
+    }
+}
+```
+
+- [ ] **Step 8: Run the test**
+
+```bash
+./mvnw -pl core/daemon-boot-minion-common test -Dtest=GrpcMessageDispatcherFactoryTest
+```
+
+Expected: 2 tests, 2 passing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/daemon-boot-minion-common/
+git commit -m "feat(v1.2.0-rc1): Minion-side gRPC dispatcher for Heartbeat
+
+- GrpcMessageDispatcherFactory: implements horizon's MessageDispatcherFactory;
+  rc1 supports only Heartbeat module-id (other sinks throw UnsupportedOp so
+  misconfiguration fails fast).
+- MinionIdentityClientInterceptor: attaches x-minion-id / x-minion-location
+  metadata on every gRPC call.
+- GrpcHeartbeatDispatcherConfiguration: produces 'heartbeatDispatcherFactory'
+  bean when minion.transport=grpc (default).
+- HeartbeatKafkaFallbackConfiguration: aliases primary Kafka factory under
+  the same bean name when minion.transport=kafka (rollback path).
+- MinionProperties extended with transport + gateway.{host,port} fields."
+```
+
+---
+
+## Task 7: HeartbeatConfiguration @Qualifier switch + compose plumbing
+
+**Files:**
+- Modify: `core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/HeartbeatConfiguration.java`
+
+The cutover commit. After this lands, default-config Minion Heartbeat goes through gRPC.
+
+- [ ] **Step 1: Add @Qualifier to HeartbeatConfiguration**
+
+Edit `core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/HeartbeatConfiguration.java` line 50–54. Add the import and qualifier:
+
+```java
+// add import:
+import org.springframework.beans.factory.annotation.Qualifier;
+
+// change the @Bean signature from:
+public Timer heartbeatTimer(
+        MinionIdentity identity,
+        MessageDispatcherFactory dispatcherFactory,
+        @Value("${spring.application.version:0.0.0}") String version) {
+
+// to:
+public Timer heartbeatTimer(
+        MinionIdentity identity,
+        @Qualifier("heartbeatDispatcherFactory") MessageDispatcherFactory dispatcherFactory,
+        @Value("${spring.application.version:0.0.0}") String version) {
+```
+
+- [ ] **Step 2: Build the daemon-boot-minion JAR**
+
+```bash
+./mvnw -pl core/daemon-boot-minion -am clean install -DskipTests
+```
+
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Rebuild the Minion image (and other daemons) using the existing build script**
+
+Per memory `feedback_rebuild_all_daemons` — always rebuild ALL daemon boot JARs before `build.sh deltav`, otherwise stale fat jars get re-baked into images. Run the canonical pipeline:
+
+```bash
+./mvnw clean install -DskipTests        # full reactor; refreshes all 12+ daemon-boot fat jars + minion-gateway
+opennms-container/delta-v/build.sh deltav
+```
+
+Expected: `pbrane/minion-boot:<version>` and `pbrane/minion-gateway:<version>` images present in local Docker. Verify: `docker images | grep -E '(minion-boot|minion-gateway)'`.
+
+- [ ] **Step 4: Smoke the full stack with MINION_TRANSPORT=grpc (default)**
+
+```bash
+cd opennms-container/delta-v
+docker compose down -v
+docker compose up -d
+sleep 60   # allow Minion warm-up + 2 heartbeat intervals
+
+# Verify Heartbeat traffic on the gRPC path (Envoy stats show requests)
+curl -s http://localhost:9901/stats | grep cluster.minion_gateway.upstream_rq_2xx
+# Expected: > 0 (acks count as 2xx-equivalent for streams)
+
+# Verify Heartbeats are landing on Kafka (republished by minion-gateway)
+docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 \
+  --topic OpenNMS.Sink.Heartbeat \
+  --from-beginning --max-messages 2 --timeout-ms 60000
+# Expected: 2 MinionIdentityDTO XML records
+
+# Verify minion-gateway metrics show Heartbeat traffic
+curl -s http://localhost:8080/actuator/prometheus | grep -E 'grpc_server_(processing_duration|requests_received)' | head
+# Expected: grpc_server_* counters incremented for HeartbeatService.Publish
+```
+
+- [ ] **Step 5: Smoke the rollback path with MINION_TRANSPORT=kafka**
+
+```bash
+docker compose down -v
+MINION_TRANSPORT=kafka docker compose up -d
+sleep 60
+
+# Heartbeats should land on Kafka via the legacy direct path (minion-gateway not in path)
+docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 \
+  --topic OpenNMS.Sink.Heartbeat \
+  --from-beginning --max-messages 2 --timeout-ms 60000
+# Expected: 2 records
+
+# Envoy stats should show NO new Heartbeat traffic
+curl -s http://localhost:9901/stats | grep cluster.minion_gateway.upstream_rq_total
+# Expected: counter unchanged from before rollback
+```
+
+If both paths work: rollback flag verified. Restore default for Task 8:
+
+```bash
+docker compose down -v
+docker compose up -d   # MINION_TRANSPORT=grpc default
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/HeartbeatConfiguration.java
+git commit -m "feat(v1.2.0-rc1): switch HeartbeatConfiguration to gRPC dispatcher
+
+Single-line change: add @Qualifier(\"heartbeatDispatcherFactory\") to the
+MessageDispatcherFactory injection. Rest of HeartbeatConfiguration unchanged.
+
+After this commit, default-config Minion sends Heartbeat via gRPC →
+Envoy → minion-gateway → OpenNMS.Sink.Heartbeat (Kafka). Set
+MINION_TRANSPORT=kafka to roll back; HeartbeatKafkaFallbackConfiguration
+aliases the primary Kafka factory under the heartbeatDispatcherFactory
+bean name so injection still resolves."
+```
+
+---
+
+## Task 8: gRPC Heartbeat E2E test
+
+**Files:**
+- Create: `tests/e2e/test-grpc-heartbeat-e2e.sh`
+
+The E2E counterpart to the existing `tests/e2e/test-minion-e2e.sh` Kafka-path test. Validates the gRPC path lands Heartbeat on Kafka **and** captures the gRPC-Heartbeat p99 for comparison against the Task 1 baseline.
+
+- [ ] **Step 1: Find the existing E2E test pattern**
+
+```bash
+ls tests/e2e/test-*.sh
+head -40 tests/e2e/test-minion-e2e.sh
+```
+
+Expected: see how an existing test sets up its env, captures output, asserts. Match its style.
+
+- [ ] **Step 2: Write `test-grpc-heartbeat-e2e.sh`**
+
+```bash
+# tests/e2e/test-grpc-heartbeat-e2e.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tests/e2e/test-grpc-heartbeat-e2e.sh — v1.2.0-rc1
+# Validates that Heartbeat from Minion lands on OpenNMS.Sink.Heartbeat
+# via the gRPC path (Envoy → minion-gateway). Asserts MINION_TRANSPORT=grpc
+# was actually used and captures gRPC-Heartbeat p99 vs the rc1 baseline.
+
+cd "$(dirname "$0")/../.."
+
+COMPOSE_DIR=opennms-container/delta-v
+COMPOSE="docker compose -f ${COMPOSE_DIR}/docker-compose.yml -f ${COMPOSE_DIR}/docker-compose.dev.yml"
+
+BASELINE_P99_MS=${BASELINE_P99_MS:-100}      # override from Task 1 measurement
+THRESHOLD_MS=${THRESHOLD_MS:-10}             # gRPC must beat baseline + 10ms
+
+echo "==> Bringing up stack with MINION_TRANSPORT=grpc"
+$COMPOSE down -v
+MINION_TRANSPORT=grpc $COMPOSE up -d
+echo "==> Waiting for Minion + minion-gateway healthy"
+for i in $(seq 1 30); do
+  if $COMPOSE ps minion-gateway | grep -q '(healthy)' && \
+     $COMPOSE ps minion | grep -q '(healthy)'; then break; fi
+  sleep 5
+done
+
+echo "==> Asserting Envoy is in path: cluster.minion_gateway counter advances"
+BEFORE=$(curl -fs http://localhost:9901/stats | grep -oE 'cluster.minion_gateway.upstream_rq_total: [0-9]+' | awk '{print $2}')
+sleep 65   # 2 heartbeat intervals + slack
+AFTER=$(curl -fs http://localhost:9901/stats | grep -oE 'cluster.minion_gateway.upstream_rq_total: [0-9]+' | awk '{print $2}')
+if [[ "${AFTER:-0}" -le "${BEFORE:-0}" ]]; then
+  echo "FAIL: Envoy minion_gateway request counter did not advance (before=$BEFORE after=$AFTER)"
+  $COMPOSE logs --tail=200 minion minion-gateway envoy
+  exit 1
+fi
+echo "    Envoy passed: $BEFORE -> $AFTER"
+
+echo "==> Asserting Heartbeats land on OpenNMS.Sink.Heartbeat"
+COUNT=$($COMPOSE exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 \
+  --topic OpenNMS.Sink.Heartbeat \
+  --from-beginning --max-messages 3 --timeout-ms 90000 2>/dev/null | grep -c '<MinionIdentityDTO>')
+if [[ "$COUNT" -lt 2 ]]; then
+  echo "FAIL: expected ≥2 heartbeats on Kafka topic, got $COUNT"
+  exit 1
+fi
+echo "    Kafka topic passed: $COUNT records"
+
+echo "==> Capturing gRPC-Heartbeat p99 RTT (10 min window)"
+mkdir -p /tmp/rc1-grpc
+$COMPOSE exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 \
+  --topic OpenNMS.Sink.Heartbeat \
+  --property print.timestamp=true \
+  --timeout-ms 600000 \
+  > /tmp/rc1-grpc/heartbeats.raw 2>&1 || true
+
+P99_MS=$(python3 - <<'PY'
+import re, sys, xml.etree.ElementTree as ET
+from datetime import datetime
+deltas = []
+text = open('/tmp/rc1-grpc/heartbeats.raw').read()
+for m in re.finditer(r'CreateTime:(\d+)\s*\n(<MinionIdentityDTO[^>]*>.*?</MinionIdentityDTO>)', text, re.DOTALL):
+    create_ms = int(m.group(1))
+    ts = ET.fromstring(m.group(2)).findtext('timestamp')
+    sent_ms = int(datetime.fromisoformat(ts.replace('Z','+00:00')).timestamp()*1000)
+    deltas.append(create_ms - sent_ms)
+deltas.sort()
+print(deltas[int(len(deltas)*0.99)] if deltas else -1)
+PY
+)
+echo "    gRPC-Heartbeat p99 = ${P99_MS} ms (baseline ${BASELINE_P99_MS} ms + threshold ${THRESHOLD_MS} ms)"
+
+if [[ "${P99_MS}" -lt 0 ]]; then
+  echo "FAIL: no heartbeats captured for p99 calculation"
+  exit 1
+fi
+if [[ "${P99_MS}" -gt $((BASELINE_P99_MS + THRESHOLD_MS)) ]]; then
+  echo "FAIL: gRPC p99 ${P99_MS}ms exceeds baseline ${BASELINE_P99_MS}ms + threshold ${THRESHOLD_MS}ms"
+  exit 1
+fi
+
+echo "==> ALL gRPC-Heartbeat E2E ASSERTIONS PASSED"
+```
+
+- [ ] **Step 3: Make executable + add to suite runner if one exists**
+
+```bash
+chmod +x tests/e2e/test-grpc-heartbeat-e2e.sh
+# If there is a runner like tests/e2e/run-all.sh:
+grep -l 'test-minion-e2e.sh\|test-perspective-e2e.sh' tests/e2e/*.sh tests/e2e/run-*.sh 2>/dev/null
+# Append the new test to whatever runner the existing tests use.
+```
+
+- [ ] **Step 4: Run the new test**
+
+```bash
+BASELINE_P99_MS=<the p99 from Task 1> ./tests/e2e/test-grpc-heartbeat-e2e.sh
+```
+
+Expected: `ALL gRPC-Heartbeat E2E ASSERTIONS PASSED`. ~13 minutes total (compose up + 1 min warm-up + 10 min capture + asserts).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/test-grpc-heartbeat-e2e.sh
+git commit -m "test(v1.2.0-rc1): E2E test for Heartbeat over gRPC path
+
+Asserts: (1) Envoy cluster counters advance during Heartbeat traffic,
+(2) Heartbeats reach OpenNMS.Sink.Heartbeat via minion-gateway translation,
+(3) gRPC-Heartbeat p99 RTT ≤ Kafka baseline + 10ms threshold.
+
+Per feedback_e2e_continuous_validation_grpc_migration: this is a NEW
+E2E test for the migrated channel; the existing tests/e2e/test-*.sh
+suite (Kafka-path) MUST CONTINUE TO PASS — non-Heartbeat E2E coverage
+is the rc1 regression detector for unmigrated channels."
+```
+
+---
+
+## Task 9: Full E2E suite regression check
+
+**Files:** none (verification only)
+
+Per `feedback_e2e_continuous_validation_grpc_migration`: every existing E2E test must keep passing. This task is the explicit regression-detection gate before the rc1 cut.
+
+- [ ] **Step 1: Inventory existing E2E tests**
+
+```bash
+ls tests/e2e/test-*.sh
+```
+
+Expected (current as of beta2): `test-minion-e2e.sh`, `test-minion-rpc-e2e.sh`, `test-perspective-e2e.sh`, `test-enlinkd-e2e.sh`, plus any others. **None of these may regress.**
+
+- [ ] **Step 2: Run each existing E2E test in sequence**
+
+```bash
+cd opennms-container/delta-v
+docker compose down -v
+docker compose up -d
+sleep 90    # full stack warm-up
+
+cd ../..
+for t in tests/e2e/test-*.sh; do
+  echo "=== Running $t ==="
+  if ! "$t"; then
+    echo "FAIL: $t regressed under rc1"
+    exit 1
+  fi
+done
+echo "ALL EXISTING E2E TESTS PASS UNDER rc1"
+```
+
+Expected: every test exits 0. If any regress, **stop the cut** and root-cause — the rc1 surgical migration is supposed to be channel-isolated.
+
+- [ ] **Step 3: Update pre-work-findings doc with E2E results**
+
+Edit `docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md`. Append:
+
+```markdown
+## E2E suite results (rc1 regression check)
+
+Run 2026-04-XX on Mac dev env, full compose stack on rc1 build:
+
+| Test | Result | Notes |
+|---|---|---|
+| test-minion-e2e.sh | PASS | |
+| test-minion-rpc-e2e.sh | PASS | |
+| test-perspective-e2e.sh | PASS | |
+| test-enlinkd-e2e.sh | PASS | |
+| test-grpc-heartbeat-e2e.sh | PASS | NEW; gRPC-Heartbeat p99 = X ms (baseline Y ms) |
+
+**No regression detected.** Channel-isolated migration verified.
+```
+
+- [ ] **Step 4: Commit findings update**
+
+```bash
+git add docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc1): record full E2E suite green under rc1 build"
+```
+
+---
+
+## Task 10: Reactor build verification + version bump prep
+
+**Files:**
+- Modify: root `pom.xml` and all child poms (via `mvn versions:set`)
+
+Per `feedback_delta_v_full_reactor_verify` and `feedback_spring_boot_repackage_needs_clean`: full reactor `clean install` is mandatory before tagging because `-pl` skips sibling cascade failures, and Spring Boot repackage reuses stale fat jars without `clean`.
+
+- [ ] **Step 1: Full reactor clean build**
+
+```bash
+./mvnw clean install -DskipTests
+```
+
+Expected: BUILD SUCCESS across all delta-v reactor modules. Failures here are blockers — typically classpath issues from new modules or BOM ordering.
+
+- [ ] **Step 2: Full reactor with tests**
+
+```bash
+./mvnw clean install
+```
+
+Expected: BUILD SUCCESS, all unit + integration tests pass. ~15-25 min.
+
+- [ ] **Step 3: Bump project version to 1.2.0-rc1**
+
+```bash
+./mvnw versions:set -DnewVersion=1.2.0-rc1 -DgenerateBackupPoms=false
+./mvnw clean install -DskipTests   # verify the bumped reactor still builds
+```
+
+Expected: every pom.xml updated; reactor builds.
+
+- [ ] **Step 4: Commit version bump as a separate chore commit**
+
+```bash
+git add pom.xml '**/pom.xml'
+git commit -m "chore: bump version 1.2.0-beta2 → 1.2.0-rc1"
+```
+
+This commit is the **tag target** — `git tag v1.2.0-rc1` lands on this commit per `feedback_delayed_tag_workflow_trigger` (tag at the bump-merge commit, not the feature-merge).
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin docs/v1.2.0-rc1-implementation-plan   # or the actual feature branch
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "feat(v1.2.0-rc1): Minion Heartbeat gRPC migration" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Migrates Minion Heartbeat sink from Kafka to gRPC end-to-end as proof-of-pattern for the v1.2.0 Minion ↔ Core gRPC transition.
+- New `minion-gateway` translator daemon (Spring Boot 4 + Spring gRPC 1.0.3) sits between Envoy and Kafka. ServiceDaemons unchanged.
+- Other sinks, RPC, and Twin remain on Kafka in rc1; rc2 picks up their migration.
+- `MINION_TRANSPORT=grpc` is the rc1 default; `MINION_TRANSPORT=kafka` is documented emergency rollback only.
+
+## Architecture
+
+Minion → gRPC bidi stream (h2c) → Envoy 8443 → minion-gateway:50051 → Kafka topic `OpenNMS.Sink.Heartbeat` → existing horizon Heartbeat consumer.
+
+Identity (`x-minion-id`, `x-minion-location`) flows in gRPC metadata; minion-gateway uses it as Kafka message key. No daemon changes required to consume the republished Heartbeat — the wire format on the Kafka topic matches horizon's existing `MinionIdentityDTO` XML.
+
+## Phase 0 decisions honored
+- Translator daemon, not per-daemon gRPC (zero-trust posture).
+- Hard cut at v1.2.0 GA (no parallel transports for the same channel).
+- No Minion-side buffer; gRPC ManagedChannel reconnect handles transient outages.
+- Envoy ingress (not Spring Cloud Gateway).
+- Heartbeat first; other sinks have .proto definitions only.
+
+## Test plan
+- [x] Heartbeat RTT baseline captured (Kafka path) — Task 1.
+- [x] Unit tests pass: `HeartbeatTranslator`, `HeartbeatGrpcService`, `GrpcMessageDispatcherFactory`, `HeartbeatGrpcServiceIT` (Testcontainers).
+- [x] Local docker compose stack runs Heartbeat over gRPC end-to-end.
+- [x] `tests/e2e/test-grpc-heartbeat-e2e.sh` PASS — gRPC-Heartbeat p99 within baseline + 10ms.
+- [x] All existing `tests/e2e/test-*.sh` PASS under rc1 build (no regression on non-migrated channels).
+- [x] `MINION_TRANSPORT=kafka` rollback verified end-to-end on the same stack.
+- [x] Full reactor `./mvnw clean install` PASS.
+
+## Out of scope (rc2)
+- RPC channel migration to gRPC (`OpenNMS.<location>.rpc-request`, `OpenNMS.rpc-response`).
+- Twin API migration.
+- Remaining sinks: Syslog, Telemetry × 4, Trap.
+- ActiveMQ + ServiceMix bundle purge from minion-boot.
+- Sink topic renames (`OpenNMS.Sink.*` → `DeltaV.Sink.*`) if any survive into v1.3.
+- "Default" Minion location retirement.
+- Echo RPC health check replacement.
+- Test harness updates for the Kafka-RPC tests (rc2 design-doc Q7).
+- TLS termination at Envoy (added pre-GA when remote-Minion deployments are validated).
+
+Tracked separately: `docs/plans/<future>-v1.2.0-rc2-implementation-plan.md` will be authored when rc1 ships.
+EOF
+)"
+```
+
+Expected: PR opened against `pbrane/delta-v` (per memory `feedback_never_pr_opennms` — never `OpenNMS/opennms`).
+
+---
+
+## Out of scope for rc1 (handed to rc2 plan doc)
+
+- RPC channel migration to gRPC (latency-critical bidi streaming).
+- Twin API migration to gRPC (server-streaming with reconnect/resubscribe semantics).
+- Implementation of Syslog, Telemetry × 4, Trap services on both sides (proto already defined).
+- Removal of Kafka transport from Minion (the entire `Kafka{Rpc,Sink,Twin}*Configuration` set in `daemon-boot-minion-common`).
+- ActiveMQ + ServiceMix bundle purge from minion-boot (`project_minion_servicemix_activemq_cleanup`).
+- Sink topic renames `OpenNMS.Sink.*` → `DeltaV.Sink.*` (`project_sink_topic_rename`).
+- Default-location retirement (`project_retire_default_minion`).
+- Echo RPC probe replacement (`project_minion_echo_probes`).
+- Updates to `test-perspective-e2e.sh` and `test-enlinkd-e2e.sh` for the gRPC RPC path (design-doc Q7).
+- Envoy TLS termination + cert provisioning workflow.
+- Auth (mTLS or JWT) — design-doc Q2.
+
+A separate `docs/plans/YYYY-MM-DD-v1.2.0-rc2-implementation-plan.md` will be authored when rc1 ships, informed by what rc1 reveals during smoke and whatever remote-Minion deployment learnings the rc1 cut produces.


### PR DESCRIPTION
## Summary

Implementation plan for v1.2.0-rc1 — migrate the Minion Heartbeat sink from Kafka to gRPC end-to-end as proof-of-pattern for the v1.2.0 Minion ↔ Core gRPC transition.

- **10 tasks**, ~2,400-line plan, TDD discipline with complete code in every code-changing step.
- Honors all Phase 0 locked decisions from PR #226 (translator daemon `minion-gateway`, hard cut at v1.2.0 GA, no Minion buffer, Envoy ingress, Heartbeat first).
- RPC, Twin, and remaining sinks are explicitly out of scope — separate rc2 plan doc when rc1 ships.

## What landed in this session before drafting the plan

- **Pre-work (1)** — RPC bytecode audit: substitution seam clean at `RpcModule` / `RpcClient` / `RpcClientFactory`. `KafkaRpcServerManager` has no public interface above it but is delta-v-constructed in `KafkaRpcServerConfiguration` — replace the @Configuration class, not horizon. `MeteredRpcModule` survives transport swap.
- **Pre-work (2)** — Minion Kafka inventory: 22 callsites, all centralized in 3 @Configuration classes in `daemon-boot-minion-common/` plus 4 listener configs that consume only the abstract `MessageDispatcherFactory`. Listener configs unchanged in rc1.
- **Pre-work (3)** — Heartbeat RTT baseline: deferred to rc1 implementation kickoff (Task 1 of the plan) per the corrected dev-vs-smoke-VM understanding. Smoke VM is release-validation only; baselines belong on Mac dev env so pre-gRPC and post-gRPC numbers are apples-to-apples on the same stack.
- **Pre-work (4)** — Spring Boot 4 gRPC integration: `org.springframework.grpc:spring-grpc-spring-boot-starter:1.0.3` chosen (Spring's official, GA, Boot 4 native). BOM ordering: spring-boot-dependencies first, spring-grpc-dependencies second.
- **Pre-work (5)** — Sink bytecode audit: `SinkModule` / `MessageDispatcherFactory` / `MessageConsumerManager` interfaces are clean substitution seams. `HeartbeatModule.getRoutingKey()` returns `Optional.empty()` today (identity in payload). For rc1 gRPC, identity moves to gRPC metadata so `minion-gateway` can key Kafka publishes correctly.

## Key architectural decisions in the plan

- **One-line cutover.** rc1's surgical migration is `@Qualifier(\"heartbeatDispatcherFactory\")` on `HeartbeatConfiguration`'s `MessageDispatcherFactory` parameter. No other listener config (Trap, Telemetry, Syslog) changes — they keep injecting the @Primary Kafka factory by type.
- **Fail-fast non-Heartbeat handling.** `GrpcMessageDispatcherFactory.createSyncDispatcher()` throws `UnsupportedOperationException` for any module-id other than \"Heartbeat\" so a misrouted listener crashes at startup instead of silently dropping data.
- **Identity in gRPC metadata, not payload.** `x-minion-id` / `x-minion-location` headers; minion-gateway uses them as the Kafka message key when republishing to `OpenNMS.Sink.Heartbeat`. Payload still echoes identity for self-describing log lines.
- **h2c plaintext within compose; no TLS in rc1.** Internal-trust posture per Phase 0 Decision 5. TLS termination at Envoy is a pre-GA add when remote-Minion deployments are validated.
- **Reuses `core/horizon-metric-bridge`** (PR #216, 2026-04-24) — no new bridge implementation; one `@Bean HorizonMetricsBridge(metricRegistry, \"opennms\")` in `MinionGatewayApplication` matches the syslogd / telemetryd / pollerd pattern.

## Test plan

The plan itself enumerates a per-task checkbox plan. Items reviewers may want to verify directly:

- [ ] Plan structure matches the kickoff prompt's commit shape (10 tasks ≈ 10–12 commits).
- [ ] Every code-changing step has complete code, no placeholders.
- [ ] All five implementation-phase open questions from the kickoff prompt have an addressed-in-plan answer (identity-in-headers, minion-gateway threading, Envoy compose placement, Heartbeat protobuf shape, test-harness).
- [ ] E2E continuity rule honored: existing `tests/e2e/test-*.sh` must keep passing; new `test-grpc-heartbeat-e2e.sh` added (Task 8 + Task 9).
- [ ] Type consistency: `GrpcMessageDispatcherFactory(ManagedChannel, MinionIdentity)` constructor matches across Tasks 4, 6, 7; `heartbeatDispatcherFactory` bean name matches across Task 6 (gRPC config), Task 6 (Kafka fallback), Task 7 (HeartbeatConfiguration @Qualifier).

## Companion artifacts

- Phase 0 decisions: docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md (PR #226)
- Original design doc: docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md
- This-session kickoff prompt: docs/superpowers/next-session-prompts/2026-04-25-v1.2.0-rc1-implementation-plan-kickoff.md (PR #227)

## Out of scope (rc2 plan doc TBD)

- RPC channel migration to gRPC (latency-critical bidi streaming).
- Twin API migration.
- Remaining sinks: Syslog, Telemetry × 4, Trap.
- ActiveMQ + ServiceMix bundle purge from minion-boot.
- Sink topic renames (`OpenNMS.Sink.*` → `DeltaV.Sink.*`).
- \"Default\" Minion location retirement.
- Echo RPC probe replacement.
- TLS termination + cert provisioning.
- Auth (mTLS or JWT).