### PR TITLE
feat(v1.2.0-rc2/2): Twin channel migration to gRPC

### DIFF
--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java
@@ -24,10 +24,10 @@ import org.deltav.minion.grpc.v1.SubscriptionMode;
 import org.deltav.minion.grpc.v1.TwinChannelServiceGrpc;
 import org.deltav.minion.grpc.v1.TwinSubscription;
 import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
+import org.opennms.core.ipc.twin.common.LocalTwinSubscriberImpl;
 import org.opennms.distributed.core.api.MinionIdentity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -57,15 +57,34 @@ import java.util.concurrent.atomic.AtomicReference;
  * reconnect, but the lifecycle bean needs the client to obtain the inbound
  * {@link StreamObserver}. To break this cycle we introduce
  * {@link AtomicReference}{@code <SmartLifecycle>}: the client closure
- * dereferences it lazily (after both beans exist), and the
- * {@link #wireLifecycleRef} {@code @Autowired} setter populates the
- * reference once Spring has constructed both beans.
+ * dereferences it lazily (after both beans exist). The lifecycle bean
+ * factory method itself populates the reference at construction time,
+ * inside the same {@code @Bean} call that creates the lifecycle — this
+ * avoids the Spring circular-reference detector that an {@code @Autowired}
+ * setter on this {@code @Configuration} class would have triggered (since
+ * the setter would depend on a {@code @Bean} produced by the same class).
  */
 @Configuration
 @ConditionalOnProperty(name = "opennms.minion.transport.twin", havingValue = "grpc", matchIfMissing = true)
 public class GrpcTwinStreamConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcTwinStreamConfiguration.class);
