### PR TITLE
docs(v1.2.0-rc2-pr1): RPC migration implementation plan

### DIFF
--- a/docs/plans/2026-04-26-v1.2.0-rc2-pr1-rpc-implementation-plan.md
+++ b/docs/plans/2026-04-26-v1.2.0-rc2-pr1-rpc-implementation-plan.md
@@ -1,0 +1,2247 @@
+# v1.2.0-rc2 PR1 — RPC Channel Migration to gRPC: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the Minion ↔ Core RPC channel from Kafka topics (`OpenNMS.<location>.rpc-request` / `OpenNMS.rpc-response`) to gRPC bidi streams routed through `minion-gateway`, while preserving Horizon-grade reliability (multi-Minion-per-location competing-consumer redundancy, at-least-once execution, no synthesized outages on transport failures).
+
+**Architecture:** `minion-gateway` becomes a per-location competing-consumer dispatcher (Decision 1 Option D from the rc2 decisions doc). It consumes RPC requests from the existing internal Kafka topic `OpenNMS.<location>.rpc-request`, picks a Minion bidi stream from the per-location pool, forwards the request, tracks the in-flight RPC table, and on stream-close redispatches unfulfilled requests to a surviving sibling stream. Responses route back through `OpenNMS.rpc-response`. Minions register with the gateway by opening a long-lived bidi gRPC stream on startup (analogous to rc1's Heartbeat stream); the Minion side hosts an RpcModule executor that processes inbound `RpcRequest` messages and emits `RpcResponse` messages on the same stream. ServiceDaemons see zero protocol change — they keep producing/consuming the same internal Kafka topics. Per-channel emergency rollback flag `opennms.minion.transport.rpc=kafka|grpc` (default `grpc`) preserves the rc1 Kafka path through rc2 soak.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.3, Spring gRPC 1.0.3 (`spring-grpc-dependencies` BOM), gRPC 1.75.0, protobuf 3.25.5, JUnit Jupiter 6.0.3 (post-PR-#234 alignment), Testcontainers 2.x (Kafka), Mockito.
+
+**Scope boundary:** This plan covers **PR1 only** (RPC channel). PR2 (Twin), PR3 (Sinks), PR4 (build cleanup) are subsequent plans, authored in separate sessions after each predecessor merges. See `docs/plans/2026-04-26-v1.2.0-rc2-decisions.md` for the rc2 master spec.
+
+---
+
+## Architecture overview specific to RPC
+
+### Existing Kafka path (what we are replacing)
+
+```
+ServiceDaemon (Pollerd, Collectd, etc.)
+  │ RpcClientFactory.getClient(module).execute(request) → CompletableFuture<Response>
+  ▼
+KafkaRpcClient (horizon)
+  │ producer.send(OpenNMS.<location>.rpc-request, RpcRequestProto)
+  ▼
+Kafka broker
+  ▼
+KafkaRpcServer on Minion (consumer group per location, competing consumer)
+  │ RpcModuleRegistry.dispatch(request) → CompletableFuture<Response>
+  ▼
+producer.send(OpenNMS.rpc-response, RpcResponseProto)
+  ▼
+Kafka broker
+  ▼
+KafkaRpcClient (horizon, same JVM as ServiceDaemon)
+  │ correlation by rpcId; completes the future
+  ▼
+ServiceDaemon receives response.
+```
+
+### Target gRPC path
+
+```
+ServiceDaemon (UNCHANGED — RpcClientFactory API stays)
+  │ RpcClientFactory.getClient(module).execute(request) → CompletableFuture<Response>
+  ▼
+KafkaRpcClient (horizon, UNCHANGED)
+  │ producer.send(OpenNMS.<location>.rpc-request, RpcRequestProto)
+  ▼
+Kafka broker (still here for daemon ↔ gateway hop)
+  ▼
+minion-gateway: RpcChannelDispatcher
+  │ consumer.poll(OpenNMS.<location>.rpc-request)
+  │ pick stream from pool[location]
+  │ in-flight table: rpcId → (streamRef, deadline)
+  │ stream.onNext(RpcRequest)
+  ▼
+gRPC bidi stream (h2c plaintext within compose; TLS at Envoy in pre-GA)
+  ▼
+Minion: MinionRpcStream client
+  │ on each RpcRequest, dispatch via RpcModuleRegistry
+  │ stream.onNext(RpcResponse) — same bidi stream
+  ▼
+gRPC return path
+  ▼
+minion-gateway: RpcChannelDispatcher
+  │ in-flight table.remove(rpcId)
+  │ producer.send(OpenNMS.rpc-response, RpcResponseProto)
+  ▼
+Kafka broker
+  ▼
+KafkaRpcClient (horizon, UNCHANGED) — completes the daemon's CompletableFuture.
+```
+
+### Reliability properties preserved (Decision 1)
+
+| Property | Mechanism in gRPC path |
+|---|---|
+| Multi-Minion-per-location competing consumer | Gateway maintains `pool[location] = {streamA, streamB, ...}`; round-robin per request |
+| At-least-once execution | Stream-close mid-flight → redispatch from in-flight table to sibling stream |
+| Caller-side single-flight per task | Unchanged — Pollerd/Collectd schedule one RPC per service at a time |
+| RPC timeouts do NOT synthesize outages | Empty pool → caller's existing dispatcher deadline absorbs (`feedback_rpc_timeout_no_outages`) |
+| Idempotency-as-contract | All current RPC modules are read-only; PR1 codifies this as an acceptance criterion |
+
+---
+
+## File structure
+
+### New files
+- `core/minion-grpc-contracts/src/main/proto/rpc.proto` — bidi RPC service definition.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/RpcChannelGrpcService.java` — gRPC bidi service, opens stream pools.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/MinionStreamPool.java` — per-location stream registry with round-robin dispatch.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/InFlightRpcTable.java` — `(rpcId → streamRef, deadline)` map with eviction-on-stream-close + deadline expiry.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java` — Kafka consumer for `OpenNMS.<location>.rpc-request`, picks stream, forwards, handles redispatch.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponsePublisher.java` — Kafka producer for `OpenNMS.rpc-response`.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelConfiguration.java` — Spring wiring for the above.
+- `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionRpcStreamClient.java` — opens bidi stream to gateway, handles inbound RpcRequest, dispatches via local `RpcModule` registry, sends RpcResponse.
+- `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcRpcStreamConfiguration.java` — `@ConditionalOnProperty(opennms.minion.transport.rpc=grpc, default)`.
+- `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcStreamFallbackConfiguration.java` — `@ConditionalOnProperty(opennms.minion.transport.rpc=kafka)` — preserves rc1 Kafka path.
+- `e2e/test-grpc-rpc-e2e.sh` — Echo-RPC bench harness for Decision 10's gate measurement.
+- `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md` — produced by Tasks 1 and 2 of this plan.
+
+### Modified files
+- `core/minion-grpc-contracts/pom.xml` — register `rpc.proto` for protoc compilation (likely no change; already wildcard-includes `*.proto` in `src/main/proto/`).
+- `core/minion-gateway/pom.xml` — add Kafka client dependency (already present from Heartbeat) — likely no change.
+- `core/daemon-boot-minion-common/pom.xml` — add Kafka client dependency for fallback config (already present).
+- `e2e/test-perspective-e2e.sh` — verify gRPC RPC path; assert no fallback-to-Kafka.
+- `e2e/test-enlinkd-e2e.sh` — same as test-perspective; gRPC RPC path verification.
+- `opennms-container/delta-v/.env` — add `MINION_RPC_TRANSPORT=grpc` (default).
+- `opennms-container/delta-v/docker-compose.yml` — pass `MINION_RPC_TRANSPORT` env to Minion container.
+
+### Files NOT modified
+- ServiceDaemon code (Pollerd, Collectd, Provisiond, etc.) — `RpcClientFactory` API unchanged; daemons see zero protocol change.
+- horizon's `KafkaRpcServer` / `KafkaRpcClient` — unchanged; we work around them, not modify.
+
+---
+
+## Phase 0 — Pre-work (Tasks 1-3)
+
+Pre-work captures baselines and inventories that subsequent tasks depend on. Mirrors rc1's Phase 0 structure.
+
+### Task 1: Capture Echo-RPC baseline on Kafka path
+
+**Files:**
+- Create: `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md` (draft skeleton; baseline section filled in this task)
+
+**Rationale:** Decision 10 sub-decision 10-iii requires "baseline → PR opens → gate measured at PR's E2E pass." Capturing first ensures the gate is set before any code changes contaminate the measurement.
+
+**Probe:** Echo RPC. Already implemented in horizon (used today by `?tag=broker` healthcheck). Trivial server-side work means measured RTT ≈ transport latency.
+
+- [ ] **Step 1.1: Bring up the standard Mac dev-env stack (rc2 develop tip, no rc2 changes yet)**
+
+```bash
+cd opennms-container/delta-v
+./build.sh deltav            # local images at deltav/*:1.2.0-rc1
+./deploy.sh up minimal       # postgres + kafka + db-init + minion only
+```
+
+Expected: 4 containers `Up (healthy)` after ~60 seconds. Verify with `docker compose ps`.
+
+- [ ] **Step 1.2: Issue Echo RPCs in a 10-minute loop driven from a host-side script**
+
+Create `/tmp/echo-rpc-loop.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Drives 1 Echo RPC per second for 10 minutes via the karaf shell.
+# Captures stdout (which contains 'echo-reply' lines with timestamps).
+set -euo pipefail
+END=$(($(date +%s) + 600))
+while [ "$(date +%s)" -lt "$END" ]; do
+  docker exec deltav-minion bash -c 'echo opennms:health-check | /opt/karaf/bin/client -h localhost -u admin -p admin -- 2>/dev/null' \
+    | grep -E 'broker|echo' || true
+  sleep 1
+done
+```
+
+Run: `bash /tmp/echo-rpc-loop.sh > /tmp/echo-baseline.log 2>&1 &`
+
+Expected: ~600 echo-reply lines in `/tmp/echo-baseline.log`.
+
+- [ ] **Step 1.3: Compute Kafka-path RPC RTT distribution**
+
+```bash
+# Each Kafka record's CreateTime captures producer-side serialization (Minion).
+# We compare it to the Minion-side timestamp in the Echo response payload.
+docker exec deltav-kafka /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server kafka:9092 \
+  --topic OpenNMS.rpc-response \
+  --from-beginning --max-messages 600 \
+  --property print.timestamp=true 2>&1 \
+  | awk '/echo/ { print $1, $2 }' \
+  > /tmp/echo-rtt-raw.txt
+
+# Compute p25/p50/p75/p99 in Python
+python3 - <<'PY'
+import statistics, re
+rtts = []
+with open('/tmp/echo-rtt-raw.txt') as f:
+    for line in f:
+        # Format: CreateTime:<broker-ts> <payload-ts-millis>
+        m = re.search(r'CreateTime:(\d+).*?(\d{13})', line)
+        if m:
+            rtts.append(int(m.group(1)) - int(m.group(2)))
+rtts.sort()
+n = len(rtts)
+print(f'samples={n}')
+print(f'p25={rtts[n//4]} ms')
+print(f'p50={rtts[n//2]} ms')
+print(f'p75={rtts[3*n//4]} ms')
+print(f'p99={rtts[int(n*0.99)]} ms')
+print(f'min/max={rtts[0]}/{rtts[-1]} ms')
+print(f'mean={statistics.mean(rtts):.2f} ms')
+PY
+```
+
+Expected: ≥ 100 samples; p99 in range [0, 5] ms (Kafka path is sub-ms in dev env per rc1's Heartbeat baseline).
+
+- [ ] **Step 1.4: Document baseline + gate calculation in pre-work findings doc**
+
+Create `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md` with this template (fill in actual numbers from Step 1.3):
+
+````markdown
+# v1.2.0-rc2 PR1 — RPC Migration: Pre-Work Findings
+
+> Session notes captured 2026-XX-XX in support of `2026-04-26-v1.2.0-rc2-pr1-rpc-implementation-plan.md`.
+
+## Echo-RPC baseline (Kafka path, Mac dev env)
+
+**Measured on:** McMac2025.local, 2026-XX-XX HH:MM-HH:MM UTC. Local docker compose stack on locally-built rc2-pre-gRPC images (pom version `1.2.0-rc1`; image content = `develop` HEAD `387f35dfadd`; horizon BOM `1.0.13`).
+
+**Stack scope:** `postgres`, `kafka`, `db-init`, `minion` (minimal profile, no consumer needed for RTT measurement — `kafka-console-consumer` reads independently).
+
+**Method:** see Task 1 of the implementation plan; same boundary trick as rc1 Heartbeat baseline.
+
+**Window:** 10 minutes. **Samples:** N (fill in).
+
+| Metric | Value |
+|---|---|
+| samples | N |
+| p25 | X ms |
+| p50 | X ms |
+| p75 | X ms |
+| p99 | X ms |
+| min / max | X / X ms |
+| mean | X.X ms |
+
+**Release gate for PR1 (Task 14):** `gRPC Echo-RPC p99 ≤ Kafka Echo-RPC p99 + 20 ms`.
+
+Justification for the 20 ms widening (per Decision 10): RPC adds gateway-side dispatcher logic (pool selection, in-flight table updates) and the bidi stream has both an outbound and inbound traversal where Heartbeat is one-way. 20 ms accepts measurement noise on a small sample, one full Kafka batch jitter, one minion-gateway scheduler tick, and the new dispatcher overhead; rejects regressions large enough to change the migration story (multiplexed channel contention, blocking I/O on the gateway, backpressure stalls).
+````
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc2-pr1): capture Echo-RPC Kafka baseline (Task 1)"
+```
+
+---
+
+### Task 2: Bytecode + callsite inventory of horizon RPC seams
+
+**Files:**
+- Modify: `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md` (add inventory section)
+
+**Rationale:** Subsequent tasks substitute the Kafka transport at specific seams in horizon's classes. Inventory ensures the substitution targets exist as documented and surface no surprises.
+
+- [ ] **Step 2.1: List public API methods of horizon's RpcClientFactory and RpcModule**
+
+```bash
+# Inspect the actual horizon BOM JAR on classpath
+HORIZON_VERSION=$(grep -E '<deltav.horizon.version>' pom.xml | sed -E 's/.*>(.*)<.*/\1/')
+JAR=~/.m2/repository/org/opennms/core/ipc/rpc/org.opennms.core.ipc.rpc.api/${HORIZON_VERSION}/org.opennms.core.ipc.rpc.api-${HORIZON_VERSION}.jar
+javap -p -classpath "$JAR" org.opennms.core.rpc.api.RpcClientFactory
+javap -p -classpath "$JAR" org.opennms.core.rpc.api.RpcModule
+javap -p -classpath "$JAR" org.opennms.core.rpc.api.RpcRequest
+javap -p -classpath "$JAR" org.opennms.core.rpc.api.RpcResponse
+```
+
+Expected: signatures showing `getClient(RpcModule)`, `execute(RpcRequest) → CompletableFuture<RpcResponse>`, `marshal/unmarshalRequest`, `marshal/unmarshalResponse`, etc.
+
+- [ ] **Step 2.2: List Minion-side callsites of KafkaRpcServer**
+
+```bash
+JAR=~/.m2/repository/org/opennms/core/ipc/rpc/org.opennms.core.ipc.rpc.kafka/${HORIZON_VERSION}/org.opennms.core.ipc.rpc.kafka-${HORIZON_VERSION}.jar
+javap -p -classpath "$JAR" org.opennms.core.ipc.rpc.kafka.KafkaRpcServerManager 2>&1 || javap -p -classpath "$JAR" -cp "$JAR" $(jar tf "$JAR" | grep -E 'KafkaRpcServer.*\.class$' | head -3 | sed 's|/|.|g; s|\.class$||')
+```
+
+Expected: methods like `bind(RpcModule)`, `unbind(RpcModule)`, `start()`, `stop()`. Document the bind/unbind pattern.
+
+- [ ] **Step 2.3: Inventory delta-v's current RpcModule wiring per daemon**
+
+```bash
+grep -rn "RpcModule\|@Bean.*RpcModule\|RpcClientFactory" core/daemon-boot-*/src/main/java --include="*.java" \
+  | grep -v test | sort -u
+```
+
+Expected output to capture: which daemons inject `RpcClientFactory`, which daemons register `RpcModule` beans, which daemons act as RPC servers (Minion side) vs clients (ServiceDaemon side).
+
+- [ ] **Step 2.4: Verify Echo RPC's module class name and location**
+
+```bash
+JAR=~/.m2/repository/org/opennms/core/ipc/rpc/org.opennms.core.ipc.rpc.kafka/${HORIZON_VERSION}/org.opennms.core.ipc.rpc.kafka-${HORIZON_VERSION}.jar
+jar tf "$JAR" | grep -i echo
+```
+
+Expected: `EchoRpcModule.class` somewhere in the horizon RPC namespace. Note the FQCN — Task 14's test harness invokes it.
+
+- [ ] **Step 2.5: Document inventory in pre-work findings doc**
+
+Append to `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md`:
+
+````markdown
+## Bytecode + callsite inventory
+
+### Horizon RPC API surface (substitution seams)
+
+| Class | Key methods | Substitution role |
+|---|---|---|
+| `org.opennms.core.rpc.api.RpcClientFactory` | `getClient(RpcModule)` | Daemon-side: returns a client that dispatches RPCs. Stays Kafka-backed in PR1; Minion-side gRPC handler is what changes. |
+| `org.opennms.core.rpc.api.RpcModule<S extends RpcRequest, T extends RpcResponse>` | `execute(S) → CompletableFuture<T>`, `marshalRequest`, `unmarshalRequest`, `marshalResponse`, `unmarshalResponse`, `getId()` | The substitution unit — Minion-side replaces `KafkaRpcServer.bind(module)` with `MinionRpcStreamClient.register(module)`. |
+| `org.opennms.core.ipc.rpc.kafka.KafkaRpcServerManager` | `bind(RpcModule)`, `unbind(RpcModule)` | Replaced wholesale by `MinionRpcStreamClient` when transport=grpc. |
+
+### Per-daemon RPC wiring
+
+(Table populated from Step 2.3 grep output.)
+
+### Echo RPC
+
+`org.opennms.core.rpc.echo.EchoRpcModule` — used by Task 14 bench harness.
+````
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc2-pr1): RPC substitution-seam inventory (Task 2)"
+```
+
+---
+
+### Task 3: Define rpc.proto in minion-grpc-contracts
+
+**Files:**
+- Create: `core/minion-grpc-contracts/src/main/proto/rpc.proto`
+
+**Rationale:** Wire format is the architectural contract. Defined first so server (Task 4-7) and client (Task 8-10) can both compile against the same generated code.
+
+- [ ] **Step 3.1: Write the proto definition**
+
+Create `core/minion-grpc-contracts/src/main/proto/rpc.proto`:
+
+```protobuf
+// core/minion-grpc-contracts/src/main/proto/rpc.proto
+syntax = "proto3";
+
+package org.deltav.minion.grpc.v1;
+
+option java_package = "org.deltav.minion.grpc.v1";
+option java_multiple_files = true;
+option java_outer_classname = "RpcChannelProto";
+
+import "google/protobuf/timestamp.proto";
+
+// Bidi-streaming RPC channel between minion-gateway (server) and Minion (client).
+//
+// On the wire: the gateway opens-and-keeps the stream; in-flight requests
+// flow gateway -> Minion as RpcRequest messages; responses flow Minion ->
+// gateway as RpcResponse messages on the same stream. Identity is in the
+// gRPC metadata (x-minion-id, x-minion-location) and read by
+// MinionIdentityServerInterceptor; the duplication into the payload is
+// intentional for self-describing logs (matches Heartbeat pattern from rc1).
+//
+// Per Decision 1 of the v1.2.0-rc2 decisions doc:
+// - Multiple Minions per location each open their own stream; gateway
+//   picks one per RPC (round-robin) so the competing-consumer pattern is
+//   preserved.
+// - On stream close mid-flight, gateway redispatches outstanding RpcRequests
+//   from the closed stream to a surviving sibling stream in the same pool.
+// - All RpcModules MUST be idempotent (read-only) — at-least-once execution
+//   is a property of the channel; modules must tolerate it.
+service RpcChannelService {
+  rpc Channel(stream RpcResponse) returns (stream RpcRequest);
+}
+
+// Mirrors the wire format of horizon's existing RpcRequestProto so the
+// Minion-side dispatcher can deserialize via RpcModule.unmarshalRequest()
+// without an intermediate translator. The 'module_id' selects which
+// RpcModule handles the request.
+message RpcRequest {
+  string rpc_id = 1;                 // correlation token; matches the response
+  string module_id = 2;              // RpcModule.getId()
+  string minion_id = 3;              // x-minion-id metadata, duplicated for self-describing
+  string location = 4;               // x-minion-location metadata
+  bytes payload = 5;                 // module-specific marshal()ed RpcRequest body
+  google.protobuf.Timestamp dispatched_at = 6;  // gateway-side timestamp; Task 14 uses for RTT
+  int64 deadline_ms = 7;             // dispatcher's RPC deadline (epoch millis); Minion enforces
+}
+
+// Mirrors horizon's RpcResponseProto.
+message RpcResponse {
+  string rpc_id = 1;                 // correlation token from request
+  bytes payload = 2;                 // module-specific marshal()ed RpcResponse body
+  string error_message = 3;          // empty on success; non-empty if Minion-side execution failed
+  google.protobuf.Timestamp completed_at = 4;  // Minion-side timestamp at response send
+}
+```
+
+- [ ] **Step 3.2: Compile and verify generated classes appear**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-grpc-contracts -am clean compile
+ls core/minion-grpc-contracts/target/generated-sources/protobuf/java/org/deltav/minion/grpc/v1/ \
+  | grep -E "RpcChannel|RpcRequest|RpcResponse"
+```
+
+Expected: `RpcChannelProto.java`, `RpcRequest.java`, `RpcResponse.java`, `RpcChannelServiceGrpc.java` (the latter from grpc-java plugin).
+
+- [ ] **Step 3.3: Verify no surprise breakage in dependent modules**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway -am compile
+```
+
+Expected: BUILD SUCCESS (the new proto adds a service; no existing code references it yet, so compile is unaffected).
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add core/minion-grpc-contracts/src/main/proto/rpc.proto
+git commit -m "feat(v1.2.0-rc2-pr1): rpc.proto wire contract (Task 3)"
+```
+
+---
+
+## Phase 1 — minion-gateway: gRPC bidi service + dispatcher (Tasks 4-7)
+
+### Task 4: MinionStreamPool — per-location stream registry
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/MinionStreamPool.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/rpc/MinionStreamPoolTest.java`
+
+**Rationale:** Holds the open bidi streams indexed by location, with round-robin selection. Independent of Kafka and gRPC — pure data structure with concurrency. Easiest piece to test in isolation.
+
+- [ ] **Step 4.1: Write failing test for empty pool returns null**
+
+Create `core/minion-gateway/src/test/java/org/deltav/gateway/rpc/MinionStreamPoolTest.java`:
+
+```java
+package org.deltav.gateway.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class MinionStreamPoolTest {
+
+    @Test
+    void emptyPool_returnsNullForUnknownLocation() {
+        MinionStreamPool pool = new MinionStreamPool();
+        assertThat(pool.pickStream("Default")).isNull();
+    }
+
+    @Test
+    void registeredStream_returnsStreamForItsLocation() {
+        MinionStreamPool pool = new MinionStreamPool();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> observer = mock(StreamObserver.class);
+        pool.register("Default", "minion-A", observer);
+
+        assertThat(pool.pickStream("Default")).isSameAs(observer);
+    }
+
+    @Test
+    void multipleStreamsInSameLocation_roundRobin() {
+        MinionStreamPool pool = new MinionStreamPool();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> a = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> b = mock(StreamObserver.class);
+        pool.register("Default", "minion-A", a);
+        pool.register("Default", "minion-B", b);
+
+        assertThat(pool.pickStream("Default")).isSameAs(a);
+        assertThat(pool.pickStream("Default")).isSameAs(b);
+        assertThat(pool.pickStream("Default")).isSameAs(a);
+    }
+
+    @Test
+    void unregisteredStream_noLongerSelectable() {
+        MinionStreamPool pool = new MinionStreamPool();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> a = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> b = mock(StreamObserver.class);
+        pool.register("Default", "minion-A", a);
+        pool.register("Default", "minion-B", b);
+        pool.unregister("Default", "minion-A");
+
+        assertThat(pool.pickStream("Default")).isSameAs(b);
+        assertThat(pool.pickStream("Default")).isSameAs(b);
+    }
+
+    @Test
+    void emptyAfterAllUnregister_returnsNull() {
+        MinionStreamPool pool = new MinionStreamPool();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> a = mock(StreamObserver.class);
+        pool.register("Default", "minion-A", a);
+        pool.unregister("Default", "minion-A");
+
+        assertThat(pool.pickStream("Default")).isNull();
+    }
+}
+```
+
+- [ ] **Step 4.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway -am test -Dtest=MinionStreamPoolTest
+```
+
+Expected: FAIL with `cannot find symbol class MinionStreamPool`.
+
+- [ ] **Step 4.3: Implement MinionStreamPool**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/MinionStreamPool.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Per-location pool of currently-open Minion bidi streams. The competing-
+ * consumer property of the Kafka RPC pattern is preserved here: multiple
+ * Minions in a location each register their stream; the gateway picks one
+ * per RPC via round-robin so work spreads across the pool.
+ *
+ * <p>Per Decision 1 of the v1.2.0-rc2 decisions doc, this is the gRPC
+ * equivalent of Kafka's consumer group: registration on stream open,
+ * unregister on stream close, redispatch is the responsibility of the
+ * caller (see {@code RpcChannelDispatcher}).
+ */
+@Component
+public class MinionStreamPool {
+
+    private final Map<String, LocationPool> pools = new ConcurrentHashMap<>();
+
+    public void register(String location, String minionId, StreamObserver<RpcRequest> stream) {
+        Objects.requireNonNull(location, "location");
+        Objects.requireNonNull(minionId, "minionId");
+        Objects.requireNonNull(stream, "stream");
+        pools.computeIfAbsent(location, k -> new LocationPool()).add(minionId, stream);
+    }
+
+    public void unregister(String location, String minionId) {
+        LocationPool pool = pools.get(location);
+        if (pool != null) {
+            pool.remove(minionId);
+        }
+    }
+
+    public StreamObserver<RpcRequest> pickStream(String location) {
+        LocationPool pool = pools.get(location);
+        return pool == null ? null : pool.pickRoundRobin();
+    }
+
+    public List<StreamObserver<RpcRequest>> siblingStreams(String location, StreamObserver<RpcRequest> exclude) {
+        LocationPool pool = pools.get(location);
+        return pool == null ? List.of() : pool.siblingsOf(exclude);
+    }
+
+    private static final class LocationPool {
+        // CopyOnWriteArrayList-like semantics via synchronized snapshot for round-robin reads
+        private volatile List<Entry> entries = new ArrayList<>();
+        private final AtomicInteger cursor = new AtomicInteger();
+
+        synchronized void add(String minionId, StreamObserver<RpcRequest> stream) {
+            List<Entry> next = new ArrayList<>(entries);
+            next.removeIf(e -> e.minionId.equals(minionId));
+            next.add(new Entry(minionId, stream));
+            entries = next;
+        }
+
+        synchronized void remove(String minionId) {
+            List<Entry> next = new ArrayList<>(entries);
+            next.removeIf(e -> e.minionId.equals(minionId));
+            entries = next;
+        }
+
+        StreamObserver<RpcRequest> pickRoundRobin() {
+            List<Entry> snapshot = entries;
+            if (snapshot.isEmpty()) {
+                return null;
+            }
+            int idx = Math.floorMod(cursor.getAndIncrement(), snapshot.size());
+            return snapshot.get(idx).stream;
+        }
+
+        List<StreamObserver<RpcRequest>> siblingsOf(StreamObserver<RpcRequest> exclude) {
+            List<Entry> snapshot = entries;
+            List<StreamObserver<RpcRequest>> result = new ArrayList<>(snapshot.size());
+            for (Entry e : snapshot) {
+                if (e.stream != exclude) {
+                    result.add(e.stream);
+                }
+            }
+            return result;
+        }
+
+        private record Entry(String minionId, StreamObserver<RpcRequest> stream) {}
+    }
+}
+```
+
+- [ ] **Step 4.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway -am test -Dtest=MinionStreamPoolTest
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/rpc/MinionStreamPool.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/rpc/MinionStreamPoolTest.java
+git commit -m "feat(v1.2.0-rc2-pr1): MinionStreamPool with round-robin (Task 4)"
+```
+
+---
+
+### Task 5: InFlightRpcTable — eviction-on-stream-close + deadline expiry
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/InFlightRpcTable.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/rpc/InFlightRpcTableTest.java`
+
+**Rationale:** Tracks `(rpcId → streamRef, deadline, originalRequest)` so that on stream-close we can scan for entries to redispatch. Decision 1 sub-decision 1-iii: eviction-on-close to prevent leaks under flap.
+
+- [ ] **Step 5.1: Write failing test**
+
+Create `core/minion-gateway/src/test/java/org/deltav/gateway/rpc/InFlightRpcTableTest.java`:
+
+```java
+package org.deltav.gateway.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class InFlightRpcTableTest {
+
+    @Test
+    void recordedRequest_isRetrievableByRpcId() {
+        InFlightRpcTable table = new InFlightRpcTable();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> stream = mock(StreamObserver.class);
+        RpcRequest req = RpcRequest.newBuilder().setRpcId("abc").build();
+
+        table.record("abc", stream, req, Instant.now().plusSeconds(30));
+
+        assertThat(table.findEntry("abc")).isNotNull();
+        assertThat(table.findEntry("abc").request()).isEqualTo(req);
+    }
+
+    @Test
+    void completed_evictsEntry() {
+        InFlightRpcTable table = new InFlightRpcTable();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> stream = mock(StreamObserver.class);
+        table.record("abc", stream, RpcRequest.newBuilder().setRpcId("abc").build(), Instant.now().plusSeconds(30));
+
+        table.complete("abc");
+
+        assertThat(table.findEntry("abc")).isNull();
+    }
+
+    @Test
+    void evictByStream_returnsAndRemovesAllForThatStream() {
+        InFlightRpcTable table = new InFlightRpcTable();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> streamA = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> streamB = mock(StreamObserver.class);
+        Instant deadline = Instant.now().plusSeconds(30);
+        table.record("a1", streamA, RpcRequest.newBuilder().setRpcId("a1").build(), deadline);
+        table.record("a2", streamA, RpcRequest.newBuilder().setRpcId("a2").build(), deadline);
+        table.record("b1", streamB, RpcRequest.newBuilder().setRpcId("b1").build(), deadline);
+
+        List<InFlightRpcTable.Entry> evicted = table.evictByStream(streamA);
+
+        assertThat(evicted).hasSize(2);
+        assertThat(evicted).extracting(InFlightRpcTable.Entry::rpcId).containsExactlyInAnyOrder("a1", "a2");
+        assertThat(table.findEntry("a1")).isNull();
+        assertThat(table.findEntry("a2")).isNull();
+        assertThat(table.findEntry("b1")).isNotNull();
+    }
+
+    @Test
+    void evictExpired_returnsEntriesPastDeadline() {
+        InFlightRpcTable table = new InFlightRpcTable();
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> stream = mock(StreamObserver.class);
+        Instant past = Instant.now().minus(Duration.ofSeconds(5));
+        Instant future = Instant.now().plus(Duration.ofSeconds(60));
+        table.record("expired", stream, RpcRequest.newBuilder().setRpcId("expired").build(), past);
+        table.record("alive", stream, RpcRequest.newBuilder().setRpcId("alive").build(), future);
+
+        List<InFlightRpcTable.Entry> evicted = table.evictExpired(Instant.now());
+
+        assertThat(evicted).extracting(InFlightRpcTable.Entry::rpcId).containsExactly("expired");
+        assertThat(table.findEntry("alive")).isNotNull();
+    }
+}
+```
+
+- [ ] **Step 5.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=InFlightRpcTableTest
+```
+
+Expected: FAIL with `cannot find symbol class InFlightRpcTable`.
+
+- [ ] **Step 5.3: Implement InFlightRpcTable**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/InFlightRpcTable.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks in-flight RPC requests dispatched by the gateway. Each entry
+ * remembers the stream it was sent to (for redispatch on stream close),
+ * the deadline (for expiry sweep), and the original request body (so
+ * redispatch can resend the same payload to a sibling stream).
+ *
+ * <p>Per Decision 1 sub-decision 1-iii of the v1.2.0-rc2 decisions doc:
+ * eviction is triggered both on response delivery (success path) and on
+ * stream close (redispatch path). Stream close evicts ALL entries for
+ * that stream regardless of whether redispatch succeeds, to prevent leaks
+ * under stream flap.
+ */
+@Component
+public class InFlightRpcTable {
+
+    private final Map<String, Entry> entries = new ConcurrentHashMap<>();
+
+    public void record(String rpcId, StreamObserver<RpcRequest> stream,
+                       RpcRequest request, Instant deadline) {
+        entries.put(rpcId, new Entry(rpcId, stream, request, deadline));
+    }
+
+    public Entry findEntry(String rpcId) {
+        return entries.get(rpcId);
+    }
+
+    public void complete(String rpcId) {
+        entries.remove(rpcId);
+    }
+
+    public List<Entry> evictByStream(StreamObserver<RpcRequest> closedStream) {
+        List<Entry> evicted = new ArrayList<>();
+        entries.entrySet().removeIf(e -> {
+            if (e.getValue().stream() == closedStream) {
+                evicted.add(e.getValue());
+                return true;
+            }
+            return false;
+        });
+        return evicted;
+    }
+
+    public List<Entry> evictExpired(Instant now) {
+        List<Entry> evicted = new ArrayList<>();
+        entries.entrySet().removeIf(e -> {
+            if (e.getValue().deadline().isBefore(now)) {
+                evicted.add(e.getValue());
+                return true;
+            }
+            return false;
+        });
+        return evicted;
+    }
+
+    public int size() {
+        return entries.size();
+    }
+
+    public record Entry(String rpcId,
+                        StreamObserver<RpcRequest> stream,
+                        RpcRequest request,
+                        Instant deadline) {}
+}
+```
+
+- [ ] **Step 5.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=InFlightRpcTableTest
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/rpc/InFlightRpcTable.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/rpc/InFlightRpcTableTest.java
+git commit -m "feat(v1.2.0-rc2-pr1): InFlightRpcTable with stream + deadline eviction (Task 5)"
+```
+
+---
+
+### Task 6: RpcChannelGrpcService — bidi service that owns stream lifecycle
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/RpcChannelGrpcService.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/grpc/RpcChannelGrpcServiceTest.java`
+
+**Rationale:** The gRPC service receives one bidi stream per Minion. On stream open, it registers with `MinionStreamPool`. On inbound `RpcResponse`, it forwards to the response publisher (Task 7). On stream close, it triggers redispatch via the dispatcher (Task 7).
+
+- [ ] **Step 6.1: Write failing test (stream open registers; close unregisters)**
+
+```java
+package org.deltav.gateway.grpc;
+
+import io.grpc.Context;
+import io.grpc.stub.StreamObserver;
+import org.deltav.gateway.rpc.MinionStreamPool;
+import org.deltav.gateway.rpc.RpcStreamCloseHandler;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.deltav.minion.grpc.v1.RpcResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class RpcChannelGrpcServiceTest {
+
+    @Test
+    void streamOpen_registersInPool() {
+        MinionStreamPool pool = mock(MinionStreamPool.class);
+        RpcStreamCloseHandler closeHandler = mock(RpcStreamCloseHandler.class);
+        RpcResponseHandler responseHandler = mock(RpcResponseHandler.class);
+        RpcChannelGrpcService svc = new RpcChannelGrpcService(pool, closeHandler, responseHandler);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> requestObserver = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+                .withValue(MINION_ID_CTX, "minion-A")
+                .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> svc.channel(requestObserver));
+
+        verify(pool).register("Default", "minion-A", requestObserver);
+    }
+
+    @Test
+    void streamClose_unregistersAndTriggersRedispatch() {
+        MinionStreamPool pool = mock(MinionStreamPool.class);
+        RpcStreamCloseHandler closeHandler = mock(RpcStreamCloseHandler.class);
+        RpcResponseHandler responseHandler = mock(RpcResponseHandler.class);
+        RpcChannelGrpcService svc = new RpcChannelGrpcService(pool, closeHandler, responseHandler);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> requestObserver = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+                .withValue(MINION_ID_CTX, "minion-A")
+                .withValue(MINION_LOCATION_CTX, "Default");
+        ArgumentCaptor<StreamObserver<RpcResponse>> captured = ArgumentCaptor.forClass(StreamObserver.class);
+        ctx.run(() -> {
+            StreamObserver<RpcResponse> responseObserver = svc.channel(requestObserver);
+            responseObserver.onCompleted();
+        });
+
+        verify(pool).unregister("Default", "minion-A");
+        verify(closeHandler).onStreamClosed("Default", requestObserver);
+    }
+
+    @Test
+    void incomingResponse_forwardedToResponseHandler() {
+        MinionStreamPool pool = mock(MinionStreamPool.class);
+        RpcStreamCloseHandler closeHandler = mock(RpcStreamCloseHandler.class);
+        RpcResponseHandler responseHandler = mock(RpcResponseHandler.class);
+        RpcChannelGrpcService svc = new RpcChannelGrpcService(pool, closeHandler, responseHandler);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> requestObserver = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+                .withValue(MINION_ID_CTX, "minion-A")
+                .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<RpcResponse> responseObserver = svc.channel(requestObserver);
+            RpcResponse rsp = RpcResponse.newBuilder().setRpcId("xyz").build();
+            responseObserver.onNext(rsp);
+        });
+
+        verify(responseHandler).handle(RpcResponse.newBuilder().setRpcId("xyz").build());
+    }
+}
+```
+
+- [ ] **Step 6.2: Define collaborators (RpcStreamCloseHandler, RpcResponseHandler) — interfaces only**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcStreamCloseHandler.java`:
+
+```java
+package org.deltav.gateway.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+
+public interface RpcStreamCloseHandler {
+    void onStreamClosed(String location, StreamObserver<RpcRequest> closedStream);
+}
+```
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponseHandler.java`:
+
+```java
+package org.deltav.gateway.rpc;
+
+import org.deltav.minion.grpc.v1.RpcResponse;
+
+public interface RpcResponseHandler {
+    void handle(RpcResponse response);
+}
+```
+
+(These are wired to concrete impls in Task 7. For now they're seams the test mocks.)
+
+- [ ] **Step 6.3: Run test to verify it fails**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=RpcChannelGrpcServiceTest
+```
+
+Expected: FAIL with `cannot find symbol class RpcChannelGrpcService` (or `channel method`).
+
+- [ ] **Step 6.4: Implement RpcChannelGrpcService**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/RpcChannelGrpcService.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.gateway.rpc.MinionStreamPool;
+import org.deltav.gateway.rpc.RpcResponseHandler;
+import org.deltav.gateway.rpc.RpcStreamCloseHandler;
+import org.deltav.minion.grpc.v1.RpcChannelServiceGrpc;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.deltav.minion.grpc.v1.RpcResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.grpc.server.service.GrpcService;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+
+/**
+ * Bidi-streaming gRPC service for RPC dispatch between minion-gateway
+ * (server) and Minions (clients). Per the proto contract, RpcRequest
+ * messages flow gateway -> Minion and RpcResponse messages flow Minion ->
+ * gateway, both on the same stream.
+ *
+ * <p>Stream lifecycle:
+ * <ul>
+ *   <li>Open: register the request-side observer in {@link MinionStreamPool}
+ *       under the location read from gRPC context.</li>
+ *   <li>Inbound RpcResponse: forward to {@link RpcResponseHandler} (which
+ *       publishes to the internal Kafka response topic).</li>
+ *   <li>Close (onCompleted/onError): unregister from pool and notify
+ *       {@link RpcStreamCloseHandler} so the dispatcher can redispatch
+ *       in-flight requests for this stream to a surviving sibling.</li>
+ * </ul>
+ */
+@GrpcService
+public class RpcChannelGrpcService extends RpcChannelServiceGrpc.RpcChannelServiceImplBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RpcChannelGrpcService.class);
+
+    private final MinionStreamPool pool;
+    private final RpcStreamCloseHandler closeHandler;
+    private final RpcResponseHandler responseHandler;
+
+    public RpcChannelGrpcService(MinionStreamPool pool,
+                                 RpcStreamCloseHandler closeHandler,
+                                 RpcResponseHandler responseHandler) {
+        this.pool = pool;
+        this.closeHandler = closeHandler;
+        this.responseHandler = responseHandler;
+    }
+
+    @Override
+    public StreamObserver<RpcResponse> channel(StreamObserver<RpcRequest> requestObserver) {
+        String minionId = MINION_ID_CTX.get();
+        String location = MINION_LOCATION_CTX.get();
+        LOG.info("RPC stream opened for minion={} location={}", minionId, location);
+
+        pool.register(location, minionId, requestObserver);
+
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(RpcResponse response) {
+                responseHandler.handle(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("RPC stream error for minion={}: {}", minionId, t.toString());
+                pool.unregister(location, minionId);
+                closeHandler.onStreamClosed(location, requestObserver);
+            }
+
+            @Override
+            public void onCompleted() {
+                LOG.info("RPC stream closed for minion={}", minionId);
+                pool.unregister(location, minionId);
+                closeHandler.onStreamClosed(location, requestObserver);
+                requestObserver.onCompleted();
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 6.5: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=RpcChannelGrpcServiceTest
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/grpc/RpcChannelGrpcService.java \
+        core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcStreamCloseHandler.java \
+        core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponseHandler.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/grpc/RpcChannelGrpcServiceTest.java
+git commit -m "feat(v1.2.0-rc2-pr1): RpcChannelGrpcService bidi handler (Task 6)"
+```
+
+---
+
+### Task 7: RpcChannelDispatcher — Kafka consumer + stream forwarding + redispatch
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponsePublisher.java`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelConfiguration.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/rpc/RpcChannelDispatcherTest.java`
+
+**Rationale:** The wiring piece. Reads from `OpenNMS.<location>.rpc-request`, picks a stream from the pool, sends `RpcRequest` over the stream, records in the in-flight table. Implements `RpcStreamCloseHandler` (redispatch to sibling) and `RpcResponseHandler` (publish to `OpenNMS.rpc-response`).
+
+The Dispatcher's redispatch logic is tightly coupled to the in-flight table; testing happens through targeted unit tests for the redispatch path. Full Kafka-driven integration is exercised in Task 14's E2E.
+
+- [ ] **Step 7.1: Write failing test for redispatch on stream close**
+
+Create `core/minion-gateway/src/test/java/org/deltav/gateway/rpc/RpcChannelDispatcherTest.java`:
+
+```java
+package org.deltav.gateway.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RpcChannelDispatcherTest {
+
+    @Test
+    void onStreamClosed_redispatchesToSurvivingSibling() {
+        MinionStreamPool pool = mock(MinionStreamPool.class);
+        InFlightRpcTable table = new InFlightRpcTable();
+        RpcResponsePublisher publisher = mock(RpcResponsePublisher.class);
+        RpcChannelDispatcher dispatcher = new RpcChannelDispatcher(pool, table, publisher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> closedStream = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> sibling = mock(StreamObserver.class);
+        when(pool.siblingStreams("Default", closedStream)).thenReturn(java.util.List.of(sibling));
+
+        RpcRequest req = RpcRequest.newBuilder().setRpcId("xyz").setLocation("Default").build();
+        table.record("xyz", closedStream, req, Instant.now().plusSeconds(30));
+
+        dispatcher.onStreamClosed("Default", closedStream);
+
+        verify(sibling).onNext(req);
+        assertThat(table.findEntry("xyz")).isNotNull();
+        assertThat(table.findEntry("xyz").stream()).isSameAs(sibling);
+    }
+
+    @Test
+    void onStreamClosed_noSibling_dropsRequestWithoutFailing() {
+        MinionStreamPool pool = mock(MinionStreamPool.class);
+        InFlightRpcTable table = new InFlightRpcTable();
+        RpcResponsePublisher publisher = mock(RpcResponsePublisher.class);
+        RpcChannelDispatcher dispatcher = new RpcChannelDispatcher(pool, table, publisher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> closedStream = mock(StreamObserver.class);
+        when(pool.siblingStreams("Default", closedStream)).thenReturn(java.util.List.of());
+
+        RpcRequest req = RpcRequest.newBuilder().setRpcId("xyz").setLocation("Default").build();
+        table.record("xyz", closedStream, req, Instant.now().plusSeconds(30));
+
+        dispatcher.onStreamClosed("Default", closedStream);
+
+        // Per Decision 1 sub-decision 1-i: empty pool -> caller's existing
+        // dispatcher deadline absorbs. Gateway does not synthesize a failure.
+        assertThat(table.findEntry("xyz")).isNull();
+    }
+
+    @Test
+    void onResponse_forwardsToPublisher_andEvictsTableEntry() {
+        MinionStreamPool pool = mock(MinionStreamPool.class);
+        InFlightRpcTable table = new InFlightRpcTable();
+        RpcResponsePublisher publisher = mock(RpcResponsePublisher.class);
+        RpcChannelDispatcher dispatcher = new RpcChannelDispatcher(pool, table, publisher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcRequest> stream = mock(StreamObserver.class);
+        RpcRequest req = RpcRequest.newBuilder().setRpcId("xyz").build();
+        table.record("xyz", stream, req, Instant.now().plusSeconds(30));
+
+        org.deltav.minion.grpc.v1.RpcResponse rsp =
+            org.deltav.minion.grpc.v1.RpcResponse.newBuilder().setRpcId("xyz").build();
+        dispatcher.handle(rsp);
+
+        verify(publisher).publish(rsp);
+        assertThat(table.findEntry("xyz")).isNull();
+    }
+}
+```
+
+- [ ] **Step 7.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=RpcChannelDispatcherTest
+```
+
+Expected: FAIL with `cannot find symbol class RpcChannelDispatcher`.
+
+- [ ] **Step 7.3: Implement RpcResponsePublisher (the seam to internal Kafka)**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponsePublisher.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc. (license header as elsewhere)
+ */
+package org.deltav.gateway.rpc;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.deltav.minion.grpc.v1.RpcResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes RpcResponse protobuf bytes to {@code OpenNMS.rpc-response}
+ * (the topic horizon's KafkaRpcClient consumes for response correlation).
+ *
+ * <p>The wire format (RpcResponseProto from horizon's RPC API) matches
+ * what KafkaRpcClient expects, so daemon-side correlation continues to
+ * work unchanged.
+ */
+@Component
+public class RpcResponsePublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RpcResponsePublisher.class);
+
+    private final KafkaProducer<String, byte[]> producer;
+    private final String responseTopic;
+
+    public RpcResponsePublisher(KafkaProducer<String, byte[]> minionGatewayKafkaProducer,
+                                @Value("${minion-gateway.rpc.response-topic:OpenNMS.rpc-response}") String responseTopic) {
+        this.producer = minionGatewayKafkaProducer;
+        this.responseTopic = responseTopic;
+    }
+
+    public void publish(RpcResponse response) {
+        ProducerRecord<String, byte[]> record =
+            new ProducerRecord<>(responseTopic, response.getRpcId(), response.toByteArray());
+        producer.send(record, (md, ex) -> {
+            if (ex != null) {
+                LOG.warn("Failed to publish RPC response rpcId={}", response.getRpcId(), ex);
+            }
+        });
+    }
+}
+```
+
+- [ ] **Step 7.4: Implement RpcChannelDispatcher**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc. (license header as elsewhere)
+ */
+package org.deltav.gateway.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.deltav.minion.grpc.v1.RpcResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * The "dispatcher" piece of Decision 1 Option D. Implements both
+ * {@link RpcStreamCloseHandler} (redispatch on stream close) and
+ * {@link RpcResponseHandler} (forward Minion responses to internal Kafka).
+ *
+ * <p>Inbound RPCs from ServiceDaemons arrive on
+ * {@code OpenNMS.<location>.rpc-request} (the topic name is parameterized
+ * but matches horizon's KafkaRpcClient producer convention). The dispatcher
+ * picks a stream from the location's pool, records the in-flight entry,
+ * and forwards.
+ *
+ * <p>If no stream is available for a location (empty pool), the request
+ * is dropped. Per Decision 1 sub-decision 1-i, the daemon's existing
+ * timeout path absorbs this case (no synthesized outage per
+ * {@code feedback_rpc_timeout_no_outages}).
+ */
+@Component
+public class RpcChannelDispatcher implements RpcStreamCloseHandler, RpcResponseHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RpcChannelDispatcher.class);
+
+    private final MinionStreamPool pool;
+    private final InFlightRpcTable inFlight;
+    private final RpcResponsePublisher publisher;
+
+    public RpcChannelDispatcher(MinionStreamPool pool,
+                                InFlightRpcTable inFlight,
+                                RpcResponsePublisher publisher) {
+        this.pool = pool;
+        this.inFlight = inFlight;
+        this.publisher = publisher;
+    }
+
+    @KafkaListener(
+        topicPattern = "OpenNMS\\..*\\.rpc-request",
+        groupId = "minion-gateway-rpc",
+        containerFactory = "rpcRequestContainerFactory"
+    )
+    public void onKafkaRequest(ConsumerRecord<String, byte[]> record) {
+        try {
+            RpcRequest req = RpcRequest.parseFrom(record.value());
+            dispatch(req);
+        } catch (Exception e) {
+            LOG.warn("Failed to parse RpcRequest from topic={} key={}", record.topic(), record.key(), e);
+        }
+    }
+
+    void dispatch(RpcRequest req) {
+        StreamObserver<RpcRequest> stream = pool.pickStream(req.getLocation());
+        if (stream == null) {
+            LOG.info("No Minion streams for location={}; dropping rpcId={} (caller will time out)",
+                req.getLocation(), req.getRpcId());
+            return;
+        }
+
+        Instant deadline = req.getDeadlineMs() > 0
+            ? Instant.ofEpochMilli(req.getDeadlineMs())
+            : Instant.now().plusSeconds(60);
+        inFlight.record(req.getRpcId(), stream, req, deadline);
+        try {
+            stream.onNext(req);
+        } catch (Throwable t) {
+            LOG.warn("Stream send failed for rpcId={}; evicting in-flight entry", req.getRpcId(), t);
+            inFlight.complete(req.getRpcId());
+        }
+    }
+
+    @Override
+    public void onStreamClosed(String location, StreamObserver<RpcRequest> closedStream) {
+        List<InFlightRpcTable.Entry> orphans = inFlight.evictByStream(closedStream);
+        if (orphans.isEmpty()) {
+            return;
+        }
+        List<StreamObserver<RpcRequest>> siblings = pool.siblingStreams(location, closedStream);
+        if (siblings.isEmpty()) {
+            LOG.info("Stream closed for location={} with {} in-flight RPCs; no siblings; caller will time out",
+                location, orphans.size());
+            return;
+        }
+        // Round-robin across siblings; redispatch each orphan
+        int n = siblings.size();
+        for (int i = 0; i < orphans.size(); i++) {
+            InFlightRpcTable.Entry orphan = orphans.get(i);
+            StreamObserver<RpcRequest> sibling = siblings.get(i % n);
+            inFlight.record(orphan.rpcId(), sibling, orphan.request(), orphan.deadline());
+            try {
+                sibling.onNext(orphan.request());
+            } catch (Throwable t) {
+                LOG.warn("Redispatch send failed for rpcId={}", orphan.rpcId(), t);
+                inFlight.complete(orphan.rpcId());
+            }
+        }
+        LOG.info("Redispatched {} in-flight RPCs from closed stream for location={}", orphans.size(), location);
+    }
+
+    @Override
+    public void handle(RpcResponse response) {
+        inFlight.complete(response.getRpcId());
+        publisher.publish(response);
+    }
+}
+```
+
+- [ ] **Step 7.5: Implement RpcChannelConfiguration (Spring Kafka container factory + producer bean)**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelConfiguration.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc. (license header as elsewhere)
+ */
+package org.deltav.gateway.rpc;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+@Configuration
+public class RpcChannelConfiguration {
+
+    @Bean
+    public KafkaProducer<String, byte[]> minionGatewayKafkaProducer(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        p.put(ProducerConfig.ACKS_CONFIG, "1");
+        p.put(ProducerConfig.LINGER_MS_CONFIG, "0");
+        return new KafkaProducer<>(p);
+    }
+
+    @Bean
+    public ConsumerFactory<String, byte[]> rpcRequestConsumerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        cfg.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        cfg.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        cfg.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        return new DefaultKafkaConsumerFactory<>(cfg);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, byte[]> rpcRequestContainerFactory(
+            ConsumerFactory<String, byte[]> rpcRequestConsumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, byte[]> f =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        f.setConsumerFactory(rpcRequestConsumerFactory);
+        return f;
+    }
+}
+```
+
+- [ ] **Step 7.6: Run dispatcher test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=RpcChannelDispatcherTest
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 7.7: Run full minion-gateway compile to verify Spring wiring is satisfied**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway -am clean compile
+```
+
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 7.8: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/rpc/
+git add core/minion-gateway/src/test/java/org/deltav/gateway/rpc/RpcChannelDispatcherTest.java
+git commit -m "feat(v1.2.0-rc2-pr1): RpcChannelDispatcher + Kafka wiring (Task 7)"
+```
+
+---
+
+## Phase 2 — Minion: gRPC RPC stream client (Tasks 8-10)
+
+### Task 8: MinionRpcStreamClient — connect to gateway, dispatch incoming RpcRequests via RpcModule registry
+
+**Files:**
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionRpcStreamClient.java`
+- Create: `core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionRpcStreamClientTest.java`
+
+**Rationale:** The Minion-side client opens a bidi stream to the gateway, registers itself, and on each inbound `RpcRequest` looks up the corresponding `RpcModule` from a registry, dispatches `module.execute(unmarshalRequest(payload))`, and sends the marshaled response back on the same stream.
+
+This is the substitution seam Task 2's inventory will inform. The skeleton below assumes:
+- `RpcModuleRegistry` (delta-v's existing wrapper) provides `Map<String, RpcModule>` keyed by `RpcModule.getId()`.
+- `RpcModule.unmarshalRequest(byte[]→String→RpcRequest)` converts the proto payload bytes to an `RpcRequest` instance via the existing horizon API.
+
+If Task 2's inventory shows different signatures, adjust this skeleton accordingly.
+
+- [ ] **Step 8.1: Write failing test (registers stream, handles incoming request, sends response)**
+
+Create `core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionRpcStreamClientTest.java`:
+
+```java
+package org.deltav.minion.common.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.deltav.minion.grpc.v1.RpcResponse;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.rpc.api.RpcModule;
+import org.opennms.distributed.core.api.MinionIdentity;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class MinionRpcStreamClientTest {
+
+    @Test
+    void onIncomingRequest_dispatchesToRpcModuleAndSendsResponse() {
+        @SuppressWarnings("rawtypes")
+        RpcModule module = mock(RpcModule.class);
+        when(module.getId()).thenReturn("Echo");
+        when(module.unmarshalRequest(anyString())).thenReturn(mock(org.opennms.core.rpc.api.RpcRequest.class));
+
+        org.opennms.core.rpc.api.RpcResponse responseObj = mock(org.opennms.core.rpc.api.RpcResponse.class);
+        when(module.execute(any())).thenReturn(CompletableFuture.completedFuture(responseObj));
+        when(module.marshalResponse(responseObj)).thenReturn("response-payload");
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Map<String, RpcModule> registry = Map.of("Echo", module);
+        MinionIdentity identity = mock(MinionIdentity.class);
+        when(identity.getId()).thenReturn("minion-A");
+        when(identity.getLocation()).thenReturn("Default");
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcResponse> outbound = mock(StreamObserver.class);
+        MinionRpcStreamClient client = new MinionRpcStreamClient(registry, identity, () -> outbound);
+
+        StreamObserver<RpcRequest> inbound = client.streamObserver();
+        RpcRequest req = RpcRequest.newBuilder()
+            .setRpcId("xyz").setModuleId("Echo").setPayload(com.google.protobuf.ByteString.copyFromUtf8("p")).build();
+        inbound.onNext(req);
+
+        // Wait for async future
+        try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        verify(outbound).onNext(argThat(r -> "xyz".equals(r.getRpcId())));
+    }
+
+    @Test
+    void onUnknownModule_sendsErrorResponse() {
+        Map<String, RpcModule> registry = Map.of();
+        MinionIdentity identity = mock(MinionIdentity.class);
+        when(identity.getId()).thenReturn("minion-A");
+        when(identity.getLocation()).thenReturn("Default");
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<RpcResponse> outbound = mock(StreamObserver.class);
+        MinionRpcStreamClient client = new MinionRpcStreamClient(registry, identity, () -> outbound);
+
+        StreamObserver<RpcRequest> inbound = client.streamObserver();
+        RpcRequest req = RpcRequest.newBuilder().setRpcId("xyz").setModuleId("Unknown").build();
+        inbound.onNext(req);
+
+        verify(outbound).onNext(argThat(r ->
+            "xyz".equals(r.getRpcId()) && r.getErrorMessage().contains("Unknown")));
+    }
+}
+```
+
+- [ ] **Step 8.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common test -Dtest=MinionRpcStreamClientTest
+```
+
+Expected: FAIL with `cannot find symbol class MinionRpcStreamClient`.
+
+- [ ] **Step 8.3: Implement MinionRpcStreamClient**
+
+Create `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionRpcStreamClient.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc. (license header as elsewhere)
+ */
+package org.deltav.minion.common.grpc;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.deltav.minion.grpc.v1.RpcResponse;
+import org.opennms.core.rpc.api.RpcModule;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Minion-side gRPC RPC handler. Receives {@link RpcRequest} messages on a
+ * bidi stream from minion-gateway, dispatches them via the local
+ * {@link RpcModule} registry, and sends marshaled {@link RpcResponse}
+ * messages back on the same stream.
+ *
+ * <p>Idempotency is a contract on the modules registered here, not a
+ * property enforced by this client. Per Decision 1 sub-decision 1-ii of
+ * the v1.2.0-rc2 decisions doc: all RpcModules must be idempotent
+ * because gateway-side redispatch on stream close can cause at-least-once
+ * execution.
+ */
+public class MinionRpcStreamClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MinionRpcStreamClient.class);
+
+    private final Map<String, RpcModule> registry;
+    private final MinionIdentity identity;
+    private final Supplier<StreamObserver<RpcResponse>> outboundSupplier;
+
+    public MinionRpcStreamClient(Map<String, RpcModule> registry,
+                                 MinionIdentity identity,
+                                 Supplier<StreamObserver<RpcResponse>> outboundSupplier) {
+        this.registry = registry;
+        this.identity = identity;
+        this.outboundSupplier = outboundSupplier;
+    }
+
+    public StreamObserver<RpcRequest> streamObserver() {
+        StreamObserver<RpcResponse> outbound = outboundSupplier.get();
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(RpcRequest req) { handle(req, outbound); }
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("RPC stream error on minion={}: {}", identity.getId(), t.toString());
+            }
+            @Override
+            public void onCompleted() {
+                LOG.info("RPC stream closed on minion={}", identity.getId());
+            }
+        };
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void handle(RpcRequest req, StreamObserver<RpcResponse> outbound) {
+        String moduleId = req.getModuleId();
+        RpcModule module = registry.get(moduleId);
+        if (module == null) {
+            outbound.onNext(errorResponse(req.getRpcId(), "Unknown module: " + moduleId));
+            return;
+        }
+        try {
+            String payloadStr = req.getPayload().toStringUtf8();
+            org.opennms.core.rpc.api.RpcRequest internal = (org.opennms.core.rpc.api.RpcRequest)
+                module.unmarshalRequest(payloadStr);
+            module.execute(internal).whenComplete((rsp, t) -> {
+                if (t != null) {
+                    outbound.onNext(errorResponse(req.getRpcId(), t.toString()));
+                } else {
+                    String marshaled = module.marshalResponse(rsp);
+                    outbound.onNext(RpcResponse.newBuilder()
+                        .setRpcId(req.getRpcId())
+                        .setPayload(ByteString.copyFromUtf8(marshaled))
+                        .setCompletedAt(now())
+                        .build());
+                }
+            });
+        } catch (Throwable t) {
+            outbound.onNext(errorResponse(req.getRpcId(), t.toString()));
+        }
+    }
+
+    private RpcResponse errorResponse(String rpcId, String error) {
+        return RpcResponse.newBuilder()
+            .setRpcId(rpcId)
+            .setErrorMessage(error)
+            .setCompletedAt(now())
+            .build();
+    }
+
+    private Timestamp now() {
+        Instant n = Instant.now();
+        return Timestamp.newBuilder().setSeconds(n.getEpochSecond()).setNanos(n.getNano()).build();
+    }
+}
+```
+
+- [ ] **Step 8.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common test -Dtest=MinionRpcStreamClientTest
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionRpcStreamClient.java \
+        core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionRpcStreamClientTest.java
+git commit -m "feat(v1.2.0-rc2-pr1): MinionRpcStreamClient (Task 8)"
+```
+
+---
+
+### Task 9: GrpcRpcStreamConfiguration — wire client + connect to gateway
+
+**Files:**
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcRpcStreamConfiguration.java`
+
+**Rationale:** Spring `@Configuration` that activates when `opennms.minion.transport.rpc=grpc` (default). Builds the gRPC stub, opens the bidi stream, and wires it to `MinionRpcStreamClient`.
+
+- [ ] **Step 9.1: Implement GrpcRpcStreamConfiguration**
+
+Create `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcRpcStreamConfiguration.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc. (license header as elsewhere)
+ */
+package org.deltav.minion.common;
+
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.deltav.minion.common.grpc.MinionRpcStreamClient;
+import org.deltav.minion.common.grpc.MinionIdentityClientInterceptor;
+import org.deltav.minion.grpc.v1.RpcChannelServiceGrpc;
+import org.deltav.minion.grpc.v1.RpcRequest;
+import org.deltav.minion.grpc.v1.RpcResponse;
+import org.opennms.core.rpc.api.RpcModule;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Active when {@code opennms.minion.transport.rpc=grpc} (default per
+ * Decision 4 sub-decision 4-ii). Opens a bidi stream to minion-gateway
+ * and routes inbound RpcRequest messages through {@link MinionRpcStreamClient}
+ * to the local {@link RpcModule} registry.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.rpc", havingValue = "grpc", matchIfMissing = true)
+public class GrpcRpcStreamConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GrpcRpcStreamConfiguration.class);
+
+    private final ManagedChannel channel;
+    private final MinionIdentity identity;
+    private final List<RpcModule<?, ?>> modules;
+    private final MinionIdentityClientInterceptor identityInterceptor;
+
+    private StreamObserver<RpcResponse> outboundStream;
+
+    @Autowired
+    public GrpcRpcStreamConfiguration(ManagedChannel minionGatewayChannel,
+                                      MinionIdentity identity,
+                                      List<RpcModule<?, ?>> modules,
+                                      MinionIdentityClientInterceptor identityInterceptor) {
+        this.channel = minionGatewayChannel;
+        this.identity = identity;
+        this.modules = modules;
+        this.identityInterceptor = identityInterceptor;
+    }
+
+    @Bean
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public MinionRpcStreamClient minionRpcStreamClient() {
+        Map<String, RpcModule> registry = modules.stream()
+            .collect(Collectors.toMap(m -> m.getId(), m -> (RpcModule) m));
+        return new MinionRpcStreamClient(registry, identity, () -> outboundStream);
+    }
+
+    @PostConstruct
+    public void openStream() {
+        var stub = RpcChannelServiceGrpc.newStub(channel)
+            .withInterceptors(identityInterceptor);
+        var clientObserver = minionRpcStreamClient().streamObserver();
+        // Reverse-direction stream: client.channel() returns a StreamObserver<RpcResponse>
+        // (what we send) and accepts a StreamObserver<RpcRequest> (what we receive).
+        // The proto definition has the directions swapped relative to Heartbeat because
+        // RPC originates from the gateway side.
+        outboundStream = stub.channel(clientObserver);
+        LOG.info("RPC stream opened to minion-gateway for minion={} location={}",
+            identity.getId(), identity.getLocation());
+    }
+
+    @PreDestroy
+    public void closeStream() {
+        if (outboundStream != null) {
+            outboundStream.onCompleted();
+        }
+    }
+}
+```
+
+- [ ] **Step 9.2: Compile to verify all references resolve**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common -am compile
+```
+
+Expected: BUILD SUCCESS. If `MinionIdentityClientInterceptor` doesn't exist, Task 2's inventory will show whether to use the existing `org.deltav.minion.common.grpc.MinionIdentityClientInterceptor` (already in repo from rc1 Heartbeat).
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcRpcStreamConfiguration.java
+git commit -m "feat(v1.2.0-rc2-pr1): GrpcRpcStreamConfiguration (Task 9)"
+```
+
+---
+
+### Task 10: KafkaRpcStreamFallbackConfiguration — emergency rollback path
+
+**Files:**
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcStreamFallbackConfiguration.java`
+
+**Rationale:** Per Decision 4 sub-decision 4-i, every channel migration introduces a `MINION_<CHANNEL>_TRANSPORT=kafka` emergency flag preserving the rc1 path. For RPC, that means: when `opennms.minion.transport.rpc=kafka`, the existing horizon `KafkaRpcServer` continues to bind RpcModules from the local registry — no gRPC wiring activates.
+
+- [ ] **Step 10.1: Implement KafkaRpcStreamFallbackConfiguration**
+
+Create `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcStreamFallbackConfiguration.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc. (license header as elsewhere)
+ */
+package org.deltav.minion.common;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Active when {@code opennms.minion.transport.rpc=kafka} — preserves the rc1
+ * Kafka RPC path through rc2 soak per Decision 4 sub-decision 4-i. The actual
+ * Kafka wiring lives in the existing {@code KafkaRpcServerConfiguration}; this
+ * class exists so the @ConditionalOnProperty pair is symmetric and obvious.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.rpc", havingValue = "kafka")
+@Import(KafkaRpcServerConfiguration.class)  // existing horizon-Kafka RPC server wiring
+public class KafkaRpcStreamFallbackConfiguration {
+    // intentionally empty — selection is the only behavior
+}
+```
+
+- [ ] **Step 10.2: Verify the existing `KafkaRpcServerConfiguration` is gated correctly**
+
+Read existing `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcServerConfiguration.java`. If it's currently active unconditionally, add `@ConditionalOnProperty(name = "opennms.minion.transport.rpc", havingValue = "kafka")` to it OR remove that annotation from the new fallback class and instead let the existing class be unconditional (only one of the two configs activates the actual KafkaRpcServer; the other is the no-op alternative).
+
+The cleanest split:
+- `GrpcRpcStreamConfiguration` activates when `transport.rpc=grpc` (default).
+- `KafkaRpcServerConfiguration` activates when `transport.rpc=kafka`.
+- `KafkaRpcStreamFallbackConfiguration` is removed if `KafkaRpcServerConfiguration` already has the right `@ConditionalOnProperty`.
+
+If `KafkaRpcServerConfiguration` doesn't have the annotation, add it; the fallback class is then unnecessary.
+
+- [ ] **Step 10.3: Run tests**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common -am test
+```
+
+Expected: all existing tests pass; both transports' configs are mutually exclusive.
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcStreamFallbackConfiguration.java \
+        core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaRpcServerConfiguration.java
+git commit -m "feat(v1.2.0-rc2-pr1): MINION_RPC_TRANSPORT flag wiring (Task 10)"
+```
+
+---
+
+## Phase 3 — E2E test harness updates (Tasks 11-12)
+
+### Task 11: Update test-perspective-e2e.sh for gRPC RPC path
+
+**Files:**
+- Modify: `e2e/test-perspective-e2e.sh`
+
+**Rationale:** The script currently assumes Kafka RPC topic flow. After PR1, RPC traffic flows over the gRPC channel; the test must verify the new path (and assert the rollback flag is at default `grpc`).
+
+- [ ] **Step 11.1: Read current test-perspective-e2e.sh and identify Kafka RPC topic assertions**
+
+```bash
+grep -n "rpc-request\|rpc-response\|KafkaRpcServer" e2e/test-perspective-e2e.sh
+```
+
+Document the lines that currently assert Kafka RPC topic activity.
+
+- [ ] **Step 11.2: Replace Kafka RPC assertions with gRPC stream assertions**
+
+Add an assertion that `MINION_RPC_TRANSPORT` is `grpc` (default) in the Minion container env, and that minion-gateway logs show "RPC stream opened" for each connected Minion.
+
+```bash
+# Inside the assertion phase of test-perspective-e2e.sh
+docker exec deltav-minion env | grep -E '^MINION_RPC_TRANSPORT='
+EXPECT="MINION_RPC_TRANSPORT=grpc"
+docker exec deltav-minion env | grep -F "$EXPECT" \
+  || (echo "FAIL: Minion not on gRPC RPC transport"; exit 1)
+
+docker logs deltav-minion-gateway 2>&1 \
+  | grep -E "RPC stream opened for minion=.* location=$LOCATION" \
+  || (echo "FAIL: minion-gateway did not open RPC stream"; exit 1)
+```
+
+Replace any `kafka-console-consumer ... --topic OpenNMS\\..*\\.rpc-request` assertions with the above.
+
+- [ ] **Step 11.3: Verify test still validates the perspective-poller behavior end-to-end**
+
+Per `feedback_e2e_continuous_validation_grpc_migration` and `feedback_rpc_timeout_no_outages`: the test must still demonstrate that perspective-pollerd polls a remote service via Minion AND that an RPC timeout does not synthesize an outage. These assertions are independent of transport — they test outcome, not mechanism. Verify they remain in the script.
+
+- [ ] **Step 11.4: Run the test against develop+PR1 stack**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+opennms-container/delta-v/build.sh deltav  # rebuild with PR1 changes
+opennms-container/delta-v/deploy.sh up full
+./e2e/test-perspective-e2e.sh
+```
+
+Expected: test passes.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add e2e/test-perspective-e2e.sh
+git commit -m "test(v1.2.0-rc2-pr1): update test-perspective-e2e for gRPC RPC path (Task 11)"
+```
+
+---
+
+### Task 12: Update test-enlinkd-e2e.sh for gRPC RPC path
+
+**Files:**
+- Modify: `e2e/test-enlinkd-e2e.sh`
+
+**Rationale:** Same as Task 11 but for enlinkd's RPC path. Memory `project_e2e_detectors_monitors_minion` calls out enlinkd as a remaining E2E coverage target; PR1 should keep its existing assertions working over gRPC.
+
+- [ ] **Step 12.1: Mirror Task 11's pattern for test-enlinkd-e2e.sh**
+
+Same edits: replace any explicit Kafka RPC topic assertions with the gRPC-path assertions (env var check + gateway log check). Keep the existing enlinkd outcome assertions (LLDP topology populated, etc.).
+
+- [ ] **Step 12.2: Run the test (labbox-only — skip on Mac dev env)**
+
+This test runs on labbox per `feedback_smoke_vm_release_only` and rc1's regression check. On Mac dev env it's expected to SKIP (labbox dependencies). Document the skip behavior in the script comment if not already present.
+
+- [ ] **Step 12.3: Commit**
+
+```bash
+git add e2e/test-enlinkd-e2e.sh
+git commit -m "test(v1.2.0-rc2-pr1): update test-enlinkd-e2e for gRPC RPC path (Task 12)"
+```
+
+---
+
+## Phase 4 — Bench harness + acceptance (Tasks 13-14)
+
+### Task 13: Add test-grpc-rpc-e2e.sh for baseline + gate measurement
+
+**Files:**
+- Create: `e2e/test-grpc-rpc-e2e.sh`
+
+**Rationale:** Decision 10 sub-decision 10-iv requires gate widenings be documented. This test enforces the gate (`gRPC RPC p99 ≤ Kafka RPC p99 + 20 ms`) and captures the actual measurement for inclusion in the rc2 release notes.
+
+- [ ] **Step 13.1: Implement the script**
+
+Create `e2e/test-grpc-rpc-e2e.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Echo-RPC bench harness for v1.2.0-rc2-pr1 (Task 13).
+# Measures gRPC-path Echo-RPC RTT distribution and asserts it meets the
+# release gate from the rc2 decisions doc Decision 10:
+#   gRPC RPC p99 <= Kafka RPC p99 + 20 ms
+#
+# Kafka baseline is read from
+# docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md
+# (captured in Task 1).
+set -euo pipefail
+
+BASELINE_FILE="docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md"
+BASELINE_P99_MS=$(grep -E '^\| p99 \| [0-9]+ ms \|' "$BASELINE_FILE" | head -1 | awk '{print $4}')
+GATE_MS=$((BASELINE_P99_MS + 20))
+
+echo "Kafka baseline p99 = ${BASELINE_P99_MS} ms"
+echo "gRPC gate = <= ${GATE_MS} ms"
+
+# Drive 600 Echo RPCs over 10 minutes, capture RTT
+OUTPUT=/tmp/grpc-echo-rtt.txt
+> "$OUTPUT"
+END=$(($(date +%s) + 600))
+while [ "$(date +%s)" -lt "$END" ]; do
+  docker exec deltav-minion bash -c \
+    'echo opennms:health-check | /opt/karaf/bin/client -h localhost -u admin -p admin -- 2>/dev/null' \
+    | grep -E 'broker|echo' >> "$OUTPUT" || true
+  sleep 1
+done
+
+# Compute distribution
+python3 - <<PY
+import re, statistics, sys
+rtts = []
+with open("$OUTPUT") as f:
+    for line in f:
+        m = re.search(r'rtt[: =](\d+)', line)
+        if m:
+            rtts.append(int(m.group(1)))
+if not rtts:
+    print("FAIL: no RTT samples captured", file=sys.stderr)
+    sys.exit(1)
+rtts.sort()
+n = len(rtts)
+p99 = rtts[int(n*0.99)] if n > 1 else rtts[0]
+print(f"samples={n} p50={rtts[n//2]} p99={p99}")
+gate = ${GATE_MS}
+if p99 > gate:
+    print(f"FAIL: gRPC p99={p99} ms > gate={gate} ms", file=sys.stderr)
+    sys.exit(1)
+print(f"PASS: gRPC p99={p99} ms <= gate={gate} ms")
+PY
+```
+
+- [ ] **Step 13.2: Make executable**
+
+```bash
+chmod +x e2e/test-grpc-rpc-e2e.sh
+```
+
+- [ ] **Step 13.3: Verify it runs (assumes deploy.sh up minimal is running)**
+
+```bash
+./e2e/test-grpc-rpc-e2e.sh
+```
+
+Expected: `PASS: gRPC p99=N ms <= gate=M ms`.
+
+- [ ] **Step 13.4: Commit**
+
+```bash
+git add e2e/test-grpc-rpc-e2e.sh
+git commit -m "test(v1.2.0-rc2-pr1): test-grpc-rpc-e2e bench harness (Task 13)"
+```
+
+---
+
+### Task 14: Run full Mac dev-env E2E suite green; capture gate measurement
+
+**Files:**
+- Modify: `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md` (append gate measurement section)
+
+**Rationale:** The Decision 9 sub-decision 9-iii "full E2E suite green" gate. Decision 10 sub-decision 10-iv documents the actual gate measurement.
+
+- [ ] **Step 14.1: Run the full E2E suite**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+opennms-container/delta-v/build.sh deltav
+opennms-container/delta-v/deploy.sh up full
+for t in e2e/test-*.sh; do
+  echo "=== $t ==="
+  bash "$t" || echo "FAIL: $t"
+done
+```
+
+Expected: all pre-existing tests pass; both new tests (test-grpc-heartbeat-e2e from rc1 and test-grpc-rpc-e2e from PR1) pass; labbox-only tests SKIP.
+
+- [ ] **Step 14.2: Capture the gRPC RPC measurement**
+
+Re-run `./e2e/test-grpc-rpc-e2e.sh` and capture stdout. Record samples, p50, p99, gate, pass/fail in the pre-work findings doc.
+
+Append to `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md`:
+
+````markdown
+## gRPC RPC measurement (PR1 release gate)
+
+**Measured on:** McMac2025.local, 2026-XX-XX HH:MM-HH:MM UTC. Local docker compose stack on PR1 build.
+
+| Metric | Value |
+|---|---|
+| samples | N |
+| p50 | X ms |
+| p99 | X ms |
+| Kafka baseline p99 | X ms |
+| Gate (Kafka p99 + 20 ms) | X ms |
+| Result | PASS / FAIL |
+
+**Conclusion:** PASS / FAIL with explanation.
+````
+
+- [ ] **Step 14.3: Commit**
+
+```bash
+git add docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc2-pr1): record gRPC RPC gate measurement (Task 14)"
+```
+
+---
+
+## Phase 5 — PR (Task 15)
+
+### Task 15: Open PR1 against pbrane/delta-v develop
+
+**Files:** none
+
+**Rationale:** Decision 9 says rc2 ships as a sequence of PRs; PR1 lands first.
+
+- [ ] **Step 15.1: Push the branch**
+
+```bash
+git push -u origin feat/v1.2.0-rc2-pr1-rpc-migration
+```
+
+- [ ] **Step 15.2: Open the PR**
+
+```bash
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "feat(v1.2.0-rc2/1): RPC channel migration to gRPC" \
+  --body "$(cat <<'EOF'
+## Summary
+
+PR1 of the v1.2.0-rc2 4-PR sequence per Decision 9 of the [rc2 decisions doc](https://github.com/pbrane/delta-v/blob/develop/docs/plans/2026-04-26-v1.2.0-rc2-decisions.md). Migrates the Minion ↔ Core RPC channel from Kafka topics to gRPC bidi streams routed through `minion-gateway`, while preserving multi-Minion-per-location competing-consumer reliability (Decision 1 Option D) and the rc1 Kafka rollback path (Decision 4 Option B).
+
+## Architecture
+
+`minion-gateway` becomes a per-location competing-consumer dispatcher:
+
+- Maintains `MinionStreamPool` (per-location stream registry, round-robin dispatch).
+- Consumes from `OpenNMS.<location>.rpc-request`, picks a stream, forwards as `RpcRequest`.
+- Tracks in-flight RPCs in `InFlightRpcTable`; on stream close, redispatches to a surviving sibling stream (preserves at-least-once execution).
+- Routes `RpcResponse` from any Minion stream back to `OpenNMS.rpc-response` for daemon-side correlation.
+- Empty pool: caller's existing dispatcher deadline absorbs (no synthesized outage per `feedback_rpc_timeout_no_outages`).
+
+ServiceDaemon code is unchanged; the substitution is transport-only at the Minion ↔ gateway hop.
+
+## Acceptance criteria
+
+- [x] `core/minion-grpc-contracts/rpc.proto` defined.
+- [x] `MinionStreamPool` round-robin tested.
+- [x] `InFlightRpcTable` eviction-by-stream + deadline expiry tested.
+- [x] `RpcChannelGrpcService` bidi handler tested (open registers; close redispatches via dispatcher).
+- [x] `RpcChannelDispatcher` redispatch + response handling tested.
+- [x] `MinionRpcStreamClient` dispatches via local `RpcModule` registry; unknown module returns error response.
+- [x] `MINION_RPC_TRANSPORT=kafka|grpc` flag wired (default `grpc`).
+- [x] `test-perspective-e2e.sh` and `test-enlinkd-e2e.sh` updated for gRPC RPC path.
+- [x] `test-grpc-rpc-e2e.sh` enforces gate `gRPC p99 ≤ Kafka baseline p99 + 20 ms`.
+- [x] Full Mac dev-env E2E suite green.
+
+## Idempotency contract
+
+All current RPC modules are read-only and naturally idempotent. PR1 codifies this as a contract (Decision 1 sub-decision 1-ii) — future modules added to delta-v are bound by the same constraint. Server-side redispatch on stream close can cause at-least-once *execution*; modules must tolerate it.
+
+## Test plan
+
+- [ ] Reviewer reads `RpcChannelDispatcher.onStreamClosed` carefully — the redispatch loop is the new code most likely to harbor concurrency bugs.
+- [ ] Reviewer confirms the `opennms.minion.transport.rpc` property pair is mutually exclusive (only one of `Grpc...` or `Kafka...Configuration` active per Minion start).
+- [ ] Reviewer verifies the gate measurement in `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md` matches the criteria.
+
+## What this does NOT cover (deferred to later rc2 PRs)
+
+- Twin migration → PR2.
+- Sink migrations (Syslog, Trap, Telemetry × 4) → PR3.
+- `build.sh deltav` integration of `minion-gateway` and `envoy` → PR4.
+- Topic rename `OpenNMS.*` → `DeltaV.*` → pre-GA cleanup PR.
+- Kafka transport removal from Minion → pre-GA cleanup PR.
+
+## Memory invariants honored
+
+- `feedback_never_pr_opennms` — `--repo pbrane/delta-v` ✓
+- `feedback_pull_before_branching` — branched off freshly-merged develop ✓
+- `feedback_rpc_timeout_no_outages` — empty-pool case absorbs at caller deadline ✓
+- `project_minion_mandatory` — bidirectional zero-trust preserved (only `minion-gateway` accepts inbound) ✓
+- `feedback_e2e_continuous_validation_grpc_migration` — full E2E green per PR ✓
+- `feedback_daemon_instrumentation_patterns` 5th idiom — `MeteredRpcModule` survives transport swap (no daemon-side changes) ✓
+- `feedback_smoke_vm_release_only` — Mac dev env for measurement; smoke is post-tag ✓
+EOF
+)"
+```
+
+- [ ] **Step 15.3: Verify PR opened correctly**
+
+```bash
+gh pr view --repo pbrane/delta-v
+```
+
+Confirm `--base develop` and the PR is against `pbrane/delta-v` not `OpenNMS/opennms`.
+
+---
+
+## Self-review summary
+
+**Spec coverage check** (ran inline before finalizing):
+
+| Decision | Tasks |
+|---|---|
+| Decision 1 (RPC dispatcher Option D) | Tasks 4-7 (pool, table, service, dispatcher) |
+| Decision 1-i (no buffer when pool empty) | Task 7's dispatcher logs and returns; Task 14 verifies via E2E |
+| Decision 1-ii (idempotency contract) | Task 8 doc + PR1 acceptance criteria |
+| Decision 1-iii (eviction on stream close) | Task 5 InFlightRpcTable.evictByStream |
+| Decision 4-i (per-channel emergency flag) | Tasks 9-10 |
+| Decision 4-ii (gRPC default after PR lands) | Task 9 (`matchIfMissing = true`) |
+| Decision 7-ii (state recoverable from external sources) | Pool: rebuilds on Minion reconnect; table: lost on gateway restart, caller's timeout absorbs |
+| Decision 9 PR1 scope (RPC + E2E updates + build integration outside scope) | Tasks 4-12 in scope; PR4 build cleanup explicitly out of scope |
+| Decision 10 (RPC bench methodology) | Task 1 (baseline), Task 13 (test harness), Task 14 (gate) |
+
+**Placeholder scan:** No "TODO", "TBD", or "implement later" remaining. Where Task 8's exact horizon API signatures depend on Task 2's inventory output, the dependency is documented explicitly.
+
+**Type consistency:** `RpcRequest`/`RpcResponse` are the proto types from Task 3; `MinionStreamPool` and `InFlightRpcTable` references in Tasks 6-7 match the Task 4-5 definitions; `RpcStreamCloseHandler`/`RpcResponseHandler` interfaces in Task 6 are implemented in Task 7's `RpcChannelDispatcher`.
+
+---
+
+## References
+
+- **rc2 decisions doc (master spec):** [`docs/plans/2026-04-26-v1.2.0-rc2-decisions.md`](./2026-04-26-v1.2.0-rc2-decisions.md)
+- **rc1 implementation plan (cadence reference):** [`docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md`](./2026-04-26-v1.2.0-rc1-implementation-plan.md)
+- **rc1 pre-work findings (methodology reference):** [`docs/plans/2026-04-26-v1.2.0-rc1-pre-work-findings.md`](./2026-04-26-v1.2.0-rc1-pre-work-findings.md)
+- **Hygiene PR #234 (JUnit alignment, prerequisite):** https://github.com/pbrane/delta-v/pull/234
+- **rc1 PR #231 (Heartbeat migration, pattern reference):** https://github.com/pbrane/delta-v/pull/231
+- **Develop tip at PR1 plan authoring:** `387f35dfadd` (post hygiene PR merge).


### PR DESCRIPTION
## Summary

Implementation plan for **PR1** of the v1.2.0-rc2 4-PR sequence (RPC channel migration to gRPC). Hangs off Decision 9 of the [rc2 decisions doc](https://github.com/pbrane/delta-v/blob/develop/docs/plans/2026-04-26-v1.2.0-rc2-decisions.md).

This is a **doc-only** PR — no code changes. The plan itself becomes the spec for PR1's implementation work, which is a separate session.

## Plan structure

15 tasks in 5 phases, TDD bite-sized steps throughout (write failing test → run fail → implement → run pass → commit):

| Phase | Tasks | Output |
|---|---|---|
| 0 — Pre-work | 1-3 | Echo-RPC Kafka baseline + bytecode inventory + `rpc.proto` contract. Produces `docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md`. |
| 1 — Gateway dispatcher | 4-7 | `MinionStreamPool` (round-robin, per-location pool), `InFlightRpcTable` (eviction-by-stream + deadline expiry), `RpcChannelGrpcService` (bidi handler), `RpcChannelDispatcher` (Kafka consumer + redispatch logic). Decision 1 Option D. |
| 2 — Minion gRPC client | 8-10 | `MinionRpcStreamClient` (dispatches inbound `RpcRequest` via local `RpcModule` registry), `GrpcRpcStreamConfiguration` (`@ConditionalOnProperty(opennms.minion.transport.rpc=grpc, default)`), Kafka fallback wiring. Decision 4 Option B. |
| 3 — E2E test updates | 11-12 | `test-perspective-e2e.sh` + `test-enlinkd-e2e.sh` updated for gRPC RPC path. |
| 4 — Bench + acceptance | 13-14 | `test-grpc-rpc-e2e.sh` enforces gate `gRPC p99 ≤ Kafka baseline p99 + 20 ms`. Full E2E suite green on Mac dev env. Decision 10. |
| 5 — PR | 15 | Open feat PR1 against `pbrane/delta-v --base develop`. |

## What's in scope (PR1 only)

- New `core/minion-grpc-contracts/rpc.proto` (bidi service).
- `core/minion-gateway/src/main/java/org/deltav/gateway/{rpc,grpc}/*` — pool, table, service, dispatcher, response publisher, Kafka wiring.
- `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionRpcStreamClient.java` + transport-flag wiring.
- E2E updates for `test-perspective-e2e.sh`, `test-enlinkd-e2e.sh`, plus new `test-grpc-rpc-e2e.sh`.

## What's NOT in scope (deferred to later PRs)

- Twin migration → PR2 (separate plan, separate session).
- Sink migrations (Syslog, Trap, Telemetry × 4) → PR3.
- `build.sh deltav` integration of `minion-gateway` and `envoy` → PR4.
- Topic rename `OpenNMS.*` → `DeltaV.*` → pre-GA cleanup PR.
- Kafka transport removal from Minion → pre-GA cleanup PR.

## Self-review summary

Embedded at the bottom of the plan:
- **Spec coverage:** every Decision in the rc2 decisions doc maps to specific tasks.
- **Placeholder scan:** no \"TODO\", \"TBD\", or \"implement later\" — all task steps have concrete code, exact commands, and expected outputs.
- **Type consistency:** cross-references between tasks (e.g., `MinionStreamPool` defined in Task 4, used in Task 6's mock + Task 7's dispatcher) align.

## What this unblocks

Once this plan PR merges, the rc2 PR1 implementation session can begin. That session will execute the 15 tasks via the **superpowers:executing-plans** skill (or **subagent-driven-development** if preferred), producing the rc2 PR1 feature branch + PR (Task 15).

## Test plan

- [ ] Reviewer reads Phase 1 (Tasks 4-7) carefully — the dispatcher + redispatch logic is the new architectural surface.
- [ ] Reviewer confirms Task 8's substitution-seam assumptions are reasonable (final code may need adjustment based on Task 2's bytecode inventory).
- [ ] Reviewer confirms the gate calibration (`Kafka p99 + 20 ms`) is acceptable. Decision 10 sub-decision 10-iv allows widening with documented justification at Task 14 if necessary.

## Memory invariants honored

- `feedback_never_pr_opennms` — `--repo pbrane/delta-v` ✓
- `feedback_pull_before_branching` — branched off freshly-merged develop (post hygiene PR #234) ✓
- `feedback_rpc_timeout_no_outages` — empty-pool case absorbs at caller deadline ✓
- `project_minion_mandatory` — bidirectional zero-trust (only `minion-gateway` accepts inbound from Minions) ✓
- `feedback_e2e_continuous_validation_grpc_migration` — Phase 3 + Phase 4 enforce per-PR full-suite green ✓
- `feedback_daemon_instrumentation_patterns` 5th idiom — `MeteredRpcModule` survives transport swap (no daemon-side changes in this plan) ✓