### PR TITLE
ci: use HORIZON_READ_TOKEN secret in codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -71,7 +71,7 @@ jobs:
         </settings>
         SETTINGS
       env:
-        PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PACKAGES_TOKEN: ${{ secrets.HORIZON_READ_TOKEN }}
 
     - name: Build all modules (Java)
       run: ./mvnw -B -DskipTests install


### PR DESCRIPTION
## Summary

Aligns `codeql-analysis.yml` with the auth pattern already used by `ci.yml` and `delta-v-build-images.yml`. One-line change: `secrets.GITHUB_TOKEN` → `secrets.HORIZON_READ_TOKEN`.

## Background

`pbrane/delta-v-horizon` publishes horizon JARs to GitHub Packages. The other delta-v workflows (`ci.yml`, `delta-v-build-images.yml`) authenticate to that registry using `secrets.HORIZON_READ_TOKEN` — a PAT with `read:packages` scope — because **`GITHUB_TOKEN` cannot read packages from a different repo by default** (cross-repo packages reads aren't granted via the workflow's `permissions:` block).

`codeql-analysis.yml` was the one outlier still using `GITHUB_TOKEN`. It happened to work as long as Maven's cache hit (cache: maven on setup-java keys on `pom.xml` hash). On cache miss it would fail to resolve transitive horizon deps.

## Trigger

PR #236 (rc2 PR1 RPC migration) changed `core/minion-gateway/pom.xml`, invalidating the Maven cache key. The post-merge CodeQL run on develop failed:

```
[ERROR] Could not find artifact org.opennms:opennms-provision-api:jar:1.0.13
        in github-deltav-horizon (https://maven.pkg.github.com/pbrane/delta-v-horizon)
```

The PR-level CodeQL had succeeded due to cache hit from earlier runs.

## Test plan

- [ ] After merge, watch the next CodeQL push run on develop (will trigger automatically). Should succeed even on cache miss.
- [ ] Optional: verify by clearing the Maven cache key (or running CodeQL after another pom-changing commit lands).

## Memory invariants

- `feedback_never_pr_opennms` — `--repo pbrane/delta-v` ✓
- `feedback_github_packages_ghost_versions` — same PAT pattern referenced (`HORIZON_READ_TOKEN` instead of needing `delete:packages`).