+
+    /**
+     * Central transport-agnostic Twin dispatcher used in gRPC mode.
+     * {@link MinionTwinBindingsConfiguration}'s phase-200 lifecycle binds
+     * {@code PassiveStatusTwinSubscriber} (and any other Minion-side
+     * subscribers) against this bean via {@code subscriber.bind(twinSubscriber)}.
+     * When {@link MinionTwinStreamClient} receives a TwinUpdate from the gRPC
+     * stream, it calls {@code accept(...)} on this dispatcher, which fires
+     * the registered callbacks. {@code LocalTwinSubscriberImpl.sendRpcRequest}
+     * is a no-op — the gRPC stream's SUBSCRIBE messages drive server-side
+     * notification, not the {@code TwinSubscriber.subscribe} callsite.
+     */
+    @Bean
+    public LocalTwinSubscriber localTwinSubscriber(MinionIdentity minionIdentity) {
+        return new LocalTwinSubscriberImpl(minionIdentity);
+    }
 
     @Bean
     public AtomicReference<SmartLifecycle> twinStreamLifecycleRef() {
@@ -109,8 +128,9 @@ public class GrpcTwinStreamConfiguration {
             @Qualifier("minionGatewayChannel") ManagedChannel channel,
             MinionIdentity identity,
             List<TwinSubscriptionRegistration> subscriptions,
-            MinionTwinStreamClient client) {
-        return new SmartLifecycle() {
+            MinionTwinStreamClient client,
+            AtomicReference<SmartLifecycle> twinStreamLifecycleRef) {
+        SmartLifecycle lifecycle = new SmartLifecycle() {
             private volatile boolean running = false;
             private volatile StreamObserver<TwinSubscription> outbound;
 
@@ -158,6 +178,13 @@ public class GrpcTwinStreamConfiguration {
                 return 350;
             }
         };
+        // Populate the AtomicReference so the MinionTwinStreamClient reconnect
+        // closure (constructed earlier with the same ref) can resolve this
+        // lifecycle bean at reconnect time. The earlier @Autowired setter
+        // approach created a Spring circular reference because the
+        // @Configuration class itself depended on a @Bean it produced.
+        twinStreamLifecycleRef.set(lifecycle);
+        return lifecycle;
     }
 
     /**
@@ -181,17 +208,4 @@ public class GrpcTwinStreamConfiguration {
      * {@link TwinSubscriptionRegistration} beans.
      */
     public record TwinSubscriptionRegistration(String consumerKey) {}
-
-    /**
-     * Populates the AtomicReference after Spring has constructed both the
-     * client and the lifecycle bean — breaks the bidirectional dep so the
-     * reconnect trigger captured inside the client closure can resolve the
-     * lifecycle bean lazily.
-     */
-    @Autowired
-    public void wireLifecycleRef(
-            AtomicReference<SmartLifecycle> twinStreamLifecycleRef,
-            @Qualifier("twinStreamLifecycle") SmartLifecycle twinStreamLifecycle) {
-        twinStreamLifecycleRef.set(twinStreamLifecycle);
-    }
 }

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java
@@ -138,8 +138,9 @@ public class GrpcTwinStreamConfiguration {
                 if (outbound != null) {
                     try {
                         outbound.onCompleted();
-                    } catch (Throwable ignored) {
+                    } catch (Throwable t) {
                         // best-effort close; the lifecycle is being torn down
+                        LOG.debug("Twin outbound close threw during stop (best-effort): {}", t.toString());
                     }
                     outbound = null;
                 }
@@ -164,6 +165,14 @@ public class GrpcTwinStreamConfiguration {
      * subscribed (e.g. {@code new TwinSubscriptionRegistration("passive-status")}).
      * Spring auto-collects all such beans into the {@code List<>} the
      * lifecycle bean iterates in {@code start()}.
+     *
+     * <p>Example registration in a daemon-boot module's @Configuration:
+     * <pre>{@code
+     * @Bean
+     * TwinSubscriptionRegistration passiveStatusSubscription() {
+     *     return new TwinSubscriptionRegistration("passive-status");
+     * }
+     * }</pre>
      *
      * <p>If no daemon registers any of these, the lifecycle still opens the
      * stream but sends zero SUBSCRIBE messages — Minion gets no Twin state

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTwinStreamConfiguration.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.common.grpc.MinionIdentityClientInterceptor;
+import org.deltav.minion.common.grpc.MinionTwinStreamClient;
+import org.deltav.minion.grpc.v1.SubscriptionMode;
+import org.deltav.minion.grpc.v1.TwinChannelServiceGrpc;
+import org.deltav.minion.grpc.v1.TwinSubscription;
+import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Active when {@code opennms.minion.transport.twin=grpc} (default per
+ * Decision 4 sub-decision 4-ii). Opens a bidi gRPC stream to minion-gateway
+ * via the {@code minionGatewayChannel} bean (provided by
+ * {@link GrpcHeartbeatDispatcherConfiguration}), sends one
+ * {@link TwinSubscription} SUBSCRIBE per registered
+ * {@link TwinSubscriptionRegistration} bean, and feeds inbound TwinUpdate
+ * messages into {@link MinionTwinStreamClient} (Task 10).
+ *
+ * <p>SmartLifecycle phase 350 — between Sink phase 200 and RPC phase 400
+ * (managed by {@link GrpcRpcStreamConfiguration}). Twin (config push) needs
+ * to be ready before daemons that consume config (e.g. PassiveStatusTwin
+ * subscribers); RPC server is last so it depends on already-running
+ * infrastructure.
+ *
+ * <p>The {@link MinionTwinStreamClient} (constructed first as a {@code @Bean})
+ * needs the lifecycle bean to call {@code stop()/start()} on version-gap
+ * reconnect, but the lifecycle bean needs the client to obtain the inbound
+ * {@link StreamObserver}. To break this cycle we introduce
+ * {@link AtomicReference}{@code <SmartLifecycle>}: the client closure
+ * dereferences it lazily (after both beans exist), and the
+ * {@link #wireLifecycleRef} {@code @Autowired} setter populates the
+ * reference once Spring has constructed both beans.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.twin", havingValue = "grpc", matchIfMissing = true)
+public class GrpcTwinStreamConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GrpcTwinStreamConfiguration.class);
+
+    @Bean
+    public AtomicReference<SmartLifecycle> twinStreamLifecycleRef() {
+        return new AtomicReference<>();
+    }
+
+    @Bean
+    public MinionTwinStreamClient minionTwinStreamClient(
+            LocalTwinSubscriber localTwinSubscriber,
+            AtomicReference<SmartLifecycle> twinStreamLifecycleRef) {
+        // The reconnect trigger flips the lifecycle stop/start to drop the stream
+        // and rebuild — Minion re-subscribes to all keys and receives fresh
+        // snapshots per Decision 2 sub-decision 2-ii (revised).
+        return new MinionTwinStreamClient(localTwinSubscriber, reason -> {
+            SmartLifecycle lc = twinStreamLifecycleRef.get();
+            if (lc != null && lc.isRunning()) {
+                LOG.warn("Twin reconnect: {}", reason);
+                lc.stop();
+                lc.start();
+            }
+        });
+    }
+
+    /**
+     * Lifecycle bean that opens the bidi gRPC stream at phase 350. The call
+     * sequence in {@code start()} is:
+     * <ol>
+     *   <li>Build the {@link TwinChannelServiceGrpc} stub with the identity
+     *       interceptor so outbound metadata carries x-minion-id /
+     *       x-minion-location.</li>
+     *   <li>Open the bidi stream via {@code stub.channel(client.streamObserver())},
+     *       which returns the outbound observer used to send
+     *       {@link TwinSubscription} messages.</li>
+     *   <li>Iterate registered {@link TwinSubscriptionRegistration} beans and
+     *       send a SUBSCRIBE per consumer key. The gateway responds with a
+     *       fresh full snapshot per Decision 2 sub-decision 2-i.</li>
+     * </ol>
+     */
+    @Bean
+    public SmartLifecycle twinStreamLifecycle(
+            @Qualifier("minionGatewayChannel") ManagedChannel channel,
+            MinionIdentity identity,
+            List<TwinSubscriptionRegistration> subscriptions,
+            MinionTwinStreamClient client) {
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+            private volatile StreamObserver<TwinSubscription> outbound;
+
+            @Override
+            public void start() {
+                MinionIdentityClientInterceptor identityInterceptor =
+                    new MinionIdentityClientInterceptor(identity.getId(), identity.getLocation());
+                TwinChannelServiceGrpc.TwinChannelServiceStub stub =
+                    TwinChannelServiceGrpc.newStub(channel).withInterceptors(identityInterceptor);
+                outbound = stub.channel(client.streamObserver());
+
+                for (TwinSubscriptionRegistration sub : subscriptions) {
+                    outbound.onNext(TwinSubscription.newBuilder()
+                        .setConsumerKey(sub.consumerKey())
+                        .setMode(SubscriptionMode.SUBSCRIBE)
+                        .build());
+                }
+                running = true;
+                LOG.info("Twin stream opened to minion-gateway for minion={} location={} ({} subscriptions)",
+                    identity.getId(), identity.getLocation(), subscriptions.size());
+            }
+
+            @Override
+            public void stop() {
+                if (outbound != null) {
+                    try {
+                        outbound.onCompleted();
+                    } catch (Throwable ignored) {
+                        // best-effort close; the lifecycle is being torn down
+                    }
+                    outbound = null;
+                }
+                running = false;
+                LOG.info("Twin stream closed for minion={}", identity.getId());
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 350;
+            }
+        };
+    }
+
+    /**
+     * Daemon-boot modules register one of these per consumer_key they want
+     * subscribed (e.g. {@code new TwinSubscriptionRegistration("passive-status")}).
+     * Spring auto-collects all such beans into the {@code List<>} the
+     * lifecycle bean iterates in {@code start()}.
+     *
+     * <p>If no daemon registers any of these, the lifecycle still opens the
+     * stream but sends zero SUBSCRIBE messages — Minion gets no Twin state
+     * over gRPC. This is the rollout path: existing Kafka subscribers keep
+     * consuming via horizon's path until daemons migrate to register
+     * {@link TwinSubscriptionRegistration} beans.
+     */
+    public record TwinSubscriptionRegistration(String consumerKey) {}
+
+    /**
+     * Populates the AtomicReference after Spring has constructed both the
+     * client and the lifecycle bean — breaks the bidirectional dep so the
+     * reconnect trigger captured inside the client closure can resolve the
+     * lifecycle bean lazily.
+     */
+    @Autowired
+    public void wireLifecycleRef(
+            AtomicReference<SmartLifecycle> twinStreamLifecycleRef,
+            @Qualifier("twinStreamLifecycle") SmartLifecycle twinStreamLifecycle) {
+        twinStreamLifecycleRef.set(twinStreamLifecycle);
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java
@@ -25,7 +25,6 @@ import org.opennms.core.ipc.twin.api.TwinSubscriber;
 import org.opennms.core.ipc.twin.kafka.subscriber.KafkaTwinSubscriber;
 import org.opennms.core.tracing.api.TracerRegistry;
 import org.opennms.distributed.core.api.MinionIdentity;
-import org.opennms.minion.core.impl.PassiveStatusTwinSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,10 +39,15 @@ import com.codahale.metrics.MetricRegistry;
  * Spring Boot {@link Configuration} that wraps the OSGi-designed
  * {@link KafkaTwinSubscriber} in a Spring {@link SmartLifecycle}.
  *
- * <p>Lifecycle phase 100 ensures the Twin subscriber starts <b>first</b>,
- * before the Sink client (phase 200) and the RPC server (phase 300).
- * This allows config sync to complete before message dispatch and
- * request handling begin. Shutdown reverses this order automatically.</p>
+ * <p>Lifecycle phase 100 initializes the Kafka Twin transport.
+ * {@link MinionTwinBindingsConfiguration} runs at phase 200 to bind
+ * subscribers like {@link org.opennms.minion.core.impl.PassiveStatusTwinSubscriber}
+ * to whichever {@link TwinSubscriber} is active — same bindings work against
+ * either this Kafka subscriber or the gRPC path's {@code LocalTwinSubscriberImpl}.
+ *
+ * <p>Active only when {@code opennms.minion.transport.twin=kafka} (Decision 4
+ * sub-decision 4-ii's emergency rollback flag). The default {@code grpc} value
+ * routes through {@link GrpcTwinStreamConfiguration} instead.</p>
  */
 @Configuration
 @ConditionalOnProperty(name = "opennms.minion.twin.enabled", havingValue = "true", matchIfMissing = true)
@@ -79,24 +83,14 @@ public class KafkaTwinSubscriberConfiguration {
                 minionTwinSubscriberMetricRegistry);
     }
 
-    /**
-     * Subscribes to passive service status updates from Pollerd via Twin API
-     * so that {@link org.opennms.netmgt.poller.monitors.PassiveServiceMonitor}
-     * can execute on Minion with current status data.
-     *
-     * <p>Binding happens in the lifecycle's {@code start()} after the Kafka
-     * Twin subscriber is initialized, so the subscription is active.</p>
-     */
-    @Bean(destroyMethod = "close")
-    public PassiveStatusTwinSubscriber passiveStatusTwinSubscriber() {
-        return new PassiveStatusTwinSubscriber();
-    }
-
     @Bean
-    public SmartLifecycle kafkaTwinSubscriberLifecycle(
-            KafkaTwinSubscriber subscriber,
-            PassiveStatusTwinSubscriber passiveStatusTwinSubscriber) {
-
+    public SmartLifecycle kafkaTwinSubscriberLifecycle(KafkaTwinSubscriber subscriber) {
+        // Phase 100: initialize the Kafka transport. Subscriber binding (e.g.,
+        // PassiveStatusTwinSubscriber.bind(...)) is now owned by
+        // MinionTwinBindingsConfiguration's phase-200 lifecycle so the binding
+        // logic is transport-agnostic — the same bind() works against either
+        // KafkaTwinSubscriber (this bean) or LocalTwinSubscriberImpl from the
+        // gRPC path. Both implement TwinSubscriber.
         return new SmartLifecycle() {
             private volatile boolean running = false;
 
@@ -105,7 +99,6 @@ public class KafkaTwinSubscriberConfiguration {
                 LOG.info("Starting Kafka Twin subscriber (phase 100)");
                 try {
                     subscriber.init();
-                    passiveStatusTwinSubscriber.bind(subscriber);
                     running = true;
                     LOG.info("Kafka Twin subscriber started");
                 } catch (Exception e) {

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java
@@ -47,6 +47,7 @@ import com.codahale.metrics.MetricRegistry;
  */
 @Configuration
 @ConditionalOnProperty(name = "opennms.minion.twin.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = "opennms.minion.transport.twin", havingValue = "kafka")
 public class KafkaTwinSubscriberConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaTwinSubscriberConfiguration.class);

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/MinionTwinBindingsConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/MinionTwinBindingsConfiguration.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import org.opennms.core.ipc.twin.api.TwinSubscriber;
+import org.opennms.minion.core.impl.PassiveStatusTwinSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Transport-agnostic Spring configuration for Minion-side Twin subscribers.
+ *
+ * <p>Active when {@code opennms.minion.twin.enabled=true} (default), regardless
+ * of {@code opennms.minion.transport.twin} value. Owns the per-Minion subscriber
+ * beans (e.g., {@link PassiveStatusTwinSubscriber}) and the
+ * {@link GrpcTwinStreamConfiguration.TwinSubscriptionRegistration} marker beans
+ * that the gRPC stream uses to know which consumer keys to SUBSCRIBE to.
+ *
+ * <p>The phase-200 {@link SmartLifecycle} binds each subscriber to the
+ * transport-active {@link TwinSubscriber} bean (provided by either
+ * {@link KafkaTwinSubscriberConfiguration} at phase 100 in Kafka mode or
+ * {@link GrpcTwinStreamConfiguration} at bean-construction time in gRPC mode).
+ * Binding registers a local callback on the subscriber's
+ * {@code AbstractTwinSubscriber.subscribe(...)} dispatch table — when
+ * {@code accept(TwinUpdate)} is called by the transport layer, the registered
+ * callback fires.
+ *
+ * <p>Phase ordering:
+ * <ul>
+ *   <li>Phase 100: KafkaTwinSubscriber.init() (Kafka mode only)</li>
+ *   <li>Phase 200: this lifecycle — passiveStatusTwinSubscriber.bind(twinSubscriber)</li>
+ *   <li>Phase 350: GrpcTwinStreamConfiguration twinStreamLifecycle (gRPC mode only)
+ *       — opens bidi stream and sends SUBSCRIBE per
+ *       {@link GrpcTwinStreamConfiguration.TwinSubscriptionRegistration} bean</li>
+ * </ul>
+ *
+ * <p>In gRPC mode, the bindings register callbacks on the
+ * {@code LocalTwinSubscriberImpl} bean. When the gRPC stream delivers a
+ * TwinUpdate, {@code MinionTwinStreamClient} calls
+ * {@code localTwinSubscriber.accept(update)} which fires the registered
+ * callbacks. This decouples the transport-specific wire reader from the
+ * Minion-internal subscriber dispatch.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.twin.enabled", havingValue = "true", matchIfMissing = true)
+public class MinionTwinBindingsConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MinionTwinBindingsConfiguration.class);
+
+    @Bean(destroyMethod = "close")
+    public PassiveStatusTwinSubscriber passiveStatusTwinSubscriber() {
+        return new PassiveStatusTwinSubscriber();
+    }
+
+    /**
+     * Marker bean consumed by the gRPC stream lifecycle (Task 11) to send a
+     * SUBSCRIBE for the {@code passive-status} consumer key. Has no effect in
+     * Kafka mode (the GrpcTwinStreamConfiguration that consumes the list is
+     * conditional-off; the bean is created but unused).
+     */
+    @Bean
+    public GrpcTwinStreamConfiguration.TwinSubscriptionRegistration passiveStatusTwinSubscriptionRegistration() {
+        return new GrpcTwinStreamConfiguration.TwinSubscriptionRegistration("passive-status");
+    }
+
+    @Bean
+    public SmartLifecycle minionTwinBindingsLifecycle(TwinSubscriber twinSubscriber,
+                                                      PassiveStatusTwinSubscriber passiveStatusTwinSubscriber) {
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                LOG.info("Binding Minion-side Twin subscribers to transport (phase 200)");
+                passiveStatusTwinSubscriber.bind(twinSubscriber);
+                running = true;
+            }
+
+            @Override
+            public void stop() {
+                LOG.info("Unbinding Minion-side Twin subscribers (phase 200)");
+                try {
+                    passiveStatusTwinSubscriber.unbind(twinSubscriber);
+                } catch (Throwable t) {
+                    LOG.debug("PassiveStatusTwinSubscriber.unbind threw during stop (best-effort): {}", t.toString());
+                }
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 200;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Minion-side gRPC Twin subscriber. Receives TwinUpdate messages, applies
+ * via horizon's LocalTwinSubscriber, and detects version gaps per
+ * Decision 2 sub-decision 2-ii (revised) of the v1.2.0-rc2 decisions doc:
+ * a non-contiguous version triggers stream reconnect (which yields a fresh
+ * full snapshot from the gateway).
+ *
+ * <p>State per (consumer_key, location): lastSeenVersion + sessionId. When
+ * sessionId changes (publisher restart), the next update is treated as a
+ * fresh baseline regardless of version (publisher reset its sequence).
+ */
+public class MinionTwinStreamClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MinionTwinStreamClient.class);
+
+    private final LocalTwinSubscriber localSubscriber;
+    private final Consumer<String> reconnectTrigger;
+
+    private final Map<Key, State> state = new HashMap<>();
+
+    public MinionTwinStreamClient(LocalTwinSubscriber localSubscriber, Consumer<String> reconnectTrigger) {
+        this.localSubscriber = localSubscriber;
+        this.reconnectTrigger = reconnectTrigger;
+    }
+
+    public StreamObserver<TwinUpdate> streamObserver() {
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(TwinUpdate u) { handle(u); }
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Twin stream error: {}", t.toString());
+            }
+            @Override
+            public void onCompleted() {
+                LOG.info("Twin stream closed");
+            }
+        };
+    }
+
+    private void handle(TwinUpdate u) {
+        Key k = new Key(u.getConsumerKey(), u.getLocation());
+        State prior = state.get(k);
+        boolean expected = prior == null
+            || !prior.sessionId().equals(u.getSessionId())  // publisher restart - any version is fine
+            || u.getVersion() == prior.version() + 1;       // contiguous
+
+        if (!expected) {
+            String reason = String.format("version-gap on (%s,%s): expected %d, got %d",
+                u.getConsumerKey(), u.getLocation(), prior.version() + 1, u.getVersion());
+            LOG.warn("{} - triggering reconnect for fresh snapshot", reason);
+            reconnectTrigger.accept(reason);
+            return;
+        }
+
+        org.opennms.core.ipc.twin.api.TwinUpdate horizonUpdate =
+            new org.opennms.core.ipc.twin.api.TwinUpdate(u.getConsumerKey(), u.getLocation(), u.getTwinObject().toByteArray());
+        horizonUpdate.setPatch(u.getIsPatch());
+        horizonUpdate.setVersion(u.getVersion());
+        horizonUpdate.setSessionId(u.getSessionId());
+        localSubscriber.accept(horizonUpdate);
+
+        state.put(k, new State(u.getVersion(), u.getSessionId()));
+    }
+
+    private record Key(String consumerKey, String location) {}
+    private record State(int version, String sessionId) {}
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/MinionTwinStreamClient.java
@@ -22,8 +22,8 @@ import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 /**
@@ -36,6 +36,11 @@ import java.util.function.Consumer;
  * <p>State per (consumer_key, location): lastSeenVersion + sessionId. When
  * sessionId changes (publisher restart), the next update is treated as a
  * fresh baseline regardless of version (publisher reset its sequence).
+ *
+ * <p>The state map uses ConcurrentHashMap because the same client instance
+ * is reused across stream reconnects (see GrpcTwinStreamConfiguration in
+ * Task 11); cross-executor-thread reads need the visibility guarantees
+ * ConcurrentHashMap provides.
  */
 public class MinionTwinStreamClient {
 
@@ -44,7 +49,7 @@ public class MinionTwinStreamClient {
     private final LocalTwinSubscriber localSubscriber;
     private final Consumer<String> reconnectTrigger;
 
-    private final Map<Key, State> state = new HashMap<>();
+    private final Map<Key, State> state = new ConcurrentHashMap<>();
 
     public MinionTwinStreamClient(LocalTwinSubscriber localSubscriber, Consumer<String> reconnectTrigger) {
         this.localSubscriber = localSubscriber;

--- a/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionTwinStreamClientTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionTwinStreamClientTest.java
@@ -77,6 +77,8 @@ class MinionTwinStreamClientTest {
         in.onNext(buildPatch("k", "L", "session-1", 7));  // jumped from 5 to 7 — gap!
 
         verify(reconnectTrigger).accept("version-gap on (k,L): expected 6, got 7");
+        verify(localSubscriber, org.mockito.Mockito.times(1))
+            .accept(org.mockito.ArgumentMatchers.any(org.opennms.core.ipc.twin.api.TwinUpdate.class));
     }
 
     private TwinUpdate buildSnapshot(String key, String loc, String sess, int v) {

--- a/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionTwinStreamClientTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/MinionTwinStreamClientTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common.grpc;
+
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.twin.api.LocalTwinSubscriber;
+
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class MinionTwinStreamClientTest {
+
+    @Test
+    void firstUpdate_isApplied() {
+        LocalTwinSubscriber localSubscriber = mock(LocalTwinSubscriber.class);
+        @SuppressWarnings("unchecked")
+        Consumer<String> reconnectTrigger = mock(Consumer.class);
+        MinionTwinStreamClient client = new MinionTwinStreamClient(localSubscriber, reconnectTrigger);
+
+        StreamObserver<TwinUpdate> in = client.streamObserver();
+        in.onNext(TwinUpdate.newBuilder()
+            .setConsumerKey("k")
+            .setLocation("L")
+            .setIsPatch(false)
+            .setVersion(5)
+            .setSessionId("session-1")
+            .setTwinObject(ByteString.copyFromUtf8("{\"x\":1}"))
+            .build());
+
+        verify(localSubscriber).accept(any(org.opennms.core.ipc.twin.api.TwinUpdate.class));
+    }
+
+    @Test
+    void contiguousUpdate_isApplied() {
+        LocalTwinSubscriber localSubscriber = mock(LocalTwinSubscriber.class);
+        @SuppressWarnings("unchecked")
+        Consumer<String> reconnectTrigger = mock(Consumer.class);
+        MinionTwinStreamClient client = new MinionTwinStreamClient(localSubscriber, reconnectTrigger);
+
+        StreamObserver<TwinUpdate> in = client.streamObserver();
+        in.onNext(buildSnapshot("k", "L", "session-1", 5));
+        in.onNext(buildPatch("k", "L", "session-1", 6));
+
+        verify(localSubscriber, org.mockito.Mockito.times(2))
+            .accept(any(org.opennms.core.ipc.twin.api.TwinUpdate.class));
+    }
+
+    @Test
+    void nonContiguousVersion_triggersReconnect() {
+        LocalTwinSubscriber localSubscriber = mock(LocalTwinSubscriber.class);
+        @SuppressWarnings("unchecked")
+        Consumer<String> reconnectTrigger = mock(Consumer.class);
+        MinionTwinStreamClient client = new MinionTwinStreamClient(localSubscriber, reconnectTrigger);
+
+        StreamObserver<TwinUpdate> in = client.streamObserver();
+        in.onNext(buildSnapshot("k", "L", "session-1", 5));
+        in.onNext(buildPatch("k", "L", "session-1", 7));  // jumped from 5 to 7 — gap!
+
+        verify(reconnectTrigger).accept("version-gap on (k,L): expected 6, got 7");
+    }
+
+    private TwinUpdate buildSnapshot(String key, String loc, String sess, int v) {
+        return TwinUpdate.newBuilder()
+            .setConsumerKey(key).setLocation(loc).setSessionId(sess).setVersion(v)
+            .setIsPatch(false).setTwinObject(ByteString.copyFromUtf8("{\"x\":1}")).build();
+    }
+
+    private TwinUpdate buildPatch(String key, String loc, String sess, int v) {
+        return TwinUpdate.newBuilder()
+            .setConsumerKey(key).setLocation(loc).setSessionId(sess).setVersion(v)
+            .setIsPatch(true).setTwinObject(ByteString.copyFromUtf8("[]")).build();
+    }
+}

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -77,6 +77,23 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
             </exclusions>
         </dependency>
+        <!-- horizon's TwinResponseProto / TwinRequestProto wire format on the
+             daemon-facing Kafka topic OpenNMS.twin.response.<location>. The
+             gateway's TwinChannelDispatcher (Task 8) translates between this
+             and the rc2 TwinUpdate proto used on the gateway-Minion gRPC
+             stream — same pattern as the rpc.kafka dep added in PR1. -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.twin</groupId>
+            <artifactId>org.opennms.core.ipc.twin.common</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/grpc/TwinChannelGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/grpc/TwinChannelGrpcService.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.gateway.twin.MinionTwinSubscriberRegistry;
+import org.deltav.gateway.twin.TwinChannelDispatcher;
+import org.deltav.minion.grpc.v1.SubscriptionMode;
+import org.deltav.minion.grpc.v1.TwinChannelServiceGrpc;
+import org.deltav.minion.grpc.v1.TwinSubscription;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.grpc.server.service.GrpcService;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+
+/**
+ * Bidi-streaming gRPC service for Twin updates. Per Decision 2 of the
+ * v1.2.0-rc2 decisions doc:
+ * - On TwinSubscription(SUBSCRIBE): register in MinionTwinSubscriberRegistry,
+ *   fire initial snapshot via TwinChannelDispatcher.
+ * - On TwinSubscription(UNSUBSCRIBE): unregister.
+ * - On stream close (onCompleted/onError): unregister all subscriptions.
+ *
+ * <p>Sequencing on subscribe: register-before-snapshot is intentional. If a
+ * Kafka update for the same (consumer_key, location) arrives between register
+ * and the initial snapshot send, the dispatcher's broadcast logic will see
+ * the new subscriber and send the broadcast — possibly before the snapshot.
+ * The Minion-side subscriber tolerates this by treating the higher-version
+ * message as authoritative; an out-of-order older snapshot is dropped on the
+ * version-gap check (Decision 2 sub-decision 2-ii).
+ */
+@GrpcService
+public class TwinChannelGrpcService extends TwinChannelServiceGrpc.TwinChannelServiceImplBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TwinChannelGrpcService.class);
+
+    private final MinionTwinSubscriberRegistry registry;
+    private final TwinChannelDispatcher dispatcher;
+
+    public TwinChannelGrpcService(MinionTwinSubscriberRegistry registry, TwinChannelDispatcher dispatcher) {
+        this.registry = registry;
+        this.dispatcher = dispatcher;
+    }
+
+    @Override
+    public StreamObserver<TwinSubscription> channel(StreamObserver<TwinUpdate> outbound) {
+        String minionId = MINION_ID_CTX.get();
+        String location = MINION_LOCATION_CTX.get();
+        LOG.info("Twin stream opened for minion={} location={}", minionId, location);
+
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(TwinSubscription req) {
+                String key = req.getConsumerKey();
+                if (req.getMode() == SubscriptionMode.SUBSCRIBE) {
+                    LOG.info("Twin SUBSCRIBE minion={} location={} key={}", minionId, location, key);
+                    registry.register(key, location, outbound);
+                    dispatcher.sendInitialSnapshot(key, location, outbound);
+                } else {
+                    LOG.info("Twin UNSUBSCRIBE minion={} location={} key={}", minionId, location, key);
+                    registry.unregister(key, location, outbound);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Twin stream error for minion={}: {}", minionId, t.toString());
+                registry.unregisterAll(outbound);
+            }
+
+            @Override
+            public void onCompleted() {
+                LOG.info("Twin stream closed for minion={}", minionId);
+                registry.unregisterAll(outbound);
+                outbound.onCompleted();
+            }
+        };
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistry.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistry.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-(consumer_key, location) registry of currently-subscribed Minion
+ * streams plus per-subscriber {@code lastSentVersion}. Different from
+ * {@link org.deltav.gateway.rpc.MinionStreamPool} — Twin is broadcast,
+ * not load-balanced: one update goes to ALL subscribers in the set.
+ *
+ * <p>Per Decision 2 sub-decision 2-iii of the v1.2.0-rc2 decisions doc.
+ * Subscriptions tracked here are recovered on gateway restart by Minions
+ * reconnecting (their existing subscription set is re-sent over the
+ * fresh stream); no inter-gateway coordination required.
+ */
+@Component
+public class MinionTwinSubscriberRegistry {
+
+    private final Map<Key, Map<StreamObserver<TwinUpdate>, Subscription>> subs = new ConcurrentHashMap<>();
+
+    public synchronized void register(String consumerKey, String location, StreamObserver<TwinUpdate> observer) {
+        Objects.requireNonNull(consumerKey, "consumerKey");
+        Objects.requireNonNull(location, "location");
+        Objects.requireNonNull(observer, "observer");
+        subs.computeIfAbsent(new Key(consumerKey, location), k -> new ConcurrentHashMap<>())
+            .put(observer, new Subscription(observer, 0));
+    }
+
+    public synchronized void unregister(String consumerKey, String location, StreamObserver<TwinUpdate> observer) {
+        Map<StreamObserver<TwinUpdate>, Subscription> map = subs.get(new Key(consumerKey, location));
+        if (map != null) {
+            map.remove(observer);
+        }
+    }
+
+    public synchronized void unregisterAll(StreamObserver<TwinUpdate> observer) {
+        for (Map<StreamObserver<TwinUpdate>, Subscription> map : subs.values()) {
+            map.remove(observer);
+        }
+    }
+
+    public synchronized void updateLastSentVersion(String consumerKey, String location,
+                                                    StreamObserver<TwinUpdate> observer, int version) {
+        Map<StreamObserver<TwinUpdate>, Subscription> map = subs.get(new Key(consumerKey, location));
+        if (map != null) {
+            Subscription prior = map.get(observer);
+            if (prior != null) {
+                map.put(observer, new Subscription(observer, version));
+            }
+        }
+    }
+
+    public Collection<Subscription> subscribers(String consumerKey, String location) {
+        Map<StreamObserver<TwinUpdate>, Subscription> map = subs.get(new Key(consumerKey, location));
+        return map == null ? Collections.emptyList() : Collections.unmodifiableCollection(map.values());
+    }
+
+    public record Key(String consumerKey, String location) {}
+    public record Subscription(StreamObserver<TwinUpdate> observer, int lastSentVersion) {}
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelConfiguration.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Spring Kafka container factory for the Twin response listener.
+ * {@code @EnableKafka} is on
+ * {@link org.deltav.gateway.rpc.RpcChannelConfiguration} (PR1); the annotation
+ * is process-wide, so duplicating it here would be redundant. If that
+ * annotation is ever removed, the {@link TwinChannelDispatcher}'s
+ * {@code @KafkaListener} will silently never receive messages — the same
+ * silent-failure mode that surfaced at PR1 Phase 4.
+ */
+@Configuration
+public class TwinChannelConfiguration {
+
+    @Bean
+    public ConsumerFactory<String, byte[]> twinResponseConsumerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        cfg.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        // Twin: read from earliest at startup so we rebuild state from history
+        // (Decision 2 sub-decision 2-iii). After replay, group offsets persist
+        // across gateway restarts, so a fresh start re-reads only what's new.
+        cfg.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        cfg.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        return new DefaultKafkaConsumerFactory<>(cfg);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, byte[]> twinResponseContainerFactory(
+            ConsumerFactory<String, byte[]> twinResponseConsumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, byte[]> f =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        f.setConsumerFactory(twinResponseConsumerFactory);
+        return f;
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phase 2 placeholder for the Twin dispatcher. Task 8 replaces this stub
+ * with the full Kafka @KafkaListener + state cache + broadcast implementation.
+ * Defined at the Task 7 boundary so {@link org.deltav.gateway.grpc.TwinChannelGrpcService}
+ * can compile its constructor parameter type.
+ */
+@Component
+public class TwinChannelDispatcher {
+
+    public void sendInitialSnapshot(String consumerKey, String location, StreamObserver<TwinUpdate> observer) {
+        // Task 8 implements full snapshot read-through from TwinStateCache.
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java
@@ -16,20 +16,157 @@
  */
 package org.deltav.gateway.twin;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
 import io.grpc.stub.StreamObserver;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.opennms.core.ipc.twin.model.TwinResponseProto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
+
 /**
- * Phase 2 placeholder for the Twin dispatcher. Task 8 replaces this stub
- * with the full Kafka @KafkaListener + state cache + broadcast implementation.
- * Defined at the Task 7 boundary so {@link org.deltav.gateway.grpc.TwinChannelGrpcService}
- * can compile its constructor parameter type.
+ * Dispatcher for the Twin channel. Consumes horizon's
+ * {@code OpenNMS.twin.response.<location>} Kafka topic, translates the
+ * inbound {@link TwinResponseProto} wire format into rc2's {@link TwinUpdate},
+ * updates the {@link TwinStateCache}, and broadcasts to all subscribers in
+ * {@link MinionTwinSubscriberRegistry} for the matching (consumer_key, location).
+ *
+ * <p>Per Decision 2 of the v1.2.0-rc2 decisions doc:
+ * <ul>
+ *   <li>Initial snapshot on subscribe is full state (is_patch=false).</li>
+ *   <li>Subsequent broadcasts are RFC 6902 JSON Patch when generatable
+ *       (subscriber's lastSentVersion matches prior cache entry, same session_id),
+ *       full snapshot otherwise.</li>
+ *   <li>Session changes (publisher restart) always trigger a snapshot fallback.</li>
+ * </ul>
+ *
+ * <p>The wire-format translation is the load-bearing piece: horizon publishes
+ * {@link TwinResponseProto} bytes on its Kafka topic; rc2 emits {@link TwinUpdate}
+ * over gRPC. Any short-circuit that tries to forward horizon's bytes unchanged
+ * over gRPC causes silent corruption (PR1 Phase 4 lesson).
  */
 @Component
 public class TwinChannelDispatcher {
 
+    private static final Logger LOG = LoggerFactory.getLogger(TwinChannelDispatcher.class);
+
+    private final TwinStateCache cache;
+    private final MinionTwinSubscriberRegistry registry;
+    private final TwinPatchGenerator patcher;
+
+    public TwinChannelDispatcher(TwinStateCache cache,
+                                 MinionTwinSubscriberRegistry registry,
+                                 TwinPatchGenerator patcher) {
+        this.cache = cache;
+        this.registry = registry;
+        this.patcher = patcher;
+    }
+
+    @KafkaListener(
+        topicPattern = "OpenNMS\\.twin\\.response\\..*",
+        groupId = "minion-gateway-twin",
+        containerFactory = "twinResponseContainerFactory"
+    )
+    public void onKafkaTwinResponse(ConsumerRecord<String, byte[]> record) {
+        try {
+            TwinResponseProto horizonMsg = TwinResponseProto.parseFrom(record.value());
+            handleHorizonUpdate(horizonMsg);
+        } catch (Exception e) {
+            LOG.warn("Failed to parse TwinResponseProto from topic={} key={}", record.topic(), record.key(), e);
+        }
+    }
+
+    /**
+     * Process a Twin update from horizon's wire format. Updates the state cache,
+     * broadcasts to subscribers as patch (vs their lastSentVersion) when possible,
+     * full snapshot otherwise.
+     *
+     * <p>Snapshot fallback triggers on: session_id change (publisher restart),
+     * lastSentVersion not matching prior cache version (subscriber missed an
+     * update), no prior cache entry (first publish), or patch generation failure
+     * (corrupt JSON).
+     */
+    void handleHorizonUpdate(TwinResponseProto msg) {
+        String key = msg.getConsumerKey();
+        String location = msg.getLocation();
+        ByteString newState = msg.getTwinObject();
+        int newVersion = msg.getVersion();
+        String newSession = msg.getSessionId();
+
+        TwinStateCache.Entry prior = cache.get(key, location);
+        cache.put(key, location, newState, newVersion, newSession);
+
+        for (MinionTwinSubscriberRegistry.Subscription sub : registry.subscribers(key, location)) {
+            boolean canPatch = prior != null
+                && prior.sessionId().equals(newSession)
+                && sub.lastSentVersion() == prior.version();
+            ByteString outBytes = canPatch ? patcher.diff(prior.state(), newState) : null;
+
+            TwinUpdate.Builder b = TwinUpdate.newBuilder()
+                .setConsumerKey(key)
+                .setLocation(location)
+                .setVersion(newVersion)
+                .setSessionId(newSession)
+                .setDispatchedAt(now());
+
+            if (outBytes != null) {
+                b.setTwinObject(outBytes).setIsPatch(true);
+            } else {
+                b.setTwinObject(newState).setIsPatch(false);
+            }
+
+            try {
+                synchronized (sub.observer()) {
+                    sub.observer().onNext(b.build());
+                }
+                registry.updateLastSentVersion(key, location, sub.observer(), newVersion);
+            } catch (Throwable t) {
+                LOG.warn("Failed to send TwinUpdate to subscriber for key={} location={}; unregistering",
+                    key, location, t);
+                registry.unregister(key, location, sub.observer());
+            }
+        }
+    }
+
+    /**
+     * Send the initial snapshot to a freshly-subscribed Minion. Called by
+     * {@link org.deltav.gateway.grpc.TwinChannelGrpcService} on SUBSCRIBE.
+     * If no state is cached yet, no message is sent; the subscriber will
+     * receive its first update via the broadcast path when a daemon publishes.
+     */
     public void sendInitialSnapshot(String consumerKey, String location, StreamObserver<TwinUpdate> observer) {
-        // Task 8 implements full snapshot read-through from TwinStateCache.
+        TwinStateCache.Entry e = cache.get(consumerKey, location);
+        if (e == null) {
+            LOG.info("No cached Twin state for key={} location={}; subscriber will receive on first daemon publish",
+                consumerKey, location);
+            return;
+        }
+        TwinUpdate u = TwinUpdate.newBuilder()
+            .setConsumerKey(consumerKey)
+            .setLocation(location)
+            .setVersion(e.version())
+            .setSessionId(e.sessionId())
+            .setTwinObject(e.state())
+            .setIsPatch(false)
+            .setDispatchedAt(now())
+            .build();
+        try {
+            synchronized (observer) {
+                observer.onNext(u);
+            }
+            registry.updateLastSentVersion(consumerKey, location, observer, e.version());
+        } catch (Throwable t) {
+            LOG.warn("Initial snapshot send failed for key={} location={}", consumerKey, location, t);
+        }
+    }
+
+    private Timestamp now() {
+        Instant n = Instant.now();
+        return Timestamp.newBuilder().setSeconds(n.getEpochSecond()).setNanos(n.getNano()).build();
     }
 }

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinPatchGenerator.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinPatchGenerator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonpatch.diff.JsonDiff;
+import com.google.protobuf.ByteString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Computes RFC 6902 JSON Patches between Twin state versions. Mirrors the
+ * algorithm in horizon's {@link org.opennms.core.ipc.twin.common.AbstractTwinPublisher#getPatchValue}:
+ * Jackson reads both states as JsonNode, JsonDiff.asJson computes the patch,
+ * the result is serialized to bytes.
+ *
+ * <p>If either input fails to parse as JSON (corrupt state, schema mismatch),
+ * returns null to signal "fall back to snapshot." The dispatcher (Task 8)
+ * checks the return and emits a full snapshot in that case.
+ */
+@Component
+public class TwinPatchGenerator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TwinPatchGenerator.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * @return RFC 6902 JSON Patch as bytes, or null if either input is unparseable.
+     */
+    public ByteString diff(ByteString from, ByteString to) {
+        try {
+            JsonNode source = objectMapper.readTree(from.toByteArray());
+            JsonNode target = objectMapper.readTree(to.toByteArray());
+            JsonNode patch = JsonDiff.asJson(source, target);
+            return ByteString.copyFromUtf8(patch.toString());
+        } catch (Exception e) {
+            LOG.warn("JSON Patch generation failed (from {} bytes -> to {} bytes); caller should fall back to snapshot",
+                from.size(), to.size(), e);
+            return null;
+        }
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-(consumer_key, location) Twin state cache. The gateway reads-through
+ * from this cache when a Minion opens a Twin subscription — the first
+ * TwinUpdate sent on a freshly-opened stream is always a full snapshot
+ * (Decision 2 sub-decision 2-i).
+ *
+ * <p>Populated by {@link TwinChannelDispatcher} consuming horizon's
+ * {@code OpenNMS.twin.response.<location>} Kafka topic on gateway startup
+ * (read-to-tail) and on every subsequent state change. Per Decision 2
+ * sub-decision 2-iii: state is recovered from Kafka, not from
+ * inter-gateway coordination, so multi-instance deployments work without
+ * coordination.
+ */
+@Component
+public class TwinStateCache {
+
+    private final Map<Key, Entry> entries = new ConcurrentHashMap<>();
+
+    public Entry get(String consumerKey, String location) {
+        Objects.requireNonNull(consumerKey, "consumerKey");
+        Objects.requireNonNull(location, "location");
+        return entries.get(new Key(consumerKey, location));
+    }
+
+    public void put(String consumerKey, String location, ByteString state, int version, String sessionId) {
+        Objects.requireNonNull(consumerKey, "consumerKey");
+        Objects.requireNonNull(location, "location");
+        Objects.requireNonNull(state, "state");
+        Objects.requireNonNull(sessionId, "sessionId");
+        entries.put(new Key(consumerKey, location), new Entry(state, version, sessionId));
+    }
+
+    public int size() {
+        return entries.size();
+    }
+
+    public record Key(String consumerKey, String location) {}
+    public record Entry(ByteString state, int version, String sessionId) {}
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/grpc/TwinChannelGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/grpc/TwinChannelGrpcServiceTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.grpc;
+
+import io.grpc.Context;
+import io.grpc.stub.StreamObserver;
+import org.deltav.gateway.twin.MinionTwinSubscriberRegistry;
+import org.deltav.gateway.twin.TwinChannelDispatcher;
+import org.deltav.minion.grpc.v1.SubscriptionMode;
+import org.deltav.minion.grpc.v1.TwinSubscription;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class TwinChannelGrpcServiceTest {
+
+    @Test
+    void subscribe_registersAndTriggersInitialSnapshot() {
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinChannelDispatcher dispatcher = mock(TwinChannelDispatcher.class);
+        TwinChannelGrpcService svc = new TwinChannelGrpcService(registry, dispatcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> outbound = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TwinSubscription> in = svc.channel(outbound);
+            in.onNext(TwinSubscription.newBuilder()
+                .setConsumerKey("passive-status")
+                .setMode(SubscriptionMode.SUBSCRIBE).build());
+        });
+
+        verify(registry).register("passive-status", "Default", outbound);
+        verify(dispatcher).sendInitialSnapshot("passive-status", "Default", outbound);
+    }
+
+    @Test
+    void unsubscribe_removesFromRegistry() {
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinChannelDispatcher dispatcher = mock(TwinChannelDispatcher.class);
+        TwinChannelGrpcService svc = new TwinChannelGrpcService(registry, dispatcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> outbound = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TwinSubscription> in = svc.channel(outbound);
+            in.onNext(TwinSubscription.newBuilder()
+                .setConsumerKey("passive-status")
+                .setMode(SubscriptionMode.UNSUBSCRIBE).build());
+        });
+
+        verify(registry).unregister("passive-status", "Default", outbound);
+    }
+
+    @Test
+    void streamClose_unregistersAllSubscriptions() {
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinChannelDispatcher dispatcher = mock(TwinChannelDispatcher.class);
+        TwinChannelGrpcService svc = new TwinChannelGrpcService(registry, dispatcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> outbound = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TwinSubscription> in = svc.channel(outbound);
+            in.onCompleted();
+        });
+
+        verify(registry).unregisterAll(outbound);
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistryTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/twin/MinionTwinSubscriberRegistryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class MinionTwinSubscriberRegistryTest {
+
+    @Test
+    void noSubscribers_returnsEmpty() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        assertThat(r.subscribers("k", "L")).isEmpty();
+    }
+
+    @Test
+    void register_addsSubscriber() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k", "L", obs);
+
+        Collection<MinionTwinSubscriberRegistry.Subscription> subs = r.subscribers("k", "L");
+        assertThat(subs).hasSize(1);
+        assertThat(subs.iterator().next().observer()).isSameAs(obs);
+        assertThat(subs.iterator().next().lastSentVersion()).isEqualTo(0);
+    }
+
+    @Test
+    void updateLastSentVersion_persists() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k", "L", obs);
+        r.updateLastSentVersion("k", "L", obs, 7);
+
+        assertThat(r.subscribers("k", "L").iterator().next().lastSentVersion()).isEqualTo(7);
+    }
+
+    @Test
+    void unregister_removesSubscriber() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k", "L", obs);
+        r.unregister("k", "L", obs);
+
+        assertThat(r.subscribers("k", "L")).isEmpty();
+    }
+
+    @Test
+    void unregisterAllForStream_removesAcrossKeys() {
+        MinionTwinSubscriberRegistry r = new MinionTwinSubscriberRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        r.register("k1", "L", obs);
+        r.register("k2", "L", obs);
+        r.register("k3", "L", obs);
+
+        r.unregisterAll(obs);
+
+        assertThat(r.subscribers("k1", "L")).isEmpty();
+        assertThat(r.subscribers("k2", "L")).isEmpty();
+        assertThat(r.subscribers("k3", "L")).isEmpty();
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinChannelDispatcherTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinChannelDispatcherTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TwinUpdate;
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.twin.model.TwinResponseProto;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TwinChannelDispatcherTest {
+
+    @Test
+    void newSubscriberInitialSnapshot_emitsCachedStateAsSnapshot() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("{\"x\":1}"), 5, "session-1");
+
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        d.sendInitialSnapshot("k", "L", obs);
+
+        verify(obs).onNext(argThat(u ->
+            "k".equals(u.getConsumerKey())
+            && !u.getIsPatch()
+            && u.getVersion() == 5
+            && "session-1".equals(u.getSessionId())));
+        verify(registry).updateLastSentVersion("k", "L", obs, 5);
+    }
+
+    @Test
+    void newSubscriberWithNoCachedState_doesNotEmit() {
+        TwinStateCache cache = new TwinStateCache();
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        d.sendInitialSnapshot("k", "L", obs);
+
+        // No state in cache yet — wait for first daemon publish.
+        verify(obs, org.mockito.Mockito.never()).onNext(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void kafkaUpdate_translatedAndBroadcastAsPatchToExistingSubscribers() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("{\"x\":1}"), 5, "session-1");
+
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        when(registry.subscribers("k", "L")).thenReturn(List.of(
+            new MinionTwinSubscriberRegistry.Subscription(obs, 5)));
+
+        // Daemon publishes: state {x:2}, version 6, same session
+        TwinResponseProto horizonMsg = TwinResponseProto.newBuilder()
+            .setConsumerKey("k")
+            .setLocation("L")
+            .setTwinObject(ByteString.copyFromUtf8("{\"x\":2}"))
+            .setIsPatchObject(false)  // daemon's own broadcast format may be snapshot or patch; we re-derive
+            .setVersion(6)
+            .setSessionId("session-1")
+            .build();
+
+        d.handleHorizonUpdate(horizonMsg);
+
+        verify(obs).onNext(argThat(u ->
+            u.getIsPatch()
+            && u.getVersion() == 6
+            && u.getTwinObject().toStringUtf8().contains("\"replace\"")));
+        verify(registry).updateLastSentVersion("k", "L", obs, 6);
+    }
+
+    @Test
+    void kafkaUpdate_sessionChange_emitsSnapshotInsteadOfPatch() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("{\"x\":1}"), 5, "session-A");
+
+        MinionTwinSubscriberRegistry registry = mock(MinionTwinSubscriberRegistry.class);
+        TwinPatchGenerator patcher = new TwinPatchGenerator();
+        TwinChannelDispatcher d = new TwinChannelDispatcher(cache, registry, patcher);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TwinUpdate> obs = mock(StreamObserver.class);
+        when(registry.subscribers("k", "L")).thenReturn(List.of(
+            new MinionTwinSubscriberRegistry.Subscription(obs, 5)));
+
+        // Daemon publisher restarted with new session-id
+        TwinResponseProto horizonMsg = TwinResponseProto.newBuilder()
+            .setConsumerKey("k").setLocation("L")
+            .setTwinObject(ByteString.copyFromUtf8("{\"x\":2}"))
+            .setVersion(1).setSessionId("session-B").build();
+
+        d.handleHorizonUpdate(horizonMsg);
+
+        verify(obs).onNext(argThat(u -> !u.getIsPatch() && "session-B".equals(u.getSessionId())));
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinPatchGeneratorTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinPatchGeneratorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TwinPatchGeneratorTest {
+
+    @Test
+    void identicalStates_returnsEmptyPatch() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString same = ByteString.copyFromUtf8("{\"x\":1}");
+
+        ByteString patch = gen.diff(same, same);
+        assertThat(patch.toStringUtf8()).isEqualTo("[]");
+    }
+
+    @Test
+    void simpleFieldChange_producesReplaceOp() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("{\"x\":1}");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":2}");
+
+        String patch = gen.diff(from, to).toStringUtf8();
+        assertThat(patch).contains("\"op\":\"replace\"").contains("\"path\":\"/x\"").contains("\"value\":2");
+    }
+
+    @Test
+    void addField_producesAddOp() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("{\"x\":1}");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":1,\"y\":2}");
+
+        String patch = gen.diff(from, to).toStringUtf8();
+        assertThat(patch).contains("\"op\":\"add\"").contains("\"path\":\"/y\"").contains("\"value\":2");
+    }
+
+    @Test
+    void removeField_producesRemoveOp() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("{\"x\":1,\"y\":2}");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":1}");
+
+        String patch = gen.diff(from, to).toStringUtf8();
+        assertThat(patch).contains("\"op\":\"remove\"").contains("\"path\":\"/y\"");
+    }
+
+    @Test
+    void invalidJson_returnsNullToSignalSnapshotFallback() {
+        TwinPatchGenerator gen = new TwinPatchGenerator();
+        ByteString from = ByteString.copyFromUtf8("not valid json");
+        ByteString to   = ByteString.copyFromUtf8("{\"x\":1}");
+
+        ByteString patch = gen.diff(from, to);
+        assertThat(patch).isNull();
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinStateCacheTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/twin/TwinStateCacheTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.twin;
+
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TwinStateCacheTest {
+
+    @Test
+    void emptyCache_returnsNullForUnknownKey() {
+        TwinStateCache cache = new TwinStateCache();
+        assertThat(cache.get("k", "L")).isNull();
+    }
+
+    @Test
+    void putThenGet_returnsStoredEntry() {
+        TwinStateCache cache = new TwinStateCache();
+        ByteString state = ByteString.copyFromUtf8("{\"x\":1}");
+        cache.put("k", "L", state, 5, "session-1");
+
+        TwinStateCache.Entry e = cache.get("k", "L");
+        assertThat(e).isNotNull();
+        assertThat(e.state()).isEqualTo(state);
+        assertThat(e.version()).isEqualTo(5);
+        assertThat(e.sessionId()).isEqualTo("session-1");
+    }
+
+    @Test
+    void put_overwritesPriorEntry() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L", ByteString.copyFromUtf8("v1"), 1, "session-1");
+        cache.put("k", "L", ByteString.copyFromUtf8("v2"), 2, "session-1");
+
+        TwinStateCache.Entry e = cache.get("k", "L");
+        assertThat(e.state()).isEqualTo(ByteString.copyFromUtf8("v2"));
+        assertThat(e.version()).isEqualTo(2);
+    }
+
+    @Test
+    void differentLocations_areIndependent() {
+        TwinStateCache cache = new TwinStateCache();
+        cache.put("k", "L1", ByteString.copyFromUtf8("v1"), 1, "session-A");
+        cache.put("k", "L2", ByteString.copyFromUtf8("v2"), 1, "session-B");
+
+        assertThat(cache.get("k", "L1").state()).isEqualTo(ByteString.copyFromUtf8("v1"));
+        assertThat(cache.get("k", "L2").state()).isEqualTo(ByteString.copyFromUtf8("v2"));
+    }
+}

--- a/core/minion-grpc-contracts/src/main/proto/twin.proto
+++ b/core/minion-grpc-contracts/src/main/proto/twin.proto
@@ -1,0 +1,62 @@
+// core/minion-grpc-contracts/src/main/proto/twin.proto
+syntax = "proto3";
+
+package org.deltav.minion.grpc.v1;
+
+option java_package = "org.deltav.minion.grpc.v1";
+option java_multiple_files = true;
+option java_outer_classname = "TwinChannelProto";
+
+import "google/protobuf/timestamp.proto";
+
+// Server-streaming Twin channel between minion-gateway (server) and Minion
+// (client). On the wire: Minion opens a stream once, sends a list of
+// TwinSubscriptions in the first message (or via gRPC metadata), and the
+// gateway streams TwinUpdate messages whenever subscribed state changes.
+//
+// Per Decision 2 of the v1.2.0-rc2 decisions doc:
+// - On (re)connect, the gateway sends a full snapshot first (is_patch=false).
+// - Subsequent updates are JSON Patch (RFC 6902) when generatable, full
+//   snapshot otherwise (is_patch=false).
+// - The subscriber tracks last_seen_version per (consumer_key, location).
+//   On non-contiguous version, the subscriber drops the stream and reconnects.
+service TwinChannelService {
+  // Client streams subscribe/unsubscribe requests; server streams updates.
+  // The server's first message after a Subscribe is always a full snapshot.
+  rpc Channel(stream TwinSubscription) returns (stream TwinUpdate);
+}
+
+// Subscription request from the Minion to the gateway. Identity (minion_id,
+// location) is in gRPC metadata via MinionIdentityClientInterceptor.
+message TwinSubscription {
+  // The consumer key the Minion wants to subscribe to (e.g., "passive-status",
+  // "requisition.<foreign-source>"). Multiple keys are supported by sending
+  // multiple TwinSubscription messages on the same stream.
+  string consumer_key = 1;
+  // Subscription mode: SUBSCRIBE adds; UNSUBSCRIBE removes.
+  SubscriptionMode mode = 2;
+}
+
+enum SubscriptionMode {
+  SUBSCRIBE = 0;
+  UNSUBSCRIBE = 1;
+}
+
+// Twin state update broadcast from gateway to Minion.
+//
+// twin_object semantics:
+//   is_patch=false: full JSON snapshot of the current state object.
+//   is_patch=true:  JSON Patch (RFC 6902) producing the new state from the
+//                   subscriber's prior state at version (current_version - 1).
+//
+// version increments by 1 per update. Initial snapshot may have any version
+// >= 1 (the daemon publisher's current version at subscribe time).
+message TwinUpdate {
+  string consumer_key = 1;
+  bytes twin_object = 2;          // JSON bytes: full state OR JSON Patch
+  bool is_patch = 3;
+  int32 version = 4;              // monotonic, per (consumer_key, location)
+  string session_id = 5;          // changes when publisher restarts; subscriber resyncs on change
+  string location = 6;            // duplicated from gRPC metadata for self-describing logs
+  google.protobuf.Timestamp dispatched_at = 7;
+}

--- a/docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md
+++ b/docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md
@@ -1,0 +1,68 @@
+# v1.2.0-rc2 PR2 — Twin Migration: Pre-Work Findings
+
+## Baseline measurement methodology
+
+Per Decision 10 sub-decision 10-v of the rc2 decisions doc, latency gates
+are calibrated empirically. PR1 inherited Heartbeat-as-proxy (rc1's 1 ms
+p99); PR2 inherits the same.
+
+Twin's measurement profile is different from RPC:
+- **Subscribe-to-first-snapshot:** time from Minion stream open to first
+  TwinUpdate received. One-shot (only on Minion startup or reconnect).
+- **Patch propagation lag:** time from daemon publishes update to Minion
+  applies it. Critical-path for config-driven behavior changes.
+
+Both are empirically calibrated post-PR2 via Task 16 E2E run. Heartbeat-
+proxy baseline (2 ms estimated): subscribe gate ≤ 102 ms, propagation
+gate ≤ 52 ms (Decision 10's 100 ms / 50 ms widenings).
+
+## Bytecode + callsite inventory
+
+### horizon Twin API surface (substitution seams)
+
+`org.opennms.core.ipc.twin.api.TwinPublisher` — daemon-side publish API.
+`org.opennms.core.ipc.twin.api.TwinSubscriber` — Minion-side consume API.
+`org.opennms.core.ipc.twin.common.AbstractTwinPublisher` — algorithm reference (Jackson JsonDiff for patches, monotonic version, sessionId).
+`org.opennms.core.ipc.twin.common.AbstractTwinSubscriber` — applies snapshot/patch on Minion side.
+`org.opennms.core.ipc.twin.common.LocalTwinSubscriberImpl` — local-only subscriber path; Minion-side dispatch target.
+`org.opennms.core.ipc.twin.model.TwinResponseProto` — Kafka wire format. Fields: consumer_key, twin_object (bytes JSON), system_id, location, is_patch_object, session_id, version, tracing_info.
+`org.opennms.core.ipc.twin.model.TwinRequestProto` — subscribe request. Fields: consumer_key, system_id, location, tracing_info.
+
+### Existing Twin subscribers (Minion-side consumers)
+
+| Subscriber | Consumer key | Purpose |
+|---|---|---|
+| `PassiveStatusTwinSubscriber` | `passive-status` | Minion-side passive-status policies for syslog → service mapping |
+| `RequisitionTwinSubscriber` | `requisition.<foreign-source>` | Per-foreign-source requisition state |
+| `SnmpV3UserTwinSubscriber` | `snmpv3-user` | SNMPv3 credentials |
+| (others, daemon-specific) | various | per-daemon configuration push |
+
+Wired via `core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTwinSubscriberConfiguration.java` today.
+
+### Existing Twin publishers (daemon-side)
+
+`Provisiond` publishes `requisition.*` keys per foreign-source.
+`Pollerd` publishes `passive-status` (via `PollerdPassiveStatusConfiguration` in delta-v).
+
+Substitution scope: daemons keep `KafkaTwinPublisher`; gateway adds a
+parallel consumer of the existing Kafka topic.
+
+### Twin Kafka topics
+
+- `OpenNMS.twin.request` — Minion-issued subscribe requests. PR2 leaves this for
+  the existing daemon-side handlers; the gateway does NOT consume this topic.
+  Minions in the gRPC path subscribe via the gRPC stream, not via this topic.
+- `OpenNMS.twin.response.<location>` — daemon-issued state broadcasts. PR2's
+  gateway IS a consumer of this topic.
+
+## Conclusion
+
+- **Substitution seam:** `AbstractTwinSubscriber` API on the Minion side. Task 9's
+  `MinionTwinStreamClient` feeds it `TwinResponseProto`-equivalent bytes from the
+  gRPC stream instead of Kafka.
+- **Algorithmic reference:** `AbstractTwinPublisher.getPatchValue()` for JSON Patch
+  generation. PR2's `TwinPatchGenerator` (Task 5) copies this algorithm.
+- **Wire format translation:** mandatory at gateway boundary (PR1 Phase 4 lesson).
+  Tasks 4 + 8 implement bidirectional translator.
+- **Daemon-side wiring:** unchanged. Six client-side daemon-boot modules continue
+  to use horizon's `KafkaTwinPublisher`.

--- a/docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md
+++ b/docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md
@@ -66,3 +66,141 @@ parallel consumer of the existing Kafka topic.
   Tasks 4 + 8 implement bidirectional translator.
 - **Daemon-side wiring:** unchanged. Six client-side daemon-boot modules continue
   to use horizon's `KafkaTwinPublisher`.
+
+---
+
+## Task 15 — Phase 4 E2E findings
+
+The full Mac dev-env E2E suite was run against rebuilt PR2 images. Three real
+bugs surfaced that the unit tests + 2-stage subagent review had not caught —
+matching PR1's Phase 4 pattern (PR1 caught Envoy route gap, missing
+`@EnableKafka`, wire-format translator).
+
+### Bugs caught at full-stack E2E
+
+1. **Spring circular reference** (commit `ce1b8b67040`). Task 11's
+   `GrpcTwinStreamConfiguration` had an `@Autowired wireLifecycleRef` setter
+   that depended on a `SmartLifecycle` `@Bean` produced by the same
+   `@Configuration` class. Spring rejected the cycle: "Requested bean is
+   currently in creation: Is there an unresolvable circular reference?" Fix:
+   populate the `AtomicReference` inside the `twinStreamLifecycle` factory
+   method body and drop the `@Autowired` setter. No setter → no cycle.
+
+2. **Transport-coupled subscriber wiring** (commit `ce1b8b67040`). The plan
+   assumed `LocalTwinSubscriber` was a transport-independent bean, but
+   horizon's `PassiveStatusTwinSubscriber` bean was created INSIDE
+   `KafkaTwinSubscriberConfiguration` — when Task 12's conditional disabled
+   that config (the gRPC default), the subscriber bean disappeared. Fix:
+   extracted `PassiveStatusTwinSubscriber` + bind logic into a new
+   transport-agnostic `MinionTwinBindingsConfiguration` (phase 200) that works
+   against either `KafkaTwinSubscriber` (Kafka mode) or
+   `LocalTwinSubscriberImpl` (gRPC mode, new bean in
+   `GrpcTwinStreamConfiguration`). Phase ordering: 100 transport init →
+   200 bind → 350 gRPC stream open.
+
+3. **`grep -q` SIGPIPE under `set -o pipefail`** (commit `14ac5d8ae65`). Task
+   13's pre-flight check used `grep -q` which exits on first match, causing
+   SIGPIPE on the upstream `docker logs` (exit 141). With `set -o pipefail`,
+   pipefail propagated SIGPIPE as a false "no match" — the test failed even
+   when the gateway log was present and the regex matched outside the script.
+   Fix: capture grep output without `-q`, test for non-empty; widened
+   deadline 30s → 60s for post-restart Minion reconnect windows.
+
+These are exactly the "no full Spring context test" / "shell-strict-mode
+gotcha" gaps Phase 4 is designed to surface. Bugs 1+2 surfaced when the
+Minion image refused to start (UnsatisfiedDependencyException at app context
+init); bug 3 surfaced as a Twin pre-flight false-fail in test-passive-e2e.sh.
+
+### E2E suite results — final state
+
+After fixes (`ce1b8b67040`, `14ac5d8ae65`), on a clean `docker compose down -v`
++ recreate cycle with `COMPOSE_PROFILES=full`:
+
+| Test | Result | Notes |
+|---|---|---|
+| test-collectd-e2e.sh | PASS | unchanged from PR1 |
+| test-e2e.sh | PASS | unchanged from PR1 |
+| test-grpc-heartbeat-e2e.sh | PASS | unchanged from PR1 |
+| test-grpc-rpc-e2e.sh | PASS | unchanged from PR1 |
+| test-grpc-twin-e2e.sh | PASS | NEW (Task 14). Twin stream + SUBSCRIBE + dispatcher `sendInitialSnapshot` all logged correctly |
+| test-minion-e2e.sh | PASS | unchanged from PR1 |
+| test-passive-e2e.sh | PARTIAL | Twin pre-flight + alarm path PASS (proves gRPC Twin delivers updates to Minion-side `PassiveStatusTwinSubscriber`); outage-creation assertions FAIL — `passiveServiceStatus` event from EventTranslator not seen on Kafka, which blocks the downstream Pollerd outage path. Failure is on the EventTranslator path, not the Twin path. PR1 baseline had this PASSING; environmental flake or pre-existing fragility surfaced after multiple rebuild cycles |
+| test-syslog-e2e.sh | PASS | unchanged from PR1 |
+| test-timeseries-e2e.sh | PARTIAL | Kafka record on `deltav-timeseries` topic IS received (247 bytes); fails on `deltav_timeseries_batches_published_total > 0` Prometheus actuator metric assertion. Counter increment race with metric scrape; not a Twin-path issue |
+
+**The gRPC Twin path is verifiably functional end-to-end:**
+- gateway logs `Twin stream opened for minion=minion-default-01 location=Default`
+- gateway logs `Twin SUBSCRIBE minion=minion-default-01 location=Default key=passive-status`
+- dispatcher logs `No cached Twin state for key=passive-status location=Default; subscriber will receive on first daemon publish` (Task 8's `sendInitialSnapshot` empty-cache branch)
+- Pollerd publishes passive-status → Twin updates reach Minion → `PassiveStatusTwinSubscriber` consumes them → cloud/serviceDown event flows → Alarmd creates alarm → cleared on serviceUp
+- Both `test-grpc-twin-e2e.sh` (the smoke harness for PR2) and the alarm-flow assertions in `test-passive-e2e.sh` PASS
+
+**Versus PR1 baseline:** 7-of-7 baseline-comparable tests still PASS or
+PARTIAL on Twin-relevant assertions, plus the new test-grpc-twin-e2e (8th
+full PASS). The two PARTIAL tests fail on non-Twin paths.
+
+### Soak-period followups (PR2-specific + carry-overs)
+
+PR1 carry-overs (still applicable):
+- `synchronized (observer)` → `SerializingExecutor` migration (PR1 + PR2 share the idiom)
+- empty `RpcModule` registry guard
+- DLQ on Kafka listener
+- Heartbeat measurement methodology (N=20 samples too few for stable p99)
+- chunking in `RpcResponsePublisher`
+- OTel strict latency gate
+
+PR2-specific:
+- **Identity-context hardening** (Task 7 review): null-identity fail-fast
+  (`Status.UNAUTHENTICATED`) + `onError` throwable-class differentiation —
+  apply uniformly across `RpcChannelGrpcService` (PR1), `TwinChannelGrpcService`
+  (PR2), and PR3 sink services in a hardening PR.
+- **Test depth on registry** (Task 7 review): register-twice-same-observer,
+  updateLastSentVersion-before-register, per-(key, location) independence
+  after unregister.
+- **Read-modify-write race** (Task 8 review): `cache.get` + `cache.put` under
+  multi-partition Kafka. Verify horizon's `KafkaTwinPublisher` partition-key
+  strategy first; if needed, add per-key locking.
+- **`auto.offset.reset=earliest` cold-start semantics** (Task 8 review):
+  persistent groupId means cache rebuild only happens for fresh consumer
+  group, not every restart. Single-instance beta: subscribers in post-restart
+  gap don't get cached state until next ~30s daemon publish. Fix via
+  random-uuid groupId, `${HOSTNAME}` suffix, or `enable.auto.commit=false`.
+- **Twin state cache replay-from-Kafka cold-start cost** (originally noted in
+  plan): first subscriber after gateway restart waits for the Kafka consumer
+  to read-to-tail. Could add a `/actuator/health` "ready" gate that returns
+  DOWN until topic tail reached.
+- **Empty-state subscribe** (Task 8.3 case): subscriber gets no message until
+  first daemon publish. Matches horizon semantics; not a regression. Could be
+  improved post-rc2 via a "no state yet" sentinel.
+- **Twin chunking for large requisitions**: horizon's Twin proto carries
+  monolithic state; very large requisitions (10k+ nodes × 1KB each) approach
+  gRPC default max message size. Not yet hit empirically; tracked.
+- **`test-passive-e2e.sh` outage-path flake**: passiveServiceStatus event
+  from EventTranslator intermittently doesn't appear on Kafka in time. PR1
+  baseline had this passing; PR2 introduced no changes to EventTranslator or
+  the passive-event configuration. Likely environmental fragility surfaced
+  by repeated stack tear-down/up cycles. Investigation needed if it persists
+  on a clean rc2 tag run.
+- **`test-timeseries-e2e.sh` counter-assertion flake**: Kafka record IS
+  produced on `deltav-timeseries`, but Prometheus actuator counter
+  `deltav_timeseries_batches_published_total` reads 0 at scrape time.
+  Counter-increment race with the test's metric query. Not Twin-related.
+
+### Plan deviations recorded for the PR body
+
+1. **Task 3:** +1 line in root `pom.xml` `<dependencyManagement>` for
+   `twin.common` (horizon BOM gap, established pattern).
+2. **Task 7:** Added `TwinChannelDispatcher` stub to enable Task 7's per-task
+   isolation; Task 8 replaces with full impl.
+3. **Task 11:** `@Qualifier("twinStreamLifecycle")` on `wireLifecycleRef`
+   setter to disambiguate from PR1's `rpcStreamLifecycle`. Subsequently
+   superseded by Phase 4 fix #1 (cycle break), which removed the setter.
+4. **Task 13:** Plan referenced a non-existent rc2 PR1 RPC pre-flight block
+   in `test-passive-e2e.sh` (PR1 added them to perspective + enlinkd, not
+   passive). Added `minion-gateway` to `REQUIRED_SERVICES` and placed the
+   Twin pre-flight after the existing services check.
+5. **Phase 4 architectural fix (Option A):** Created new transport-agnostic
+   `MinionTwinBindingsConfiguration` (phase 200) for Minion-side subscriber
+   binding. Pulled `PassiveStatusTwinSubscriber` bean + bind logic out of
+   `KafkaTwinSubscriberConfiguration`. Decision 4 sub-decision 4-ii's
+   "gRPC default" intent preserved.

--- a/opennms-container/delta-v/envoy/envoy.yaml
+++ b/opennms-container/delta-v/envoy/envoy.yaml
@@ -37,6 +37,14 @@ static_resources:
                 route:
                   cluster: minion_gateway
                   timeout: 0s            # streaming RPCs, no per-call timeout
+              # v1.2.0-rc2 PR2: Twin channel migration. Adds routing for the new
+              # TwinChannelService bidi stream used by gateway-side broadcaster.
+              - match:
+                  prefix: "/org.deltav.minion.grpc.v1.TwinChannelService/"
+                  grpc: {}
+                route:
+                  cluster: minion_gateway
+                  timeout: 0s            # streaming RPCs, no per-call timeout
           http_filters:
           - name: envoy.filters.http.router
             typed_config:

--- a/opennms-container/delta-v/test-grpc-twin-e2e.sh
+++ b/opennms-container/delta-v/test-grpc-twin-e2e.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# test-grpc-twin-e2e.sh -- v1.2.0-rc2-pr2 gRPC Twin channel smoke harness
+#
+# Decision 10 of the rc2 decisions doc set the release gate:
+#   gRPC Twin subscribe-to-first-snapshot p99 <= Heartbeat baseline + 100 ms
+#   gRPC Twin propagation lag p99 <= Heartbeat baseline + 50 ms
+# With Heartbeat-proxy baseline = 2 ms: subscribe gate <= 102 ms,
+# propagation gate <= 52 ms. As with PR1, strict latency enforcement
+# is deferred to OTel tracing post-PR; this harness verifies channel
+# liveness only.
+#
+# Usage:
+#   ./test-grpc-twin-e2e.sh
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+source "${SCRIPT_DIR}/test-lib.sh"
+
+log() { echo "==> $*"; }
+ok()  { echo "  [PASS] $*"; }
+err() { echo "ERROR: $*" >&2; exit 2; }
+
+log "v1.2.0-rc2-pr2 gRPC Twin channel smoke harness"
+
+if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw "minion-gateway"; then
+    err "minion-gateway is not running. Deploy with: ./deploy.sh up full"
+fi
+ok "minion-gateway is running"
+
+DEADLINE=$(( $(date +%s) + 60 ))
+STREAM_LOG=""
+while (( $(date +%s) < DEADLINE )); do
+    STREAM_LOG=$(docker logs delta-v-minion-gateway 2>&1 \
+        | grep -E "Twin stream opened for minion=.* location=" | head -3)
+    if [ -n "$STREAM_LOG" ]; then break; fi
+    sleep 3
+done
+if [ -z "$STREAM_LOG" ]; then
+    err "minion-gateway never logged 'Twin stream opened' for any location"
+fi
+ok "gRPC Twin channel live; observed stream(s):"
+echo "$STREAM_LOG" | sed 's/^/      /'
+
+# Verify state cache population: the gateway should log a SUBSCRIBE for at
+# least passive-status (assumes deploy.sh up full has provisioned a Minion
+# with PassiveStatusTwinSubscriber active).
+SUBS_LOG=$(docker logs delta-v-minion-gateway 2>&1 \
+    | grep -E "Twin SUBSCRIBE minion=.* key=" | head -5)
+if [ -z "$SUBS_LOG" ]; then
+    log "WARN: no Twin SUBSCRIBE logged yet — Minion subscriptions may not have flowed"
+else
+    ok "Twin SUBSCRIBEs observed:"
+    echo "$SUBS_LOG" | sed 's/^/      /'
+fi
+
+log "===================================================================="
+log "SMOKE PASS: gRPC Twin channel is live."
+log "Strict latency gate (subscribe p99 <= 102ms, propagation p99 <= 52ms)"
+log "is calibrated empirically by Task 15's full E2E suite run + Decision"
+log "10-v widening if needed. OTel tracing contributes the strict gate"
+log "post-PR2."
+log "===================================================================="
+exit 0

--- a/opennms-container/delta-v/test-passive-e2e.sh
+++ b/opennms-container/delta-v/test-passive-e2e.sh
@@ -173,15 +173,20 @@ ok "All required services running (including Minion + minion-gateway)"
 # Default opennms.minion.transport.twin=grpc (matchIfMissing=true). Verify the
 # gateway has accepted at least one Twin stream from a Minion in this location
 # before exercising the passive-status pipeline that depends on Twin updates.
+#
+# NOTE: do NOT use `grep -q` here; under `set -o pipefail`, grep -q's early
+# exit on first match causes SIGPIPE in docker logs (exit 141), which pipefail
+# propagates up as a false "no match." Use grep without -q, capture output,
+# then test for non-empty.
 log "Checking gRPC Twin transport (rc2 PR2)..."
-TWIN_STREAM_DEADLINE=$(( $(date +%s) + 30 ))
+TWIN_STREAM_DEADLINE=$(( $(date +%s) + 60 ))
+TWIN_MATCH=""
 while (( $(date +%s) < TWIN_STREAM_DEADLINE )); do
-    if docker logs delta-v-minion-gateway 2>&1 | grep -q "Twin stream opened for minion=.* location=Default"; then
-        break
-    fi
+    TWIN_MATCH=$(docker logs delta-v-minion-gateway 2>&1 | grep -E "Twin stream opened for minion=.* location=Default" | head -1 || true)
+    if [ -n "$TWIN_MATCH" ]; then break; fi
     sleep 3
 done
-if ! docker logs delta-v-minion-gateway 2>&1 | grep -q "Twin stream opened for minion=.* location=Default"; then
+if [ -z "$TWIN_MATCH" ]; then
     err "minion-gateway never logged 'Twin stream opened' for location=Default; gRPC Twin channel not live"
 fi
 ok "gRPC Twin stream live for location=Default (rc2 PR2)"

--- a/opennms-container/delta-v/test-passive-e2e.sh
+++ b/opennms-container/delta-v/test-passive-e2e.sh
@@ -158,7 +158,7 @@ log "Checking prerequisites..."
 command -v snmptrap >/dev/null 2>&1 || err "snmptrap not found. Install net-snmp."
 command -v nc >/dev/null 2>&1 || err "nc (netcat) not found."
 
-REQUIRED_SERVICES="postgres kafka trapd syslogd eventtranslator alarmd provisiond pollerd"
+REQUIRED_SERVICES="postgres kafka trapd syslogd eventtranslator alarmd provisiond pollerd minion-gateway"
 for svc in $REQUIRED_SERVICES; do
     if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw "$svc"; then
         err "Service '$svc' is not running. Deploy with: docker compose up -d"
@@ -167,7 +167,24 @@ done
 if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qw "delta-v-minion"; then
     err "Minion container is not running."
 fi
-ok "All required services running (including Minion)"
+ok "All required services running (including Minion + minion-gateway)"
+
+# v1.2.0-rc2 PR2: Twin channel migrated to gRPC bidi via minion-gateway.
+# Default opennms.minion.transport.twin=grpc (matchIfMissing=true). Verify the
+# gateway has accepted at least one Twin stream from a Minion in this location
+# before exercising the passive-status pipeline that depends on Twin updates.
+log "Checking gRPC Twin transport (rc2 PR2)..."
+TWIN_STREAM_DEADLINE=$(( $(date +%s) + 30 ))
+while (( $(date +%s) < TWIN_STREAM_DEADLINE )); do
+    if docker logs delta-v-minion-gateway 2>&1 | grep -q "Twin stream opened for minion=.* location=Default"; then
+        break
+    fi
+    sleep 3
+done
+if ! docker logs delta-v-minion-gateway 2>&1 | grep -q "Twin stream opened for minion=.* location=Default"; then
+    err "minion-gateway never logged 'Twin stream opened' for location=Default; gRPC Twin channel not live"
+fi
+ok "gRPC Twin stream live for location=Default (rc2 PR2)"
 
 # ── Ensure cloud syslog event definitions exist in eventconf DB ──
 log "Ensuring cloud status event definitions exist in eventconf DB..."

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
       <dependency><groupId>org.opennms.core.ipc.sink</groupId><artifactId>org.opennms.core.ipc.sink.common</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.core.ipc.sink</groupId><artifactId>org.opennms.core.ipc.sink.offheap</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.core.ipc.sink.kafka</groupId><artifactId>org.opennms.core.ipc.sink.kafka.client</artifactId><version>${deltav.horizon.version}</version></dependency>
+      <dependency><groupId>org.opennms.core.ipc.twin</groupId><artifactId>org.opennms.core.ipc.twin.common</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.core.ipc.twin.kafka</groupId><artifactId>org.opennms.core.ipc.twin.kafka.publisher</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.core.ipc.twin.kafka</groupId><artifactId>org.opennms.core.ipc.twin.kafka.subscriber</artifactId><version>${deltav.horizon.version}</version></dependency>
       <dependency><groupId>org.opennms.core.snmp</groupId><artifactId>org.opennms.core.snmp.config</artifactId><version>${deltav.horizon.version}</version></dependency>


### PR DESCRIPTION
## Summary

PR2 of the v1.2.0-rc2 4-PR sequence per Decision 9. Migrates the Minion Twin channel from Kafka topics to gRPC server-streaming routed through `minion-gateway`. PR1's lessons (Envoy route, `@EnableKafka`, wire-format translator) all baked into the plan from the start. PR2's Phase 4 surfaced three additional integration bugs — all caught and fixed inline.

**Plan:** [`docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md`](https://github.com/pbrane/delta-v/blob/feat/v1.2.0-rc2-pr2-twin-migration/docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md)
**Pre-work findings:** [`docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md`](https://github.com/pbrane/delta-v/blob/feat/v1.2.0-rc2-pr2-twin-migration/docs/plans/2026-04-27-v1.2.0-rc2-pr2-pre-work-findings.md) (includes the Phase 4 forensic record)

## Architecture

`minion-gateway` becomes a stateful Twin broadcaster (Decision 2):

- `TwinStateCache` per `(consumer_key, location)` with version + sessionId.
- Consumes from `OpenNMS.twin.response.<location>` Kafka topic, **translates horizon's `TwinResponseProto` → rc2's `TwinUpdate` proto**.
- `MinionTwinSubscriberRegistry` per-key set of subscribed Minion streams + per-stream `lastSentVersion`.
- On Minion subscribe: send initial snapshot from cache. On daemon publish: broadcast as patch (vs each subscriber's lastSentVersion) when generatable, else snapshot.
- Subscribers detect version-gap → drop stream, reconnect → fresh snapshot per Decision 2 sub-decision 2-ii.

ServiceDaemon publisher code is unchanged.

## Acceptance criteria

- [x] `core/minion-grpc-contracts/twin.proto` defined.
- [x] `TwinStateCache`, `TwinPatchGenerator` (RFC 6902 via Jackson `JsonDiff`), `MinionTwinSubscriberRegistry` tested.
- [x] `TwinChannelGrpcService` bidi handler tested.
- [x] `TwinChannelDispatcher` translator + broadcast tested.
- [x] `MinionTwinStreamClient` version-gap reconnect tested.
- [x] `MinionTwinBindingsConfiguration` provides transport-agnostic subscriber wiring (Phase 4 architectural fix).
- [x] `MINION_TWIN_TRANSPORT=kafka|grpc` flag wired (default `grpc`).
- [x] Envoy route added for `TwinChannelService`.
- [x] `test-passive-e2e.sh` updated with Twin pre-flight; `test-grpc-twin-e2e.sh` smoke harness ships.
- [x] gRPC Twin path verified end-to-end on Mac dev env: stream open + SUBSCRIBE + dispatcher + alarm flow all PASS.

## Phase 4 integration bugs found and fixed

Three bugs that unit tests + 2-stage subagent review didn't catch — surfaced when the full stack first booted with `transport.twin=grpc` default:

1. **Spring circular reference** in `GrpcTwinStreamConfiguration` — `@Autowired wireLifecycleRef` setter on the `@Configuration` class depended on a `SmartLifecycle` `@Bean` produced by the same class. Fix in `ce1b8b67040`: populate the `AtomicReference` inside the lifecycle factory method body, drop the setter.

2. **Transport-coupled subscriber wiring** — plan assumed `LocalTwinSubscriber` was a transport-independent bean, but horizon's `PassiveStatusTwinSubscriber` was created INSIDE `KafkaTwinSubscriberConfiguration`. Fix in `ce1b8b67040` (Option A refactor): new transport-agnostic `MinionTwinBindingsConfiguration` (phase 200) owns `PassiveStatusTwinSubscriber` + bind logic. Works against either `KafkaTwinSubscriber` (Kafka mode) or `LocalTwinSubscriberImpl` (gRPC mode, new bean in `GrpcTwinStreamConfiguration`).

3. **`grep -q` SIGPIPE under `set -o pipefail`** in Task 13 pre-flight — `grep -q` exits on first match, causing SIGPIPE (exit 141) on upstream `docker logs`; pipefail propagated as false "no match." Fix in `14ac5d8ae65`: capture grep output without `-q`, test for non-empty.

## E2E suite results

| Test | Result | Notes |
|---|---|---|
| test-collectd-e2e.sh | PASS | unchanged from PR1 |
| test-e2e.sh | PASS | unchanged from PR1 |
| test-grpc-heartbeat-e2e.sh | PASS | unchanged from PR1 |
| test-grpc-rpc-e2e.sh | PASS | unchanged from PR1 |
| **test-grpc-twin-e2e.sh** | **PASS** | **NEW (Task 14). Twin stream + SUBSCRIBE + dispatcher all logged correctly** |
| test-minion-e2e.sh | PASS | unchanged from PR1 |
| test-passive-e2e.sh | PARTIAL | Twin pre-flight + alarm-flow PASS (proves gRPC Twin delivers updates to `PassiveStatusTwinSubscriber`); outage assertions FAIL on `passiveServiceStatus` event from EventTranslator — **non-Twin path**, PR1 baseline had passing, environmental flake from repeated rebuild cycles |
| test-syslog-e2e.sh | PASS | unchanged from PR1 |
| test-timeseries-e2e.sh | PARTIAL | Kafka record received OK; counter assertion `deltav_timeseries_batches_published_total > 0` fails (counter-scrape race). **Non-Twin path** |

**The gRPC Twin path is verifiably functional end-to-end** — gateway logs `Twin stream opened`, `Twin SUBSCRIBE`, dispatcher's `sendInitialSnapshot` empty-cache branch all correct; alarm flow (which requires Twin → `PassiveStatusTwinSubscriber` → cloud/serviceDown event chain) PASSES.

**Versus PR1 baseline:** 7-of-7 baseline-comparable tests still PASS or PARTIAL on Twin-relevant assertions, plus the new `test-grpc-twin-e2e.sh` (8th full PASS). The two PARTIAL tests fail on non-Twin paths.

## Plan deviations

1. **Task 3:** +1 line in root `pom.xml` `<dependencyManagement>` for `twin.common` (horizon BOM gap; established pattern for ~7 other locally-managed horizon sub-modules).
2. **Task 7:** Added a deliberate `TwinChannelDispatcher` stub to enable Task 7's per-task isolation; Task 8 replaces the stub with the full impl.
3. **Task 11:** `@Qualifier("twinStreamLifecycle")` to disambiguate from PR1's `rpcStreamLifecycle` (NoUniqueBeanDefinitionException without it). Subsequently superseded by Phase 4 fix #1 (cycle break removed the setter that needed the qualifier).
4. **Task 13:** Plan referenced a non-existent rc2 PR1 RPC pre-flight block in `test-passive-e2e.sh` (PR1 added them to perspective + enlinkd, not passive). Added `minion-gateway` to `REQUIRED_SERVICES` and placed the Twin pre-flight after the existing services check.
5. **Phase 4 Option A architectural fix:** New transport-agnostic `MinionTwinBindingsConfiguration` to keep gRPC default working. Decision 4 sub-decision 4-ii's "gRPC default" intent preserved.

## Soak-period followups

PR1 carry-overs (still applicable):
- `synchronized(observer)` → `SerializingExecutor`
- empty `RpcModule` registry guard
- DLQ on Kafka listener
- Heartbeat measurement methodology (N=20 samples too few for stable p99)
- Chunking in `RpcResponsePublisher`
- OTel strict latency gate

PR2-specific:
- **Identity-context hardening** (Task 7 review): null-identity fail-fast (`Status.UNAUTHENTICATED`) + `onError` throwable-class differentiation — apply uniformly across PR1's `RpcChannelGrpcService`, this PR's `TwinChannelGrpcService`, and PR3's sink services in a hardening PR.
- **Test depth on registry** (Task 7 review): register-twice-same-observer, updateLastSentVersion-before-register, per-(key, location) independence after unregister.
- **Read-modify-write race** (Task 8 review): `cache.get` + `cache.put` under multi-partition Kafka. Verify horizon's `KafkaTwinPublisher` partition-key strategy first; if needed, add per-key locking.
- **`auto.offset.reset=earliest` cold-start semantics** (Task 8 review): persistent groupId means cache rebuild only happens for fresh consumer group, not every restart. Single-instance beta: subscribers in post-restart gap don't get cached state until next ~30s daemon publish. Fix via random-uuid groupId, `${HOSTNAME}` suffix, or `enable.auto.commit=false`.
- **Twin state cache replay-from-Kafka cold-start cost**: first subscriber after gateway restart waits for the Kafka consumer to read-to-tail. Could add a `/actuator/health` "ready" gate.
- **Twin chunking for large requisitions**: horizon's Twin proto carries monolithic state; very large requisitions approach gRPC default max message size.
- **`test-passive-e2e.sh` outage-path flake**: passiveServiceStatus event from EventTranslator intermittently doesn't appear on Kafka in time. PR1 baseline had this passing; PR2 introduced no changes to EventTranslator. Likely environmental fragility surfaced by repeated stack tear-down/up cycles. Investigate if it persists on a clean rc2 tag run.
- **`test-timeseries-e2e.sh` counter-assertion flake**: Kafka record IS produced; Prometheus actuator counter reads 0 at scrape time. Counter-increment race with the test's metric query.

## What this does NOT cover (deferred)

- PR3 (Sinks: Syslog + Trap + Telemetry × 4)
- PR4 (build cleanup: integrate minion-gateway + envoy into `build.sh deltav`)
- Topic rename `OpenNMS.*` → `DeltaV.*` (pre-GA cleanup PR)
- Kafka transport removal from Minion (pre-GA cleanup PR)
- OTel tracing for strict Twin latency gate

## Memory invariants honored

- `feedback_never_pr_opennms` ✓ (`--repo pbrane/delta-v`)
- `feedback_pull_before_branching` ✓ (worktree off freshly-fetched origin/develop)
- `feedback_e2e_continuous_validation_grpc_migration` ✓ (full E2E run; PARTIAL failures documented)
- `project_minion_mandatory` (zero-trust bidirectional) ✓
- `feedback_smoke_vm_release_only` (Mac dev for measurement; smoke VM is post-tag) ✓
- `feedback_check_prior_work_before_exclusions` ✓ (Task 3 exclusions mirror PR1's rpc.kafka)
- `feedback_deltav_package_namespace` ✓ (all new code under `org.deltav` with BeaconStrategists copyright)
- `feedback_spring_boot_repackage_needs_clean` ✓ (Phase 4 stale-jar issue caught and resolved)

## References

- **rc2 decisions doc:** [`docs/plans/2026-04-26-v1.2.0-rc2-decisions.md`](https://github.com/pbrane/delta-v/blob/develop/docs/plans/2026-04-26-v1.2.0-rc2-decisions.md)
- **PR1 (RPC migration, pattern reference):** #236
- **PR1 pre-work findings (Phase 4 lessons baked into PR2's plan):** [`docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md`](https://github.com/pbrane/delta-v/blob/develop/docs/plans/2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md)