### PR TITLE
docs(v1.2.0-rc2): Phase 0 decisions for rc2 design kickoff

### DIFF
--- a/docs/plans/2026-04-26-v1.2.0-rc2-decisions.md
+++ b/docs/plans/2026-04-26-v1.2.0-rc2-decisions.md
@@ -1,0 +1,875 @@
+# v1.2.0-rc2 Minion gRPC Migration — Phase 0 Decisions
+
+> **Status:** Phase 0 design decisions captured 2026-04-26 during the v1.2.0-rc2
+> design kickoff session. Sibling addendum to
+> [`2026-04-22-v1.2.0-minion-grpc-migration-design.md`](./2026-04-22-v1.2.0-minion-grpc-migration-design.md)
+> and successor to
+> [`2026-04-25-v1.2.0-minion-grpc-migration-decisions.md`](./2026-04-25-v1.2.0-minion-grpc-migration-decisions.md)
+> (rc1's Phase 0 decisions). Implementation has not started; that work is the
+> subject of a separate session.
+
+This document captures the architectural decisions made during the rc2 kickoff
+session. The kickoff prompt
+([`docs/superpowers/next-session-prompts/2026-04-26-v1.2.0-rc2-design-kickoff.md`](../superpowers/next-session-prompts/2026-04-26-v1.2.0-rc2-design-kickoff.md))
+identified ten architectural questions blocking the rc2 implementation plan.
+All ten are now resolved.
+
+The recurring theme of this session: **preserve Horizon-grade reliability and
+scalability through the migration.** Several initial recommendations were
+revised after surfacing reliability properties the Kafka path was buying us
+that an unconsidered gRPC path would lose — most notably the multi-Minion
+competing-consumer pattern at a location, which is the standard operational
+mode for Horizon-derived deployments.
+
+---
+
+## Decisions at a glance
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | RPC reconnect semantics | **Option D — `minion-gateway` is a per-location competing-consumer dispatcher with redispatch-on-stream-close. Idempotency-as-contract for all RPC modules. No gateway-side queue when location's pool is empty.** |
+| 2 | Twin resubscribe semantics | **Option B — delta-v fresh `.proto`, snapshot+patch+version. Full snapshot on (re)connect; JSON Patch on subsequent updates; subscriber-side version-gap detection triggers reconnect → snapshot.** |
+| 3 | Cutover staging within rc2 | **Option C — single rc2 tag, sequential channel PRs landing on develop. Each PR gated by full Mac dev-env E2E green before merge.** |
+| 4 | Kafka transport removal timing | **Option B — defer to a pre-GA cleanup PR. Per-channel `MINION_<CHANNEL>_TRANSPORT` emergency flags through rc2 soak. Default `grpc` after each channel's PR lands.** |
+| 5 | Sink topic rename coupling | **Decoupled — rename in a separate pre-GA cleanup PR, not part of any channel migration. Scope is global (all `OpenNMS.*` internal topics → `DeltaV.*`).** |
+| 6 | Sink topic rename method | **Option B — hard cut. Single coordinated PR. Accept seconds-bounded transient gap during atomic image swap. CI grep guard prevents regression.** |
+| 7 | minion-gateway scaling model | **Option C — single-instance deployment in rc2; multi-instance-friendly protocol from day one. All gateway state must be reconstructible from Kafka + Minion reconnects. Multi-instance deployment is a v1.3 milestone with protocol gates pre-met.** |
+| 8 | JUnit Platform alignment fix scope | **A2 + B1 — separate hygiene PR before rc2 starts. Root-pom `<junit-platform.version>` property override + remove per-module pins.** |
+| 9 | rc2 PR shape | **Sequence of 4 PRs: RPC → Twin → Sinks → build cleanup. Each independently mergeable with full E2E green; rc2 tag cut after PR4.** |
+| 10 | RPC / Twin baseline measurement | **RPC: Echo-RPC probe, gate `gRPC p99 ≤ Kafka p99 + 20 ms`. Twin: subscribe-latency gate `+100 ms`, propagation-lag gate `+50 ms`. Per-channel baselines captured before each channel's PR opens. OTel tracing deferred — contributed after gRPC fully functional.** |
+
+---
+
+## Decision 1 — RPC reconnect: gateway as competing-consumer dispatcher
+
+**Resolution:** `minion-gateway` becomes a per-location competing-consumer
+dispatcher for RPC. It maintains a pool of currently-open Minion bidi streams
+per location, picks a stream per inbound RPC, tracks the in-flight RPC table,
+and redispatches on stream-close to a surviving sibling stream. This preserves
+the multi-Minion-per-location reliability property that the Kafka pattern was
+providing.
+
+### Why none of the prompt's original A/B/C options were sufficient
+
+The kickoff prompt offered three reconnect options scoped to a single Minion
+per location: drop-and-propagate (A), client-side replay log (B), or caller
+idempotence + dispatcher backoff (C). All three implicitly assumed one Minion
+per location.
+
+The user clarified during the session that multi-Minion-per-location is the
+standard operational mode. Kafka's competing-consumer group on
+`OpenNMS.<location>.rpc-request` was buying meaningful reliability:
+
+| Property Kafka was providing | What it meant operationally |
+|---|---|
+| N-way Minion redundancy at a location | Lose 1 of N Minions, the rest keep draining the queue. No human intervention. |
+| At-least-once delivery (commit-after-process) | Minion crashes mid-RPC → message returns to queue → sibling picks it up. |
+| Broker-side bounded buffer | Transient core-side glitches don't lose RPC requests; they queue. |
+| Backpressure via consumer lag | Observable, alertable, well-understood by operators. |
+
+Options A/B/C as originally framed all regress N-way redundancy at a location.
+Stream reset under Option A propagates failure to the caller; Option B's
+client-side replay is on the wrong end of the wire (Minion side, not gateway
+side, where the pool lives); Option C is just A with a sub-discipline.
+Preserving Horizon-grade reliability requires a **fourth option** — what we
+labeled Option D — where the gateway IS the competing-consumer dispatcher.
+
+### The Option D mechanic
+
+```
+                         per-location pool[L] = { streamA, streamB, streamC }
+                         in-flight[rpcId]  = (streamRef, deadline)
+                                              │
+ServiceDaemon ──Kafka──► minion-gateway ◄──┴──► gRPC bidi ◄──► Minion-A,B,C in L
+                                              │
+       If streamB closes mid-flight:        │
+       gateway scans in-flight for          │
+       entries where streamRef == streamB,  │
+       redispatches each to a surviving     │
+       sibling in pool[L].                  │
+```
+
+Concretely:
+
+- Each Minion in location L opens its own bidi RPC stream to the gateway when
+  it boots. Gateway maintains `pool[L] = {minionA-stream, minionB-stream, …}`.
+- An RPC arrives from a ServiceDaemon (via internal Kafka
+  `OpenNMS.<location>.rpc-request`). Gateway picks a stream from `pool[L]`
+  (round-robin or least-loaded — implementation-plan detail) and forwards.
+  Records `inflight[rpcId] = (streamRef, deadline)`.
+- Minion processes and responds on its stream. Gateway routes the response
+  back to `OpenNMS.rpc-response`. Removes `inflight[rpcId]`.
+- **Stream close mid-flight:** gateway sees the close, scans `inflight` for
+  entries where `streamRef == closed`, **redispatches** them to a surviving
+  sibling in `pool[L]`. This is the gRPC-equivalent of Kafka's "uncommitted
+  message returns to queue."
+
+### Sub-decision 1-i — No gateway-side queue when pool is empty
+
+When `pool[L]` is empty (all Minions in L are down), the request times out at
+the dispatcher's normal deadline — same behavior as if L had no Minions at all
+in the Kafka world. `feedback_rpc_timeout_no_outages` covers this case (RPC
+failures must not synthesize outage events; existing dispatcher timeout-tolerance
+absorbs).
+
+A bounded gateway-side queue (recover from sub-N-second total-outage events)
+was considered and deferred to v1.3. The current Kafka pattern's recovery
+window for "all Minions in L down" is bounded in practice by the dispatcher's
+RPC deadline (typically <60s) rather than by Kafka topic retention; D-i
+preserves that behavior without introducing new gateway-side stateful
+queueing complexity in rc2.
+
+### Sub-decision 1-ii — Idempotency as a design contract
+
+Server-side redispatch can cause at-least-once *execution* if a Minion
+processed a request but its stream closed before the response was sent.
+The next Minion in the pool gets a duplicate. Inspection of the existing
+RPC module set confirms all current modules are read-only and naturally
+idempotent:
+
+| Module | Idempotent? |
+|---|---|
+| `PollerClientRpcModule` (service polls) | Yes — read-only |
+| `PingProxyRpcModule` / `PingSweepRpcModule` (ICMP) | Yes |
+| `SnmpProxyRpcModule` (get/walk) | Yes — read-only |
+| Detector RPCs | Yes — read-only by definition |
+| Collector RPCs | Yes — read-only |
+| SNMP `set` (theoretical) | Not idempotent — not in delta-v's monitoring path |
+
+The implementation plan must include an explicit acceptance criterion:
+"all RPC modules are idempotent." Future RPC additions are bound by the
+same contract.
+
+### Sub-decision 1-iii — In-flight table eviction on stream-close
+
+The gateway's in-flight RPC table evicts entries on stream-close (regardless
+of whether redispatch succeeded), not just on response-delivery. Otherwise
+flapping streams leak entries.
+
+### Coupling to Decision 7 (gateway scaling)
+
+Option D makes the gateway the new RPC reliability bottleneck. Gateway
+availability matters more under D than it would have under A/B/C. Decision 7
+addresses this by acknowledging gateway as the rc2 SPOF and committing to
+multi-instance-friendly protocol design from day one (deployment is single-
+instance in rc2; multi-instance is a v1.3 milestone).
+
+---
+
+## Decision 2 — Twin: snapshot + patch + version, delta-v fresh proto
+
+**Resolution:** Twin uses a delta-v-fresh `.proto` shipped in
+`core/minion-grpc-contracts/twin.proto`. The wire format includes
+`is_patch_object` boolean + monotonic `version` integer + `session_id` string,
+mirroring the design horizon's `AbstractTwinPublisher` validated. Initial
+subscribe and stream reconnect → full snapshot. Subsequent updates while the
+stream is alive → JSON Patch (RFC 6902) computed from the previous state to
+the current state. Subscriber-side version-gap detection (received version
+≠ lastVersion + 1) triggers stream disconnect-and-reconnect, which yields a
+fresh snapshot.
+
+### Why the original Option A (snapshot only) was insufficient
+
+The kickoff prompt offered "Option A: server resends full state on every
+(re)connect" vs "Option B: client tracks last-seen revision; server sends
+delta + late-binding catch-up." Option A is operationally fine in lab but
+amplifies traffic at scale: a 10K-node requisition with N Minions per
+location × M locations on every Minion (re)connect produces network bursts
+that scale with deployment size.
+
+Mid-session investigation revealed that horizon already shipped a
+production-grade Twin gRPC implementation at
+`core/ipc/twin/grpc/{publisher,subscriber,common}/`. Horizon's
+`AbstractTwinPublisher` uses a hybrid: full snapshot on initial subscribe
+via `getTwin()`, JSON Patch (RFC 6902) on subsequent updates via
+`getTwinUpdateFromUpdatedObj()`. This proved both that the snapshot+patch
+hybrid is implementable and that the wire format design is battle-tested.
+
+### Three considered options
+
+- **Option A** — delta-v fresh `.proto`, snapshot only.
+- **Option B** — delta-v fresh `.proto`, snapshot+patch+version (chosen).
+- **Option C** — reuse horizon's Twin gRPC stack directly. Lowest new code
+  but ties delta-v's wire format to horizon's evolution. Asymmetric with
+  rc1 Heartbeat (delta-v fresh) and Decision 1 RPC (delta-v fresh).
+
+Option B was chosen for three reasons:
+
+1. **Reliability bar.** A 200-byte JSON Patch is materially less network
+   traffic than a 10KB rebroadcast × N Minions on every state change.
+   Option A is fine in lab; patches are what makes it scale.
+2. **Architectural symmetry with rc1 and Decision 1.** Heartbeat
+   shipped delta-v-fresh; RPC under Decision 1 ships delta-v-fresh; Twin
+   should too. Option C would make Twin the only asymmetric channel.
+3. **Loose coupling.** Option B inherits horizon's *design* without
+   inheriting horizon's *coupling*. We own the wire format.
+
+### Sub-decision 2-i — Reconnect is full snapshot, always
+
+Same semantics horizon uses. Subscriber doesn't track last-seen-version
+across reconnects (no client-side persistence required); gateway treats
+every new stream as "fresh subscriber, send current state."
+
+### Sub-decision 2-ii — Subscriber-side gap detection triggers reconnect
+
+When the stream is alive, patches arrive with monotonically increasing
+version numbers (`v1, v2, v3, …`). If the subscriber receives a
+non-contiguous version (e.g., received `v=10` when expecting `v=8`), it
+treats the gap as an integrity violation and drops the stream. The
+reconnect then yields a full snapshot per 2-i. No server-side replay
+history is maintained — the gateway only holds current state, not a
+history of previous states.
+
+### Sub-decision 2-iii — Gateway is stateful for Twin via Kafka read-through cache
+
+Gateway holds `{(key, location) → currentState, version}` and per-stream
+`lastSentVersion` for active subscribers. On gateway startup, this state
+is reconstructed by consuming the internal Twin Kafka topic
+(currently `OpenNMS.twin.response.<location>`, post-rename
+`DeltaV.twin.response.<location>`) from the topic tail. This is a
+read-through cache — Kafka is the source of truth, gateway is a derived
+view. Multi-instance deployment under Decision 7 works because each
+gateway instance independently reconstructs the same state from the same
+Kafka topic. No inter-gateway coordination required.
+
+### Wire format reuse note
+
+Although we ship a delta-v-fresh `.proto` (under `org.deltav.minion.twin`
+package), the *design* of the message (full state vs JSON patch
+distinguished by an `is_patch` field; monotonic version; session id) is
+copied directly from horizon's validated implementation. The
+implementation plan should reference horizon's `AbstractTwinPublisher`
+and `AbstractTwinSubscriber` as the algorithmic reference.
+
+---
+
+## Decision 3 — Cutover staging: single rc2 tag, sequential channel PRs
+
+**Resolution:** rc2 ships as a single `v1.2.0-rc2` tag. Channel migrations
+land as sequential PRs into develop, in order: RPC → Twin → Sinks → build
+cleanup. Each PR is independently mergeable with full Mac dev-env E2E
+suite green as the merge gate. After all rc2 PRs merge, the rc2 tag is
+cut, smoke runs once on the smoke VM.
+
+### Why not the prompt's stepwise-tag option
+
+The prompt offered "rc2.0=RPC, rc2.1=Twin, rc2.2=sinks tagged separately"
+vs "everything bundled in a single rc2 tag." The stepwise-tag approach
+gives maximum isolation but at 3× smoke cycles per channel. For a
+small-team release model, the smoke-cycle cost is significant. The
+isolation value is mostly preserved by per-PR E2E gates; per-channel
+*tagging* adds release-machinery overhead without commensurate regression-
+detection value.
+
+### Sub-decision 3-i — Per-PR E2E gate is "full suite green"
+
+Per `feedback_e2e_continuous_validation_grpc_migration`, every commit on
+develop must keep the existing E2E tests passing. Each rc2 PR's merge
+gate is the **full E2E suite** on Mac dev env, not just the channel
+under test. Twin's PR must demonstrate Pollerd RPC E2E still passes;
+Sinks' PR must demonstrate Twin and RPC still pass. This is the
+per-PR regression detector.
+
+### Sub-decision 3-ii — Develop is the integration point
+
+PRs land sequentially on develop. Develop is always in a known-good
+intermediate state between PRs. The intermediate states are deployable
+because the channels are independent (RPC migrated + Twin/sinks still
+on Kafka = a fully functional system).
+
+---
+
+## Decision 4 — Kafka transport removal deferred to pre-GA
+
+**Resolution:** rc2 ships with Kafka transport code still present in
+`daemon-boot-minion-common`, gated by per-channel emergency flags
+(`MINION_RPC_TRANSPORT`, `MINION_TWIN_TRANSPORT`,
+`MINION_SINK_<TYPE>_TRANSPORT`). Each channel migration PR adds gRPC
+support, flips the channel's default to `grpc`, but leaves the Kafka
+path reachable via the emergency flag. A focused pre-GA cleanup PR
+removes all Kafka transport code from Minion + the per-channel flags.
+
+### Why deferral is consistent with locked Decision 2 (rc1)
+
+Locked Decision 2 from rc1 says "hard-cut at v1.2.0 GA boundary."
+Removing Kafka transport in rc2 final commit (the prompt's Option A)
+would tighten that beyond what was locked. Option B (defer to pre-GA)
+matches what was locked exactly.
+
+### Why per-channel rather than whole-Minion flags
+
+The channel-isolation pattern from rc1 (`MINION_TRANSPORT` flag) extends
+naturally to per-channel granularity. With per-channel flags, an
+operator can roll back exactly the channel that's misbehaving in smoke
+while keeping the others on gRPC. Whole-Minion rollback is too coarse
+for the channel-isolation contract this migration is built on.
+
+### Sub-decision 4-i — Per-channel granularity
+
+Each channel migration PR introduces its own
+`MINION_<CHANNEL>_TRANSPORT=kafka|grpc` flag. Mixed configurations
+(e.g., RPC on gRPC, Twin on Kafka) are operationally permitted but not
+tested in CI — consistent with rc1's "tests target gRPC only, CI does
+not double-run" discipline.
+
+### Sub-decision 4-ii — gRPC default after each channel's PR lands
+
+Each channel's PR also flips its default from Kafka (rc2 entry state) to
+gRPC. The Kafka path becomes dormant code reachable only via emergency
+flag.
+
+### Sub-decision 4-iii — Pre-GA cleanup PR scope
+
+The pre-GA cleanup PR removes:
+- All `Kafka{Rpc,Sink,Twin}*Configuration` classes from
+  `daemon-boot-minion-common`.
+- Per-channel `MINION_<CHANNEL>_TRANSPORT` flags + their wiring.
+- 17 ActiveMQ + 15 ServiceMix bundles from Minion (per memory
+  `project_minion_servicemix_activemq_cleanup`).
+- Kafka client jar from Minion image build.
+
+One coordinated PR, its own E2E pass, its own commit message. Sibling
+to the topic-rename PR (Decision 5), not bundled with it.
+
+---
+
+## Decision 5 — Sink topic rename: decoupled from gRPC migration
+
+**Resolution:** The `OpenNMS.*` → `DeltaV.*` internal-topic rename happens
+in a separate pre-GA cleanup PR, not as part of any channel migration
+PR. Scope is global — all internal topics (sink, RPC, Twin, events)
+rename at once.
+
+### Why not coupled
+
+Topic renames have a hard property: producer and consumer must change in
+lockstep. Bundling the rename with a channel migration PR adds a second
+independent failure mode to that PR. A regression could be in either
+the transport swap or the rename, and bisecting is harder when both
+happened at once.
+
+The rename is also purely cosmetic (per memory `project_sink_topic_rename`)
+— same bytes on the wire, different topic name. It doesn't unlock any
+architectural property. Decoupling preserves rc2 PR focus.
+
+### Sub-decision 5-i — Rename PR is its own pre-GA cleanup PR
+
+Sibling to the Kafka-transport-removal PR (Decision 4-iii), not bundled
+into it. Each pre-GA cleanup PR has a single concern. The pre-GA epic
+ends up being 2-3 small focused PRs rather than one mega-PR.
+
+### Sub-decision 5-ii — Rename scope is global
+
+All internal `OpenNMS.*` topic references rename at once: sinks
+(`OpenNMS.Sink.*` → `DeltaV.Sink.*`), RPC topics
+(`OpenNMS.<location>.rpc-request` → `DeltaV.<location>.rpc-request`,
+`OpenNMS.rpc-response` → `DeltaV.rpc-response`), Twin topics
+(`OpenNMS.twin.*` → `DeltaV.twin.*`), and any other `OpenNMS.*` internal
+topics in delta-v's surface. Single review, consistent end-state.
+
+### Sub-decision 5-iii — Heartbeat retroactive rename in scope
+
+rc1 shipped `OpenNMS.Sink.Heartbeat`. The rename PR catches it up to
+`DeltaV.Sink.Heartbeat`. No special-casing.
+
+---
+
+## Decision 6 — Topic rename method: hard cut
+
+**Resolution:** Single coordinated PR atomically renames topics across
+producers, consumers, tests, E2E scripts, and docs. Accept the seconds-
+bounded transient gap during atomic image swap. Add a CI lint guard
+preventing regression.
+
+### Why not parallel-publish-and-drain
+
+Parallel-publish-and-drain (Option A in the prompt) is a graceful
+migration pattern for installations that have *long-lived state spanning
+the upgrade*. delta-v's deployment model (`curl docker-compose.yml;
+docker compose up -d` per `project_v1_2_self_contained_images`) is
+atomic image swap — all daemons restart together on tag bump. There's
+no rolling-upgrade story through Kafka topic boundaries. Option A's
+coordination complexity (3+ coordinated PRs, 2× Kafka load during the
+window) exists to solve a problem we don't have.
+
+### Why the transient gap is tolerable
+
+The locked Decision 3 from rc1 already accepted "transient gaps are fine
+for the lossy channels." That reasoning extends:
+
+- **Sinks:** lossy by design (sFlow sampling, syslog UDP, traps UDP).
+- **RPC:** Decision 1's caller-retry safety net + `feedback_rpc_timeout_no_outages`.
+- **Twin:** Decision 2's snapshot-on-reconnect recovers state.
+
+### Sub-decision 6-i — Single coordinated PR
+
+All callsites — producers, consumers, integration tests, E2E shell
+scripts, deploy.sh, docs — change in one PR. PR touches everything that
+references the old names atomically.
+
+### Sub-decision 6-ii — Topic auto-creation handled in same PR
+
+If any container (kafka-init, db-init) explicitly creates topics, those
+names update in the same PR. Brokers will lazily create new-named
+topics anyway, but explicit creation prevents first-boot races.
+
+### Sub-decision 6-iii — CI grep guard
+
+A lint check (shell script in CI) fails the build if any source file
+contains a literal `"OpenNMS.Sink."`, `"OpenNMS.twin."`, or
+`"OpenNMS.<location>"` topic-name pattern. Becomes part of the standard
+CI gate after the rename PR merges; prevents accidental regression on
+future PRs.
+
+### Sub-decision 6-iv — Cutover window documented, not engineered around
+
+The cutover window is bounded by container restart time (~seconds) under
+delta-v's atomic image swap deployment model. Documented in the rename
+PR body and v1.2.0 release notes; no buffering, aliasing, or special
+handling.
+
+### Sub-decision 6-v — Old topics get deleted, not retained
+
+Once the rename PR ships, old-named topics are dead state. The PR can
+either let Kafka's retention age them out, or invoke `kafka-topics --delete`
+as a cleanup step (implementation-plan tactical detail).
+
+---
+
+## Decision 7 — Gateway scaling: single-instance deployment, multi-instance protocol
+
+**Resolution:** rc2 ships a single `minion-gateway` pod. SPOF is
+acknowledged and documented. All gateway state must be reconstructible
+from external sources (Kafka topics, Minion reconnects); no inter-gateway
+coordination is part of the rc2 protocol contract. Horizontal scaling
+is a v1.3 milestone — operational work (Envoy routing, consumer-group
+partitioning), not architectural redesign.
+
+### Why this is more than "single-instance for simplicity"
+
+Decisions 1 and 2 already made the gateway stateful. The Q7 question
+collapses to "is this state coordination-required (multi-instance hard)
+or recovery-from-Kafka (multi-instance easy)?" Decisions 1 and 2 chose
+the latter:
+
+- RPC stream pools rebuild from Minion reconnects.
+- RPC in-flight table loss falls back to caller-retry per
+  `feedback_rpc_timeout_no_outages`.
+- Twin state cache rebuilds from internal Twin Kafka topic on startup.
+- Per-stream Twin version tracker loss triggers fresh snapshot per 2-ii.
+
+So the protocol is multi-instance-friendly. Q7 just makes that explicit
+and constrains future work to maintain the property.
+
+### Sub-decision 7-i — rc2 ships single-instance
+
+One pod. Standard K8s readiness/liveness probes. Documented SPOF.
+
+### Sub-decision 7-ii — Every state element must have a documented recovery source
+
+Load-bearing constraint. The implementation plan must include a checklist
+item: "for every piece of state held in `minion-gateway`, document the
+recovery source." If a state element doesn't have a recovery source,
+it's a design bug to fix before shipping. APIs and service implementations
+that contribute new gateway state are bound by the same discipline.
+
+### Sub-decision 7-iii — No inter-gateway coordination in the rc2 protocol
+
+No leader election, no gossip, no shared cache. Each gateway instance is
+independently functional given Kafka access + Minion connectivity.
+
+### Sub-decision 7-iv — SPOF behaviors documented in rc2 PR body and release notes
+
+Specifically:
+- **RPC during gateway downtime:** in-flight RPCs fail; caller's existing
+  timeout path absorbs (no outages per `feedback_rpc_timeout_no_outages`);
+  new RPCs queue in `OpenNMS.<location>.rpc-request` until gateway recovers.
+- **Sinks during gateway downtime:** messages from Minions are lost
+  (consistent with locked Decision 3 — sink protocols are lossy by design).
+- **Twin during gateway downtime:** Minions disconnect; on gateway
+  recovery, Minions reconnect and receive full snapshots per 2-i.
+
+### Sub-decision 7-v — v1.3 multi-instance is operational, not architectural
+
+The v1.3 scope is operational: stand up replicas, configure Envoy routing,
+partition Kafka consumer groups by location, multi-instance E2E tests.
+Not architectural: protocol contract is already multi-instance-friendly
+in rc2. This is a meaningful guarantee — the v1.3 work won't surface
+"oh, the protocol assumed single-instance" surprises mid-implementation.
+
+### Active-passive HA noted as out-of-scope
+
+With persistent gRPC connections, an active-passive failover forces all
+Minions to reconnect anyway — at which point you're functionally
+indistinguishable from "single instance restarted with proper readiness
+probes." Standard K8s rolling-restart with readiness probes is the
+v1.2.0 answer.
+
+---
+
+## Decision 8 — JUnit Platform alignment: separate hygiene PR, root-pom fix
+
+**Resolution:** A separate hygiene PR (not part of rc2) lands before
+rc2's first PR opens. The fix is a single root-pom
+`<junit-platform.version>` property override + removal of redundant
+per-module surefire pins.
+
+### Why separate from rc2
+
+This is pre-existing develop debt (reproduces on develop without rc1
+commits). Folding it into rc2 conflates "channel-migration regressions"
+with "JUnit alignment regressions" — two independent failure modes in
+the same PR. Per `feedback_boot4_junit_platform_launcher`, the
+misalignment between `junit.jupiter.engine 6.0.3` (from Boot 4 BOM)
+and stale `junit-platform-* 1.12.1` per-module pins causes test
+failures or silent skips.
+
+### Why root-pom rather than per-module
+
+Single source of truth. Future module additions inherit automatically.
+Per-module pins create a maintenance footgun — every new module is a
+chance to forget the override and silently regress. Boot 4 BOM bumps
+align via one root-pom property change rather than N module edits.
+
+### Sub-decision 8-i — Hygiene PR is its own session
+
+Not part of this design session, not part of the rc2 implementation
+plan. Separately scoped, separately reviewed. Can run in parallel to
+the rc2 implementation plan authoring.
+
+### Sub-decision 8-ii — rc2 inherits a clean reactor
+
+Acceptance criterion for the rc2 implementation plan: "before the first
+rc2 PR opens, full reactor + tests must pass on develop."
+
+### Sub-decision 8-iii — Audit current per-module pins as part of the hygiene PR
+
+Find every `<junit-platform-*.version>` reference (whether direct dep
+version pins or surefire/failsafe configuration), confirm the root-pom
+property catches them all. A `grep` + `mvn dependency:tree | grep
+junit-platform` audit.
+
+### Sub-decision 8-iv — Verify with full reactor test run
+
+The hygiene PR's gate is "full reactor build + tests passes on Mac dev
+env." This isn't a smoke milestone; it's a develop-branch gate.
+
+---
+
+## Decision 9 — rc2 PR shape: 4-PR sequence
+
+**Resolution:** rc2 lands as 4 sequential PRs into develop. Each PR is
+independently mergeable with full Mac dev-env E2E suite green. After
+PR4 merges, `v1.2.0-rc2` tag is cut and smoke runs on the smoke VM.
+
+### The 4 PRs
+
+**PR1 — RPC channel migration.**
+- New `core/minion-grpc-contracts/rpc.proto` with bidi service.
+- `minion-gateway` gets the Decision 1 Option D dispatcher.
+- Minion gets gRPC RPC client; daemon-side `RpcClientFactory` wires
+  through new gRPC transport when `MINION_RPC_TRANSPORT=grpc` (default
+  after this PR).
+- `MINION_RPC_TRANSPORT=kafka` per-channel emergency flag wired
+  (Decision 4-i).
+- Updates `test-perspective-e2e.sh` and `test-enlinkd-e2e.sh` for the
+  gRPC RPC path.
+- Acceptance gate: full Mac dev-env E2E suite green.
+- Estimated 10-15 commits.
+
+**PR2 — Twin channel migration.**
+- New `core/minion-grpc-contracts/twin.proto` with server-streaming +
+  initial-snapshot semantics.
+- `minion-gateway` gets Decision 2 Option B implementation
+  (snapshot+patch+version, `TwinTracker` per `(key, location)`, JSON
+  Patch generation referencing horizon's `AbstractTwinPublisher`
+  algorithm).
+- Minion gets gRPC Twin subscriber with version-gap detection (2-ii).
+- `MINION_TWIN_TRANSPORT=kafka` per-channel emergency flag wired.
+- Acceptance gate: full Mac dev-env E2E suite green; specifically
+  `test-passive-e2e.sh` validates Twin flow.
+- Estimated 8-12 commits.
+
+**PR3 — Sink migrations (bundled).**
+- Syslog, Trap, Telemetry-IPFIX, Telemetry-Netflow5, Telemetry-Netflow9,
+  Telemetry-sFlow.
+- All 6 use the same architectural pattern as rc1 Heartbeat (`.proto`
+  definitions already shipped in rc1 at `core/minion-grpc-contracts/`,
+  just need server + client implementations).
+- Per-sink commits within the PR for bisect granularity.
+- Per-sink emergency flags: `MINION_SINK_<TYPE>_TRANSPORT=kafka|grpc`.
+- Acceptance gate: full Mac dev-env E2E suite green; specifically
+  `test-syslog-e2e.sh`, `test-flows-e2e.sh`, `test-minion-e2e.sh`
+  validate sink flows.
+- Estimated 8-12 commits.
+
+**PR4 — Build integration cleanup.**
+- `build.sh deltav` integrates `minion-gateway` and `envoy` builds into
+  the canonical pipeline (item 7 from the kickoff prompt).
+- `opennms-container/delta-v/minion-gateway/Dockerfile`: `EXPOSE 50051`
+  → `EXPOSE 9090` (item 8 from the kickoff prompt).
+- Acceptance gate: full reactor build clean + full E2E suite green.
+- Estimated 2-4 commits.
+
+### Why not single PR with N commits
+
+rc1 shipped as single-PR-with-11-commits. rc2's scope is materially
+larger (estimated 30-40 commits across 4 channels' work). A 30-40
+commit single PR is hard to review. Sequential PRs at 8-15 commits each
+are much more reviewable and align with Decision 3's per-channel E2E
+gate.
+
+### Why bundle sinks rather than 6 per-sink PRs
+
+The 6 sinks share an architectural pattern (rc1 Heartbeat's wire shape).
+Six PRs that are 90% identical mechanical pattern is wasteful. Bisect
+granularity is preserved by per-sink commits within PR3.
+
+### Why test-harness updates fold into PR1
+
+`test-perspective-e2e.sh` and `test-enlinkd-e2e.sh` exercise the Kafka
+RPC path today. They must be updated when RPC migrates to gRPC. The
+update belongs in PR1 (RPC migration), not as a separate PR.
+
+### Sub-decision 9-i — PRs land sequentially
+
+PR2 doesn't open until PR1 has merged. PR3 doesn't open until PR2 has
+merged. Sequential, not parallel. Avoids merge conflicts in
+`minion-gateway` (each PR adds new code in the same daemon module) and
+preserves the "develop is always E2E green" property.
+
+### Sub-decision 9-ii — Each PR's branch is fresh from develop
+
+Per `feedback_pull_before_branching`. No branching from a previous
+channel's branch.
+
+### Sub-decision 9-iii — Each PR runs full E2E on Mac dev env
+
+Per `feedback_e2e_continuous_validation_grpc_migration`. Twin's PR must
+pass `test-perspective-e2e.sh` (RPC channel still on whatever transport
+it's on at that moment) and Sinks' PR must pass everything.
+
+### Sub-decision 9-iv — rc2 tag cut after PR4 merges
+
+PR4's build integration is part of the rc2 acceptance criteria from the
+kickoff prompt; tagging before it would ship rc2 with a known
+incomplete build pipeline.
+
+### Sub-decision 9-v — PR titles encode position
+
+Recommended format: `feat(v1.2.0-rc2/N): <channel> migration to gRPC`.
+Lets reviewers see "this is the 2nd of 4 rc2 PRs" at a glance.
+
+---
+
+## Decision 10 — Baseline measurement: per-channel pre-PR baselines
+
+**Resolution:** Each channel migration PR is gated by a baseline
+measurement captured on develop tip *before that PR opens*. Methodology
+mirrors rc1's `2026-04-26-v1.2.0-rc1-pre-work-findings.md`.
+
+### RPC measurement plan
+
+- **Probe:** Echo RPC (already implemented per `project_minion_echo_probes`).
+  Trivial server-side work means measured RTT ≈ transport latency.
+- **Measurement:** caller-side `t_request_start` and `t_response_received`,
+  RTT = difference.
+- **Sample size:** 10-minute window, target ≥ 100 samples (driven
+  explicitly via test harness loop).
+- **Statistics captured:** p25 / p50 / p75 / p99 / min / max / mean /
+  sample count.
+- **Gate:** `gRPC RPC p99 ≤ Kafka RPC p99 + 20 ms`. Wider than rc1
+  Heartbeat's 10 ms because RPC adds gateway-side dispatcher logic
+  (Decision 1 Option D — pool selection, in-flight table updates) and
+  the bidi stream has both an outbound + inbound traversal where
+  Heartbeat is one-way.
+
+### Twin measurement plan
+
+Two distinct measurement surfaces:
+
+**Measurement A — subscribe-to-first-snapshot latency.**
+- Trigger: Minion subscribes to a Twin key (on Minion startup or stream
+  reconnect).
+- `t_subscribe_start` = subscribe call issued from Minion.
+- `t_first_snapshot` = first snapshot bytes received and applied on Minion.
+- Sample size: ≥ 30 (driven by docker compose restart loop).
+- Gate: `gRPC subscribe p99 ≤ Kafka subscribe p99 + 100 ms`. Wider
+  because subscribe is one-shot, not in critical path.
+
+**Measurement B — steady-state propagation lag.**
+- Trigger: daemon publishes a Twin update via
+  `TwinPublisher.Session.publish()`.
+- `t_publish` = timestamp at the publisher's `setTimestamp()`-equivalent
+  embedded in the Twin payload.
+- `t_minion_apply` = timestamp at Minion's `TwinSubscriber.accept()`
+  invocation.
+- Sample size: ≥ 50 (driven by toggling a passive-status policy
+  attribute in a loop).
+- Gate: `gRPC propagation p99 ≤ Kafka propagation p99 + 50 ms`.
+  Tighter than subscribe because propagation IS in critical path —
+  config-driven behavior changes propagate via this path.
+
+### Test harness deliverables
+
+Per Decision 9's PR scoping:
+- **PR1 ships `test-grpc-rpc-e2e.sh`.** Mirrors `test-grpc-heartbeat-e2e.sh`.
+  Loops Echo RPCs, captures RTT distribution, asserts gate.
+- **PR2 ships `test-grpc-twin-e2e.sh`.** Captures both subscribe-latency
+  and propagation-lag distributions, asserts both gates.
+
+These tests run both in Mac dev env (full E2E gate) and on the smoke VM
+(post-tag validation).
+
+### Sub-decision 10-i — Pre-work findings doc mirrors rc1
+
+Same sections (baseline measurements, methodology caveats, sample sizes,
+gate calculations, conclusion). Same file naming convention:
+`docs/plans/<date>-v1.2.0-rc2-pre-work-findings.md`.
+
+### Sub-decision 10-ii — Baselines captured on Mac dev env
+
+Per `feedback_smoke_vm_release_only`. Smoke VM is for release validation;
+baselines are dev-env work.
+
+### Sub-decision 10-iii — Strict ordering: baseline → PR opens → gate measured
+
+Each channel's baseline is captured before that channel's PR opens.
+Avoids the failure mode where a regression in PR1 contaminates PR2's
+baseline.
+
+### Sub-decision 10-iv — Gate widenings documented inline
+
+rc1's pre-work findings explicitly justified the 10 ms widening with
+reasoning. rc2's findings document the 20 / 50 / 100 ms widenings
+identically.
+
+### Sub-decision 10-v — Gate failure does not auto-block
+
+If gRPC p99 lands above the gate but reasoning shows the overhead is
+purely necessary translator+dispatcher work, the gate may be widened
+with a documented justification (mirrors rc1's exact language). Prevents
+the gate from being a brittle blocker on cosmetic measurement noise.
+
+### OTel tracing deferred — contributed after gRPC fully functional
+
+The user noted during the session that OpenTelemetry tracing will be
+contributed to the delta-v project after gRPC is fully functional.
+Decision 10's baseline+gate methodology is the rc2 stand-in for what
+will become richer per-call distributed tracing in a later release.
+
+---
+
+## rc2 implementation implications
+
+These decisions tighten the rc2 acceptance criteria from the kickoff prompt:
+
+1. **`minion-gateway` is a real dispatcher, not a transparent stream pipe.**
+   Per-location stream pools, in-flight RPC tables, redispatch logic
+   (Decision 1). Per-(key, location) Twin state caches, version trackers
+   (Decision 2). All gateway state must have a documented recovery
+   source from Kafka or Minion reconnects (Decision 7).
+
+2. **Two delta-v fresh `.proto`s in rc2 (RPC, Twin) — sinks reuse rc1's.**
+   `core/minion-grpc-contracts/rpc.proto` and
+   `core/minion-grpc-contracts/twin.proto` are new in rc2. Sink
+   `.proto`s shipped in rc1 and just need server+client implementations.
+
+3. **Per-channel emergency flags wired in each migration PR.**
+   `MINION_RPC_TRANSPORT`, `MINION_TWIN_TRANSPORT`,
+   `MINION_SINK_<TYPE>_TRANSPORT`. Tests target gRPC. CI does not
+   double-run.
+
+4. **Idempotency-as-contract for RPC modules.** Acceptance criterion in
+   the implementation plan. All current modules pass; future modules
+   are bound by the same contract.
+
+5. **CI grep guard added in pre-GA topic-rename PR.** Becomes part of
+   the standard CI gate on develop after that PR merges.
+
+6. **The hygiene PR (Decision 8) is a prerequisite, not part of rc2.**
+   rc2's first PR (PR1) does not open until the hygiene PR has merged
+   to develop and the full reactor + tests pass on develop.
+
+7. **rc2 ships single-instance `minion-gateway` with documented SPOF.**
+   Multi-instance deployment is a v1.3 milestone; protocol contract is
+   already multi-instance-friendly.
+
+---
+
+## Pre-GA scope after rc2 ships
+
+Once the `v1.2.0-rc2` tag is cut and smoked, a pre-GA push covers:
+
+- **Pre-GA cleanup PR A:** Kafka transport removal from Minion +
+  per-channel emergency flag removal + 17 ActiveMQ + 15 ServiceMix
+  bundle purge (Decision 4-iii).
+- **Pre-GA cleanup PR B:** Internal topic rename, `OpenNMS.*` →
+  `DeltaV.*`, all internal topics (Decisions 5 and 6).
+- **TLS termination at Envoy + cert provisioning workflow** (deferred
+  from rc1 Decision 5; design-doc Q2).
+- **Auth (mTLS or JWT)** (deferred from rc1 Decision 5; design-doc Q2).
+- **Default Minion location retirement**
+  (`project_retire_default_minion`).
+- **Echo RPC probe replacement** (`project_minion_echo_probes`); the
+  current `?tag=broker` mitigation goes away when echo does.
+- **OTel tracing** (per Decision 10's note — contributed after gRPC is
+  fully functional).
+
+These will get their own design + planning sessions, driven by what
+rc2 actually delivers.
+
+---
+
+## Open follow-ups for the rc2 implementation plan
+
+These items remain open and will be addressed when the rc2 implementation
+plan is written (next session, via `superpowers:writing-plans`):
+
+- **Pre-work bytecode + inventory passes for RPC and Twin.** Mirrors
+  rc1's pre-work agent reports. Identify horizon's `RpcClientFactory` /
+  `RpcModule` substitution seams for the gRPC transport swap (already
+  proven during rc1 to be `RpcModule`-API-substitutable). For Twin,
+  identify the `TwinPublisher` / `TwinSubscriber` substitution seams.
+- **Internal Kafka topic dependencies of `minion-gateway` for Twin.**
+  The gateway's Twin state cache reads from
+  `OpenNMS.twin.response.<location>` (or post-rename equivalent). The
+  implementation plan should enumerate exact topic names and producer-
+  daemon mappings.
+- **Per-stream version-gap detection wire.** Decision 2-ii says the
+  subscriber detects gaps and reconnects. The implementation plan needs
+  to specify exactly where this lives in the Minion-side gRPC subscriber
+  code path.
+- **Echo RPC probe specifics for RPC baseline.** Where it's invoked
+  from, how the loop driver runs (Pollerd-driven? standalone test
+  harness?), how RTT is captured at the caller side, how it's
+  parameterized per location.
+- **Stream-pool selection algorithm for Decision 1's dispatcher.**
+  Round-robin vs least-loaded vs random. Tactical detail for the
+  implementation plan; not architecturally significant for rc2.
+- **Gateway-side eviction mechanics for in-flight RPC table.** Per
+  Decision 1's eviction-on-stream-close note. Implementation specifics
+  (data structure, locking, eviction trigger order) for the plan.
+
+---
+
+## References
+
+- **Design doc:** [`2026-04-22-v1.2.0-minion-grpc-migration-design.md`](./2026-04-22-v1.2.0-minion-grpc-migration-design.md)
+- **rc1 Phase 0 decisions:** [`2026-04-25-v1.2.0-minion-grpc-migration-decisions.md`](./2026-04-25-v1.2.0-minion-grpc-migration-decisions.md)
+- **rc1 implementation plan:** [`2026-04-26-v1.2.0-rc1-implementation-plan.md`](./2026-04-26-v1.2.0-rc1-implementation-plan.md)
+- **rc1 pre-work findings:** [`2026-04-26-v1.2.0-rc1-pre-work-findings.md`](./2026-04-26-v1.2.0-rc1-pre-work-findings.md)
+- **rc2 design kickoff prompt:** [`docs/superpowers/next-session-prompts/2026-04-26-v1.2.0-rc2-design-kickoff.md`](../superpowers/next-session-prompts/2026-04-26-v1.2.0-rc2-design-kickoff.md)
+- **Release plan:** [`2026-04-23-v1.2.0-release-plan.md`](./2026-04-23-v1.2.0-release-plan.md)
+- **Invariants:** memory `project_minion_mandatory` (zero-trust,
+  bidirectional), `feedback_no_local_polling`,
+  `feedback_rpc_timeout_no_outages`,
+  `feedback_e2e_continuous_validation_grpc_migration`.
+- **Cross-cutting patterns:** memory `feedback_daemon_instrumentation_patterns`
+  (5th idiom — `MeteredRpcModule` survives transport swap),
+  `feedback_smoke_vm_release_only`, `feedback_pull_before_branching`,
+  `feedback_clean_m2_between_branches`, `feedback_never_pr_opennms`.
+- **Last cut tag:** `v1.2.0-rc1` at `b820bda5ffb`.
+- **Develop tip at rc2 design kickoff:** `14855ae8b68` (post rc2 design
+  kickoff prompt merge, PR #232).
+- **Horizon BOM in use:** `1.0.13` (root `pom.xml` `deltav.horizon.version`).


### PR DESCRIPTION
## Summary

Captures the architectural decisions made during the v1.2.0-rc2 design kickoff session for ten open questions blocking the rc2 implementation plan. Recurring theme of the session: **preserve Horizon-grade reliability and scalability through the migration.** Several initial recommendations were revised after surfacing reliability properties the Kafka path was buying us that an unconsidered gRPC path would lose — most notably the multi-Minion competing-consumer pattern at a location.

This PR is **design-only**; no code changes. The rc2 implementation plan is a separate session, mirroring rc1's cadence (decisions PR → implementation plan PR → execution PRs).

## Decisions at a glance

| # | Question | Decision |
|---|---|---|
| 1 | RPC reconnect semantics | **Option D** — `minion-gateway` is a per-location competing-consumer dispatcher with redispatch-on-stream-close. Idempotency-as-contract for all RPC modules. No gateway-side queue when location's pool is empty. |
| 2 | Twin resubscribe semantics | **Option B** — delta-v fresh `.proto`, snapshot+patch+version. Full snapshot on (re)connect; JSON Patch on subsequent updates; subscriber-side version-gap detection triggers reconnect → snapshot. |
| 3 | Cutover staging within rc2 | **Option C** — single rc2 tag, sequential channel PRs landing on develop. Each PR gated by full Mac dev-env E2E green before merge. |
| 4 | Kafka transport removal timing | **Option B** — defer to a pre-GA cleanup PR. Per-channel `MINION_<CHANNEL>_TRANSPORT` emergency flags through rc2 soak. Default `grpc` after each channel's PR lands. |
| 5 | Sink topic rename coupling | **Decoupled** — rename in a separate pre-GA cleanup PR. Scope is global (all `OpenNMS.*` internal topics → `DeltaV.*`). |
| 6 | Sink topic rename method | **Option B** — hard cut. Single coordinated PR. CI grep guard prevents regression. |
| 7 | minion-gateway scaling model | **Option C** — single-instance deployment in rc2; multi-instance-friendly protocol from day one. All gateway state must be reconstructible from Kafka + Minion reconnects. v1.3 milestone with protocol gates pre-met. |
| 8 | JUnit Platform alignment fix scope | **A2 + B1** — separate hygiene PR before rc2 starts. Root-pom `<junit-platform.version>` property override + remove per-module pins. |
| 9 | rc2 PR shape | **4-PR sequence**: RPC → Twin → Sinks → build cleanup. Each independently mergeable with full E2E green; rc2 tag cut after PR4. |
| 10 | RPC / Twin baseline measurement | RPC: Echo-RPC probe, gate `gRPC p99 ≤ Kafka p99 + 20 ms`. Twin: subscribe gate `+100 ms`, propagation gate `+50 ms`. Per-channel baselines captured before each channel's PR opens. OTel tracing deferred — contributed after gRPC fully functional. |

## What changed from the kickoff prompt's framing

- **Q1 was reframed entirely.** The prompt's A/B/C options all implicitly assumed one Minion per location. Multi-Minion-per-location is the standard operational mode (competing-consumer Kafka groups), so a fourth option — Option D, gateway as competing-consumer dispatcher with redispatch-on-stream-close — was needed to preserve N-way reliability at a location.
- **Q2 was reshaped by a mid-session find** — horizon already shipped a production-grade Twin gRPC implementation at `core/ipc/twin/grpc/*` with snapshot+patch+version semantics. We adopt the *design* (delta-v fresh `.proto` mirroring the wire shape) without inheriting the *coupling* (don't reuse horizon's classes directly).
- **Q4's Option A was stricter than locked Decision 2** from rc1 (which says "hard-cut at GA boundary"). Option B exactly matches what was locked.
- **Q5 was decoupled from gRPC migration** entirely — topic rename is purely cosmetic and bundling it would add an independent failure mode to each channel migration PR.
- **Q9's 4-PR sequence** is more granular than rc1's single-PR pattern because rc2's scope is materially larger (estimated 30-40 commits across 4 channel-equivalents).

## What's deferred to pre-GA

After `v1.2.0-rc2` is cut and smoked, a pre-GA push covers:

- Kafka transport removal from Minion + per-channel emergency flag removal + 17 ActiveMQ + 15 ServiceMix bundle purge (Decision 4-iii).
- Internal topic rename, `OpenNMS.*` → `DeltaV.*`, all internal topics (Decisions 5 and 6).
- TLS termination at Envoy + cert provisioning workflow.
- Auth (mTLS or JWT).
- Default Minion location retirement (`project_retire_default_minion`).
- Echo RPC probe replacement (`project_minion_echo_probes`); the current `?tag=broker` mitigation goes away when echo does.
- OTel tracing (per Decision 10's note).

## Test plan

- [ ] User-reviewed the decisions doc on disk before this PR opened (done).
- [ ] Reviewer reads through Decision 1 (Option D mechanic) carefully — biggest reframe from the kickoff prompt.
- [ ] Reviewer reads through Decision 2's "reuse the design, not the implementation" framing.
- [ ] Reviewer confirms Decision 9's 4-PR sequence is the desired skeleton for the implementation plan.
- [ ] Reviewer confirms Decision 10's gate widenings (20ms / 50ms / 100ms) are the numbers we'll be held to in CI.

## Next session

After this PR merges, a separate session writes the rc2 implementation plan via `superpowers:writing-plans`, hanging off Decision 9's 4-PR skeleton. Implementation execution is yet another session, per rc1's multi-session cadence.

## Memory invariants honored

- `feedback_never_pr_opennms` — `--repo pbrane/delta-v` ✓
- `feedback_pull_before_branching` — branched off freshly-fetched develop ✓
- `feedback_e2e_continuous_validation_grpc_migration` — encoded in Decision 3 sub-decision 3-i ✓
- `feedback_rpc_timeout_no_outages` — hard floor on Decision 1 ✓
- `project_minion_mandatory` — bidirectional zero-trust preserved across all decisions ✓