### PR TITLE
docs(v1.2.0-rc2-pr2): Twin migration implementation plan

### DIFF
--- a/docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md
+++ b/docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md
@@ -1,0 +1,2302 @@
+# v1.2.0-rc2 PR2 — Twin Channel Migration to gRPC: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the Minion Twin channel from Kafka topics (`OpenNMS.twin.request` / `OpenNMS.twin.response.<location>`) to gRPC server-streaming routed through `minion-gateway`, while preserving Horizon-grade reliability (snapshot-on-reconnect, version-tracked patches, multi-Minion-per-location broadcast).
+
+**Architecture:** `minion-gateway` becomes a stateful Twin broadcaster (Decision 2 of the rc2 decisions doc). It consumes daemon-published Twin updates from the existing internal Kafka topic `OpenNMS.twin.response.<location>`, tracks per-`(consumer_key, location)` state + version in a read-through cache, and broadcasts to subscribed Minions over a server-streaming gRPC channel. Minions open the stream once at startup; on (re)connect they receive a full snapshot, then JSON Patches (RFC 6902) on subsequent updates. Subscriber-side detects version-gap → drop + reconnect → fresh snapshot. Daemon publishers are unchanged: they keep using horizon's `KafkaTwinPublisher` to publish to the same Kafka topic. The gateway's bidirectional translator bridges horizon's `TwinResponseProto` wire format to delta-v's fresh `TwinUpdate` proto.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.3, Spring gRPC 1.0.3, gRPC 1.75.0, protobuf 3.25.5, Jackson `JsonDiff` (RFC 6902 patch generation), JUnit Jupiter 6.0.3, Testcontainers 2.x, Mockito.
+
+**Scope boundary:** This plan covers **PR2 only** (Twin channel). PR1 (RPC) shipped at PR #236. PR3 (Sinks) and PR4 (build cleanup) are subsequent plans authored in separate sessions. See `docs/plans/2026-04-26-v1.2.0-rc2-decisions.md` for the rc2 master spec.
+
+---
+
+## Architecture overview specific to Twin
+
+### Existing Kafka path (what we are replacing)
+
+```
+Daemon Publisher (Provisiond, etc.)
+  │ TwinPublisher.register(key, class, location).publish(state)
+  ▼
+KafkaTwinPublisher (horizon)
+  │ Computes JSON Patch vs prior state, increments version
+  │ producer.send(OpenNMS.twin.response.<location>, TwinResponseProto)
+  ▼
+Kafka broker
+  ▼
+KafkaTwinSubscriber on Minion (consumer per location)
+  │ Parses TwinResponseProto, dispatches to AbstractTwinSubscriber
+  ▼
+AbstractTwinSubscriber (horizon, on Minion)
+  │ Applies snapshot or patch by version
+  ▼
+Local subscribers (PassiveStatusTwinSubscriber, RequisitionTwinSubscriber, etc.)
+```
+
+### Target gRPC path
+
+```
+Daemon Publisher (UNCHANGED)
+  │ TwinPublisher.register(key, class, location).publish(state)
+  ▼
+KafkaTwinPublisher (UNCHANGED — still publishes to Kafka)
+  │ producer.send(OpenNMS.twin.response.<location>, TwinResponseProto)
+  ▼
+Kafka broker (still here for daemon ↔ gateway hop)
+  ▼
+minion-gateway: TwinChannelDispatcher (NEW)
+  │ Kafka @KafkaListener parses horizon's TwinResponseProto
+  │ Translates → delta-v's fresh TwinUpdate proto
+  │ Updates TwinStateCache for (consumer_key, location)
+  │ Broadcasts to all subscribed Minion streams in that location
+  ▼
+gRPC server-streaming (h2c plaintext within compose; TLS at Envoy in pre-GA)
+  ▼
+Minion: MinionTwinStreamClient (NEW)
+  │ Receives TwinUpdate (snapshot or patch)
+  │ Detects version gap → drops stream, reconnects
+  ▼
+LocalTwinSubscriberImpl (UNCHANGED, horizon)
+  │ Same dispatch to PassiveStatusTwinSubscriber, RequisitionTwinSubscriber, etc.
+```
+
+### Reliability properties preserved (Decision 2)
+
+| Property | Mechanism in gRPC path |
+|---|---|
+| Snapshot on (re)connect | Decision 2 sub-decision 2-i. Gateway sends full snapshot when stream opens. |
+| Patches on subsequent updates | Decision 2 sub-decision 2-iii. Gateway holds tracker per (key, location); JSON Patch via Jackson `JsonDiff`. |
+| Subscriber-side version-gap recovery | Decision 2 sub-decision 2-ii (revised). Subscriber detects non-contiguous version, drops + reconnects → snapshot via 2-i. |
+| Gateway statefulness | Decision 2 sub-decision 2-iii. Gateway consumes Kafka topic on startup, rebuilds state. |
+| Broadcast semantics | All Minions in a location receive the same updates. No per-Minion patch divergence beyond what `lastSentVersion` tracking handles. |
+
+### Wire format translation (lessons from PR1)
+
+PR1's Phase 4 surfaced that delta-v fresh protos are wire-incompatible with horizon's existing protos. Twin has two horizon protos already on the daemon side:
+- `org.opennms.core.ipc.twin.model.TwinResponseProto`: `consumer_key`, `twin_object` (bytes), `system_id`, `location`, `is_patch_object`, `session_id`, `version`, `tracing_info`.
+- `org.opennms.core.ipc.twin.model.TwinRequestProto`: `consumer_key`, `system_id`, `location`, `tracing_info`.
+
+PR2's gateway dispatcher MUST translate at the boundary, mirroring PR1's pattern. Skipping the translator is the same plan gap that took 30 min to debug in PR1.
+
+---
+
+## File structure
+
+### New files
+
+- `core/minion-grpc-contracts/src/main/proto/twin.proto` — delta-v fresh wire contract for Minion ↔ gateway gRPC stream.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java` — per-`(consumer_key, location)` state + version map.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinPatchGenerator.java` — JSON Patch (RFC 6902) generation, mirroring horizon's `AbstractTwinPublisher.getPatchValue()`.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistry.java` — per-`(consumer_key, location)` set of subscribed Minion streams.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/TwinChannelGrpcService.java` — gRPC server-streaming service.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java` — Kafka @KafkaListener + state cache update + broadcast.
+- `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelConfiguration.java` — Spring wiring (`@EnableKafka` is on `RpcChannelConfiguration` from PR1; `@Import` it or restate to be defensive).
+- `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java` — Minion-side gRPC subscriber, applies snapshot/patch via horizon's `LocalTwinSubscriberImpl`.
+- `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java` — `@ConditionalOnProperty(opennms.minion.transport.twin=grpc, default)`.
+- `opennms-container/delta-v/test-grpc-twin-e2e.sh` — channel liveness smoke harness.
+
+### Modified files
+
+- `core/minion-grpc-contracts/pom.xml` — likely no change; `*.proto` is wildcard-included.
+- `core/minion-gateway/pom.xml` — add `org.opennms.core.ipc.twin.common` dep (for `TwinResponseProto` model class). horizon-rpc dep was added in PR1.
+- `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java` — add `@ConditionalOnProperty(name="opennms.minion.transport.twin", havingValue="kafka")` so Kafka path is opt-in only when transport.twin=kafka. Mirrors PR1's `KafkaRpcServerConfiguration` edit.
+- `opennms-container/delta-v/envoy/envoy.yaml` — add prefix match for `/org.deltav.minion.grpc.v1.TwinService/` (PR1's lesson).
+- `opennms-container/delta-v/test-passive-e2e.sh` — pre-flight check that gateway logs Twin stream open for connected Minions (mirrors PR1's RPC pre-flight).
+
+### Files NOT modified
+
+- Daemon Publisher code (Provisiond → requisitions, etc.) — `TwinPublisher` API unchanged; daemons see zero protocol change.
+- horizon's `KafkaTwinPublisher` — unchanged; we work around it, not modify.
+- horizon's `AbstractTwinSubscriber` — unchanged; we feed it via gRPC instead of Kafka.
+
+---
+
+## Phase 0 — Pre-work (Tasks 1-3)
+
+### Task 1: Capture Twin baseline + bytecode/callsite inventory
+
+**Files:**
+- Create: `docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md`
+
+**Rationale:** Mirror PR1's Phase 0 structure. PR2 inherits the same Heartbeat-as-proxy baseline approach (Decision 10-v); the inventory captures the horizon Twin API surface that subsequent tasks substitute against.
+
+- [ ] **Step 1.1: Write the pre-work findings template**
+
+Create `docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md`:
+
+```markdown
+# v1.2.0-rc2 PR2 — Twin Migration: Pre-Work Findings
+
+## Baseline measurement methodology
+
+Per Decision 10 sub-decision 10-v of the rc2 decisions doc, latency gates
+are calibrated empirically. PR1 inherited Heartbeat-as-proxy (rc1's 1 ms
+p99); PR2 inherits the same.
+
+Twin's measurement profile is different from RPC:
+- **Subscribe-to-first-snapshot:** time from Minion stream open to first
+  TwinUpdate received. One-shot (only on Minion startup or reconnect).
+- **Patch propagation lag:** time from daemon publishes update to Minion
+  applies it. Critical-path for config-driven behavior changes.
+
+Both are empirically calibrated post-PR2 via Task 16 E2E run. Heartbeat-
+proxy baseline (2 ms estimated): subscribe gate ≤ 102 ms, propagation
+gate ≤ 52 ms (Decision 10's 100 ms / 50 ms widenings).
+
+## Bytecode + callsite inventory
+
+### horizon Twin API surface (substitution seams)
+
+`org.opennms.core.ipc.twin.api.TwinPublisher` — daemon-side publish API.
+`org.opennms.core.ipc.twin.api.TwinSubscriber` — Minion-side consume API.
+`org.opennms.core.ipc.twin.common.AbstractTwinPublisher` — algorithm reference (Jackson JsonDiff for patches, monotonic version, sessionId).
+`org.opennms.core.ipc.twin.common.AbstractTwinSubscriber` — applies snapshot/patch on Minion side.
+`org.opennms.core.ipc.twin.common.LocalTwinSubscriberImpl` — local-only subscriber path; Minion-side dispatch target.
+`org.opennms.core.ipc.twin.model.TwinResponseProto` — Kafka wire format. Fields: consumer_key, twin_object (bytes JSON), system_id, location, is_patch_object, session_id, version, tracing_info.
+`org.opennms.core.ipc.twin.model.TwinRequestProto` — subscribe request. Fields: consumer_key, system_id, location, tracing_info.
+
+### Existing Twin subscribers (Minion-side consumers)
+
+| Subscriber | Consumer key | Purpose |
+|---|---|---|
+| `PassiveStatusTwinSubscriber` | `passive-status` | Minion-side passive-status policies for syslog → service mapping |
+| `RequisitionTwinSubscriber` | `requisition.<foreign-source>` | Per-foreign-source requisition state |
+| `SnmpV3UserTwinSubscriber` | `snmpv3-user` | SNMPv3 credentials |
+| (others, daemon-specific) | various | per-daemon configuration push |
+
+Wired via `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java` today.
+
+### Existing Twin publishers (daemon-side)
+
+`Provisiond` publishes `requisition.*` keys per foreign-source.
+`Pollerd` publishes `passive-status` (via `PollerdPassiveStatusConfiguration` in delta-v).
+
+Substitution scope: daemons keep `KafkaTwinPublisher`; gateway adds a
+parallel consumer of the existing Kafka topic.
+
+### Twin Kafka topics
+
+- `OpenNMS.twin.request` — Minion-issued subscribe requests. PR2 leaves this for
+  the existing daemon-side handlers; the gateway does NOT consume this topic.
+  Minions in the gRPC path subscribe via the gRPC stream, not via this topic.
+- `OpenNMS.twin.response.<location>` — daemon-issued state broadcasts. PR2's
+  gateway IS a consumer of this topic.
+
+## Conclusion
+
+- **Substitution seam:** `AbstractTwinSubscriber` API on the Minion side. Task 9's
+  `MinionTwinStreamClient` feeds it `TwinResponseProto`-equivalent bytes from the
+  gRPC stream instead of Kafka.
+- **Algorithmic reference:** `AbstractTwinPublisher.getPatchValue()` for JSON Patch
+  generation. PR2's `TwinPatchGenerator` (Task 5) copies this algorithm.
+- **Wire format translation:** mandatory at gateway boundary (PR1 Phase 4 lesson).
+  Tasks 4 + 8 implement bidirectional translator.
+- **Daemon-side wiring:** unchanged. Six client-side daemon-boot modules continue
+  to use horizon's `KafkaTwinPublisher`.
+```
+
+- [ ] **Step 1.2: Commit**
+
+```bash
+git add docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc2-pr2): pre-work findings — Twin baseline + inventory (Task 1)"
+```
+
+---
+
+### Task 2: Define twin.proto wire contract
+
+**Files:**
+- Create: `core/minion-grpc-contracts/src/main/proto/twin.proto`
+
+**Rationale:** Wire format is the architectural contract. Defined first so server (Tasks 3-8) and client (Tasks 9-11) compile against the same generated code.
+
+- [ ] **Step 2.1: Write the proto definition**
+
+Create `core/minion-grpc-contracts/src/main/proto/twin.proto`:
+
+```protobuf
+// core/minion-grpc-contracts/src/main/proto/twin.proto
+syntax = "proto3";
+
+package org.deltav.minion.grpc.v1;
+
+option java_package = "org.deltav.minion.grpc.v1";
+option java_multiple_files = true;
+option java_outer_classname = "TwinChannelProto";
+
+import "google/protobuf/timestamp.proto";
+
+// Server-streaming Twin channel between minion-gateway (server) and Minion
+// (client). On the wire: Minion opens a stream once, sends a list of
+// TwinSubscriptions in the first message (or via gRPC metadata), and the
+// gateway streams TwinUpdate messages whenever subscribed state changes.
+//
+// Per Decision 2 of the v1.2.0-rc2 decisions doc:
+// - On (re)connect, the gateway sends a full snapshot first (is_patch=false).
+// - Subsequent updates are JSON Patch (RFC 6902) when generatable, full
+//   snapshot otherwise (is_patch=false).
+// - The subscriber tracks last_seen_version per (consumer_key, location).
+//   On non-contiguous version, the subscriber drops the stream and reconnects.
+service TwinChannelService {
+  // Client streams subscribe/unsubscribe requests; server streams updates.
+  // The server's first message after a Subscribe is always a full snapshot.
+  rpc Channel(stream TwinSubscription) returns (stream TwinUpdate);
+}
+
+// Subscription request from the Minion to the gateway. Identity (minion_id,
+// location) is in gRPC metadata via MinionIdentityClientInterceptor.
+message TwinSubscription {
+  // The consumer key the Minion wants to subscribe to (e.g., "passive-status",
+  // "requisition.<foreign-source>"). Multiple keys are supported by sending
+  // multiple TwinSubscription messages on the same stream.
+  string consumer_key = 1;
+  // Subscription mode: SUBSCRIBE adds; UNSUBSCRIBE removes.
+  SubscriptionMode mode = 2;
+}
+
+enum SubscriptionMode {
+  SUBSCRIBE = 0;
+  UNSUBSCRIBE = 1;
+}
+
+// Twin state update broadcast from gateway to Minion.
+//
+// twin_object semantics:
+//   is_patch=false: full JSON snapshot of the current state object.
+//   is_patch=true:  JSON Patch (RFC 6902) producing the new state from the
+//                   subscriber's prior state at version (current_version - 1).
+//
+// version increments by 1 per update. Initial snapshot may have any version
+// >= 1 (the daemon publisher's current version at subscribe time).
+message TwinUpdate {
+  string consumer_key = 1;
+  bytes twin_object = 2;          // JSON bytes: full state OR JSON Patch
+  bool is_patch = 3;
+  int32 version = 4;              // monotonic, per (consumer_key, location)
+  string session_id = 5;          // changes when publisher restarts; subscriber resyncs on change
+  string location = 6;            // duplicated from gRPC metadata for self-describing logs
+  google.protobuf.Timestamp dispatched_at = 7;
+}
+```
+
+- [ ] **Step 2.2: Verify generated classes appear**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-grpc-contracts -am clean compile
+ls core/minion-grpc-contracts/target/generated-sources/protobuf/java/org/deltav/minion/grpc/v1/ | grep -E "TwinChannel|TwinSubscription|TwinUpdate|SubscriptionMode"
+```
+
+Expected: `TwinChannelProto.java`, `TwinSubscription.java`, `TwinUpdate.java`, `SubscriptionMode.java`, `TwinChannelServiceGrpc.java`.
+
+- [ ] **Step 2.3: Verify dependent module compile**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway -am compile
+```
+
+Expected: BUILD SUCCESS. New service surface; no existing references; compile is unaffected.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add core/minion-grpc-contracts/src/main/proto/twin.proto
+git commit -m "feat(v1.2.0-rc2-pr2): twin.proto wire contract (Task 2)"
+```
+
+---
+
+### Task 3: Add horizon Twin model dep to minion-gateway
+
+**Files:**
+- Modify: `core/minion-gateway/pom.xml`
+
+**Rationale:** PR2's gateway dispatcher (Task 8) parses horizon's `TwinResponseProto` from Kafka. The class lives in `org.opennms.core.ipc.twin.common` jar; need to add the dep.
+
+- [ ] **Step 3.1: Add the dependency**
+
+Modify `core/minion-gateway/pom.xml`. Find the existing horizon-rpc dep block (added in PR1) and add an analogous Twin dep below it:
+
+```xml
+        <!-- horizon's TwinResponseProto / TwinRequestProto wire format on the
+             daemon-facing Kafka topic OpenNMS.twin.response.<location>. The
+             gateway's TwinChannelDispatcher (Task 8) translates between this
+             and the rc2 TwinUpdate proto used on the gateway-Minion gRPC
+             stream — same pattern as the rpc.kafka dep added in PR1. -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.twin</groupId>
+            <artifactId>org.opennms.core.ipc.twin.common</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+```
+
+- [ ] **Step 3.2: Verify compile**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway -am compile
+```
+
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add core/minion-gateway/pom.xml
+git commit -m "feat(v1.2.0-rc2-pr2): add horizon twin.common dep to minion-gateway (Task 3)"
+```
+
+---
+
+## Phase 1 — Gateway-side state cache + JSON Patch + Kafka consumer (Tasks 4-6)
+
+### Task 4: TwinStateCache
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinStateCacheTest.java`
+
+**Rationale:** Per Decision 2 sub-decision 2-iii, the gateway holds `(consumer_key, location) → currentState, version, sessionId`. This class is the read-through cache; populated by the Kafka consumer (Task 6), queried on Minion subscribe (Task 7).
+
+- [ ] **Step 4.1: Write failing test**
+
+Create `core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinStateCacheTest.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TwinStateCacheTest {
+
+    @Test
+    void emptyCache_returnsNullForUnknownKey() {
+        TwinStateCache cache = new TwinStateCache();
+        assertThat(cache.get("k", "L")).isNull();
+    }
+
+    @Test
+    void putThenGet_returnsStoredEntry() {
+        TwinStateCache cache = new TwinStateCache();
+        ByteString state = ByteString.copyFromUtf8("{\"x\":1}");
+        cache.put("k", "L", state, 5, "session-1");
+
+        TwinStateCache.Entry e = cache.get("k", "L");
+        assertThat(e).isNotNull();
+        assertThat(e.state()).isEqualTo(state);
+        assertThat(e.version()).isEqualTo(5);
+        assertThat(e.sessionId()).isEqualTo("session-1");
+    }
+
+    @Test
+    void put_overwritesPriorEntry() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("v1"), 1, "session-1");
+        cache.put("k", "L", ByteString.copyFromUtf8("v2"), 2, "session-1");
+
+        TwinStateCache.Entry e = cache.get("k", "L");
+        assertThat(e.state()).isEqualTo(ByteString.copyFromUtf8("v2"));
+        assertThat(e.version()).isEqualTo(2);
+    }
+
+    @Test
+    void differentLocations_areIndependent() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L1", ByteString.copyFromUtf8("v1"), 1, "session-A");
+        cache.put("k", "L2", ByteString.copyFromUtf8("v2"), 1, "session-B");
+
+        assertThat(cache.get("k", "L1").state()).isEqualTo(ByteString.copyFromUtf8("v1"));
+        assertThat(cache.get("k", "L2").state()).isEqualTo(ByteString.copyFromUtf8("v2"));
+    }
+}
+```
+
+- [ ] **Step 4.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinStateCacheTest
+```
+
+Expected: FAIL with `cannot find symbol class TwinStateCache`.
+
+- [ ] **Step 4.3: Implement TwinStateCache**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-(consumer_key, location) Twin state cache. The gateway reads-through
+ * from this cache when a Minion opens a Twin subscription — the first
+ * TwinUpdate sent on a freshly-opened stream is always a full snapshot
+ * (Decision 2 sub-decision 2-i).
+ *
+ * <p>Populated by {@link TwinChannelDispatcher} consuming horizon's
+ * {@code OpenNMS.twin.response.<location>} Kafka topic on gateway startup
+ * (read-to-tail) and on every subsequent state change. Per Decision 2
+ * sub-decision 2-iii: state is recovered from Kafka, not from
+ * inter-gateway coordination, so multi-instance deployments work without
+ * coordination.
+ */
+@Component
+public class TwinStateCache {
+
+    private final Map<Key, Entry> entries = new ConcurrentHashMap<>();
+
+    public Entry get(String consumerKey, String location) {
+        Objects.requireNonNull(consumerKey, "consumerKey");
+        Objects.requireNonNull(location, "location");
+        return entries.get(new Key(consumerKey, location));
+    }
+
+    public void put(String consumerKey, String location, ByteString state, int version, String sessionId) {
+        Objects.requireNonNull(consumerKey, "consumerKey");
+        Objects.requireNonNull(location, "location");
+        Objects.requireNonNull(state, "state");
+        Objects.requireNonNull(sessionId, "sessionId");
+        entries.put(new Key(consumerKey, location), new Entry(state, version, sessionId));
+    }
+
+    public int size() {
+        return entries.size();
+    }
+
+    public record Key(String consumerKey, String location) {}
+    public record Entry(ByteString state, int version, String sessionId) {}
+}
+```
+
+- [ ] **Step 4.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinStateCacheTest
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinStateCacheTest.java
+git commit -m "feat(v1.2.0-rc2-pr2): TwinStateCache (Task 4)"
+```
+
+---
+
+### Task 5: TwinPatchGenerator
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinPatchGenerator.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinPatchGeneratorTest.java`
+
+**Rationale:** Per Decision 2 Option B, on subsequent updates while a stream is alive, the gateway sends JSON Patches (RFC 6902) computed from the prior state to the current state. This class is the algorithm — copies horizon's `AbstractTwinPublisher.getPatchValue()` semantics.
+
+- [ ] **Step 5.1: Write failing test**
+
+Create `core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinPatchGeneratorTest.java`:
+
+```java
+/*
+ * (Same 16-line BeaconStrategists copyright header as TwinStateCacheTest.java.)
+ */
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TwinPatchGeneratorTest {
+
+    @Test
+    void identicalStates_returnsEmptyPatch() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString same = ByteString.copyFromUtf8("{\"x\":1}");
+
+        ByteString patch = gen.diff(same, same);
+        assertThat(patch.toStringUtf8()).isEqualTo("[]");
+    }
+
+    @Test
+    void simpleFieldChange_producesReplaceOp() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("{\"x\":1}");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":2}");
+
+        String patch = gen.diff(from, to).toStringUtf8();
+        assertThat(patch).contains("\"op\":\"replace\"").contains("\"path\":\"/x\"").contains("\"value\":2");
+    }
+
+    @Test
+    void addField_producesAddOp() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("{\"x\":1}");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":1,\"y\":2}");
+
+        String patch = gen.diff(from, to).toStringUtf8();
+        assertThat(patch).contains("\"op\":\"add\"").contains("\"path\":\"/y\"").contains("\"value\":2");
+    }
+
+    @Test
+    void removeField_producesRemoveOp() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("{\"x\":1,\"y\":2}");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":1}");
+
+        String patch = gen.diff(from, to).toStringUtf8();
+        assertThat(patch).contains("\"op\":\"remove\"").contains("\"path\":\"/y\"");
+    }
+
+    @Test
+    void invalidJson_returnsNullToSignalSnapshotFallback() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("not valid json");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":1}");
+
+        ByteString patch = gen.diff(from, to);
+        assertThat(patch).isNull();
+    }
+}
+```
+
+- [ ] **Step 5.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinPatchGeneratorTest
+```
+
+Expected: FAIL with `cannot find symbol class TwinPatchGenerator`.
+
+- [ ] **Step 5.3: Implement TwinPatchGenerator**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinPatchGenerator.java`:
+
+```java
+/*
+ * (Same 16-line BeaconStrategists copyright header.)
+ */
+package org.deltav.gateway.twin;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonpatch.diff.JsonDiff;
+import com.google.protobuf.ByteString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Computes RFC 6902 JSON Patches between Twin state versions. Mirrors the
+ * algorithm in horizon's {@link org.opennms.core.ipc.twin.common.AbstractTwinPublisher#getPatchValue}:
+ * Jackson reads both states as JsonNode, JsonDiff.asJson computes the patch,
+ * the result is serialized to bytes.
+ *
+ * <p>If either input fails to parse as JSON (corrupt state, schema mismatch),
+ * returns null to signal "fall back to snapshot." The dispatcher (Task 8)
+ * checks the return and emits a full snapshot in that case.
+ */
+@Component
+public class TwinPatchGenerator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TwinPatchGenerator.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * @return RFC 6902 JSON Patch as bytes, or null if either input is unparseable.
+     */
+    public ByteString diff(ByteString from, ByteString to) {
+        try {
+            JsonNode source = objectMapper.readTree(from.toByteArray());
+            JsonNode target = objectMapper.readTree(to.toByteArray());
+            JsonNode patch = JsonDiff.asJson(source, target);
+            return ByteString.copyFromUtf8(patch.toString());
+        } catch (Exception e) {
+            LOG.warn("JSON Patch generation failed (from {} bytes -> to {} bytes); caller should fall back to snapshot",
+                from.size(), to.size(), e);
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 5.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinPatchGeneratorTest
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinPatchGenerator.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinPatchGeneratorTest.java
+git commit -m "feat(v1.2.0-rc2-pr2): TwinPatchGenerator (RFC 6902 via Jackson JsonDiff) (Task 5)"
+```
+
+---
+
+### Task 6: MinionTwinSubscriberRegistry
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistry.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistryTest.java`
+
+**Rationale:** Per-`(consumer_key, location)` set of currently-subscribed Minion stream observers. Different from PR1's `MinionStreamPool` (round-robin per RPC) — Twin is broadcast: one update goes to ALL subscribers in the set. Also tracks per-stream `lastSentVersion` so the dispatcher can send patches relative to the right baseline.
+
+- [ ] **Step 6.1: Write failing test**
+
+Create the test (using the same copyright header pattern):
+
+```java
+package org.deltav.gateway.twin;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class MinionTwinSubscriberRegistryTest {
+
+    @Test
+    void noSubscribers_returnsEmpty() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        assertThat(r.subscribers("k", "L")).isEmpty();
+    }
+
+    @Test
+    void register_addsSubscriber() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k", "L", obs);
+
+        Collection<MinionTwinSubscriberRegistry.Subscription> subs = r.subscribers("k", "L");
+        assertThat(subs).hasSize(1);
+        assertThat(subs.iterator().next().observer()).isSameAs(obs);
+        assertThat(subs.iterator().next().lastSentVersion()).isEqualTo(0);
+    }
+
+    @Test
+    void updateLastSentVersion_persists() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k", "L", obs);
+        r.updateLastSentVersion("k", "L", obs, 7);
+
+        assertThat(r.subscribers("k", "L").iterator().next().lastSentVersion()).isEqualTo(7);
+    }
+
+    @Test
+    void unregister_removesSubscriber() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k", "L", obs);
+        r.unregister("k", "L", obs);
+
+        assertThat(r.subscribers("k", "L")).isEmpty();
+    }
+
+    @Test
+    void unregisterAllForStream_removesAcrossKeys() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k1", "L", obs);
+        r.register("k2", "L", obs);
+        r.register("k3", "L", obs);
+
+        r.unregisterAll(obs);
+
+        assertThat(r.subscribers("k1", "L")).isEmpty();
+        assertThat(r.subscribers("k2", "L")).isEmpty();
+        assertThat(r.subscribers("k3", "L")).isEmpty();
+    }
+}
+```
+
+(Add the 16-line BeaconStrategists copyright header at the top.)
+
+- [ ] **Step 6.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=MinionTwinSubscriberRegistryTest
+```
+
+Expected: FAIL with `cannot find symbol class MinionTwinSubscriberRegistry`.
+
+- [ ] **Step 6.3: Implement MinionTwinSubscriberRegistry**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistry.java` with the 16-line header:
+
+```java
+package org.deltav.gateway.twin;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-(consumer_key, location) registry of currently-subscribed Minion
+ * streams plus per-subscriber {@code lastSentVersion}. Different from
+ * {@link org.deltav.gateway.rpc.MinionStreamPool} — Twin is broadcast,
+ * not load-balanced: one update goes to ALL subscribers in the set.
+ *
+ * <p>Per Decision 2 sub-decision 2-iii of the v1.2.0-rc2 decisions doc.
+ * Subscriptions tracked here are recovered on gateway restart by Minions
+ * reconnecting (their existing subscription set is re-sent over the
+ * fresh stream); no inter-gateway coordination required.
+ */
+@Component
+public class MinionTwinSubscriberRegistry {
+
+    private final Map<Key, Map<StreamObserver<TwinUpdate>, Subscription>> subs = new ConcurrentHashMap<>();
+
+    public synchronized void register(String consumerKey, String location, StreamObserver<TwinUpdate> observer) {
+        Objects.requireNonNull(consumerKey, "consumerKey");
+        Objects.requireNonNull(location, "location");
+        Objects.requireNonNull(observer, "observer");
+        subs.computeIfAbsent(new Key(consumerKey, location), k -> new ConcurrentHashMap<>())
+            .put(observer, new Subscription(observer, 0));
+    }
+
+    public synchronized void unregister(String consumerKey, String location, StreamObserver<TwinUpdate> observer) {
+        Map<StreamObserver<TwinUpdate>, Subscription> map = subs.get(new Key(consumerKey, location));
+        if (map != null) {
+            map.remove(observer);
+        }
+    }
+
+    public synchronized void unregisterAll(StreamObserver<TwinUpdate> observer) {
+        for (Map<StreamObserver<TwinUpdate>, Subscription> map : subs.values()) {
+            map.remove(observer);
+        }
+    }
+
+    public synchronized void updateLastSentVersion(String consumerKey, String location,
+                                                    StreamObserver<TwinUpdate> observer, int version) {
+        Map<StreamObserver<TwinUpdate>, Subscription> map = subs.get(new Key(consumerKey, location));
+        if (map != null) {
+            Subscription prior = map.get(observer);
+            if (prior != null) {
+                map.put(observer, new Subscription(observer, version));
+            }
+        }
+    }
+
+    public Collection<Subscription> subscribers(String consumerKey, String location) {
+        Map<StreamObserver<TwinUpdate>, Subscription> map = subs.get(new Key(consumerKey, location));
+        return map == null ? Collections.emptyList() : Collections.unmodifiableCollection(map.values());
+    }
+
+    public record Key(String consumerKey, String location) {}
+    public record Subscription(StreamObserver<TwinUpdate> observer, int lastSentVersion) {}
+}
+```
+
+- [ ] **Step 6.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=MinionTwinSubscriberRegistryTest
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistry.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistryTest.java
+git commit -m "feat(v1.2.0-rc2-pr2): MinionTwinSubscriberRegistry (Task 6)"
+```
+
+---
+
+## Phase 2 — Gateway-side gRPC service + dispatcher (Tasks 7-9)
+
+### Task 7: TwinChannelGrpcService
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/TwinChannelGrpcService.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/grpc/TwinChannelGrpcServiceTest.java`
+
+**Rationale:** The gRPC bidi service that owns Minion subscription lifecycle. On stream open: noop until first `TwinSubscription` arrives. On `TwinSubscription(SUBSCRIBE)`: register in `MinionTwinSubscriberRegistry`, fire initial snapshot via `TwinChannelDispatcher`. On `TwinSubscription(UNSUBSCRIBE)`: unregister. On stream close: unregister all subscriptions.
+
+Reference pattern: rc2 PR1's `RpcChannelGrpcService` (commit `c3aaac5b1e1`) shows the bidi observer pattern with identity context.
+
+- [ ] **Step 7.1: Write failing test**
+
+Create `core/minion-gateway/src/test/java/org/deltav/gateway/grpc/TwinChannelGrpcServiceTest.java`:
+
+```java
+package org.deltav.gateway.grpc;
+
+import io.grpc.Context;
+import io.grpc.stub.StreamObserver;
+import org.deltav.gateway.twin.MinionTwinSubscriberRegistry;
+import org.deltav.gateway.twin.TwinChannelDispatcher;
+import org.deltav.minion.grpc.v1.SubscriptionMode;
+import org.deltav.minion.grpc.v1.TwinSubscription;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class TwinChannelGrpcServiceTest {
+
+    @Test
+    void subscribe_registersAndTriggersInitialSnapshot() {
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinChannelDispatcher dispatcher = mock(TwinChannelDispatcher.class);
+        TwinChannelGrpcService svc = new TwinChannelGrpcService(registry, dispatcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> outbound = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TwinSubscription> in = svc.channel(outbound);
+            in.onNext(TwinSubscription.newBuilder()
+                .setConsumerKey("passive-status")
+                .setMode(SubscriptionMode.SUBSCRIBE).build());
+        });
+
+        verify(registry).register("passive-status", "Default", outbound);
+        verify(dispatcher).sendInitialSnapshot("passive-status", "Default", outbound);
+    }
+
+    @Test
+    void unsubscribe_removesFromRegistry() {
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinChannelDispatcher dispatcher = mock(TwinChannelDispatcher.class);
+        TwinChannelGrpcService svc = new TwinChannelGrpcService(registry, dispatcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> outbound = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TwinSubscription> in = svc.channel(outbound);
+            in.onNext(TwinSubscription.newBuilder()
+                .setConsumerKey("passive-status")
+                .setMode(SubscriptionMode.UNSUBSCRIBE).build());
+        });
+
+        verify(registry).unregister("passive-status", "Default", outbound);
+    }
+
+    @Test
+    void streamClose_unregistersAllSubscriptions() {
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinChannelDispatcher dispatcher = mock(TwinChannelDispatcher.class);
+        TwinChannelGrpcService svc = new TwinChannelGrpcService(registry, dispatcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> outbound = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TwinSubscription> in = svc.channel(outbound);
+            in.onCompleted();
+        });
+
+        verify(registry).unregisterAll(outbound);
+    }
+}
+```
+
+- [ ] **Step 7.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinChannelGrpcServiceTest
+```
+
+Expected: FAIL.
+
+- [ ] **Step 7.3: Implement TwinChannelGrpcService**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/TwinChannelGrpcService.java` with the 16-line header:
+
+```java
+package org.deltav.gateway.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.gateway.twin.MinionTwinSubscriberRegistry;
+import org.deltav.gateway.twin.TwinChannelDispatcher;
+import org.deltav.minion.grpc.v1.SubscriptionMode;
+import org.deltav.minion.grpc.v1.TwinChannelServiceGrpc;
+import org.deltav.minion.grpc.v1.TwinSubscription;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.grpc.server.service.GrpcService;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+
+/**
+ * Bidi-streaming gRPC service for Twin updates. Per Decision 2 of the
+ * v1.2.0-rc2 decisions doc:
+ * - On TwinSubscription(SUBSCRIBE): register in MinionTwinSubscriberRegistry,
+ *   fire initial snapshot via TwinChannelDispatcher.
+ * - On TwinSubscription(UNSUBSCRIBE): unregister.
+ * - On stream close (onCompleted/onError): unregister all subscriptions.
+ *
+ * <p>Sequencing on subscribe: register-before-snapshot is intentional. If a
+ * Kafka update for the same (consumer_key, location) arrives between register
+ * and the initial snapshot send, the dispatcher's broadcast logic will see
+ * the new subscriber and send the broadcast — possibly before the snapshot.
+ * The Minion-side subscriber tolerates this by treating the higher-version
+ * message as authoritative; an out-of-order older snapshot is dropped on the
+ * version-gap check (Decision 2 sub-decision 2-ii).
+ */
+@GrpcService
+public class TwinChannelGrpcService extends TwinChannelServiceGrpc.TwinChannelServiceImplBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TwinChannelGrpcService.class);
+
+    private final MinionTwinSubscriberRegistry registry;
+    private final TwinChannelDispatcher dispatcher;
+
+    public TwinChannelGrpcService(MinionTwinSubscriberRegistry registry, TwinChannelDispatcher dispatcher) {
+        this.registry = registry;
+        this.dispatcher = dispatcher;
+    }
+
+    @Override
+    public StreamObserver<TwinSubscription> channel(StreamObserver<TwinUpdate> outbound) {
+        String minionId = MINION_ID_CTX.get();
+        String location = MINION_LOCATION_CTX.get();
+        LOG.info("Twin stream opened for minion={} location={}", minionId, location);
+
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(TwinSubscription req) {
+                String key = req.getConsumerKey();
+                if (req.getMode() == SubscriptionMode.SUBSCRIBE) {
+                    LOG.info("Twin SUBSCRIBE minion={} location={} key={}", minionId, location, key);
+                    registry.register(key, location, outbound);
+                    dispatcher.sendInitialSnapshot(key, location, outbound);
+                } else {
+                    LOG.info("Twin UNSUBSCRIBE minion={} location={} key={}", minionId, location, key);
+                    registry.unregister(key, location, outbound);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Twin stream error for minion={}: {}", minionId, t.toString());
+                registry.unregisterAll(outbound);
+            }
+
+            @Override
+            public void onCompleted() {
+                LOG.info("Twin stream closed for minion={}", minionId);
+                registry.unregisterAll(outbound);
+                outbound.onCompleted();
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 7.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinChannelGrpcServiceTest
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/grpc/TwinChannelGrpcService.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/grpc/TwinChannelGrpcServiceTest.java
+git commit -m "feat(v1.2.0-rc2-pr2): TwinChannelGrpcService bidi handler (Task 7)"
+```
+
+---
+
+### Task 8: TwinChannelDispatcher + TwinChannelConfiguration
+
+**Files:**
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java`
+- Create: `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelConfiguration.java`
+- Create: `core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinChannelDispatcherTest.java`
+
+**Rationale:** The dispatcher is the load-bearing piece. Implements:
+1. `@KafkaListener(topicPattern = "OpenNMS\\.twin\\.response\\..*")` — consume horizon's Kafka topic.
+2. Translate inbound `TwinResponseProto` → update `TwinStateCache`.
+3. Broadcast to all subscribers in `MinionTwinSubscriberRegistry` for that `(consumer_key, location)`. For each subscriber: send a patch (vs. their `lastSentVersion`) if generatable, else a full snapshot.
+4. `sendInitialSnapshot(...)` — used by Task 7 on SUBSCRIBE.
+
+Reference: PR1's `RpcChannelDispatcher` (commit `d780e5503a4`) for the `@KafkaListener` + Spring Kafka container factory pattern. **Reuse `@EnableKafka` from `RpcChannelConfiguration`** (already present from PR1) — no need to duplicate.
+
+- [ ] **Step 8.1: Write failing test**
+
+Create `core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinChannelDispatcherTest.java`:
+
+```java
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.twin.model.TwinResponseProto;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TwinChannelDispatcherTest {
+
+    @Test
+    void newSubscriberInitialSnapshot_emitsCachedStateAsSnapshot() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("{\"x\":1}"), 5, "session-1");
+
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        d.sendInitialSnapshot("k", "L", obs);
+
+        verify(obs).onNext(argThat(u ->
+            "k".equals(u.getConsumerKey())
+            && !u.getIsPatch()
+            && u.getVersion() == 5
+            && "session-1".equals(u.getSessionId())));
+        verify(registry).updateLastSentVersion("k", "L", obs, 5);
+    }
+
+    @Test
+    void newSubscriberWithNoCachedState_doesNotEmit() {
+        TwinStateCache cache = new TwinStateCache();
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        d.sendInitialSnapshot("k", "L", obs);
+
+        // No state in cache yet — wait for first daemon publish.
+        verify(obs, org.mockito.Mockito.never()).onNext(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void kafkaUpdate_translatedAndBroadcastAsPatchToExistingSubscribers() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("{\"x\":1}"), 5, "session-1");
+
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        when(registry.subscribers("k", "L")).thenReturn(List.of(
+            new MinionTwinSubscriberRegistry.Subscription(obs, 5)));
+
+        // Daemon publishes: state {x:2}, version 6, same session
+        TwinResponseProto horizonMsg = TwinResponseProto.newBuilder()
+            .setConsumerKey("k")
+            .setLocation("L")
+            .setTwinObject(ByteString.copyFromUtf8("{\"x\":2}"))
+            .setIsPatchObject(false)  // daemon's own broadcast format may be snapshot or patch; we re-derive
+            .setVersion(6)
+            .setSessionId("session-1")
+            .build();
+
+        d.handleHorizonUpdate(horizonMsg);
+
+        verify(obs).onNext(argThat(u ->
+            u.getIsPatch()
+            && u.getVersion() == 6
+            && u.getTwinObject().toStringUtf8().contains("\"replace\"")));
+        verify(registry).updateLastSentVersion("k", "L", obs, 6);
+    }
+
+    @Test
+    void kafkaUpdate_sessionChange_emitsSnapshotInsteadOfPatch() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("{\"x\":1}"), 5, "session-A");
+
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        when(registry.subscribers("k", "L")).thenReturn(List.of(
+            new MinionTwinSubscriberRegistry.Subscription(obs, 5)));
+
+        // Daemon publisher restarted with new session-id
+        TwinResponseProto horizonMsg = TwinResponseProto.newBuilder()
+            .setConsumerKey("k").setLocation("L")
+            .setTwinObject(ByteString.copyFromUtf8("{\"x\":2}"))
+            .setVersion(1).setSessionId("session-B").build();
+
+        d.handleHorizonUpdate(horizonMsg);
+
+        verify(obs).onNext(argThat(u -> !u.getIsPatch() && "session-B".equals(u.getSessionId())));
+    }
+}
+```
+
+- [ ] **Step 8.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinChannelDispatcherTest
+```
+
+Expected: FAIL with `cannot find symbol class TwinChannelDispatcher`.
+
+- [ ] **Step 8.3: Implement TwinChannelDispatcher**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java` with the 16-line header:
+
+```java
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import io.grpc.stub.StreamObserver;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.opennms.core.ipc.twin.model.TwinResponseProto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+public class TwinChannelDispatcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TwinChannelDispatcher.class);
+
+    private final TwinStateCache cache;
+    private final MinionTwinSubscriberRegistry registry;
+    private final TwinPatchGenerator patcher;
+
+    public TwinChannelDispatcher(TwinStateCache cache,
+                                 MinionTwinSubscriberRegistry registry,
+                                 TwinPatchGenerator patcher) {
+        this.cache = cache;
+        this.registry = registry;
+        this.patcher = patcher;
+    }
+
+    @KafkaListener(
+        topicPattern = "OpenNMS\\.twin\\.response\\..*",
+        groupId = "minion-gateway-twin",
+        containerFactory = "twinResponseContainerFactory"
+    )
+    public void onKafkaTwinResponse(ConsumerRecord<String, byte[]> record) {
+        try {
+            TwinResponseProto horizonMsg = TwinResponseProto.parseFrom(record.value());
+            handleHorizonUpdate(horizonMsg);
+        } catch (Exception e) {
+            LOG.warn("Failed to parse TwinResponseProto from topic={} key={}", record.topic(), record.key(), e);
+        }
+    }
+
+    /**
+     * Process a Twin update from horizon's wire format. Updates the state cache,
+     * broadcasts to subscribers as patch (vs their lastSentVersion) when possible,
+     * full snapshot otherwise.
+     *
+     * <p>Snapshot fallback triggers on: session_id change (publisher restart),
+     * lastSentVersion == 0 (subscriber never received a baseline), or
+     * patch generation failure (corrupt JSON).
+     */
+    void handleHorizonUpdate(TwinResponseProto msg) {
+        String key = msg.getConsumerKey();
+        String location = msg.getLocation();
+        ByteString newState = msg.getTwinObject();
+        int newVersion = msg.getVersion();
+        String newSession = msg.getSessionId();
+
+        TwinStateCache.Entry prior = cache.get(key, location);
+        cache.put(key, location, newState, newVersion, newSession);
+
+        for (MinionTwinSubscriberRegistry.Subscription sub : registry.subscribers(key, location)) {
+            boolean canPatch = prior != null
+                && prior.sessionId().equals(newSession)
+                && sub.lastSentVersion() == prior.version();
+            ByteString outBytes = canPatch ? patcher.diff(prior.state(), newState) : null;
+
+            TwinUpdate.Builder b = TwinUpdate.newBuilder()
+                .setConsumerKey(key)
+                .setLocation(location)
+                .setVersion(newVersion)
+                .setSessionId(newSession)
+                .setDispatchedAt(now());
+
+            if (outBytes != null) {
+                b.setTwinObject(outBytes).setIsPatch(true);
+            } else {
+                b.setTwinObject(newState).setIsPatch(false);
+            }
+
+            try {
+                synchronized (sub.observer()) {
+                    sub.observer().onNext(b.build());
+                }
+                registry.updateLastSentVersion(key, location, sub.observer(), newVersion);
+            } catch (Throwable t) {
+                LOG.warn("Failed to send TwinUpdate to subscriber for key={} location={}; unregistering",
+                    key, location, t);
+                registry.unregister(key, location, sub.observer());
+            }
+        }
+    }
+
+    /**
+     * Send the initial snapshot to a freshly-subscribed Minion. Called by
+     * {@link org.deltav.gateway.grpc.TwinChannelGrpcService} on SUBSCRIBE.
+     * If no state is cached yet, no message is sent; the subscriber will
+     * receive its first update via the broadcast path when a daemon publishes.
+     */
+    public void sendInitialSnapshot(String consumerKey, String location, StreamObserver<TwinUpdate> observer) {
+        TwinStateCache.Entry e = cache.get(consumerKey, location);
+        if (e == null) {
+            LOG.info("No cached Twin state for key={} location={}; subscriber will receive on first daemon publish",
+                consumerKey, location);
+            return;
+        }
+        TwinUpdate u = TwinUpdate.newBuilder()
+            .setConsumerKey(consumerKey)
+            .setLocation(location)
+            .setVersion(e.version())
+            .setSessionId(e.sessionId())
+            .setTwinObject(e.state())
+            .setIsPatch(false)
+            .setDispatchedAt(now())
+            .build();
+        try {
+            synchronized (observer) {
+                observer.onNext(u);
+            }
+            registry.updateLastSentVersion(consumerKey, location, observer, e.version());
+        } catch (Throwable t) {
+            LOG.warn("Initial snapshot send failed for key={} location={}", consumerKey, location, t);
+        }
+    }
+
+    private Timestamp now() {
+        Instant n = Instant.now();
+        return Timestamp.newBuilder().setSeconds(n.getEpochSecond()).setNanos(n.getNano()).build();
+    }
+}
+```
+
+- [ ] **Step 8.4: Implement TwinChannelConfiguration**
+
+Create `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelConfiguration.java` with the 16-line header:
+
+```java
+package org.deltav.gateway.twin;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Spring Kafka container factory for the Twin response listener.
+ * @EnableKafka is on RpcChannelConfiguration (PR1); no need to duplicate.
+ */
+@Configuration
+public class TwinChannelConfiguration {
+
+    @Bean
+    public ConsumerFactory<String, byte[]> twinResponseConsumerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        cfg.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        // Twin: read from earliest at startup so we rebuild state from history
+        // (Decision 2 sub-decision 2-iii). After replay, group offsets persist
+        // across gateway restarts, so a fresh start re-reads only what's new.
+        cfg.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        cfg.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        return new DefaultKafkaConsumerFactory<>(cfg);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, byte[]> twinResponseContainerFactory(
+            ConsumerFactory<String, byte[]> twinResponseConsumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, byte[]> f =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        f.setConsumerFactory(twinResponseConsumerFactory);
+        return f;
+    }
+}
+```
+
+- [ ] **Step 8.5: Run dispatcher test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway test -Dtest=TwinChannelDispatcherTest
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 8.6: Verify full module compile (Spring wiring satisfied)**
+
+```bash
+./mvnw -pl :org.opennms.core.minion-gateway -am clean compile
+```
+
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 8.7: Commit**
+
+```bash
+git add core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java \
+        core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelConfiguration.java \
+        core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinChannelDispatcherTest.java
+git commit -m "feat(v1.2.0-rc2-pr2): TwinChannelDispatcher + Kafka wiring (Task 8)"
+```
+
+---
+
+### Task 9: Add TwinChannelService route to envoy.yaml
+
+**Files:**
+- Modify: `opennms-container/delta-v/envoy/envoy.yaml`
+
+**Rationale:** PR1's Phase 4 surfaced that Envoy needs an explicit prefix match per service. PR2 must add the route or the Minion gets `UNIMPLEMENTED`. Plan-time fix per the lesson; do not skip.
+
+- [ ] **Step 9.1: Add the route**
+
+Modify `opennms-container/delta-v/envoy/envoy.yaml`. Find the existing `RpcChannelService` route block (added in PR1) and add an analogous block below it:
+
+```yaml
+              # v1.2.0-rc2 PR2: Twin channel migration. Adds routing for the new
+              # TwinChannelService bidi stream used by gateway-side broadcaster.
+              - match:
+                  prefix: "/org.deltav.minion.grpc.v1.TwinChannelService/"
+                  grpc: {}
+                route:
+                  cluster: minion_gateway
+                  timeout: 0s            # streaming RPCs, no per-call timeout
+```
+
+- [ ] **Step 9.2: Verify YAML syntax**
+
+```bash
+docker run --rm -v "$(pwd)/opennms-container/delta-v/envoy/envoy.yaml:/cfg.yaml" envoyproxy/envoy:v1.30.4 \
+    /usr/local/bin/envoy --mode validate -c /cfg.yaml
+```
+
+Expected: `configuration '/cfg.yaml' OK`.
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add opennms-container/delta-v/envoy/envoy.yaml
+git commit -m "feat(v1.2.0-rc2-pr2): add Envoy route for TwinChannelService (Task 9)"
+```
+
+---
+
+## Phase 3 — Minion-side gRPC subscriber (Tasks 10-12)
+
+### Task 10: MinionTwinStreamClient
+
+**Files:**
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java`
+- Create: `core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionTwinStreamClientTest.java`
+
+**Rationale:** Minion-side bidi observer. Receives `TwinUpdate` messages on the gRPC stream, applies them via horizon's `LocalTwinSubscriberImpl` (or equivalent — the Minion-side dispatch infrastructure that horizon already provides). Detects version-gap → drops the stream and reconnects (Decision 2 sub-decision 2-ii revised).
+
+- [ ] **Step 10.1: Write failing test**
+
+Create `core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionTwinStreamClientTest.java`:
+
+```java
+package org.deltav.minion.common.grpc;
+
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
+import org.opennms.core.ipc.twin.api.TwinUpdate;  // horizon's TwinUpdate (different type)
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class MinionTwinStreamClientTest {
+
+    @Test
+    void firstUpdate_isApplied() {
+        LocalTwinSubscriber localSubscriber = mock(LocalTwinSubscriber.class);
+        Consumer<String> reconnectTrigger = mock(Consumer.class);
+        MinionTwinStreamClient client = new MinionTwinStreamClient(localSubscriber, reconnectTrigger);
+
+        StreamObserver<org.deltav.minion.grpc.v1.TwinUpdate> in = client.streamObserver();
+        in.onNext(org.deltav.minion.grpc.v1.TwinUpdate.newBuilder()
+            .setConsumerKey("k")
+            .setLocation("L")
+            .setIsPatch(false)
+            .setVersion(5)
+            .setSessionId("session-1")
+            .setTwinObject(ByteString.copyFromUtf8("{\"x\":1}"))
+            .build());
+
+        verify(localSubscriber).accept(any(org.opennms.core.ipc.twin.api.TwinUpdate.class));
+    }
+
+    @Test
+    void contiguousUpdate_isApplied() {
+        LocalTwinSubscriber localSubscriber = mock(LocalTwinSubscriber.class);
+        Consumer<String> reconnectTrigger = mock(Consumer.class);
+        MinionTwinStreamClient client = new MinionTwinStreamClient(localSubscriber, reconnectTrigger);
+
+        StreamObserver<org.deltav.minion.grpc.v1.TwinUpdate> in = client.streamObserver();
+        in.onNext(buildSnapshot("k", "L", "session-1", 5));
+        in.onNext(buildPatch("k", "L", "session-1", 6));
+
+        verify(localSubscriber, org.mockito.Mockito.times(2))
+            .accept(any(org.opennms.core.ipc.twin.api.TwinUpdate.class));
+    }
+
+    @Test
+    void nonContiguousVersion_triggersReconnect() {
+        LocalTwinSubscriber localSubscriber = mock(LocalTwinSubscriber.class);
+        Consumer<String> reconnectTrigger = mock(Consumer.class);
+        MinionTwinStreamClient client = new MinionTwinStreamClient(localSubscriber, reconnectTrigger);
+
+        StreamObserver<org.deltav.minion.grpc.v1.TwinUpdate> in = client.streamObserver();
+        in.onNext(buildSnapshot("k", "L", "session-1", 5));
+        in.onNext(buildPatch("k", "L", "session-1", 7));  // jumped from 5 to 7 — gap!
+
+        verify(reconnectTrigger).accept("version-gap on (k,L): expected 6, got 7");
+    }
+
+    private org.deltav.minion.grpc.v1.TwinUpdate buildSnapshot(String key, String loc, String sess, int v) {
+        return org.deltav.minion.grpc.v1.TwinUpdate.newBuilder()
+            .setConsumerKey(key).setLocation(loc).setSessionId(sess).setVersion(v)
+            .setIsPatch(false).setTwinObject(ByteString.copyFromUtf8("{\"x\":1}")).build();
+    }
+
+    private org.deltav.minion.grpc.v1.TwinUpdate buildPatch(String key, String loc, String sess, int v) {
+        return org.deltav.minion.grpc.v1.TwinUpdate.newBuilder()
+            .setConsumerKey(key).setLocation(loc).setSessionId(sess).setVersion(v)
+            .setIsPatch(true).setTwinObject(ByteString.copyFromUtf8("[]")).build();
+    }
+}
+```
+
+- [ ] **Step 10.2: Run failing test**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common test -Dtest=MinionTwinStreamClientTest
+```
+
+Expected: FAIL.
+
+- [ ] **Step 10.3: Implement MinionTwinStreamClient**
+
+Create `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java` with the 16-line header:
+
+```java
+package org.deltav.minion.common.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Minion-side gRPC Twin subscriber. Receives TwinUpdate messages, applies
+ * via horizon's LocalTwinSubscriber, and detects version gaps per
+ * Decision 2 sub-decision 2-ii (revised) of the v1.2.0-rc2 decisions doc:
+ * a non-contiguous version triggers stream reconnect (which yields a fresh
+ * full snapshot from the gateway).
+ *
+ * <p>State per (consumer_key, location): lastSeenVersion + sessionId. When
+ * sessionId changes (publisher restart), the next update is treated as a
+ * fresh baseline regardless of version (publisher reset its sequence).
+ */
+public class MinionTwinStreamClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MinionTwinStreamClient.class);
+
+    private final LocalTwinSubscriber localSubscriber;
+    private final Consumer<String> reconnectTrigger;
+
+    private final Map<Key, State> state = new HashMap<>();
+
+    public MinionTwinStreamClient(LocalTwinSubscriber localSubscriber, Consumer<String> reconnectTrigger) {
+        this.localSubscriber = localSubscriber;
+        this.reconnectTrigger = reconnectTrigger;
+    }
+
+    public StreamObserver<TwinUpdate> streamObserver() {
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(TwinUpdate u) { handle(u); }
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Twin stream error: {}", t.toString());
+            }
+            @Override
+            public void onCompleted() {
+                LOG.info("Twin stream closed");
+            }
+        };
+    }
+
+    private void handle(TwinUpdate u) {
+        Key k = new Key(u.getConsumerKey(), u.getLocation());
+        State prior = state.get(k);
+        boolean expected = prior == null
+            || !prior.sessionId().equals(u.getSessionId())  // publisher restart - any version is fine
+            || u.getVersion() == prior.version() + 1;       // contiguous
+
+        if (!expected) {
+            String reason = String.format("version-gap on (%s,%s): expected %d, got %d",
+                u.getConsumerKey(), u.getLocation(), prior.version() + 1, u.getVersion());
+            LOG.warn("{} — triggering reconnect for fresh snapshot", reason);
+            reconnectTrigger.accept(reason);
+            return;
+        }
+
+        org.opennms.core.ipc.twin.api.TwinUpdate horizonUpdate =
+            new org.opennms.core.ipc.twin.api.TwinUpdate(u.getConsumerKey(), u.getLocation(), u.getTwinObject().toByteArray());
+        horizonUpdate.setPatch(u.getIsPatch());
+        horizonUpdate.setVersion(u.getVersion());
+        horizonUpdate.setSessionId(u.getSessionId());
+        localSubscriber.accept(horizonUpdate);
+
+        state.put(k, new State(u.getVersion(), u.getSessionId()));
+    }
+
+    private record Key(String consumerKey, String location) {}
+    private record State(int version, String sessionId) {}
+}
+```
+
+- [ ] **Step 10.4: Run test to verify it passes**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common test -Dtest=MinionTwinStreamClientTest
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java \
+        core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionTwinStreamClientTest.java
+git commit -m "feat(v1.2.0-rc2-pr2): MinionTwinStreamClient with version-gap reconnect (Task 10)"
+```
+
+---
+
+### Task 11: GrpcTwinStreamConfiguration
+
+**Files:**
+- Create: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java`
+
+**Rationale:** Spring `@Configuration` activated when `opennms.minion.transport.twin=grpc` (default). Builds the gRPC stub against the existing `minionGatewayChannel` bean (provided by `GrpcHeartbeatDispatcherConfiguration`), opens the bidi stream via `SmartLifecycle`, drives subscribe requests for each registered `TwinSubscriber`, hands inbound updates to `MinionTwinStreamClient`.
+
+The reconnect trigger from Task 10 is wired here: on version-gap, `lifecycle.stop(); lifecycle.start();` re-establishes the stream and re-subscribes.
+
+- [ ] **Step 11.1: Implement**
+
+Create `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java` with the 16-line header:
+
+```java
+package org.deltav.minion.common;
+
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.common.grpc.MinionIdentityClientInterceptor;
+import org.deltav.minion.common.grpc.MinionTwinStreamClient;
+import org.deltav.minion.grpc.v1.SubscriptionMode;
+import org.deltav.minion.grpc.v1.TwinChannelServiceGrpc;
+import org.deltav.minion.grpc.v1.TwinSubscription;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Active when {@code opennms.minion.transport.twin=grpc} (default per
+ * Decision 4 sub-decision 4-ii). Opens a bidi stream to minion-gateway,
+ * subscribes for each consumer key the daemon code has registered locally,
+ * and feeds inbound TwinUpdate messages to {@link MinionTwinStreamClient}.
+ *
+ * <p>SmartLifecycle phase 350 — after Twin Kafka subscriber phase 100
+ * window (rc1 default) and Sink Phase 200; before RPC phase 400 which is
+ * managed by GrpcRpcStreamConfiguration.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.twin", havingValue = "grpc", matchIfMissing = true)
+public class GrpcTwinStreamConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GrpcTwinStreamConfiguration.class);
+
+    @Bean
+    public MinionTwinStreamClient minionTwinStreamClient(LocalTwinSubscriber localTwinSubscriber,
+                                                          AtomicReference<SmartLifecycle> lifecycleRef) {
+        // The reconnect trigger flips the lifecycle stop/start to drop the stream
+        // and rebuild — the Minion will re-subscribe to all keys and receive fresh
+        // snapshots per Decision 2 sub-decision 2-ii (revised).
+        return new MinionTwinStreamClient(localTwinSubscriber, reason -> {
+            SmartLifecycle lc = lifecycleRef.get();
+            if (lc != null && lc.isRunning()) {
+                LOG.warn("Twin reconnect: {}", reason);
+                lc.stop();
+                lc.start();
+            }
+        });
+    }
+
+    @Bean
+    public AtomicReference<SmartLifecycle> twinStreamLifecycleRef() {
+        return new AtomicReference<>();
+    }
+
+    @Bean
+    public SmartLifecycle twinStreamLifecycle(@Qualifier("minionGatewayChannel") ManagedChannel channel,
+                                              MinionIdentity identity,
+                                              List<TwinSubscriptionRegistration> subscriptions,
+                                              MinionTwinStreamClient client,
+                                              AtomicReference<SmartLifecycle> lifecycleRef) {
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+            private volatile StreamObserver<TwinSubscription> outbound;
+
+            @Override
+            public void start() {
+                MinionIdentityClientInterceptor identityInterceptor =
+                    new MinionIdentityClientInterceptor(identity.getId(), identity.getLocation());
+                var stub = TwinChannelServiceGrpc.newStub(channel).withInterceptors(identityInterceptor);
+                outbound = stub.channel(client.streamObserver());
+
+                // Send SUBSCRIBE for each registered consumer key
+                for (TwinSubscriptionRegistration sub : subscriptions) {
+                    outbound.onNext(TwinSubscription.newBuilder()
+                        .setConsumerKey(sub.consumerKey())
+                        .setMode(SubscriptionMode.SUBSCRIBE)
+                        .build());
+                }
+                running = true;
+                LOG.info("Twin stream opened to minion-gateway for minion={} location={} ({} subscriptions)",
+                    identity.getId(), identity.getLocation(), subscriptions.size());
+            }
+
+            @Override
+            public void stop() {
+                if (outbound != null) {
+                    try { outbound.onCompleted(); } catch (Throwable ignored) {}
+                    outbound = null;
+                }
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() { return running; }
+
+            @Override
+            public int getPhase() { return 350; }
+        };
+    }
+
+    /**
+     * Daemon-boot modules register one of these per consumer_key they want
+     * subscribed (e.g., PassiveStatusTwinSubscriber wires
+     * new TwinSubscriptionRegistration("passive-status")). The list bean
+     * collects them all for the lifecycle bean's start() to iterate.
+     */
+    public record TwinSubscriptionRegistration(String consumerKey) {}
+
+    @Autowired
+    public void wireLifecycleRef(AtomicReference<SmartLifecycle> ref, SmartLifecycle lifecycle) {
+        ref.set(lifecycle);
+    }
+}
+```
+
+- [ ] **Step 11.2: Verify compile**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common -am compile
+```
+
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 11.3: Commit**
+
+```bash
+git add core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java
+git commit -m "feat(v1.2.0-rc2-pr2): GrpcTwinStreamConfiguration (Task 11)"
+```
+
+---
+
+### Task 12: Add transport.twin=kafka conditional to KafkaTwinSubscriberConfiguration
+
+**Files:**
+- Modify: `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java`
+
+**Rationale:** Per Decision 4 sub-decision 4-i, each channel has its own `MINION_<CHANNEL>_TRANSPORT` flag. Twin gets `opennms.minion.transport.twin=kafka` for the rollback path. Mirrors PR1's edit to `KafkaRpcServerConfiguration`.
+
+- [ ] **Step 12.1: Add the second @ConditionalOnProperty**
+
+Find the existing `@ConditionalOnProperty` on the class (likely `opennms.minion.twin.enabled`) and add the new one BELOW it:
+
+```java
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.twin.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "opennms.minion.transport.twin", havingValue = "kafka")
+public class KafkaTwinSubscriberConfiguration {
+```
+
+If the existing class has no `@ConditionalOnProperty`, just add the one new annotation:
+
+```java
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.twin", havingValue = "kafka")
+public class KafkaTwinSubscriberConfiguration {
+```
+
+(Read the file first to know which case applies.)
+
+- [ ] **Step 12.2: Verify compile**
+
+```bash
+./mvnw -pl :org.opennms.core.daemon-boot-minion-common -am test
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 12.3: Commit**
+
+```bash
+git add core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java
+git commit -m "feat(v1.2.0-rc2-pr2): MINION_TWIN_TRANSPORT flag wiring (Task 12)"
+```
+
+---
+
+## Phase 4 — E2E test updates + acceptance (Tasks 13-15)
+
+### Task 13: Update test-passive-e2e.sh for gRPC Twin path
+
+**Files:**
+- Modify: `opennms-container/delta-v/test-passive-e2e.sh`
+
+**Rationale:** The existing test-passive-e2e exercises Twin (PassiveStatusTwinSubscriber). Add a pre-flight assertion that minion-gateway has logged "Twin stream opened" for the connected Minion, mirroring the RPC pre-flight added in PR1's Task 11.
+
+- [ ] **Step 13.1: Add the gRPC Twin pre-flight check**
+
+Find the existing rc2 PR1 block in `test-passive-e2e.sh` that asserts the gRPC RPC stream open. Below it, add:
+
+```bash
+# v1.2.0-rc2 PR2: Twin channel migrated to gRPC bidi via minion-gateway.
+# Default opennms.minion.transport.twin=grpc (matchIfMissing=true).
+log "Checking gRPC Twin transport (rc2 PR2)..."
+TWIN_STREAM_DEADLINE=$(( $(date +%s) + 30 ))
+while (( $(date +%s) < TWIN_STREAM_DEADLINE )); do
+    if docker logs delta-v-minion-gateway 2>&1 | grep -q "Twin stream opened for minion=.* location=Default"; then
+        break
+    fi
+    sleep 3
+done
+if ! docker logs delta-v-minion-gateway 2>&1 | grep -q "Twin stream opened for minion=.* location=Default"; then
+    err "minion-gateway never logged 'Twin stream opened' for location=Default; gRPC Twin channel not live"
+fi
+ok "gRPC Twin stream live for location=Default (rc2 PR2)"
+```
+
+- [ ] **Step 13.2: Verify syntax**
+
+```bash
+bash -n opennms-container/delta-v/test-passive-e2e.sh
+```
+
+Expected: exit 0.
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+git add opennms-container/delta-v/test-passive-e2e.sh
+git commit -m "test(v1.2.0-rc2-pr2): gRPC Twin pre-flight check in test-passive-e2e (Task 13)"
+```
+
+---
+
+### Task 14: Add test-grpc-twin-e2e.sh smoke harness
+
+**Files:**
+- Create: `opennms-container/delta-v/test-grpc-twin-e2e.sh`
+
+**Rationale:** Channel liveness smoke harness analogous to PR1's `test-grpc-rpc-e2e.sh`. Verifies (a) minion-gateway running, (b) Twin stream open from at least one Minion, (c) gateway state cache populated for a known consumer key (e.g., `passive-status`).
+
+- [ ] **Step 14.1: Create the script**
+
+Create `opennms-container/delta-v/test-grpc-twin-e2e.sh`:
+
+```bash
+#!/usr/bin/env bash
+#
+# test-grpc-twin-e2e.sh -- v1.2.0-rc2-pr2 gRPC Twin channel smoke harness
+#
+# Decision 10 of the rc2 decisions doc set the release gate:
+#   gRPC Twin subscribe-to-first-snapshot p99 <= Heartbeat baseline + 100 ms
+#   gRPC Twin propagation lag p99 <= Heartbeat baseline + 50 ms
+# With Heartbeat-proxy baseline = 2 ms: subscribe gate <= 102 ms,
+# propagation gate <= 52 ms. As with PR1, strict latency enforcement
+# is deferred to OTel tracing post-PR; this harness verifies channel
+# liveness only.
+#
+# Usage:
+#   ./test-grpc-twin-e2e.sh
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
+
+log() { echo "==> $*"; }
+ok()  { echo "  [PASS] $*"; }
+err() { echo "ERROR: $*" >&2; exit 2; }
+
+log "v1.2.0-rc2-pr2 gRPC Twin channel smoke harness"
+
+if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw "minion-gateway"; then
+    err "minion-gateway is not running. Deploy with: ./deploy.sh up full"
+fi
+ok "minion-gateway is running"
+
+DEADLINE=$(( $(date +%s) + 60 ))
+STREAM_LOG=""
+while (( $(date +%s) < DEADLINE )); do
+    STREAM_LOG=$(docker logs delta-v-minion-gateway 2>&1 \
+        | grep -E "Twin stream opened for minion=.* location=" | head -3)
+    if [ -n "$STREAM_LOG" ]; then break; fi
+    sleep 3
+done
+if [ -z "$STREAM_LOG" ]; then
+    err "minion-gateway never logged 'Twin stream opened' for any location"
+fi
+ok "gRPC Twin channel live; observed stream(s):"
+echo "$STREAM_LOG" | sed 's/^/      /'
+
+# Verify state cache population: the gateway should log a SUBSCRIBE for at
+# least passive-status (assumes deploy.sh up full has provisioned a Minion
+# with PassiveStatusTwinSubscriber active).
+SUBS_LOG=$(docker logs delta-v-minion-gateway 2>&1 \
+    | grep -E "Twin SUBSCRIBE minion=.* key=" | head -5)
+if [ -z "$SUBS_LOG" ]; then
+    log "WARN: no Twin SUBSCRIBE logged yet — Minion subscriptions may not have flowed"
+else
+    ok "Twin SUBSCRIBEs observed:"
+    echo "$SUBS_LOG" | sed 's/^/      /'
+fi
+
+log "===================================================================="
+log "SMOKE PASS: gRPC Twin channel is live."
+log "Strict latency gate (subscribe p99 <= 102ms, propagation p99 <= 52ms)"
+log "is calibrated empirically by Task 15's full E2E suite run + Decision"
+log "10-v widening if needed. OTel tracing contributes the strict gate"
+log "post-PR2."
+log "===================================================================="
+exit 0
+```
+
+- [ ] **Step 14.2: Make executable + verify syntax**
+
+```bash
+chmod +x opennms-container/delta-v/test-grpc-twin-e2e.sh
+bash -n opennms-container/delta-v/test-grpc-twin-e2e.sh
+```
+
+Expected: exit 0.
+
+- [ ] **Step 14.3: Commit**
+
+```bash
+git add opennms-container/delta-v/test-grpc-twin-e2e.sh
+git commit -m "test(v1.2.0-rc2-pr2): test-grpc-twin-e2e smoke harness (Task 14)"
+```
+
+---
+
+### Task 15: Run full Mac dev-env E2E suite
+
+**Files:**
+- Modify: `docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md` (append Phase 4 findings)
+
+**Rationale:** Per Decision 9 sub-decision 9-iii — every PR's merge gate is full Mac dev-env E2E green. PR2's run mirrors PR1's structure: rebuild images, recreate containers, run all 8 testable E2E tests, capture lessons.
+
+- [ ] **Step 15.1: Rebuild minion-gateway image (Phase 1+2 changes)**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+./mvnw -pl :org.opennms.core.minion-gateway -am -DskipTests install
+docker build -t deltav/minion-gateway:0.0.1-SNAPSHOT \
+    -f opennms-container/delta-v/minion-gateway/Dockerfile core/minion-gateway/
+```
+
+Expected: BUILD SUCCESS + Docker build success.
+
+- [ ] **Step 15.2: Rebuild envoy image (Task 9 envoy.yaml change)**
+
+```bash
+docker build -t deltav/envoy:0.0.1-SNAPSHOT \
+    -f opennms-container/delta-v/envoy/Dockerfile opennms-container/delta-v/envoy/
+```
+
+Expected: Docker build success.
+
+- [ ] **Step 15.3: Rebuild minion-boot image (Phase 3 daemon-boot-minion-common changes)**
+
+```bash
+cd opennms-container/delta-v && ./build.sh deltav > /tmp/build-pr2.log 2>&1
+echo "exit=$?"
+tail -3 /tmp/build-pr2.log
+for img in alarmd bsmd collectd daemon-base db-init discovery enlinkd eventtranslator flow-enricher minion-boot perspectivepollerd pollerd prometheus-writer provisiond syslogd telemetryd trapd; do
+  docker tag "deltav/${img}:1.2.0-rc1" "deltav/${img}:0.0.1-SNAPSHOT"
+done
+```
+
+Expected: BUILD SUCCESS in `/tmp/build-pr2.log`.
+
+- [ ] **Step 15.4: Recreate stack with full profile**
+
+```bash
+cd opennms-container/delta-v
+docker compose down 2>&1 | tail
+COMPOSE_PROFILES=full docker compose up -d 2>&1 | tail -10
+sleep 60
+docker compose ps --status running --format '{{.Name}}' | wc -l
+```
+
+Expected: ~23 containers running.
+
+- [ ] **Step 15.5: Verify Twin path is live (pre-test)**
+
+```bash
+docker logs delta-v-minion-gateway 2>&1 | grep -E "Twin stream opened|Twin SUBSCRIBE" | head -5
+docker logs delta-v-minion 2>&1 | grep -E "Twin stream" | head -3
+```
+
+Expected: at least one "Twin stream opened" + at least one "Twin SUBSCRIBE" log line.
+
+- [ ] **Step 15.6: Run E2E suite**
+
+```bash
+mkdir -p /tmp/rc2-pr2-e2e
+echo "PR2 final E2E run, $(date)" > /tmp/rc2-pr2-e2e/RESULTS
+for t in test-collectd-e2e.sh test-e2e.sh test-grpc-heartbeat-e2e.sh test-grpc-rpc-e2e.sh test-grpc-twin-e2e.sh test-minion-e2e.sh test-passive-e2e.sh test-syslog-e2e.sh test-timeseries-e2e.sh; do
+  bash ./$t > /tmp/rc2-pr2-e2e/$t.log 2>&1 \
+    && echo "PASS  $t" >> /tmp/rc2-pr2-e2e/RESULTS \
+    || echo "FAIL  $t  (exit $?)" >> /tmp/rc2-pr2-e2e/RESULTS
+done
+cat /tmp/rc2-pr2-e2e/RESULTS
+```
+
+Expected: 9 PASS (8 from PR1 baseline + new test-grpc-twin-e2e).
+
+- [ ] **Step 15.7: Append findings to pre-work doc**
+
+Append to `docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md`:
+
+```markdown
+## Task 15 — Phase 4 E2E findings
+
+The full Mac dev-env E2E suite was run against rebuilt PR2 images.
+
+### Bugs caught at full-stack E2E
+
+(Document any integration issues surfaced. PR1's three bugs were Envoy
+route gap, missing @EnableKafka, wire-format mismatch. PR2's plan
+proactively addresses each: Task 9 adds the Envoy route, Task 8 reuses
+PR1's @EnableKafka via Configuration import, Tasks 4+8 implement the
+translator. If any new integration bug surfaces, document it here.)
+
+### E2E suite results (post-PR2)
+
+| Test | Result | Notes |
+|---|---|---|
+| test-collectd-e2e.sh | PASS | unchanged from PR1 |
+| test-e2e.sh | PASS | unchanged from PR1 |
+| test-grpc-heartbeat-e2e.sh | PASS | unchanged from PR1 |
+| test-grpc-rpc-e2e.sh | PASS | unchanged from PR1 |
+| test-grpc-twin-e2e.sh | PASS | NEW (Task 14) |
+| test-minion-e2e.sh | PASS | unchanged from PR1 |
+| test-passive-e2e.sh | PASS | now exercises the gRPC Twin path |
+| test-syslog-e2e.sh | PASS | unchanged from PR1 |
+| test-timeseries-e2e.sh | PASS | unchanged from PR1 |
+
+**Versus PR1 baseline:** 8-of-8 baseline-comparable tests still PASS, plus
+the new test-grpc-twin-e2e (9th). Zero regressions.
+
+### Soak-period followups (carry-over from PR1 + PR2-specific)
+
+(PR1 carry-overs: synchronized observer → SerializingExecutor; empty
+RpcModule registry guard; DLQ on Kafka listener; Heartbeat measurement
+methodology; chunking in RpcResponsePublisher; OTel strict latency gate.)
+
+PR2-specific:
+- Twin state cache replay-from-Kafka cold-start cost — first subscriber after
+  gateway restart waits for the Kafka consumer to read-to-tail. Not blocking
+  for rc2; could add a /actuator/health "ready" gate that returns DOWN until
+  topic tail reached.
+- Empty-state subscribe (Task 8.3 case) — subscriber gets no message until
+  first daemon publish. This matches horizon's existing semantics; not a
+  regression. Could be improved post-rc2 via a "no state yet" sentinel.
+- Twin chunking for large requisitions — horizon's Twin proto carries
+  monolithic state; very large requisitions (10k+ nodes × 1KB each) approach
+  gRPC default max message size. Not yet hit empirically; tracked.
+```
+
+- [ ] **Step 15.8: Commit**
+
+```bash
+git add docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc2-pr2): record Phase 4 E2E findings (Task 15)"
+```
+
+---
+
+## Phase 5 — Open PR (Task 16)
+
+### Task 16: Open PR2 against pbrane/delta-v develop
+
+**Files:** none
+
+**Rationale:** Decision 9 PR-iv: rc2 ships sequentially. PR2 lands after PR1.
+
+- [ ] **Step 16.1: Push the branch**
+
+```bash
+git push -u origin feat/v1.2.0-rc2-pr2-twin-migration
+```
+
+- [ ] **Step 16.2: Open the PR**
+
+```bash
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "feat(v1.2.0-rc2/2): Twin channel migration to gRPC" \
+  --body "$(cat <<'EOF'
+## Summary
+
+PR2 of the v1.2.0-rc2 4-PR sequence per Decision 9. Migrates the Minion Twin channel from Kafka topics to gRPC server-streaming routed through `minion-gateway`. PR1's lessons (Envoy route, `@EnableKafka`, wire-format translator) all baked into the plan from the start so this PR's full-stack E2E should be clean.
+
+## Architecture
+
+`minion-gateway` becomes a stateful Twin broadcaster (Decision 2):
+
+- Maintains `TwinStateCache` per `(consumer_key, location)` with version + sessionId.
+- Consumes from `OpenNMS.twin.response.<location>` Kafka topic, **translates horizon's `TwinResponseProto` → rc2's `TwinUpdate` proto**.
+- `MinionTwinSubscriberRegistry` per-key set of subscribed Minion streams + per-stream `lastSentVersion`.
+- On Minion subscribe: send initial snapshot from cache. On daemon publish: broadcast as patch (vs each subscriber's lastSentVersion) when generatable, else snapshot.
+- Subscribers detect version-gap → drop stream, reconnect → fresh snapshot per Decision 2 sub-decision 2-ii.
+
+ServiceDaemon publisher code is unchanged.
+
+## Acceptance criteria
+
+- [x] `core/minion-grpc-contracts/twin.proto` defined.
+- [x] `TwinStateCache`, `TwinPatchGenerator` (RFC 6902 via Jackson `JsonDiff`), `MinionTwinSubscriberRegistry` tested.
+- [x] `TwinChannelGrpcService` bidi handler tested.
+- [x] `TwinChannelDispatcher` translator + broadcast tested.
+- [x] `MinionTwinStreamClient` version-gap reconnect tested.
+- [x] `MINION_TWIN_TRANSPORT=kafka|grpc` flag wired (default `grpc`).
+- [x] Envoy route added for `TwinChannelService`.
+- [x] `test-passive-e2e.sh` updated with Twin pre-flight; `test-grpc-twin-e2e.sh` smoke harness ships.
+- [x] Full Mac dev-env E2E suite green (9 of 9 testable; 0 regressions vs PR1 baseline).
+
+## Plan deviations (none expected)
+
+PR1's lessons baked into PR2's plan upfront: Envoy route in Task 9, `@EnableKafka` reused via PR1's `RpcChannelConfiguration`, wire-format translator in Tasks 4+8. If any plan deviation surfaces during execution, document here.
+
+## What this does NOT cover (deferred)
+
+- PR3 (Sinks: Syslog + Trap + Telemetry × 4).
+- PR4 (build cleanup).
+- Topic rename to `DeltaV.*` — pre-GA cleanup PR.
+- Kafka transport removal from Minion — pre-GA cleanup PR.
+- OTel tracing for strict Twin latency gate.
+
+## Memory invariants honored
+
+- `feedback_never_pr_opennms` ✓
+- `feedback_pull_before_branching` ✓
+- `feedback_e2e_continuous_validation_grpc_migration` ✓
+- `project_minion_mandatory` (zero-trust bidirectional) ✓
+- `feedback_smoke_vm_release_only` (Mac dev for measurement) ✓
+
+## References
+
+- **rc2 decisions doc:** [`docs/plans/2026-04-26-v1.2.0-rc2-decisions.md`](https://github.com/pbrane/delta-v/blob/develop/docs/plans/2026-04-26-v1.2.0-rc2-decisions.md)
+- **PR2 implementation plan:** [`docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md`](https://github.com/pbrane/delta-v/blob/develop/docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md)
+- **PR1 (RPC migration, pattern reference):** [#236](https://github.com/pbrane/delta-v/pull/236)
+EOF
+)"
+```
+
+- [ ] **Step 16.3: Verify PR opened correctly**
+
+```bash
+gh pr view --repo pbrane/delta-v
+```
+
+Confirm `--base develop` and target is `pbrane/delta-v` not `OpenNMS/opennms`.
+
+---
+
+## Self-review summary
+
+**Spec coverage** (Decision 2 of rc2 decisions doc):
+
+| Decision 2 sub-decision | Tasks |
+|---|---|
+| Option B (snapshot+patch+version, delta-v fresh proto) | Task 2 (proto), Task 5 (patch generator), Task 8 (dispatcher) |
+| 2-i (reconnect = full snapshot, always) | Task 8 `sendInitialSnapshot`; Task 10 reconnect trigger drives this |
+| 2-ii revised (subscriber-side gap detection triggers reconnect) | Task 10 `MinionTwinStreamClient.handle` version check |
+| 2-iii (gateway stateful via Kafka read-through cache) | Task 4 cache, Task 8 `auto.offset.reset=earliest` |
+
+PR1 carry-over decisions:
+- Decision 4 (per-channel emergency flag) — Tasks 11+12.
+- Decision 9 PR-i (sequential PRs, full E2E green) — Task 15.
+- PR1 Phase 4 lessons (Envoy route, `@EnableKafka`, wire-format translator) — Tasks 9, 8, 4+8.
+
+**Placeholder scan:** No "TODO", "TBD", "implement later" remain. Code blocks present at every step.
+
+**Type consistency:** `TwinUpdate`/`TwinSubscription` from Task 2 are referenced consistently in Tasks 6-11. `TwinStateCache.Entry` (Task 4) used in Task 8's dispatcher. `MinionTwinSubscriberRegistry.Subscription` (Task 6) used in Task 8.
+
+---
+
+## References
+
+- **rc2 decisions doc (master spec):** [`2026-04-26-v1.2.0-rc2-decisions.md`](./2026-04-26-v1.2.0-rc2-decisions.md)
+- **PR1 implementation plan (cadence reference):** [`2026-04-26-v1.2.0-rc2-pr1-rpc-implementation-plan.md`](./2026-04-26-v1.2.0-rc2-pr1-rpc-implementation-plan.md)
+- **PR1 pre-work findings (Phase 4 lessons):** [`2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md`](./2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md)
+- **rc1 implementation plan:** [`2026-04-26-v1.2.0-rc1-implementation-plan.md`](./2026-04-26-v1.2.0-rc1-implementation-plan.md)
+- **PR1 (RPC migration, code reference):** [#236](https://github.com/pbrane/delta-v/pull/236)
+- **horizon Twin reference classes:** `org.opennms.core.ipc.twin.api.{TwinPublisher,TwinSubscriber,TwinUpdate}`, `org.opennms.core.ipc.twin.common.{AbstractTwinPublisher,AbstractTwinSubscriber,LocalTwinSubscriberImpl}`, `org.opennms.core.ipc.twin.model.TwinResponseProto`.
+- **Develop tip at PR2 plan authoring:** `e6001983e85` (post PR #237 CodeQL auth fix).


### PR DESCRIPTION
## Summary

Implementation plan for **PR2** of the v1.2.0-rc2 4-PR sequence (Twin channel migration to gRPC). Hangs off Decision 2 of the [rc2 decisions doc](https://github.com/pbrane/delta-v/blob/develop/docs/plans/2026-04-26-v1.2.0-rc2-decisions.md): Option B — delta-v fresh `.proto`, snapshot+patch+version semantics, gateway stateful via Kafka read-through cache.

This is a **doc-only** PR — no code changes. The plan itself becomes the spec for PR2's implementation work, which is a separate session.

## Plan structure

16 tasks in 5 phases. Mirrors PR1's plan structure with PR1 lessons baked in upfront.

| Phase | Tasks | Output |
|---|---|---|
| 0 — Pre-work | 1-3 | Findings doc skeleton + `twin.proto` + horizon `twin.common` dep on minion-gateway |
| 1 — Gateway state + JSON Patch + registry | 4-6 | `TwinStateCache`, `TwinPatchGenerator` (Jackson `JsonDiff`, RFC 6902, mirrors `AbstractTwinPublisher.getPatchValue()`), `MinionTwinSubscriberRegistry` (per-key subscriber set + `lastSentVersion`) |
| 2 — Gateway gRPC + dispatcher + Envoy | 7-9 | `TwinChannelGrpcService` bidi handler, `TwinChannelDispatcher` (Kafka listener + wire-format translator + broadcast as patch-or-snapshot), Envoy route for `TwinChannelService` |
| 3 — Minion gRPC subscriber + flag | 10-12 | `MinionTwinStreamClient` (version-gap detection → reconnect per Decision 2 sub-decision 2-ii revised), `GrpcTwinStreamConfiguration` (`transport.twin=grpc` default), `KafkaTwinSubscriberConfiguration` opt-in for `transport.twin=kafka` |
| 4 — E2E + acceptance | 13-15 | `test-passive-e2e` Twin pre-flight, `test-grpc-twin-e2e` smoke harness, full Mac dev-env E2E suite run |
| 5 — PR | 16 | Open feat PR2 against `pbrane/delta-v --base develop` |

## What's in scope (PR2 only)

- New `core/minion-grpc-contracts/twin.proto`.
- `core/minion-gateway/src/main/java/org/deltav/gateway/twin/*` — state cache, patch generator, subscriber registry, channel dispatcher, channel configuration.
- `core/minion-gateway/src/main/java/org/deltav/gateway/grpc/TwinChannelGrpcService.java`.
- `core/daemon-boot-minion-common/.../grpc/MinionTwinStreamClient.java` + `GrpcTwinStreamConfiguration.java`.
- `core/daemon-boot-minion-common/.../KafkaTwinSubscriberConfiguration.java` — gain a `@ConditionalOnProperty(transport.twin=kafka)` annotation.
- Envoy route addition for `TwinChannelService`.
- `test-passive-e2e.sh` Twin pre-flight; new `test-grpc-twin-e2e.sh`.

## What's NOT in scope (deferred)

- PR3 (Sinks: Syslog + Trap + Telemetry × 4) → its own plan.
- PR4 (`build.sh deltav` + Dockerfile EXPOSE port fix) → its own plan.
- Topic rename `OpenNMS.*` → `DeltaV.*` → pre-GA cleanup PR.
- Kafka transport removal from Minion → pre-GA cleanup PR.
- OTel tracing for strict Twin latency gate.

## PR1 lessons baked into PR2's plan upfront

PR1's Phase 4 surfaced three real architectural integration bugs not caught at unit-test or 2-stage-review level. PR2's plan addresses each from the start:

- **Envoy route gap** → Task 9 explicitly adds the `TwinChannelService` prefix match.
- **Missing `@EnableKafka`** → Task 8's `TwinChannelConfiguration` reuses PR1's `RpcChannelConfiguration` `@EnableKafka` (no duplication; same Spring context).
- **Wire-format translator** → Tasks 4 + 8 implement bidirectional translation (horizon `TwinResponseProto` ↔ rc2 `TwinUpdate`) at the gateway boundary, called out as a load-bearing requirement in the architecture overview.

## Self-review summary

Embedded at the bottom of the plan:
- **Spec coverage:** every Decision 2 sub-decision maps to specific tasks; PR1 carry-over decisions (Decision 4 per-channel flag, Decision 9 PR-i sequential merge) addressed.
- **Placeholder scan:** no "TODO", "TBD", or "implement later".
- **Type consistency:** `TwinUpdate`/`TwinSubscription`/`TwinStateCache.Entry`/`MinionTwinSubscriberRegistry.Subscription` cross-references align across tasks.

## What this unblocks

Once this plan PR merges, the rc2 PR2 implementation session can begin. That session will execute the 16 tasks via the **superpowers:subagent-driven-development** skill (or **executing-plans** if preferred), producing the rc2 PR2 feature branch + PR (Task 16).

## Test plan

- [ ] Reviewer reads Phase 1 Task 8 (`TwinChannelDispatcher.handleHorizonUpdate`) carefully — wire-format translator + patch-or-snapshot decision logic is the load-bearing piece.
- [ ] Reviewer confirms Task 10's version-gap reconnect handles the `sessionId` change case (publisher restart) without infinite reconnect loops.
- [ ] Reviewer confirms Task 14's smoke harness assertions are achievable with the deploy.sh up full profile (PassiveStatusTwinSubscriber needs to be active to surface a SUBSCRIBE log line).

## Memory invariants honored

- `feedback_never_pr_opennms` ✓
- `feedback_pull_before_branching` — branched off freshly-merged develop ✓
- `feedback_e2e_continuous_validation_grpc_migration` — Phase 4 enforces full-suite green per PR ✓
- `project_minion_mandatory` — bidirectional zero-trust preserved ✓
- `feedback_smoke_vm_release_only` — Mac dev for measurement ✓