### PR TITLE
docs(v1.2.0-rc2): next-session prompt for rc2 design kickoff

### DIFF
--- a/docs/superpowers/next-session-prompts/2026-04-26-v1.2.0-rc2-design-kickoff.md
+++ b/docs/superpowers/next-session-prompts/2026-04-26-v1.2.0-rc2-design-kickoff.md
@@ -1,0 +1,208 @@
+# Next session: v1.2.0-rc2 — design kickoff (RPC + Twin + remaining sinks gRPC)
+
+**This is the design kickoff prompt for v1.2.0-rc2.** rc1 shipped 2026-04-26 as PR #231, tag `v1.2.0-rc1` at commit `b820bda5ffb`. The Heartbeat sink is now on gRPC end-to-end; everything else (RPC, Twin, Syslog, Telemetry, Trap) remains on Kafka. rc2 finishes the migration: moves the remaining channels to gRPC, removes Kafka transport from Minion entirely, and ships the cleanup that's been deferred.
+
+This session is for **design + Phase 0 decisions only** — no implementation. Outputs: a decisions doc at `docs/plans/<date>-v1.2.0-rc2-decisions.md` and a docs PR. Subsequent sessions handle the implementation plan and execution, mirroring the rc1 cadence.
+
+**Read first** — these are not optional preamble:
+
+- [rc1 PR #231](https://github.com/pbrane/delta-v/pull/231) — what shipped (merged 2026-04-26).
+- [Original design doc](../../plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md) — broader gRPC architecture; design-doc Q2 (auth) / Q4 / Q6 / Q7 are still open.
+- [rc1 Phase 0 decisions](../../plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md) — what's locked, **do not relitigate.**
+- [rc1 implementation plan](../../plans/2026-04-26-v1.2.0-rc1-implementation-plan.md) — context on the rc1 task structure (rc2 will follow the same pattern).
+- [rc1 pre-work findings](../../plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md) — Heartbeat baseline (Kafka p99 = 1ms; gRPC p99 = 5ms) + Task 9 sweep results.
+- Memory invariants that bind every commit: `feedback_no_local_polling`, `feedback_rpc_timeout_no_outages`, `project_minion_mandatory`, `feedback_e2e_continuous_validation_grpc_migration`, `feedback_never_pr_opennms`.
+
+---
+
+## Where we are (post-rc1)
+
+| Track | Status |
+|---|---|
+| Heartbeat sink — gRPC | ✅ Shipped rc1 |
+| RPC channel — Kafka | ⏳ rc2 |
+| Twin API — Kafka | ⏳ rc2 |
+| Syslog / Trap / Telemetry sinks — Kafka | ⏳ rc2 |
+| Kafka transport in Minion | ⏳ rc2 cleanup |
+| ActiveMQ + ServiceMix bundles in Minion | ⏳ rc2 cleanup |
+| TLS termination at Envoy | ⏳ pre-GA |
+| Auth (mTLS / JWT) | ⏳ pre-GA |
+| Default Minion location retirement | ⏳ pre-GA / v1.3 |
+| Echo RPC probe replacement | ⏳ pre-GA / v1.3 |
+
+---
+
+## rc2 scope (this design session frames it; the plan session breaks it down)
+
+**Channel migrations (the bulk of rc2 work):**
+
+1. **RPC** — bidi streaming, reconnect/resubscribe semantics, in-flight request tracking. Covers ALL RPC traffic: detectors, monitors, collectors, scriptd, etc. Latency-critical (some RPCs are blocking poll-cycles).
+2. **Twin API** — server-streaming with subscribe/resubscribe semantics. Used for `PassiveStatusTwinSubscriber`, `RequisitionTwinSubscriber`, etc.
+3. **Sink implementations:** Syslog, Telemetry × 4 (IPFIX / Netflow5 / Netflow9 / sFlow), Trap. `.proto` definitions already shipped in rc1 at `core/minion-grpc-contracts/`.
+
+**Cleanup work:**
+
+4. **Kafka transport removal from Minion** — `Kafka{Rpc,Sink,Twin}*Configuration` in `daemon-boot-minion-common`. After all channels migrate, the Kafka clients come out of the Minion entirely.
+5. **ActiveMQ + ServiceMix bundle purge** — per memory `project_minion_servicemix_activemq_cleanup` (17 ActiveMQ + 15 ServiceMix bundles still in Minion at last count).
+6. **Sink topic renames** — `OpenNMS.Sink.*` → `DeltaV.Sink.*` per memory `project_sink_topic_rename`.
+7. **`build.sh deltav` integration of `minion-gateway` and `envoy`** — Task 5 left these outside the canonical build pipeline (ad-hoc `docker build`); fold them in.
+8. **`Dockerfile EXPOSE 50051` → `9090`** — stale port metadata in `opennms-container/delta-v/minion-gateway/Dockerfile` (Spring gRPC actually binds 9090).
+9. **JUnit Platform alignment across the reactor** — the latent debt called out in the rc1 PR body: `junit.jupiter.engine 6.0.3` (from Boot 4 BOM) vs `junit.platform.commons 1.12.1` (stale per-module surefire pins). Likely a root-pom `<junit-platform.version>` override + removal of redundant per-module surefire blocks. Reproduces on develop without rc1 commits.
+
+**Test harness updates:**
+
+10. **`test-perspective-e2e.sh` + `test-enlinkd-e2e.sh` updates** for the gRPC RPC path (per design-doc Q7).
+
+**Pre-GA enablers (likely a separate v1.2.0 PR before GA, NOT part of rc2):**
+
+- TLS termination at Envoy + cert provisioning workflow.
+- Auth (mTLS or JWT, design-doc Q2).
+- Default Minion location retirement (`project_retire_default_minion`).
+- Echo RPC probe replacement (`project_minion_echo_probes`); current `?tag=broker` mitigation goes away when echo does.
+
+---
+
+## Open architectural questions for the design session
+
+These need decisions BEFORE the implementation plan can be authored. Brainstorm with the user.
+
+**Q1: RPC reconnect semantics — how do in-flight RPCs survive a stream reset?**
+- Option A: drop in-flight requests on reset, propagate failure to caller, let caller retry.
+- Option B: client-side request log + replay on reconnect (similar to Kafka producer's idempotent retries).
+- Option C: rely on caller idempotence + exponential backoff at the dispatcher level.
+- Memory invariant: `feedback_rpc_timeout_no_outages` — RPC failures must NOT create outages, regardless of mechanism chosen.
+
+**Q2: Twin resubscribe semantics — full snapshot vs delta?**
+- The Twin protocol is fundamentally state-broadcast (location-scoped state, e.g. requisitions, passive-status policies). A reconnecting client needs the current state.
+- Option A: server resends full state on every (re)connect.
+- Option B: client tracks last-seen revision; server sends delta + late-binding catch-up.
+- Option A is simpler; Option B is more efficient at scale. rc1's Heartbeat is too simple to inform this — needs to be thought about standalone.
+
+**Q3: Cutover staging — all-at-once or channel-by-channel within rc2?**
+- Phase 0 Decision 2 still binds: hard-cut at v1.2.0 GA boundary (no parallel transports for the same channel). But rc2 itself can stage:
+  - rc2.0: ship RPC migration. rc2.1: Twin. rc2.2: sinks. v1.2.0 GA: hard-cut Kafka removal.
+  - OR rc2 ships everything together; only one beta cycle of rollback testing before GA.
+- Either way, the channel-isolation pattern from rc1 (single `@Qualifier` cutover per channel) is reusable.
+
+**Q4: Kafka transport removal timing**
+- Option A: remove in rc2 final commit (cleanest, single transport at GA).
+- Option B: defer to a v1.2.0-rc3 or pre-GA commit after rc2 soaks (lets us preserve `MINION_TRANSPORT=kafka` rollback for one more cycle).
+- The rollback only works while the Kafka client code is still there. Removing it commits us to gRPC.
+
+**Q5: Sink topic renames — when?**
+- `OpenNMS.Sink.*` → `DeltaV.Sink.*` is mostly a documentation/branding change; topic content unchanged.
+- Coupled vs decoupled from gRPC migration:
+  - Coupled: minion-gateway publishes to `DeltaV.Sink.*` directly; old topics empty. Existing consumers (alarmd, etc.) need to switch reads.
+  - Decoupled: do the rename in a separate v1.2.0 cleanup PR after gRPC lands. Less risk of mixing concerns.
+
+**Q6: Sink topic rename method — alias vs hard switch?**
+- Kafka has no native topic aliases. Option A: ship two parallel publishes, drain one. Option B: hard cut at a specific commit, accept brief gap. Option C: defer to v1.3.
+
+**Q7: minion-gateway scaling model**
+- rc1 ships a single `minion-gateway` instance (no replicas). For RPC + Twin in rc2, all Minion connections flow through it.
+- Option A: keep single instance for rc2; horizontal scale is a v1.3 concern.
+- Option B: design rc2 with stateless minion-gateway from the start; Envoy round-robins; no per-stream affinity required. Twin's per-location state-broadcast may not be stateless-friendly — surface as a sub-question.
+
+**Q8: JUnit Platform alignment fix scope**
+- Option A: root-pom `<junit-platform.version>` property override. Removes the need for per-module surefire pins.
+- Option B: per-module fix (the tactical pattern surfaced in rc1 Task 10). More files, more visibility.
+- Option C: separate hygiene PR before rc2 starts. Cleaner scoping.
+- Either way: confirm before scope-creeping into the rc2 PR.
+
+**Q9: rc2 PR shape — single PR or sequence?**
+- rc1 was a single PR with 11 commits. rc2's scope is materially larger (3 channel migrations + cleanup + topic renames). Options:
+  - Single PR with channel-isolated commits (parallel to rc1's structure).
+  - Sequence of PRs: RPC → Twin → sinks → cleanup. Each shippable independently.
+  - Hybrid: design + .proto consolidation as one PR, then per-channel PRs.
+
+**Q10: Bench plan — RPC/Twin baseline measurement**
+- rc1 measured Heartbeat RTT (Kafka baseline → gRPC). RPC and Twin have different latency profiles (request-response for RPC; long-lived broadcast for Twin).
+- Need baseline-then-gate methodology for both. RPC: per-request latency (analogous to Heartbeat). Twin: subscribe-to-first-message latency + ongoing message lag.
+
+---
+
+## Recommended workflow for the design session
+
+1. **Brainstorm first** — invoke `superpowers:brainstorming` skill. Walk through Q1-Q10 with the user, surface tradeoffs, lock decisions.
+2. **Author Phase 0 decisions doc** at `docs/plans/<date>-v1.2.0-rc2-decisions.md`. Mirror structure of `docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md` (rc1's decisions doc).
+3. **Open PR for the decisions doc** against `pbrane/delta-v` `--base develop`. Review before writing the implementation plan.
+
+After the decisions PR merges, a separate session writes the implementation plan, and another session executes it — same multi-session cadence as rc1.
+
+---
+
+## Memory invariants (still apply)
+
+All carry forward from rc1:
+- `feedback_no_local_polling` — daemons never poll directly; all I/O via Minion.
+- `feedback_rpc_timeout_no_outages` — RPC failures must NOT create outages.
+- `project_minion_mandatory` — bidirectional zero-trust; Minion never accepts inbound; ServiceDaemons never accept inbound from Minions; only `minion-gateway` accepts inbound.
+- `feedback_e2e_continuous_validation_grpc_migration` — every gRPC migration commit must keep existing E2E tests passing (the regression detector).
+- `feedback_smoke_vm_release_only` — Mac dev for measurement, smoke VM for release validation.
+- `feedback_daemon_instrumentation_patterns` 5th idiom — `MeteredRpcModule` survives transport swap; reuse for the RPC channel migration.
+- `feedback_never_pr_opennms` — CRITICAL — `--repo pbrane/delta-v` always.
+- `feedback_pull_before_branching`, `feedback_clean_m2_between_branches`, `feedback_feature_branches`.
+- `feedback_bom_import_precedence` — spring-boot-dependencies before horizon BOM (relevant if deps shift).
+
+---
+
+## Branch + workflow for THIS session
+
+- **Pull develop first** (`feedback_pull_before_branching`). Develop is at `17223b20284` (rc1 PR merge). Tag `v1.2.0-rc1` at `b820bda5ffb`.
+- **Branch off freshly-pulled develop:** suggested name `docs/v1.2.0-rc2-design` for the design phase (decisions doc only).
+- Implementation phase will use a separate `feat/v1.2.0-rc2-...` branch in a future session.
+- Per rc1 pattern: commit decisions doc → PR → merge → next session writes the implementation plan.
+
+---
+
+## What NOT to do in this session
+
+- **Don't start writing code.** This session is design + decisions. Implementation comes later.
+- **Don't relitigate rc1 Phase 0 decisions** — translator daemon (not per-daemon gRPC), hard-cut at GA, no Minion-side buffer, Envoy ingress, h2c plaintext within compose. All locked.
+- **Don't pre-empt the implementation plan structure.** The plan-writing session works from the decisions doc; design now, plan later.
+- **Don't push to `OpenNMS/opennms`** — `--repo pbrane/delta-v` always (CRITICAL `feedback_never_pr_opennms`).
+- **Don't bake auth / TLS / cert provisioning into rc2 scope.** They're pre-GA work, separate from rc2's channel migrations. Decisions session should note them as pre-GA dependencies but not design them.
+- **Don't fold the JUnit alignment fix into rc2 by default.** It's a pre-existing develop debt; consider a separate hygiene PR (see Q8).
+
+---
+
+## rc2 acceptance criteria (working list — refine in the design session)
+
+- [ ] All four `.proto` services from `core/minion-grpc-contracts/` have implementations: Heartbeat (rc1) + Syslog + Telemetry × 4 + Trap.
+- [ ] RPC channel migrated to gRPC end-to-end; existing RPC consumers unchanged.
+- [ ] Twin API migrated to gRPC end-to-end; existing Twin subscribers unchanged.
+- [ ] `MINION_TRANSPORT=kafka` rollback path either preserved through rc2 (if Q4 = Option B) or explicitly removed with a documented commit (if Q4 = Option A).
+- [ ] Per-channel E2E tests green for each migrated channel.
+- [ ] Full existing E2E suite passes (regression detector).
+- [ ] minion-gateway integrated into `build.sh deltav` (item 7).
+- [ ] Reactor build clean (full + with tests) — JUnit alignment fix landed somewhere upstream of rc2 PR (Q8).
+- [ ] PR opened against `pbrane/delta-v --base develop`.
+
+After rc2 ships: cut `v1.2.0-rc2` tag, run smoke against the published GHCR images, then a pre-GA effort lands TLS + auth + Default-Minion retirement before `v1.2.0` GA.
+
+---
+
+## What lands after rc2
+
+Once rc2 ships, a pre-GA push covers:
+- TLS termination at Envoy + cert provisioning workflow.
+- Auth (mTLS or JWT — design-doc Q2).
+- Default Minion location retirement (`project_retire_default_minion`).
+- Echo RPC probe replacement (`project_minion_echo_probes`).
+- Any remaining `OpenNMS.Sink.*` → `DeltaV.Sink.*` if rc2 didn't ship the full rename.
+
+These will get their own planning session(s), driven by what rc2 actually delivers.
+
+---
+
+## References
+
+- **rc1 PR:** https://github.com/pbrane/delta-v/pull/231
+- **rc1 tag:** `v1.2.0-rc1` at `b820bda5ffb`
+- **Develop tip at rc1 merge:** `17223b20284`
+- **rc1 decisions doc:** `docs/plans/2026-04-25-v1.2.0-minion-grpc-migration-decisions.md`
+- **rc1 implementation plan:** `docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md`
+- **rc1 pre-work findings (baseline + sweep):** `docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md`
+- **Original design doc:** `docs/plans/2026-04-22-v1.2.0-minion-grpc-migration-design.md`
+- **rc1 implementation kickoff (parent of rc1 execution session):** `docs/superpowers/next-session-prompts/2026-04-26-v1.2.0-rc1-implementation-kickoff.md`
+- **Memory carryover:** `feedback_e2e_continuous_validation_grpc_migration`, `feedback_rpc_timeout_no_outages`, `feedback_daemon_instrumentation_patterns` (5th idiom).


### PR DESCRIPTION
## Summary

Adds the next-session prompt that kicks off **v1.2.0-rc2 Phase 0 (design + decisions)**. Mirrors the rc1 cadence: design session → decisions doc PR → plan-writing session → implementation plan PR → implementation execution.

rc1 (PR #231, tag `v1.2.0-rc1` at `b820bda5ffb`) shipped the Heartbeat sink on gRPC end-to-end. rc2 finishes the migration: RPC + Twin + remaining sinks (Syslog / Telemetry × 4 / Trap), Kafka transport removal from Minion, ActiveMQ + ServiceMix purge, sink topic renames, plus the deferred items from rc1 (`build.sh deltav` integration of minion-gateway/envoy, JUnit Platform alignment).

## What's in the prompt

- **rc2 scope:** channel migrations + cleanup work, with pre-GA items (TLS, auth, default-Minion retirement, echo replacement) explicitly carved out.
- **10 architectural questions** for the design session: RPC reconnect semantics, Twin resubscribe (snapshot vs delta), cutover staging, Kafka removal timing, sink topic rename method, minion-gateway scaling, JUnit alignment scope, rc2 PR shape, RPC/Twin baseline measurement.
- **Recommended workflow:** brainstorm with `superpowers:brainstorming` → author decisions doc → docs PR.
- **Memory invariants** still binding from rc1 (`feedback_no_local_polling`, `feedback_rpc_timeout_no_outages`, `project_minion_mandatory`, `feedback_e2e_continuous_validation_grpc_migration`, `feedback_never_pr_opennms`).
- **What NOT to do:** don't relitigate rc1 Phase 0 (translator daemon, hard-cut at GA, h2c plaintext, no Minion-side buffer, Envoy ingress); don't bake auth/TLS into rc2 scope.
- Working acceptance criteria for rc2 (refined in the design session).

## Test plan

- [x] No code change — docs-only.
- [x] Markdown renders cleanly on GitHub.

## Out of scope

This PR is the prompt only. The rc2 design / decisions / implementation work happens in subsequent sessions and PRs.