### PR TITLE
fix: CLAUDE.md Java version 17 → 21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ gh pr create ...  # defaults to OpenNMS/opennms
 
 ## Project Overview
 
-OpenNMS Horizon is an enterprise-grade open-source network monitoring platform. Version 36.0.0-SNAPSHOT, licensed under AGPL v3. Java 17 required (enforced range `[17,18)`).
+OpenNMS Horizon is an enterprise-grade open-source network monitoring platform. Version 36.0.0-SNAPSHOT, licensed under AGPL v3. Java 21 required (`<java.version>21</java.version>` set in root `pom.xml` and every `core/*` module pom).
 
 ## Build Commands
 
@@ -118,7 +118,7 @@ OpenNMS embeds Apache Karaf (4.3.10) as an OSGi container. Karaf is embedded *ab
 
 | Layer | Technology |
 |-------|-----------|
-| Language | Java 17 |
+| Language | Java 21 |
 | Build | Maven (bundled), Perl wrapper scripts |
 | OSGi Container | Apache Karaf 4.3.10 |
 | Web Framework | Spring 4.2.x (OpenNMS-patched fork), Spring Security 4.2.x (patched) |


### PR DESCRIPTION
## Summary

Targeted fix for two stale references in `CLAUDE.md` that asserted Java 17. Delta-V has been Java 21 reactor-wide; the project-memory file was inherited from upstream OpenNMS Horizon and never updated when delta-v moved to 21.

## Why this matters

The stale guidance has been actively misleading Claude sessions. Caught during the v1.2.0-rc1 implementation-plan review (PR #228) — the plan initially prescribed `<java.version>17</java.version>` for two new module poms because I followed CLAUDE.md instead of grepping pom.xml. User caught it during plan review.

Saved a session memory (`feedback_delta_v_java_version`) capturing the discipline of \"verify Java version from pom.xml, not from CLAUDE.md\" — that memory becomes redundant once this PR lands and can be pruned at that point.

## Out of scope

The same `Key Technology Stack` table has additional stale entries that were intentionally left untouched in this PR to keep the change minimal:

- `OSGi Container | Apache Karaf 4.3.10` — Karaf was removed (memory `feedback_karaf_is_dead`).
- `ORM | Hibernate 3.6.11 (OpenNMS build)` — delta-v is on Hibernate 7 (memory `project_hibernate7_e2e_fixes`).
- `Build | Maven (bundled), Perl wrapper scripts` — delta-v uses `./mvnw`, not `compile.pl` (memory `feedback_delta_v_uses_mvnw_not_compile_pl`).
- `Web Framework | Spring 4.2.x` — delta-v is on Spring Boot 4.0.3.

A holistic CLAUDE.md audit pass (potentially via the `claude-md-management:claude-md-improver` skill) would be a useful follow-up.

## Test plan

- [x] `grep -n 'Java 17' CLAUDE.md` returns nothing.
- [x] `grep -n '<java.version>' pom.xml core/*/pom.xml` confirms 21 reactor-wide.
- [ ] Reviewer eyeballs the diff for clarity of the new wording.