### PR TITLE
feat(v1.2.0-rc2/3): sink channel migration to gRPC

### DIFF
--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -183,8 +183,30 @@
             <groupId>org.opennms.features.poller</groupId>
             <artifactId>org.opennms.features.poller.api</artifactId>
             <exclusions>
+                <!-- Exclude ALL ServiceMix Spring 4.2.x bundles; Spring Boot 4 provides Spring 7.
+                     Without this, @SpringBootTest in this module fails with NoSuchMethodError
+                     because Spring 4.2 ReflectionUtils$MethodFilter shadows the modern API. -->
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context-support</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-expression</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-instrument</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jdbc</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-jms</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-messaging</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
+                <!-- Exclude Hibernate 3.x -->
+                <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
+                <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
             </exclusions>
         </dependency>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -183,9 +183,21 @@
             <groupId>org.opennms.features.poller</groupId>
             <artifactId>org.opennms.features.poller.api</artifactId>
             <exclusions>
-                <!-- Exclude ALL ServiceMix Spring 4.2.x bundles; Spring Boot 4 provides Spring 7.
-                     Without this, @SpringBootTest in this module fails with NoSuchMethodError
-                     because Spring 4.2 ReflectionUtils$MethodFilter shadows the modern API. -->
+                <!-- horizon's poller.api drags in three pre-Boot4 transitives that conflict with
+                     this module's Spring Boot 4 / Spring 7 / Hibernate 6 stack. Exclusions match
+                     the precedent already established earlier in this POM (see daemon-common +
+                     IPC dependency blocks above). Per `feedback_fix_horizon_not_exclusions` the
+                     structurally correct fix is in horizon (poller.api should be split or its
+                     test-only deps moved to test scope) but the horizon change is out of scope
+                     for PR3; this exclusion block is the pragmatic block-the-leak fix that
+                     unblocks @SpringBootTest in this module. Track removal at the next horizon
+                     poller.api cleanup. -->
+                <!--
+                  ServiceMix Spring 4.2.x bundles. Without exclusion, @SpringBootTest in this
+                  module fails with NoSuchMethodError because Spring 4.2's
+                  ReflectionUtils$MethodFilter shadows the Spring 7 API at runtime classpath
+                  resolution.
+                -->
                 <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aop</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-aspects</artifactId></exclusion>
@@ -201,11 +213,20 @@
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-orm</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-oxm</artifactId></exclusion>
                 <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-tx</artifactId></exclusion>
-                <!-- Exclude Hibernate 3.x -->
+                <!--
+                  Hibernate 3.x (transitive friend of the same poller.api dependency). The
+                  daemon-boot stack uses Hibernate 6; allowing the 3.x classes onto the test
+                  classpath produces JPA-API conflicts when @SpringBootTest stands up the JPA
+                  EntityManagerFactory.
+                -->
                 <exclusion><groupId>org.hibernate</groupId><artifactId>hibernate-core</artifactId></exclusion>
                 <exclusion><groupId>org.hibernate.javax.persistence</groupId><artifactId>hibernate-jpa-2.0-api</artifactId></exclusion>
                 <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
                 <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <!--
+                  commons-logging is banned project-wide by the Maven Enforcer (use slf4j-api).
+                  Excluded here because poller.api carries it transitively.
+                -->
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
             </exclusions>
         </dependency>

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcSyslogDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcSyslogDispatcherConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import io.grpc.ManagedChannel;
+import org.deltav.minion.common.grpc.GrpcSinkDispatcherFactory;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * gRPC-backed Syslog sink dispatcher factory. Active when
+ * {@code opennms.minion.transport.sink.syslog=grpc} (default per
+ * Decision 4 sub-decision 4-ii). Reuses {@code minionGatewayChannel}
+ * provided by {@link GrpcHeartbeatDispatcherConfiguration} (rc1).
+ *
+ * <p>Mutually exclusive with {@link KafkaSyslogDispatcherConfiguration}; both
+ * register the same {@code @Bean(name = "syslogDispatcherFactory")} but only
+ * one activates at a time via the per-sink transport flag.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.sink.syslog",
+                       havingValue = "grpc", matchIfMissing = true)
+public class GrpcSyslogDispatcherConfiguration {
+
+    @Bean(name = "syslogDispatcherFactory")
+    public MessageDispatcherFactory syslogDispatcherFactory(
+            @Qualifier("minionGatewayChannel") ManagedChannel minionGatewayChannel,
+            MinionIdentity identity) {
+        return new GrpcSinkDispatcherFactory(minionGatewayChannel, identity);
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTelemetryDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTelemetryDispatcherConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import io.grpc.ManagedChannel;
+import org.deltav.minion.common.grpc.GrpcSinkDispatcherFactory;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * gRPC-backed Telemetry sink dispatcher factory. A single factory serves all
+ * four flow protocols (IPFIX, Netflow v5, Netflow v9, sFlow); the underlying
+ * {@link GrpcSinkDispatcherFactory} routes per-module-id to the matching
+ * {@code TelemetryService.Publish*} RPC. Active when
+ * {@code opennms.minion.transport.sink.telemetry=grpc} (default per Decision 4
+ * sub-decision 4-ii). Reuses {@code minionGatewayChannel} provided by
+ * {@link GrpcHeartbeatDispatcherConfiguration} (rc1).
+ *
+ * <p>Mutually exclusive with {@link KafkaTelemetryDispatcherConfiguration}; both
+ * register the same {@code @Bean(name = "telemetryDispatcherFactory")} but only
+ * one activates at a time via the per-sink transport flag.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.sink.telemetry",
+                       havingValue = "grpc", matchIfMissing = true)
+public class GrpcTelemetryDispatcherConfiguration {
+
+    @Bean(name = "telemetryDispatcherFactory")
+    public MessageDispatcherFactory telemetryDispatcherFactory(
+            @Qualifier("minionGatewayChannel") ManagedChannel minionGatewayChannel,
+            MinionIdentity identity) {
+        return new GrpcSinkDispatcherFactory(minionGatewayChannel, identity);
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTrapDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/GrpcTrapDispatcherConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import io.grpc.ManagedChannel;
+import org.deltav.minion.common.grpc.GrpcSinkDispatcherFactory;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * gRPC-backed SNMP Trap sink dispatcher factory. Active when
+ * {@code opennms.minion.transport.sink.trap=grpc} (default per Decision 4
+ * sub-decision 4-ii). Reuses {@code minionGatewayChannel} provided by
+ * {@link GrpcHeartbeatDispatcherConfiguration} (rc1).
+ *
+ * <p>Mutually exclusive with {@link KafkaTrapDispatcherConfiguration}; both
+ * register the same {@code @Bean(name = "trapDispatcherFactory")} but only
+ * one activates at a time via the per-sink transport flag.
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.sink.trap",
+                       havingValue = "grpc", matchIfMissing = true)
+public class GrpcTrapDispatcherConfiguration {
+
+    @Bean(name = "trapDispatcherFactory")
+    public MessageDispatcherFactory trapDispatcherFactory(
+            @Qualifier("minionGatewayChannel") ManagedChannel minionGatewayChannel,
+            MinionIdentity identity) {
+        return new GrpcSinkDispatcherFactory(minionGatewayChannel, identity);
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/HeartbeatKafkaFallbackConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/HeartbeatKafkaFallbackConfiguration.java
@@ -17,23 +17,38 @@
 package org.deltav.minion.common;
 
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * {@code MINION_TRANSPORT=kafka} rollback path: aliases the primary Kafka
+ * {@code MINION_TRANSPORT=kafka} rollback path: aliases the Kafka Syslog
  * {@link MessageDispatcherFactory} under the {@code heartbeatDispatcherFactory}
  * bean name so HeartbeatConfiguration's {@code @Qualifier} injection still
  * resolves regardless of selected transport.
+ *
+ * <p>After PR3's per-sink split (Task 4) the rc1 monolithic
+ * {@code KafkaSinkClientConfiguration} no longer exists. Heartbeat does not
+ * have its own Kafka {@link MessageDispatcherFactory}, so the fallback now
+ * borrows the syslog one. The factory class itself is the same regardless of
+ * which sink it serves; any qualified Kafka factory bean would do here.
+ *
+ * <p><b>Operational coupling:</b> rolling back to {@code MINION_TRANSPORT=kafka}
+ * also requires {@code MINION_SINK_SYSLOG_TRANSPORT=kafka} so the
+ * {@code syslogDispatcherFactory} bean exists. This is operationally uncommon
+ * (mixing transport flags) and may be cleaned up post-rc2 by giving heartbeat
+ * its own dedicated Kafka @Configuration.
  */
 @Configuration
-@ConditionalOnProperty(name = "opennms.minion.transport", havingValue = "kafka")
+@ConditionalOnExpression(
+        "'${opennms.minion.transport:grpc}' == 'kafka' "
+        + "&& '${opennms.minion.transport.sink.syslog:grpc}' == 'kafka'")
 public class HeartbeatKafkaFallbackConfiguration {
 
     @Bean(name = "heartbeatDispatcherFactory")
     public MessageDispatcherFactory heartbeatDispatcherFactory(
-            MessageDispatcherFactory kafkaPrimary) {
-        return kafkaPrimary;
+            @Qualifier("syslogDispatcherFactory") MessageDispatcherFactory kafkaSyslog) {
+        return kafkaSyslog;
     }
 }

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaSyslogDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaSyslogDispatcherConfiguration.java
@@ -19,7 +19,6 @@ package org.deltav.minion.common;
 import java.util.Properties;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.deltav.horizon.metrics.HorizonMetricsBridge;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.core.ipc.sink.kafka.client.KafkaRemoteMessageDispatcherFactory;
 import org.opennms.core.tracing.api.TracerRegistry;
@@ -31,41 +30,26 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 import com.codahale.metrics.MetricRegistry;
 
 /**
- * Spring Boot {@link Configuration} that wraps the OSGi-designed
- * {@link KafkaRemoteMessageDispatcherFactory} in a Spring {@link SmartLifecycle}.
+ * Kafka-backed {@link MessageDispatcherFactory} for the Syslog sink.
+ * Active when {@code opennms.minion.transport.sink.syslog=kafka} (rollback
+ * path); the default is {@code grpc}, served by
+ * {@code GrpcSyslogDispatcherConfiguration} (Task 5).
  *
- * <p>The factory uses setter injection because it was designed for OSGi blueprint
- * wiring. We set {@code bundleContext} to {@code null} so the factory's
- * {@code onInit()} skips OSGi metrics registration.</p>
- *
- * <p>Lifecycle phase 200 ensures the Sink client starts <b>after</b> the
- * Twin subscriber (phase 100) and <b>before</b> the RPC server (phase 300).
- * Shutdown reverses this order automatically.</p>
+ * <p>Lifecycle phase 200 — same as rc1's monolithic config. SmartLifecycle
+ * start order: Sink (200) before RPC (300) before listeners (400).
  */
 @Configuration
-@ConditionalOnProperty(name = "opennms.minion.sink.enabled", havingValue = "true", matchIfMissing = true)
-public class KafkaSinkClientConfiguration {
+@ConditionalOnProperty(name = "opennms.minion.transport.sink.syslog", havingValue = "kafka")
+public class KafkaSyslogDispatcherConfiguration {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaSinkClientConfiguration.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSyslogDispatcherConfiguration.class);
 
-    @Bean
-    public MetricRegistry minionSinkMetricRegistry() {
-        return new MetricRegistry();
-    }
-
-    @Bean
-    public HorizonMetricsBridge minionSinkMetricsBridge(MetricRegistry minionSinkMetricRegistry) {
-        return new HorizonMetricsBridge(minionSinkMetricRegistry, "opennms");
-    }
-
-    @Bean
-    @Primary
-    public KafkaRemoteMessageDispatcherFactory kafkaRemoteMessageDispatcherFactory(
+    @Bean(name = "syslogDispatcherFactory")
+    public KafkaRemoteMessageDispatcherFactory syslogDispatcherFactory(
             @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
             MinionIdentity minionIdentity,
             TracerRegistry tracerRegistry,
@@ -80,35 +64,32 @@ public class KafkaSinkClientConfiguration {
         factory.setTracerRegistry(tracerRegistry);
         factory.setIdentity(minionIdentity);
         factory.setMetrics(minionSinkMetricRegistry);
-
         return factory;
     }
 
     @Bean
-    public SmartLifecycle kafkaSinkClientLifecycle(
-            KafkaRemoteMessageDispatcherFactory factory) {
-
+    public SmartLifecycle syslogDispatcherFactoryLifecycle(
+            @org.springframework.beans.factory.annotation.Qualifier("syslogDispatcherFactory")
+            KafkaRemoteMessageDispatcherFactory syslogDispatcherFactory) {
         return new SmartLifecycle() {
             private volatile boolean running = false;
 
             @Override
             public void start() {
-                LOG.info("Starting Kafka Sink client (phase 200)");
+                LOG.info("Starting Kafka Syslog dispatcher (phase 200)");
                 try {
-                    factory.init();
+                    syslogDispatcherFactory.init();
                     running = true;
-                    LOG.info("Kafka Sink client started");
                 } catch (Exception e) {
-                    LOG.error("Failed to initialize Kafka Sink client", e);
+                    LOG.error("Failed to init Kafka Syslog dispatcher", e);
                 }
             }
 
             @Override
             public void stop() {
-                LOG.info("Stopping Kafka Sink client (phase 200)");
-                factory.destroy();
+                LOG.info("Stopping Kafka Syslog dispatcher");
+                syslogDispatcherFactory.destroy();
                 running = false;
-                LOG.info("Kafka Sink client stopped");
             }
 
             @Override

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaSyslogDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaSyslogDispatcherConfiguration.java
@@ -25,6 +25,7 @@ import org.opennms.core.tracing.api.TracerRegistry;
 import org.opennms.distributed.core.api.MinionIdentity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -69,8 +70,7 @@ public class KafkaSyslogDispatcherConfiguration {
 
     @Bean
     public SmartLifecycle syslogDispatcherFactoryLifecycle(
-            @org.springframework.beans.factory.annotation.Qualifier("syslogDispatcherFactory")
-            KafkaRemoteMessageDispatcherFactory syslogDispatcherFactory) {
+            @Qualifier("syslogDispatcherFactory") KafkaRemoteMessageDispatcherFactory syslogDispatcherFactory) {
         return new SmartLifecycle() {
             private volatile boolean running = false;
 

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTelemetryDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTelemetryDispatcherConfiguration.java
@@ -25,6 +25,7 @@ import org.opennms.core.tracing.api.TracerRegistry;
 import org.opennms.distributed.core.api.MinionIdentity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -71,8 +72,7 @@ public class KafkaTelemetryDispatcherConfiguration {
 
     @Bean
     public SmartLifecycle telemetryDispatcherFactoryLifecycle(
-            @org.springframework.beans.factory.annotation.Qualifier("telemetryDispatcherFactory")
-            KafkaRemoteMessageDispatcherFactory telemetryDispatcherFactory) {
+            @Qualifier("telemetryDispatcherFactory") KafkaRemoteMessageDispatcherFactory telemetryDispatcherFactory) {
         return new SmartLifecycle() {
             private volatile boolean running = false;
 

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTelemetryDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTelemetryDispatcherConfiguration.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.ipc.sink.kafka.client.KafkaRemoteMessageDispatcherFactory;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Kafka-backed {@link MessageDispatcherFactory} for the Telemetry sink. This
+ * single factory serves all four flow protocols (IPFIX, Netflow v5, Netflow v9,
+ * sFlow) since they share UDP port 4729 and the same decoder pipeline.
+ * Active when {@code opennms.minion.transport.sink.telemetry=kafka} (rollback
+ * path); the default is {@code grpc}, served by
+ * {@code GrpcTelemetryDispatcherConfiguration} (Task 5).
+ *
+ * <p>Lifecycle phase 200 — same as rc1's monolithic config. SmartLifecycle
+ * start order: Sink (200) before RPC (300) before listeners (400).
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.sink.telemetry", havingValue = "kafka")
+public class KafkaTelemetryDispatcherConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTelemetryDispatcherConfiguration.class);
+
+    @Bean(name = "telemetryDispatcherFactory")
+    public KafkaRemoteMessageDispatcherFactory telemetryDispatcherFactory(
+            @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
+            MinionIdentity minionIdentity,
+            TracerRegistry tracerRegistry,
+            MetricRegistry minionSinkMetricRegistry) {
+
+        Properties kafkaProps = new Properties();
+        kafkaProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        KafkaRemoteMessageDispatcherFactory factory = new KafkaRemoteMessageDispatcherFactory();
+        factory.setConfigAdmin(new SpringConfigurationAdmin(kafkaProps));
+        factory.setBundleContext(null);
+        factory.setTracerRegistry(tracerRegistry);
+        factory.setIdentity(minionIdentity);
+        factory.setMetrics(minionSinkMetricRegistry);
+        return factory;
+    }
+
+    @Bean
+    public SmartLifecycle telemetryDispatcherFactoryLifecycle(
+            @org.springframework.beans.factory.annotation.Qualifier("telemetryDispatcherFactory")
+            KafkaRemoteMessageDispatcherFactory telemetryDispatcherFactory) {
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                LOG.info("Starting Kafka Telemetry dispatcher (phase 200)");
+                try {
+                    telemetryDispatcherFactory.init();
+                    running = true;
+                } catch (Exception e) {
+                    LOG.error("Failed to init Kafka Telemetry dispatcher", e);
+                }
+            }
+
+            @Override
+            public void stop() {
+                LOG.info("Stopping Kafka Telemetry dispatcher");
+                telemetryDispatcherFactory.destroy();
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 200;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTrapDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTrapDispatcherConfiguration.java
@@ -25,6 +25,7 @@ import org.opennms.core.tracing.api.TracerRegistry;
 import org.opennms.distributed.core.api.MinionIdentity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -69,8 +70,7 @@ public class KafkaTrapDispatcherConfiguration {
 
     @Bean
     public SmartLifecycle trapDispatcherFactoryLifecycle(
-            @org.springframework.beans.factory.annotation.Qualifier("trapDispatcherFactory")
-            KafkaRemoteMessageDispatcherFactory trapDispatcherFactory) {
+            @Qualifier("trapDispatcherFactory") KafkaRemoteMessageDispatcherFactory trapDispatcherFactory) {
         return new SmartLifecycle() {
             private volatile boolean running = false;
 

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTrapDispatcherConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaTrapDispatcherConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.ipc.sink.kafka.client.KafkaRemoteMessageDispatcherFactory;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Kafka-backed {@link MessageDispatcherFactory} for the SNMP Trap sink.
+ * Active when {@code opennms.minion.transport.sink.trap=kafka} (rollback
+ * path); the default is {@code grpc}, served by
+ * {@code GrpcTrapDispatcherConfiguration} (Task 5).
+ *
+ * <p>Lifecycle phase 200 — same as rc1's monolithic config. SmartLifecycle
+ * start order: Sink (200) before RPC (300) before listeners (400).
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.transport.sink.trap", havingValue = "kafka")
+public class KafkaTrapDispatcherConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTrapDispatcherConfiguration.class);
+
+    @Bean(name = "trapDispatcherFactory")
+    public KafkaRemoteMessageDispatcherFactory trapDispatcherFactory(
+            @Value("${opennms.kafka.bootstrap-servers:localhost:9092}") String bootstrapServers,
+            MinionIdentity minionIdentity,
+            TracerRegistry tracerRegistry,
+            MetricRegistry minionSinkMetricRegistry) {
+
+        Properties kafkaProps = new Properties();
+        kafkaProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        KafkaRemoteMessageDispatcherFactory factory = new KafkaRemoteMessageDispatcherFactory();
+        factory.setConfigAdmin(new SpringConfigurationAdmin(kafkaProps));
+        factory.setBundleContext(null);
+        factory.setTracerRegistry(tracerRegistry);
+        factory.setIdentity(minionIdentity);
+        factory.setMetrics(minionSinkMetricRegistry);
+        return factory;
+    }
+
+    @Bean
+    public SmartLifecycle trapDispatcherFactoryLifecycle(
+            @org.springframework.beans.factory.annotation.Qualifier("trapDispatcherFactory")
+            KafkaRemoteMessageDispatcherFactory trapDispatcherFactory) {
+        return new SmartLifecycle() {
+            private volatile boolean running = false;
+
+            @Override
+            public void start() {
+                LOG.info("Starting Kafka Trap dispatcher (phase 200)");
+                try {
+                    trapDispatcherFactory.init();
+                    running = true;
+                } catch (Exception e) {
+                    LOG.error("Failed to init Kafka Trap dispatcher", e);
+                }
+            }
+
+            @Override
+            public void stop() {
+                LOG.info("Stopping Kafka Trap dispatcher");
+                trapDispatcherFactory.destroy();
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
+            }
+
+            @Override
+            public int getPhase() {
+                return 200;
+            }
+        };
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/MinionSinkMetricsConfiguration.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/MinionSinkMetricsConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import org.deltav.horizon.metrics.HorizonMetricsBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Transport-agnostic Sink metric wiring. Holds the Dropwizard
+ * {@link MetricRegistry} used by horizon Sink module instrumentation
+ * and the {@link HorizonMetricsBridge} that publishes those meters at
+ * {@code /actuator/prometheus} under the {@code opennms_} prefix.
+ *
+ * <p>Extracted from the rc1 {@code KafkaSinkClientConfiguration} as
+ * part of PR3's transport-coupled bean separation
+ * (per {@code feedback_transport_coupled_subscriber_beans}). Both the
+ * Kafka and gRPC sink dispatcher factories register against this
+ * registry, so per-sink rollback flags don't disturb metric continuity.
+ */
+@Configuration
+public class MinionSinkMetricsConfiguration {
+
+    @Bean
+    public MetricRegistry minionSinkMetricRegistry() {
+        return new MetricRegistry();
+    }
+
+    @Bean
+    public HorizonMetricsBridge minionSinkMetricsBridge(MetricRegistry minionSinkMetricRegistry) {
+        return new HorizonMetricsBridge(minionSinkMetricRegistry, "opennms");
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactory.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactory.java
@@ -59,8 +59,6 @@ public class GrpcSinkDispatcherFactory implements MessageDispatcherFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcSinkDispatcherFactory.class);
 
-    private final ManagedChannel channel;
-    private final MinionIdentity identity;
     private final SinkStreamRegistry streams = new SinkStreamRegistry();
 
     private final SyslogServiceGrpc.SyslogServiceStub syslogStub;
@@ -68,8 +66,6 @@ public class GrpcSinkDispatcherFactory implements MessageDispatcherFactory {
     private final TelemetryServiceGrpc.TelemetryServiceStub telemetryStub;
 
     public GrpcSinkDispatcherFactory(ManagedChannel channel, MinionIdentity identity) {
-        this.channel = channel;
-        this.identity = identity;
         MinionIdentityClientInterceptor interceptor =
             new MinionIdentityClientInterceptor(identity.getId(), identity.getLocation());
         this.syslogStub = SyslogServiceGrpc.newStub(channel).withInterceptors(interceptor);
@@ -101,16 +97,6 @@ public class GrpcSinkDispatcherFactory implements MessageDispatcherFactory {
         };
     }
 
-    /**
-     * Marshal a producer message via the module. Sinks routed through this factory
-     * are non-aggregating so {@code S == T}; mirrors the unchecked cast precedent in
-     * horizon's {@code AbstractMessageDispatcherFactory.DirectDispatcher.send}.
-     */
-    @SuppressWarnings("unchecked")
-    private static <S extends Message, T extends Message> byte[] marshal(SinkModule<S, T> module, S message) {
-        return module.marshal((T) message);
-    }
-
     private <S extends Message, T extends Message> AsyncDispatcher<S> syslogDispatcher(SinkModule<S, T> module) {
         return new AsyncDispatcher<>() {
             @Override
@@ -119,7 +105,7 @@ public class GrpcSinkDispatcherFactory implements MessageDispatcherFactory {
                     syslogStub.publish(noopAck("Syslog")));
                 try {
                     stream.onNext(SyslogMessage.newBuilder()
-                        .setPayload(ByteString.copyFrom(marshal(module, message)))
+                        .setPayload(ByteString.copyFrom(module.marshalSingleMessage(message)))
                         .setReceivedAt(now())
                         .build());
                     return CompletableFuture.completedFuture(DispatchStatus.QUEUED);
@@ -142,7 +128,7 @@ public class GrpcSinkDispatcherFactory implements MessageDispatcherFactory {
                     trapStub.publish(noopAck("Trap")));
                 try {
                     stream.onNext(SnmpTrap.newBuilder()
-                        .setPayload(ByteString.copyFrom(marshal(module, message)))
+                        .setPayload(ByteString.copyFrom(module.marshalSingleMessage(message)))
                         .setReceivedAt(now())
                         .build());
                     return CompletableFuture.completedFuture(DispatchStatus.QUEUED);
@@ -168,7 +154,7 @@ public class GrpcSinkDispatcherFactory implements MessageDispatcherFactory {
                     opener.apply(noopAck(id)));
                 try {
                     stream.onNext(TelemetryDatagram.newBuilder()
-                        .setPayload(ByteString.copyFrom(marshal(module, message)))
+                        .setPayload(ByteString.copyFrom(module.marshalSingleMessage(message)))
                         .setReceivedAt(now())
                         .build());
                     return CompletableFuture.completedFuture(DispatchStatus.QUEUED);

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactory.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactory.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common.grpc;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.SnmpTrap;
+import org.deltav.minion.grpc.v1.SyslogMessage;
+import org.deltav.minion.grpc.v1.SyslogServiceGrpc;
+import org.deltav.minion.grpc.v1.TelemetryAck;
+import org.deltav.minion.grpc.v1.TelemetryDatagram;
+import org.deltav.minion.grpc.v1.TelemetryServiceGrpc;
+import org.deltav.minion.grpc.v1.TrapServiceGrpc;
+import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.ipc.sink.api.Message;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.ipc.sink.api.SinkModule;
+import org.opennms.core.ipc.sink.api.SyncDispatcher;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * gRPC-backed {@link MessageDispatcherFactory} for Minion sinks.
+ * Routes by {@link SinkModule#getId() module id}:
+ * Syslog / Trap / Telemetry-{IPFIX,Netflow-5,Netflow-9,SFlow}.
+ *
+ * <p>Each module gets a single long-lived client-streaming gRPC stream
+ * cached in {@link SinkStreamRegistry}. On stream error, the entry is
+ * reset and the next send opens a fresh stream.
+ *
+ * <p>Per Decision 4 sub-decision 4-i, this factory exists alongside the
+ * Kafka factories — they're mutually exclusive on
+ * {@code opennms.minion.transport.sink.<type>}. Module ids not in the set
+ * above throw {@link UnsupportedOperationException}; this prevents new
+ * sinks from being silently misrouted.
+ */
+public class GrpcSinkDispatcherFactory implements MessageDispatcherFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GrpcSinkDispatcherFactory.class);
+
+    private final ManagedChannel channel;
+    private final MinionIdentity identity;
+    private final SinkStreamRegistry streams = new SinkStreamRegistry();
+
+    private final SyslogServiceGrpc.SyslogServiceStub syslogStub;
+    private final TrapServiceGrpc.TrapServiceStub trapStub;
+    private final TelemetryServiceGrpc.TelemetryServiceStub telemetryStub;
+
+    public GrpcSinkDispatcherFactory(ManagedChannel channel, MinionIdentity identity) {
+        this.channel = channel;
+        this.identity = identity;
+        MinionIdentityClientInterceptor interceptor =
+            new MinionIdentityClientInterceptor(identity.getId(), identity.getLocation());
+        this.syslogStub = SyslogServiceGrpc.newStub(channel).withInterceptors(interceptor);
+        this.trapStub = TrapServiceGrpc.newStub(channel).withInterceptors(interceptor);
+        this.telemetryStub = TelemetryServiceGrpc.newStub(channel).withInterceptors(interceptor);
+    }
+
+    @Override
+    public <S extends Message, T extends Message> SyncDispatcher<S> createSyncDispatcher(SinkModule<S, T> module) {
+        throw new UnsupportedOperationException(
+            "GrpcSinkDispatcherFactory supports async dispatch only; got sync request for module '"
+            + module.getId() + "'. Sync sinks (Heartbeat) use heartbeatDispatcherFactory.");
+    }
+
+    @Override
+    public <S extends Message, T extends Message> AsyncDispatcher<S> createAsyncDispatcher(SinkModule<S, T> module) {
+        String id = module.getId();
+        return switch (id) {
+            case "Syslog" -> syslogDispatcher(module);
+            case "Trap" -> trapDispatcher(module);
+            case "Telemetry-IPFIX" -> telemetryDispatcher(module, telemetryStub::publishIpfix);
+            case "Telemetry-Netflow-5" -> telemetryDispatcher(module, telemetryStub::publishNetflow5);
+            case "Telemetry-Netflow-9" -> telemetryDispatcher(module, telemetryStub::publishNetflow9);
+            case "Telemetry-SFlow" -> telemetryDispatcher(module, telemetryStub::publishSflow);
+            default -> throw new UnsupportedOperationException(
+                "GrpcSinkDispatcherFactory has no route for module '" + id
+                + "'. Supported: Syslog, Trap, Telemetry-IPFIX, Telemetry-Netflow-5, "
+                + "Telemetry-Netflow-9, Telemetry-SFlow.");
+        };
+    }
+
+    /**
+     * Marshal a producer message via the module. Sinks routed through this factory
+     * are non-aggregating so {@code S == T}; mirrors the unchecked cast precedent in
+     * horizon's {@code AbstractMessageDispatcherFactory.DirectDispatcher.send}.
+     */
+    @SuppressWarnings("unchecked")
+    private static <S extends Message, T extends Message> byte[] marshal(SinkModule<S, T> module, S message) {
+        return module.marshal((T) message);
+    }
+
+    private <S extends Message, T extends Message> AsyncDispatcher<S> syslogDispatcher(SinkModule<S, T> module) {
+        return new AsyncDispatcher<>() {
+            @Override
+            public CompletableFuture<DispatchStatus> send(S message) {
+                StreamObserver<SyslogMessage> stream = streams.getOrOpen("Syslog", () ->
+                    syslogStub.publish(noopAck("Syslog")));
+                try {
+                    stream.onNext(SyslogMessage.newBuilder()
+                        .setPayload(ByteString.copyFrom(marshal(module, message)))
+                        .setReceivedAt(now())
+                        .build());
+                    return CompletableFuture.completedFuture(DispatchStatus.QUEUED);
+                } catch (RuntimeException e) {
+                    LOG.warn("Syslog gRPC send failed; resetting stream", e);
+                    streams.reset("Syslog");
+                    return CompletableFuture.failedFuture(e);
+                }
+            }
+            @Override public int getQueueSize() { return 0; }
+            @Override public void close() {}
+        };
+    }
+
+    private <S extends Message, T extends Message> AsyncDispatcher<S> trapDispatcher(SinkModule<S, T> module) {
+        return new AsyncDispatcher<>() {
+            @Override
+            public CompletableFuture<DispatchStatus> send(S message) {
+                StreamObserver<SnmpTrap> stream = streams.getOrOpen("Trap", () ->
+                    trapStub.publish(noopAck("Trap")));
+                try {
+                    stream.onNext(SnmpTrap.newBuilder()
+                        .setPayload(ByteString.copyFrom(marshal(module, message)))
+                        .setReceivedAt(now())
+                        .build());
+                    return CompletableFuture.completedFuture(DispatchStatus.QUEUED);
+                } catch (RuntimeException e) {
+                    LOG.warn("Trap gRPC send failed; resetting stream", e);
+                    streams.reset("Trap");
+                    return CompletableFuture.failedFuture(e);
+                }
+            }
+            @Override public int getQueueSize() { return 0; }
+            @Override public void close() {}
+        };
+    }
+
+    private <S extends Message, T extends Message> AsyncDispatcher<S> telemetryDispatcher(
+            SinkModule<S, T> module,
+            Function<StreamObserver<TelemetryAck>, StreamObserver<TelemetryDatagram>> opener) {
+        String id = module.getId();
+        return new AsyncDispatcher<>() {
+            @Override
+            public CompletableFuture<DispatchStatus> send(S message) {
+                StreamObserver<TelemetryDatagram> stream = streams.getOrOpen(id, () ->
+                    opener.apply(noopAck(id)));
+                try {
+                    stream.onNext(TelemetryDatagram.newBuilder()
+                        .setPayload(ByteString.copyFrom(marshal(module, message)))
+                        .setReceivedAt(now())
+                        .build());
+                    return CompletableFuture.completedFuture(DispatchStatus.QUEUED);
+                } catch (RuntimeException e) {
+                    LOG.warn("Telemetry gRPC send failed for {}; resetting stream", id, e);
+                    streams.reset(id);
+                    return CompletableFuture.failedFuture(e);
+                }
+            }
+            @Override public int getQueueSize() { return 0; }
+            @Override public void close() {}
+        };
+    }
+
+    private <T> StreamObserver<T> noopAck(String moduleId) {
+        return new StreamObserver<>() {
+            @Override public void onNext(T value) { /* swallow ack */ }
+            @Override public void onError(Throwable t) {
+                LOG.warn("Sink stream {} error from gateway; resetting", moduleId, t);
+                streams.reset(moduleId);
+            }
+            @Override public void onCompleted() {
+                LOG.info("Sink stream {} closed by gateway", moduleId);
+                streams.reset(moduleId);
+            }
+        };
+    }
+
+    private static Timestamp now() {
+        Instant n = Instant.now();
+        return Timestamp.newBuilder().setSeconds(n.getEpochSecond()).setNanos(n.getNano()).build();
+    }
+}

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/SinkStreamRegistry.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/SinkStreamRegistry.java
@@ -53,6 +53,18 @@ public class SinkStreamRegistry {
         return entries.computeIfAbsent(moduleId, k -> opener.get());
     }
 
+    /**
+     * Drop the cached entry for {@code moduleId}. Next {@link #getOrOpen}
+     * for that id opens a fresh stream.
+     *
+     * <p>Known race: a producer thread that observed a stream error and
+     * another caller that already opened a fresh stream can collide — the
+     * producer's reset will evict the healthy fresh stream, costing one
+     * message until the next reopen. Window is microseconds and matches
+     * rc1's {@code GrpcMessageDispatcherFactory} pattern. A
+     * {@code Map.remove(key, expectedValue)} variant could close it but
+     * adds API surface; deferred until evidence of operational impact.
+     */
     public void reset(String moduleId) {
         entries.remove(moduleId);
     }

--- a/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/SinkStreamRegistry.java
+++ b/core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/grpc/SinkStreamRegistry.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common.grpc;
+
+import io.grpc.stub.StreamObserver;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Per-(sink-module-id) cache of currently-open Minion-side
+ * {@link StreamObserver} instances. Each unique module id (e.g. "Syslog",
+ * "Trap", "Telemetry-IPFIX") gets its own entry; the supplier opens a new
+ * gRPC client-streaming stream on cache miss.
+ *
+ * <p>{@link #reset(String)} drops the cached entry without closing it;
+ * the caller is responsible for invoking {@code onCompleted()} or
+ * {@code onError()} on the returned observer, after which the entry can
+ * be reset so the next send opens a fresh stream. This mirrors rc1's
+ * {@code GrpcMessageDispatcherFactory.heartbeatStream} reset-on-error
+ * pattern.
+ *
+ * <p>Stream observers are not type-parameterised at the registry level
+ * because protobuf message types differ per sink; the caller's supplier
+ * binds the concrete type. The registry stores them as raw
+ * {@code StreamObserver<?>} and the caller casts on get-or-open.
+ */
+public class SinkStreamRegistry {
+
+    @SuppressWarnings("rawtypes")
+    private final Map<String, StreamObserver> entries = new ConcurrentHashMap<>();
+
+    @SuppressWarnings("unchecked")
+    public <T> StreamObserver<T> getOrOpen(String moduleId, Supplier<StreamObserver<T>> opener) {
+        Objects.requireNonNull(moduleId, "moduleId");
+        Objects.requireNonNull(opener, "opener");
+        return entries.computeIfAbsent(moduleId, k -> opener.get());
+    }
+
+    public void reset(String moduleId) {
+        entries.remove(moduleId);
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/SinkDispatcherWiringIT.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/SinkDispatcherWiringIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Wiring integration test verifying the per-sink Kafka {@link MessageDispatcherFactory}
+ * beans load independently and resolve under their qualified names.
+ *
+ * <p>Each Kafka sink @Configuration is gated by its own
+ * {@code opennms.minion.transport.sink.<type>=kafka} property; this test forces
+ * all three on so we can assert all three qualified beans coexist.
+ */
+@SpringBootTest(classes = {
+        MinionSinkMetricsConfiguration.class,
+        KafkaSyslogDispatcherConfiguration.class,
+        KafkaTrapDispatcherConfiguration.class,
+        KafkaTelemetryDispatcherConfiguration.class,
+})
+@TestPropertySource(properties = {
+        "opennms.minion.transport.sink.syslog=kafka",
+        "opennms.minion.transport.sink.trap=kafka",
+        "opennms.minion.transport.sink.telemetry=kafka",
+        "opennms.kafka.bootstrap-servers=localhost:9092",
+})
+class SinkDispatcherWiringIT {
+
+    @MockitoBean
+    MinionIdentity minionIdentity;
+
+    @MockitoBean
+    TracerRegistry tracerRegistry;
+
+    @Autowired
+    @Qualifier("syslogDispatcherFactory")
+    MessageDispatcherFactory syslogFactory;
+
+    @Autowired
+    @Qualifier("trapDispatcherFactory")
+    MessageDispatcherFactory trapFactory;
+
+    @Autowired
+    @Qualifier("telemetryDispatcherFactory")
+    MessageDispatcherFactory telemetryFactory;
+
+    @Test
+    void allThreeQualifiedFactories_loadIndependently() {
+        assertThat(syslogFactory).isNotNull();
+        assertThat(trapFactory).isNotNull();
+        assertThat(telemetryFactory).isNotNull();
+        assertThat(syslogFactory).isNotSameAs(trapFactory);
+        assertThat(trapFactory).isNotSameAs(telemetryFactory);
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactoryTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactoryTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common.grpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.SnmpTrap;
+import org.deltav.minion.grpc.v1.SyslogAck;
+import org.deltav.minion.grpc.v1.SyslogMessage;
+import org.deltav.minion.grpc.v1.SyslogServiceGrpc;
+import org.deltav.minion.grpc.v1.TelemetryAck;
+import org.deltav.minion.grpc.v1.TelemetryDatagram;
+import org.deltav.minion.grpc.v1.TelemetryServiceGrpc;
+import org.deltav.minion.grpc.v1.TrapAck;
+import org.deltav.minion.grpc.v1.TrapServiceGrpc;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.ipc.sink.api.Message;
+import org.opennms.core.ipc.sink.api.SinkModule;
+import org.opennms.distributed.core.api.MinionIdentity;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * In-process gRPC server round-trip test for {@link GrpcSinkDispatcherFactory}.
+ *
+ * <p>Uses programmatic lifecycle (BeforeEach/AfterEach) instead of JUnit 4
+ * {@code GrpcCleanupRule} since this module is on JUnit 5 (Jupiter 6.x via
+ * Spring Boot 4.0.3).
+ */
+class GrpcSinkDispatcherFactoryTest {
+
+    private Server server;
+    private ManagedChannel clientChannel;
+
+    private CountDownLatch syslogLatch;
+    private volatile SyslogMessage lastSyslog;
+
+    private CountDownLatch trapLatch;
+    private volatile SnmpTrap lastTrap;
+
+    private CountDownLatch ipfixLatch;
+    private volatile TelemetryDatagram lastIpfix;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        syslogLatch = new CountDownLatch(1);
+        trapLatch = new CountDownLatch(1);
+        ipfixLatch = new CountDownLatch(1);
+
+        String name = InProcessServerBuilder.generateName();
+        server = InProcessServerBuilder.forName(name).directExecutor()
+            .addService(new SyslogServiceGrpc.SyslogServiceImplBase() {
+                @Override
+                public StreamObserver<SyslogMessage> publish(StreamObserver<SyslogAck> ack) {
+                    return new StreamObserver<>() {
+                        @Override public void onNext(SyslogMessage value) {
+                            lastSyslog = value;
+                            syslogLatch.countDown();
+                        }
+                        @Override public void onError(Throwable t) {}
+                        @Override public void onCompleted() { ack.onCompleted(); }
+                    };
+                }
+            })
+            .addService(new TrapServiceGrpc.TrapServiceImplBase() {
+                @Override
+                public StreamObserver<SnmpTrap> publish(StreamObserver<TrapAck> ack) {
+                    return new StreamObserver<>() {
+                        @Override public void onNext(SnmpTrap value) {
+                            lastTrap = value;
+                            trapLatch.countDown();
+                        }
+                        @Override public void onError(Throwable t) {}
+                        @Override public void onCompleted() { ack.onCompleted(); }
+                    };
+                }
+            })
+            .addService(new TelemetryServiceGrpc.TelemetryServiceImplBase() {
+                @Override
+                public StreamObserver<TelemetryDatagram> publishIpfix(StreamObserver<TelemetryAck> ack) {
+                    return new StreamObserver<>() {
+                        @Override public void onNext(TelemetryDatagram value) {
+                            lastIpfix = value;
+                            ipfixLatch.countDown();
+                        }
+                        @Override public void onError(Throwable t) {}
+                        @Override public void onCompleted() { ack.onCompleted(); }
+                    };
+                }
+            })
+            .build()
+            .start();
+
+        clientChannel = InProcessChannelBuilder.forName(name).directExecutor().build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (clientChannel != null) {
+            clientChannel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+        }
+        if (server != null) {
+            server.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void syslogModule_dispatchesViaSyslogServiceStub() throws Exception {
+        GrpcSinkDispatcherFactory factory = newFactory();
+        @SuppressWarnings("unchecked")
+        SinkModule<Message, Message> syslog = Mockito.mock(SinkModule.class);
+        Mockito.when(syslog.getId()).thenReturn("Syslog");
+        Mockito.when(syslog.marshal(Mockito.any())).thenReturn("hello-syslog".getBytes());
+
+        AsyncDispatcher<Message> dispatcher = factory.createAsyncDispatcher(syslog);
+        dispatcher.send(Mockito.mock(Message.class));
+
+        assertThat(syslogLatch.await(5, TimeUnit.SECONDS))
+            .as("syslog stream should have received one message")
+            .isTrue();
+        assertThat(lastSyslog.getPayload().toByteArray()).isEqualTo("hello-syslog".getBytes());
+    }
+
+    @Test
+    void telemetryModuleIpfix_dispatchesViaPublishIpfixMethod() throws Exception {
+        GrpcSinkDispatcherFactory factory = newFactory();
+        @SuppressWarnings("unchecked")
+        SinkModule<Message, Message> ipfix = Mockito.mock(SinkModule.class);
+        Mockito.when(ipfix.getId()).thenReturn("Telemetry-IPFIX");
+        Mockito.when(ipfix.marshal(Mockito.any())).thenReturn("ipfix-bytes".getBytes());
+
+        AsyncDispatcher<Message> dispatcher = factory.createAsyncDispatcher(ipfix);
+        dispatcher.send(Mockito.mock(Message.class));
+
+        assertThat(ipfixLatch.await(5, TimeUnit.SECONDS))
+            .as("IPFIX stream should have received one message")
+            .isTrue();
+        assertThat(lastIpfix.getPayload().toByteArray()).isEqualTo("ipfix-bytes".getBytes());
+    }
+
+    @Test
+    void unknownModuleId_throwsUnsupportedOperationException() {
+        GrpcSinkDispatcherFactory factory = newFactory();
+        @SuppressWarnings("unchecked")
+        SinkModule<Message, Message> unknown = Mockito.mock(SinkModule.class);
+        Mockito.when(unknown.getId()).thenReturn("Unknown-Module");
+
+        assertThatThrownBy(() -> factory.createAsyncDispatcher(unknown))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("Unknown-Module");
+    }
+
+    private GrpcSinkDispatcherFactory newFactory() {
+        MinionIdentity identity = Mockito.mock(MinionIdentity.class);
+        Mockito.when(identity.getId()).thenReturn("minion-A");
+        Mockito.when(identity.getLocation()).thenReturn("loc-DC1");
+        return new GrpcSinkDispatcherFactory(clientChannel, identity);
+    }
+}

--- a/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactoryTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/GrpcSinkDispatcherFactoryTest.java
@@ -135,7 +135,7 @@ class GrpcSinkDispatcherFactoryTest {
         @SuppressWarnings("unchecked")
         SinkModule<Message, Message> syslog = Mockito.mock(SinkModule.class);
         Mockito.when(syslog.getId()).thenReturn("Syslog");
-        Mockito.when(syslog.marshal(Mockito.any())).thenReturn("hello-syslog".getBytes());
+        Mockito.when(syslog.marshalSingleMessage(Mockito.any())).thenReturn("hello-syslog".getBytes());
 
         AsyncDispatcher<Message> dispatcher = factory.createAsyncDispatcher(syslog);
         dispatcher.send(Mockito.mock(Message.class));
@@ -152,7 +152,7 @@ class GrpcSinkDispatcherFactoryTest {
         @SuppressWarnings("unchecked")
         SinkModule<Message, Message> ipfix = Mockito.mock(SinkModule.class);
         Mockito.when(ipfix.getId()).thenReturn("Telemetry-IPFIX");
-        Mockito.when(ipfix.marshal(Mockito.any())).thenReturn("ipfix-bytes".getBytes());
+        Mockito.when(ipfix.marshalSingleMessage(Mockito.any())).thenReturn("ipfix-bytes".getBytes());
 
         AsyncDispatcher<Message> dispatcher = factory.createAsyncDispatcher(ipfix);
         dispatcher.send(Mockito.mock(Message.class));

--- a/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/SinkStreamRegistryTest.java
+++ b/core/daemon-boot-minion-common/src/test/java/org/deltav/minion/common/grpc/SinkStreamRegistryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.common.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.SyslogMessage;
+import org.deltav.minion.grpc.v1.TelemetryDatagram;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SinkStreamRegistryTest {
+
+    @Test
+    void firstCall_invokesSupplierAndCachesResult() {
+        SinkStreamRegistry registry = new SinkStreamRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<SyslogMessage> obs = mock(StreamObserver.class);
+        AtomicInteger calls = new AtomicInteger();
+        Supplier<StreamObserver<SyslogMessage>> supplier = () -> {
+            calls.incrementAndGet();
+            return obs;
+        };
+
+        StreamObserver<SyslogMessage> result1 = registry.getOrOpen("Syslog", supplier);
+        StreamObserver<SyslogMessage> result2 = registry.getOrOpen("Syslog", supplier);
+
+        assertThat(result1).isSameAs(obs);
+        assertThat(result2).isSameAs(obs);
+        assertThat(calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void differentModuleIds_haveIndependentEntries() {
+        SinkStreamRegistry registry = new SinkStreamRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<SyslogMessage> syslogObs = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<TelemetryDatagram> telemetryObs = mock(StreamObserver.class);
+
+        StreamObserver<SyslogMessage> r1 = registry.getOrOpen("Syslog", () -> syslogObs);
+        StreamObserver<TelemetryDatagram> r2 = registry.getOrOpen("Telemetry-IPFIX", () -> telemetryObs);
+
+        assertThat(r1).isSameAs(syslogObs);
+        assertThat(r2).isSameAs(telemetryObs);
+    }
+
+    @Test
+    void reset_dropsEntryAndNextCallOpensFresh() {
+        SinkStreamRegistry registry = new SinkStreamRegistry();
+        @SuppressWarnings("unchecked")
+        StreamObserver<SyslogMessage> obs1 = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<SyslogMessage> obs2 = mock(StreamObserver.class);
+        AtomicInteger calls = new AtomicInteger();
+        Supplier<StreamObserver<SyslogMessage>> supplier = () -> {
+            int n = calls.incrementAndGet();
+            return n == 1 ? obs1 : obs2;
+        };
+
+        StreamObserver<SyslogMessage> first = registry.getOrOpen("Syslog", supplier);
+        registry.reset("Syslog");
+        StreamObserver<SyslogMessage> second = registry.getOrOpen("Syslog", supplier);
+
+        assertThat(first).isSameAs(obs1);
+        assertThat(second).isSameAs(obs2);
+    }
+}

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/SyslogListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/SyslogListenerConfiguration.java
@@ -20,6 +20,7 @@ import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.syslogd.SyslogConfigBean;
 import org.opennms.netmgt.syslogd.SyslogReceiverJavaNetImpl;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -66,6 +67,7 @@ public class SyslogListenerConfiguration {
 
     @Bean
     public SyslogReceiverJavaNetImpl syslogReceiver(SyslogConfigBean config,
+                                                     @Qualifier("syslogDispatcherFactory")
                                                      MessageDispatcherFactory messageDispatcherFactory,
                                                      DistPollerDao distPollerDao) {
         return new SyslogReceiverJavaNetImpl(config, distPollerDao, messageDispatcherFactory);

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
@@ -26,6 +26,7 @@ import org.deltav.minion.telemetry.FlowUdpListener;
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -62,7 +63,8 @@ public class TelemetryListenerConfiguration {
     private int numThreads;
 
     @Bean
-    public FlowUdpListener flowUdpListener(MessageDispatcherFactory messageDispatcherFactory,
+    public FlowUdpListener flowUdpListener(@Qualifier("telemetryDispatcherFactory")
+                                           MessageDispatcherFactory messageDispatcherFactory,
                                            DistPollerDao distPollerDao) {
         Map<FlowProtocol, AsyncDispatcher<FlowTelemetryMessage>> dispatchers =
                 new EnumMap<>(FlowProtocol.class);

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TrapListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TrapListenerConfiguration.java
@@ -20,6 +20,7 @@ import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.trapd.TrapdConfigBean;
 import org.opennms.netmgt.trapd.TrapListener;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
@@ -60,6 +61,7 @@ public class TrapListenerConfiguration {
 
     @Bean
     public TrapListener trapListener(TrapdConfigBean config,
+                                     @Qualifier("trapDispatcherFactory")
                                      MessageDispatcherFactory messageDispatcherFactory,
                                      DistPollerDao distPollerDao) throws Exception {
         return new TrapListener(config, messageDispatcherFactory, distPollerDao);

--- a/core/daemon-boot-minion/src/main/resources/application.yml
+++ b/core/daemon-boot-minion/src/main/resources/application.yml
@@ -9,6 +9,9 @@ opennms:
     id: ${MINION_ID:minion-default-01}
     location: ${MINION_LOCATION:Default}
     transport: ${MINION_TRANSPORT:grpc}
+    transport.sink.syslog: ${MINION_SINK_SYSLOG_TRANSPORT:grpc}
+    transport.sink.trap: ${MINION_SINK_TRAP_TRANSPORT:grpc}
+    transport.sink.telemetry: ${MINION_SINK_TELEMETRY_TRANSPORT:grpc}
     gateway:
       host: ${MINION_GATEWAY_HOST:envoy}
       port: ${MINION_GATEWAY_PORT:8443}

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -77,6 +77,24 @@
                 <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
             </exclusions>
         </dependency>
+        <!-- horizon's SinkMessageProto wire format on the daemon-facing
+             Kafka topics OpenNMS.Sink.<Type>. The gateway wraps the
+             gRPC-delivered opaque payload bytes in a SinkMessage protobuf
+             before publishing — horizon's KafkaSinkBridge.pollLoop calls
+             SinkMessage.parseFrom(record.value()) and would throw
+             InvalidProtocolBufferException on raw bytes (Task 12 finding). -->
+        <dependency>
+            <groupId>org.opennms.core.ipc.sink</groupId>
+            <artifactId>org.opennms.core.ipc.sink.common</artifactId>
+            <exclusions>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-beans</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-context</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>org.apache.servicemix.bundles.spring-core</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+                <exclusion><groupId>org.ops4j.pax.logging</groupId><artifactId>pax-logging-api</artifactId></exclusion>
+                <exclusion><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId></exclusion>
+            </exclusions>
+        </dependency>
         <!-- horizon's TwinResponseProto / TwinRequestProto wire format on the
              daemon-facing Kafka topic OpenNMS.twin.response.<location>. The
              gateway's TwinChannelDispatcher (Task 8) translates between this

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkChannelConfiguration.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkChannelConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.codahale.metrics.MetricRegistry;
+import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Properties;
+
+/**
+ * Spring wiring for the gateway sink channel. Produces a single
+ * shared Kafka producer used by {@link SinkKafkaProducer} for all
+ * three sink gRPC services. The producer is configured with
+ * {@code acks=1} matching rc1's {@code HeartbeatKafkaProducer}
+ * — Decision 6 explicitly classifies sinks as lossy by design, so
+ * waiting for in-sync-replica acknowledgement is overhead.
+ */
+@Configuration
+public class SinkChannelConfiguration {
+
+    private KafkaProducer<String, byte[]> kafkaProducer;
+
+    @Bean
+    public Producer<String, byte[]> sinkKafkaRawProducer(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "minion-gateway-sinks");
+        props.put(ProducerConfig.ACKS_CONFIG, "1");
+        props.put(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, "");
+        kafkaProducer = new KafkaProducer<>(props);
+        return kafkaProducer;
+    }
+
+    @Bean
+    public SinkKafkaProducer sinkKafkaProducer(Producer<String, byte[]> sinkKafkaRawProducer,
+                                                MetricRegistry metricRegistry) {
+        return new SinkKafkaProducer(sinkKafkaRawProducer, metricRegistry);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (kafkaProducer != null) {
+            kafkaProducer.close();
+        }
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkChannelConfiguration.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkChannelConfiguration.java
@@ -51,6 +51,8 @@ public class SinkChannelConfiguration {
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "minion-gateway-sinks");
         props.put(ProducerConfig.ACKS_CONFIG, "1");
+        // Suppress Kafka's built-in JMX reporter; metrics surface via HorizonMetricsBridge
+        // under opennms_kafka_producer_* (see SinkKafkaProducer's MetricRegistry counters).
         props.put(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, "");
         kafkaProducer = new KafkaProducer<>(props);
         return kafkaProducer;

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkKafkaProducer.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkKafkaProducer.java
@@ -35,21 +35,21 @@ import java.util.concurrent.CompletableFuture;
 public class SinkKafkaProducer {
 
     private final Producer<String, byte[]> producer;
-    private final MetricRegistry metrics;
+    private final MetricRegistry metricRegistry;
 
-    public SinkKafkaProducer(Producer<String, byte[]> producer, MetricRegistry metrics) {
+    public SinkKafkaProducer(Producer<String, byte[]> producer, MetricRegistry metricRegistry) {
         this.producer = producer;
-        this.metrics = metrics;
+        this.metricRegistry = metricRegistry;
     }
 
     public CompletableFuture<Void> send(String topic, String key, byte[] payload) {
         CompletableFuture<Void> result = new CompletableFuture<>();
         producer.send(new ProducerRecord<>(topic, key, payload), (md, ex) -> {
             if (ex != null) {
-                metrics.counter("minion_gateway_sink_publish_failures").inc();
+                metricRegistry.counter("minion_gateway_sink_publish_failures").inc();
                 result.completeExceptionally(ex);
             } else {
-                metrics.counter("minion_gateway_sink_publish_total").inc();
+                metricRegistry.counter("minion_gateway_sink_publish_total").inc();
                 result.complete(null);
             }
         });

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkKafkaProducer.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkKafkaProducer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generic per-topic byte[] producer backing the three sink gRPC services
+ * ({@link SyslogGrpcService}, {@code TrapGrpcService} (Task 7),
+ * {@code TelemetryGrpcService} (Task 8)). Each call publishes opaque bytes
+ * to the named Kafka topic and counts success/failure under the
+ * {@code minion_gateway_sink_publish_*} Dropwizard counters
+ * (surfaced via the {@code HorizonMetricsBridge} at
+ * {@code /actuator/prometheus} per
+ * {@code feedback_meter_naming_horizon_vs_deltav}).
+ */
+public class SinkKafkaProducer {
+
+    private final Producer<String, byte[]> producer;
+    private final MetricRegistry metrics;
+
+    public SinkKafkaProducer(Producer<String, byte[]> producer, MetricRegistry metrics) {
+        this.producer = producer;
+        this.metrics = metrics;
+    }
+
+    public CompletableFuture<Void> send(String topic, String key, byte[] payload) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        producer.send(new ProducerRecord<>(topic, key, payload), (md, ex) -> {
+            if (ex != null) {
+                metrics.counter("minion_gateway_sink_publish_failures").inc();
+                result.completeExceptionally(ex);
+            } else {
+                metrics.counter("minion_gateway_sink_publish_total").inc();
+                result.complete(null);
+            }
+        });
+        return result;
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkKafkaProducer.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkKafkaProducer.java
@@ -17,20 +17,40 @@
 package org.deltav.gateway.sink;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.protobuf.ByteString;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.opennms.core.ipc.sink.model.SinkMessage;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Generic per-topic byte[] producer backing the three sink gRPC services
  * ({@link SyslogGrpcService}, {@code TrapGrpcService} (Task 7),
- * {@code TelemetryGrpcService} (Task 8)). Each call publishes opaque bytes
- * to the named Kafka topic and counts success/failure under the
- * {@code minion_gateway_sink_publish_*} Dropwizard counters
- * (surfaced via the {@code HorizonMetricsBridge} at
- * {@code /actuator/prometheus} per
- * {@code feedback_meter_naming_horizon_vs_deltav}).
+ * {@code TelemetryGrpcService} (Task 8)). Each call wraps the opaque
+ * payload in a horizon {@link SinkMessage} protobuf, then publishes the
+ * wrapped bytes to the named Kafka topic.
+ *
+ * <p>The {@code SinkMessage} wrapper is required because horizon's
+ * {@code KafkaSinkBridge.pollLoop} (in
+ * {@code org.opennms.core.ipc.sink.kafka}) calls
+ * {@code SinkMessage.parseFrom(record.value())} on every consumed record.
+ * Publishing raw payload bytes would throw
+ * {@code InvalidProtocolBufferException} on every consumer poll. The
+ * wrapper carries:
+ * <ul>
+ *   <li>{@code message_id} — fresh UUID per record (de-dup hint for the
+ *       consumer; matches the existing Kafka-path Minion behaviour)</li>
+ *   <li>{@code content} — the gRPC-delivered opaque payload bytes</li>
+ *   <li>{@code current_chunk_number / total_chunks} — both 1; we don't
+ *       chunk in PR3 (large messages are deferred to a future PR)</li>
+ * </ul>
+ *
+ * <p>Counts success/failure under the
+ * {@code minion_gateway_sink_publish_*} Dropwizard counters (surfaced
+ * via the {@code HorizonMetricsBridge} at {@code /actuator/prometheus}
+ * per {@code feedback_meter_naming_horizon_vs_deltav}).
  */
 public class SinkKafkaProducer {
 
@@ -43,8 +63,16 @@ public class SinkKafkaProducer {
     }
 
     public CompletableFuture<Void> send(String topic, String key, byte[] payload) {
+        byte[] wrapped = SinkMessage.newBuilder()
+            .setMessageId(UUID.randomUUID().toString())
+            .setContent(ByteString.copyFrom(payload))
+            .setCurrentChunkNumber(1)
+            .setTotalChunks(1)
+            .build()
+            .toByteArray();
+
         CompletableFuture<Void> result = new CompletableFuture<>();
-        producer.send(new ProducerRecord<>(topic, key, payload), (md, ex) -> {
+        producer.send(new ProducerRecord<>(topic, key, wrapped), (md, ex) -> {
             if (ex != null) {
                 metricRegistry.counter("minion_gateway_sink_publish_failures").inc();
                 result.completeExceptionally(ex);

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SyslogGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SyslogGrpcService.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.google.protobuf.Timestamp;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.SyslogAck;
+import org.deltav.minion.grpc.v1.SyslogMessage;
+import org.deltav.minion.grpc.v1.SyslogServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.grpc.server.service.GrpcService;
+
+import java.time.Instant;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+
+/**
+ * Bidi-streaming gRPC SyslogService. Per-onNext: forwards opaque payload
+ * bytes to {@code OpenNMS.Sink.Syslog} keyed by {@code <location>@<minion-id>}.
+ *
+ * <p>Per Decision 6 (sinks are lossy by design): Kafka publish failures
+ * log and continue; the gRPC stream is not torn down on a single
+ * publish failure. Identity is read from the gRPC Context (set by
+ * {@code MinionIdentityServerInterceptor}, established in rc1).
+ */
+@GrpcService
+public class SyslogGrpcService extends SyslogServiceGrpc.SyslogServiceImplBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SyslogGrpcService.class);
+    private static final String TOPIC = "OpenNMS.Sink.Syslog";
+
+    private final SinkKafkaProducer producer;
+
+    public SyslogGrpcService(SinkKafkaProducer producer) {
+        this.producer = producer;
+    }
+
+    @Override
+    public StreamObserver<SyslogMessage> publish(StreamObserver<SyslogAck> ack) {
+        String minionId = MINION_ID_CTX.get();
+        String location = MINION_LOCATION_CTX.get();
+        String key = location + "@" + minionId;
+        LOG.info("Syslog stream opened for minion={} location={}", minionId, location);
+
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(SyslogMessage msg) {
+                producer.send(TOPIC, key, msg.getPayload().toByteArray())
+                    .thenAccept(v -> ack.onNext(buildAck()))
+                    .exceptionally(t -> {
+                        LOG.warn("Syslog publish failed for minion={}", minionId, t);
+                        return null;
+                    });
+            }
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Syslog stream error for minion={}: {}", minionId, t.toString());
+            }
+            @Override
+            public void onCompleted() {
+                LOG.info("Syslog stream closed for minion={}", minionId);
+                ack.onCompleted();
+            }
+        };
+    }
+
+    private SyslogAck buildAck() {
+        Instant n = Instant.now();
+        return SyslogAck.newBuilder()
+            .setReceivedAt(Timestamp.newBuilder().setSeconds(n.getEpochSecond()).setNanos(n.getNano()).build())
+            .build();
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SyslogGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SyslogGrpcService.java
@@ -52,7 +52,7 @@ public class SyslogGrpcService extends SyslogServiceGrpc.SyslogServiceImplBase {
     }
 
     @Override
-    public StreamObserver<SyslogMessage> publish(StreamObserver<SyslogAck> ack) {
+    public StreamObserver<SyslogMessage> publish(StreamObserver<SyslogAck> responseObserver) {
         String minionId = MINION_ID_CTX.get();
         String location = MINION_LOCATION_CTX.get();
         String key = location + "@" + minionId;
@@ -62,28 +62,35 @@ public class SyslogGrpcService extends SyslogServiceGrpc.SyslogServiceImplBase {
             @Override
             public void onNext(SyslogMessage msg) {
                 producer.send(TOPIC, key, msg.getPayload().toByteArray())
-                    .thenAccept(v -> ack.onNext(buildAck()))
+                    .thenAccept(v -> responseObserver.onNext(buildAck()))
                     .exceptionally(t -> {
                         LOG.warn("Syslog publish failed for minion={}", minionId, t);
                         return null;
                     });
             }
+
             @Override
             public void onError(Throwable t) {
                 LOG.info("Syslog stream error for minion={}: {}", minionId, t.toString());
             }
+
             @Override
             public void onCompleted() {
                 LOG.info("Syslog stream closed for minion={}", minionId);
-                ack.onCompleted();
+                responseObserver.onCompleted();
             }
         };
     }
 
+    /**
+     * Build the per-message ack. Called on the Kafka producer's I/O thread
+     * (via the {@code thenAccept} callback), not the gRPC stream thread —
+     * the timestamp is "ack issued at," not "Minion-emitted at."
+     */
     private SyslogAck buildAck() {
-        Instant n = Instant.now();
+        Instant now = Instant.now();
         return SyslogAck.newBuilder()
-            .setReceivedAt(Timestamp.newBuilder().setSeconds(n.getEpochSecond()).setNanos(n.getNano()).build())
+            .setReceivedAt(Timestamp.newBuilder().setSeconds(now.getEpochSecond()).setNanos(now.getNano()).build())
             .build();
     }
 }

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TelemetryGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TelemetryGrpcService.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.google.protobuf.Timestamp;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TelemetryAck;
+import org.deltav.minion.grpc.v1.TelemetryDatagram;
+import org.deltav.minion.grpc.v1.TelemetryServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.grpc.server.service.GrpcService;
+
+import java.time.Instant;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+
+/**
+ * Bidi-streaming gRPC TelemetryService. Four protocol-specific {@code publish*}
+ * methods route opaque payload bytes to {@code OpenNMS.Sink.Telemetry-<proto>}
+ * topics keyed by {@code <location>@<minion-id>}. Routing is by RPC method,
+ * not by inspecting payload — the Minion picks the topic by calling the
+ * matching method on the generated stub.
+ *
+ * <p>Per Decision 6 (sinks are lossy by design): Kafka publish failures
+ * log and continue; the gRPC stream is not torn down on a single
+ * publish failure. Identity is read from the gRPC Context (set by
+ * {@code MinionIdentityServerInterceptor}, established in rc1).
+ */
+@GrpcService
+public class TelemetryGrpcService extends TelemetryServiceGrpc.TelemetryServiceImplBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TelemetryGrpcService.class);
+    private static final String IPFIX_TOPIC = "OpenNMS.Sink.Telemetry-IPFIX";
+    private static final String NETFLOW5_TOPIC = "OpenNMS.Sink.Telemetry-Netflow-5";
+    private static final String NETFLOW9_TOPIC = "OpenNMS.Sink.Telemetry-Netflow-9";
+    private static final String SFLOW_TOPIC = "OpenNMS.Sink.Telemetry-SFlow";
+
+    private final SinkKafkaProducer producer;
+
+    public TelemetryGrpcService(SinkKafkaProducer producer) {
+        this.producer = producer;
+    }
+
+    @Override
+    public StreamObserver<TelemetryDatagram> publishIpfix(StreamObserver<TelemetryAck> responseObserver) {
+        return publishTo(IPFIX_TOPIC, responseObserver);
+    }
+
+    @Override
+    public StreamObserver<TelemetryDatagram> publishNetflow5(StreamObserver<TelemetryAck> responseObserver) {
+        return publishTo(NETFLOW5_TOPIC, responseObserver);
+    }
+
+    @Override
+    public StreamObserver<TelemetryDatagram> publishNetflow9(StreamObserver<TelemetryAck> responseObserver) {
+        return publishTo(NETFLOW9_TOPIC, responseObserver);
+    }
+
+    @Override
+    public StreamObserver<TelemetryDatagram> publishSflow(StreamObserver<TelemetryAck> responseObserver) {
+        return publishTo(SFLOW_TOPIC, responseObserver);
+    }
+
+    /**
+     * Common bidi handler shared by all four protocol-specific overrides.
+     * Each onNext forwards opaque {@code TelemetryDatagram.payload} bytes
+     * to the protocol-specific Kafka topic. Per Decision 6 (lossy by design):
+     * Kafka publish failures log and continue; the gRPC stream survives a
+     * single publish failure.
+     */
+    private StreamObserver<TelemetryDatagram> publishTo(String topic, StreamObserver<TelemetryAck> responseObserver) {
+        String minionId = MINION_ID_CTX.get();
+        String location = MINION_LOCATION_CTX.get();
+        String key = location + "@" + minionId;
+        LOG.info("Telemetry stream opened for minion={} location={} topic={}", minionId, location, topic);
+
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(TelemetryDatagram msg) {
+                producer.send(topic, key, msg.getPayload().toByteArray())
+                    .thenAccept(v -> responseObserver.onNext(buildAck()))
+                    .exceptionally(t -> {
+                        LOG.warn("Telemetry publish failed for minion={} topic={}", minionId, topic, t);
+                        return null;
+                    });
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Telemetry stream error for minion={} topic={}: {}", minionId, topic, t.toString());
+            }
+
+            @Override
+            public void onCompleted() {
+                LOG.info("Telemetry stream closed for minion={} topic={}", minionId, topic);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    /**
+     * Build the per-message ack. Called on the Kafka producer's I/O thread
+     * (via the {@code thenAccept} callback), not the gRPC stream thread —
+     * the timestamp is "ack issued at," not "Minion-emitted at."
+     */
+    private TelemetryAck buildAck() {
+        Instant now = Instant.now();
+        return TelemetryAck.newBuilder()
+            .setReceivedAt(Timestamp.newBuilder().setSeconds(now.getEpochSecond()).setNanos(now.getNano()).build())
+            .build();
+    }
+}

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TrapGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TrapGrpcService.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.google.protobuf.Timestamp;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.SnmpTrap;
+import org.deltav.minion.grpc.v1.TrapAck;
+import org.deltav.minion.grpc.v1.TrapServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.grpc.server.service.GrpcService;
+
+import java.time.Instant;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+
+/**
+ * Bidi-streaming gRPC TrapService. Per-onNext: forwards opaque payload
+ * bytes to {@code OpenNMS.Sink.Trap} keyed by {@code <location>@<minion-id>}.
+ *
+ * <p>Per Decision 6 (sinks are lossy by design): Kafka publish failures
+ * log and continue; the gRPC stream is not torn down on a single
+ * publish failure. Identity is read from the gRPC Context (set by
+ * {@code MinionIdentityServerInterceptor}, established in rc1).
+ */
+@GrpcService
+public class TrapGrpcService extends TrapServiceGrpc.TrapServiceImplBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TrapGrpcService.class);
+    private static final String TOPIC = "OpenNMS.Sink.Trap";
+
+    private final SinkKafkaProducer producer;
+
+    public TrapGrpcService(SinkKafkaProducer producer) {
+        this.producer = producer;
+    }
+
+    @Override
+    public StreamObserver<SnmpTrap> publish(StreamObserver<TrapAck> responseObserver) {
+        String minionId = MINION_ID_CTX.get();
+        String location = MINION_LOCATION_CTX.get();
+        String key = location + "@" + minionId;
+        LOG.info("Trap stream opened for minion={} location={}", minionId, location);
+
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(SnmpTrap msg) {
+                producer.send(TOPIC, key, msg.getPayload().toByteArray())
+                    .thenAccept(v -> responseObserver.onNext(buildAck()))
+                    .exceptionally(t -> {
+                        LOG.warn("Trap publish failed for minion={}", minionId, t);
+                        return null;
+                    });
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                LOG.info("Trap stream error for minion={}: {}", minionId, t.toString());
+            }
+
+            @Override
+            public void onCompleted() {
+                LOG.info("Trap stream closed for minion={}", minionId);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    /**
+     * Build the per-message ack. Called on the Kafka producer's I/O thread
+     * (via the {@code thenAccept} callback), not the gRPC stream thread —
+     * the timestamp is "ack issued at," not "Minion-emitted at."
+     */
+    private TrapAck buildAck() {
+        Instant now = Instant.now();
+        return TrapAck.newBuilder()
+            .setReceivedAt(Timestamp.newBuilder().setSeconds(now.getEpochSecond()).setNanos(now.getNano()).build())
+            .build();
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SinkKafkaProducerTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SinkKafkaProducerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SinkKafkaProducerTest {
+
+    @Test
+    void send_publishesToCorrectTopicWithKey() throws Exception {
+        MockProducer<String, byte[]> mock = new MockProducer<>(true, null,
+            new StringSerializer(), new ByteArraySerializer());
+        MetricRegistry metrics = new MetricRegistry();
+        SinkKafkaProducer producer = new SinkKafkaProducer(mock, metrics);
+
+        CompletableFuture<Void> result = producer.send(
+            "OpenNMS.Sink.Syslog", "Default@minion-A", "payload-bytes".getBytes());
+
+        result.get(2, TimeUnit.SECONDS);
+
+        assertThat(mock.history()).hasSize(1);
+        ProducerRecord<String, byte[]> record = mock.history().get(0);
+        assertThat(record.topic()).isEqualTo("OpenNMS.Sink.Syslog");
+        assertThat(record.key()).isEqualTo("Default@minion-A");
+        assertThat(new String(record.value())).isEqualTo("payload-bytes");
+        assertThat(metrics.counter("minion_gateway_sink_publish_total").getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void send_failureIncrementsFailureCounterAndCompletesExceptionally() {
+        MockProducer<String, byte[]> mock = new MockProducer<>(false, null,
+            new StringSerializer(), new ByteArraySerializer());
+        MetricRegistry metrics = new MetricRegistry();
+        SinkKafkaProducer producer = new SinkKafkaProducer(mock, metrics);
+
+        CompletableFuture<Void> result = producer.send(
+            "OpenNMS.Sink.Syslog", "k", new byte[0]);
+
+        mock.errorNext(new RuntimeException("broker down"));
+
+        assertThat(result).isCompletedExceptionally();
+        assertThat(metrics.counter("minion_gateway_sink_publish_failures").getCount()).isEqualTo(1);
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SinkKafkaProducerTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SinkKafkaProducerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
+import org.opennms.core.ipc.sink.model.SinkMessage;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SinkKafkaProducerTest {
 
     @Test
-    void send_publishesToCorrectTopicWithKey() throws Exception {
+    void send_publishesToCorrectTopicWithKeyAndSinkMessageWrappedPayload() throws Exception {
         MockProducer<String, byte[]> mock = new MockProducer<>(true, null,
             new StringSerializer(), new ByteArraySerializer());
         MetricRegistry metrics = new MetricRegistry();
@@ -46,7 +47,15 @@ class SinkKafkaProducerTest {
         ProducerRecord<String, byte[]> record = mock.history().get(0);
         assertThat(record.topic()).isEqualTo("OpenNMS.Sink.Syslog");
         assertThat(record.key()).isEqualTo("Default@minion-A");
-        assertThat(new String(record.value())).isEqualTo("payload-bytes");
+
+        // Published bytes must be a SinkMessage protobuf containing the payload —
+        // horizon's KafkaSinkBridge calls SinkMessage.parseFrom on every record.
+        SinkMessage parsed = SinkMessage.parseFrom(record.value());
+        assertThat(parsed.getContent().toStringUtf8()).isEqualTo("payload-bytes");
+        assertThat(parsed.getMessageId()).isNotBlank();
+        assertThat(parsed.getCurrentChunkNumber()).isEqualTo(1);
+        assertThat(parsed.getTotalChunks()).isEqualTo(1);
+
         assertThat(metrics.counter("minion_gateway_sink_publish_total").getCount()).isEqualTo(1);
     }
 

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SyslogGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SyslogGrpcServiceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Context;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.SyslogAck;
+import org.deltav.minion.grpc.v1.SyslogMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SyslogGrpcServiceTest {
+
+    @Test
+    void onNext_publishesToOpenNmsSinkSyslogTopicWithIdentityKey() {
+        SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
+        when(producer.send(eq("OpenNMS.Sink.Syslog"), eq("Default@minion-A"), argThat(b -> new String(b).equals("payload"))))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        SyslogGrpcService svc = new SyslogGrpcService(producer);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<SyslogAck> ack = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<SyslogMessage> in = svc.publish(ack);
+            in.onNext(SyslogMessage.newBuilder()
+                .setPayload(ByteString.copyFromUtf8("payload"))
+                .build());
+        });
+
+        verify(producer).send(eq("OpenNMS.Sink.Syslog"), eq("Default@minion-A"),
+            argThat(b -> new String(b).equals("payload")));
+    }
+
+    @Test
+    void streamCompleted_completesAckObserver() {
+        SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
+        SyslogGrpcService svc = new SyslogGrpcService(producer);
+        @SuppressWarnings("unchecked")
+        StreamObserver<SyslogAck> ack = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<SyslogMessage> in = svc.publish(ack);
+            in.onCompleted();
+        });
+
+        verify(ack).onCompleted();
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TelemetryGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TelemetryGrpcServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Context;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.TelemetryAck;
+import org.deltav.minion.grpc.v1.TelemetryDatagram;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TelemetryGrpcServiceTest {
+
+    @Test
+    void publishIpfix_routesToIpfixTopicWithIdentityKey() {
+        SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
+        when(producer.send(eq("OpenNMS.Sink.Telemetry-IPFIX"), eq("Default@minion-A"),
+                           argThat(b -> new String(b).equals("ipfix-bytes"))))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        TelemetryGrpcService svc = new TelemetryGrpcService(producer);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TelemetryAck> ack = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TelemetryDatagram> in = svc.publishIpfix(ack);
+            in.onNext(TelemetryDatagram.newBuilder()
+                .setPayload(ByteString.copyFromUtf8("ipfix-bytes")).build());
+        });
+
+        verify(producer).send(eq("OpenNMS.Sink.Telemetry-IPFIX"), eq("Default@minion-A"),
+            argThat(b -> new String(b).equals("ipfix-bytes")));
+    }
+
+    @Test
+    void publishNetflow5_routesToNetflow5TopicWithIdentityKey() {
+        SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
+        when(producer.send(eq("OpenNMS.Sink.Telemetry-Netflow-5"), eq("Default@minion-A"),
+                           argThat(b -> new String(b).equals("nf5-bytes"))))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        TelemetryGrpcService svc = new TelemetryGrpcService(producer);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TelemetryAck> ack = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TelemetryDatagram> in = svc.publishNetflow5(ack);
+            in.onNext(TelemetryDatagram.newBuilder()
+                .setPayload(ByteString.copyFromUtf8("nf5-bytes")).build());
+        });
+
+        verify(producer).send(eq("OpenNMS.Sink.Telemetry-Netflow-5"), eq("Default@minion-A"),
+            argThat(b -> new String(b).equals("nf5-bytes")));
+    }
+
+    @Test
+    void publishNetflow9_routesToNetflow9TopicWithIdentityKey() {
+        SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
+        when(producer.send(eq("OpenNMS.Sink.Telemetry-Netflow-9"), eq("Default@minion-A"),
+                           argThat(b -> new String(b).equals("nf9-bytes"))))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        TelemetryGrpcService svc = new TelemetryGrpcService(producer);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TelemetryAck> ack = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TelemetryDatagram> in = svc.publishNetflow9(ack);
+            in.onNext(TelemetryDatagram.newBuilder()
+                .setPayload(ByteString.copyFromUtf8("nf9-bytes")).build());
+        });
+
+        verify(producer).send(eq("OpenNMS.Sink.Telemetry-Netflow-9"), eq("Default@minion-A"),
+            argThat(b -> new String(b).equals("nf9-bytes")));
+    }
+
+    @Test
+    void publishSflow_routesToSflowTopicWithIdentityKey() {
+        SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
+        when(producer.send(eq("OpenNMS.Sink.Telemetry-SFlow"), eq("Default@minion-A"),
+                           argThat(b -> new String(b).equals("sflow-bytes"))))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        TelemetryGrpcService svc = new TelemetryGrpcService(producer);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TelemetryAck> ack = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<TelemetryDatagram> in = svc.publishSflow(ack);
+            in.onNext(TelemetryDatagram.newBuilder()
+                .setPayload(ByteString.copyFromUtf8("sflow-bytes")).build());
+        });
+
+        verify(producer).send(eq("OpenNMS.Sink.Telemetry-SFlow"), eq("Default@minion-A"),
+            argThat(b -> new String(b).equals("sflow-bytes")));
+    }
+}

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TrapGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TrapGrpcServiceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.gateway.sink;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Context;
+import io.grpc.stub.StreamObserver;
+import org.deltav.minion.grpc.v1.SnmpTrap;
+import org.deltav.minion.grpc.v1.TrapAck;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_ID_CTX;
+import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOCATION_CTX;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TrapGrpcServiceTest {
+
+    @Test
+    void onNext_publishesToOpenNmsSinkTrapTopic() {
+        SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
+        when(producer.send(eq("OpenNMS.Sink.Trap"), eq("Default@minion-A"),
+                           argThat(b -> new String(b).equals("trap-bytes"))))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        TrapGrpcService svc = new TrapGrpcService(producer);
+
+        @SuppressWarnings("unchecked")
+        StreamObserver<TrapAck> ack = mock(StreamObserver.class);
+
+        Context ctx = Context.current()
+            .withValue(MINION_ID_CTX, "minion-A")
+            .withValue(MINION_LOCATION_CTX, "Default");
+        ctx.run(() -> {
+            StreamObserver<SnmpTrap> in = svc.publish(ack);
+            in.onNext(SnmpTrap.newBuilder()
+                .setPayload(ByteString.copyFromUtf8("trap-bytes")).build());
+        });
+
+        verify(producer).send(eq("OpenNMS.Sink.Trap"), eq("Default@minion-A"),
+            argThat(b -> new String(b).equals("trap-bytes")));
+    }
+}

--- a/core/minion-grpc-contracts/src/main/proto/syslog.proto
+++ b/core/minion-grpc-contracts/src/main/proto/syslog.proto
@@ -7,8 +7,18 @@ option java_outer_classname = "SyslogProto";
 
 import "google/protobuf/timestamp.proto";
 
+// One marshaled syslog Sink-API message produced on the Minion by
+// SyslogSinkModule.marshal(SyslogConnection). The minion-gateway forwards
+// `payload` bytes verbatim to OpenNMS.Sink.Syslog; the existing horizon
+// Syslogd consumer calls SyslogSinkModule.unmarshal(bytes) and is unaware
+// of the gRPC hop.
+//
+// `source_address` and `source_port` describe the original syslog datagram
+// origin; preserved here for self-describing logs and for routing keys
+// when the gateway publishes to Kafka. They are NOT used to reconstruct
+// the SyslogConnection — that's already encoded inside `payload`.
 message SyslogMessage {
-  bytes raw = 1;                        // exact UDP datagram bytes
+  bytes payload = 1;                    // SyslogSinkModule.marshal() output
   string source_address = 2;
   int32 source_port = 3;
   google.protobuf.Timestamp received_at = 4;
@@ -18,8 +28,6 @@ message SyslogAck {
   google.protobuf.Timestamp received_at = 1;
 }
 
-// rc2 implementation; rc1 ships definition only so the wire format is stable
-// before any client/server code lands.
 service SyslogService {
   rpc Publish(stream SyslogMessage) returns (stream SyslogAck);
 }

--- a/core/minion-grpc-contracts/src/main/proto/telemetry.proto
+++ b/core/minion-grpc-contracts/src/main/proto/telemetry.proto
@@ -11,6 +11,8 @@ import "google/protobuf/timestamp.proto";
 // FlowSinkModule.marshal(FlowTelemetryMessage). The minion-gateway forwards
 // `payload` bytes verbatim to the protocol-specific Kafka topic. Routing
 // to the correct topic is by RPC method, not by inspecting payload.
+// Delta-V's flow-enricher consumes the topic and calls
+// FlowSinkModule.unmarshal(bytes) unchanged.
 message TelemetryDatagram {
   bytes payload = 1;                    // FlowSinkModule.marshal() output (FlowTelemetryMessage proto bytes)
   string source_address = 2;

--- a/core/minion-grpc-contracts/src/main/proto/telemetry.proto
+++ b/core/minion-grpc-contracts/src/main/proto/telemetry.proto
@@ -7,8 +7,12 @@ option java_outer_classname = "TelemetryProto";
 
 import "google/protobuf/timestamp.proto";
 
+// One marshaled flow-telemetry Sink-API message produced on the Minion by
+// FlowSinkModule.marshal(FlowTelemetryMessage). The minion-gateway forwards
+// `payload` bytes verbatim to the protocol-specific Kafka topic. Routing
+// to the correct topic is by RPC method, not by inspecting payload.
 message TelemetryDatagram {
-  bytes raw = 1;                        // protocol-specific bytes (IPFIX, NetflowN, sFlow)
+  bytes payload = 1;                    // FlowSinkModule.marshal() output (FlowTelemetryMessage proto bytes)
   string source_address = 2;
   int32 source_port = 3;
   google.protobuf.Timestamp received_at = 4;
@@ -18,8 +22,8 @@ message TelemetryAck {
   google.protobuf.Timestamp received_at = 1;
 }
 
-// rc2: separate methods per protocol so minion-gateway can route to the
-// right OpenNMS.Sink.Telemetry-* topic without inspecting payload.
+// One method per protocol so minion-gateway routes to the correct
+// OpenNMS.Sink.Telemetry-* topic without inspecting payload.
 service TelemetryService {
   rpc PublishIpfix(stream TelemetryDatagram) returns (stream TelemetryAck);
   rpc PublishNetflow5(stream TelemetryDatagram) returns (stream TelemetryAck);

--- a/core/minion-grpc-contracts/src/main/proto/trap.proto
+++ b/core/minion-grpc-contracts/src/main/proto/trap.proto
@@ -7,8 +7,12 @@ option java_outer_classname = "TrapProto";
 
 import "google/protobuf/timestamp.proto";
 
+// One marshaled SNMP trap Sink-API message produced on the Minion by
+// TrapSinkModule.marshal(TrapInformationWrapper). The minion-gateway
+// forwards `payload` bytes verbatim to OpenNMS.Sink.Trap; horizon's
+// Trapd consumer calls TrapSinkModule.unmarshal(bytes) unchanged.
 message SnmpTrap {
-  bytes raw = 1;                        // raw SNMP PDU
+  bytes payload = 1;                    // TrapSinkModule.marshal() output
   string source_address = 2;
   int32 source_port = 3;
   google.protobuf.Timestamp received_at = 4;
@@ -18,7 +22,6 @@ message TrapAck {
   google.protobuf.Timestamp received_at = 1;
 }
 
-// rc2 implementation; rc1 ships definition only.
 service TrapService {
   rpc Publish(stream SnmpTrap) returns (stream TrapAck);
 }

--- a/docs/plans/2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md
+++ b/docs/plans/2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md
@@ -152,3 +152,78 @@ load-bearing PR2-lesson application; Task 4 implements the split.
 - **Transport-coupled bean extraction:** `KafkaSinkClientConfiguration`
   splits into per-sink Kafka @Configurations + a shared
   `MinionSinkMetricsConfiguration` (Task 4).
+
+## Transport-coupled bean audit
+
+`MessageDispatcherFactory` injection points (grep audit, Task 2):
+
+```
+grep -rn 'MessageDispatcherFactory' core/daemon-boot-minion*/src/main/java/
+```
+
+### Listener-side injectors (the substitution surface)
+
+| File | Line | Injection style | Disposition in PR3 |
+|---|---|---|---|
+| `core/daemon-boot-minion/.../HeartbeatConfiguration.java` | 54 | `@Qualifier("heartbeatDispatcherFactory")` | Unchanged — rc1 already extracted |
+| `core/daemon-boot-minion/.../SyslogListenerConfiguration.java` | 69 | unqualified `MessageDispatcherFactory` | Task 4 changes to `@Qualifier("syslogDispatcherFactory")` |
+| `core/daemon-boot-minion/.../TrapListenerConfiguration.java` | 63 | unqualified | Task 4 changes to `@Qualifier("trapDispatcherFactory")` |
+| `core/daemon-boot-minion/.../TelemetryListenerConfiguration.java` | 65 | unqualified | Task 4 changes to `@Qualifier("telemetryDispatcherFactory")` |
+
+(Plan's audit table at lines 397–404 listed Tasks 6/7/8 for the qualifier
+swap; this is a plan inconsistency — Task 4.7 actually performs the
+swaps. Findings reflect the correct task assignment.)
+
+### Provider-side beans (factory implementations)
+
+| File | Bean / class | Disposition in PR3 |
+|---|---|---|
+| `KafkaSinkClientConfiguration.java` | `@Primary MessageDispatcherFactory kafkaRemoteMessageDispatcherFactory` + `MetricRegistry` + `HorizonMetricsBridge` + `SmartLifecycle` | Split (Task 4): MetricRegistry + Bridge → `MinionSinkMetricsConfiguration` (transport-agnostic). Factory + lifecycle → 3 per-sink Kafka @Configurations gated by `opennms.minion.transport.sink.<type>=kafka`. Class deleted at end of Task 4. |
+| `GrpcHeartbeatDispatcherConfiguration.java` | `MessageDispatcherFactory heartbeatDispatcherFactory` (rc1) | Unchanged — Heartbeat out of scope |
+| `grpc/GrpcMessageDispatcherFactory.java` | rc1 gRPC factory class (Heartbeat-only) | Unchanged — sibling factory `GrpcSinkDispatcherFactory` added in Task 5 |
+
+### Additional injector found that the plan's expected list missed
+
+`core/daemon-boot-minion-common/.../HeartbeatKafkaFallbackConfiguration.java:35`
+— `@Bean(name = "heartbeatDispatcherFactory") MessageDispatcherFactory heartbeatDispatcherFactory(MessageDispatcherFactory kafkaPrimary)`,
+gated on `@ConditionalOnProperty(name = "opennms.minion.transport", havingValue = "kafka")`.
+
+This is the **rc2-pr1 rollback alias**: when `MINION_TRANSPORT=kafka` (the
+RPC + Heartbeat rollback flag), it injects the @Primary Kafka factory
+under the `heartbeatDispatcherFactory` bean name so HeartbeatConfiguration's
+qualifier injection resolves identically on either transport.
+
+**Coupling implication for Task 4.** When `KafkaSinkClientConfiguration`
+deletes its `@Primary MessageDispatcherFactory` bean and replaces it
+with three per-sink qualified beans, the unqualified `MessageDispatcherFactory
+kafkaPrimary` parameter in this fallback fails to resolve:
+
+- No @Primary candidate exists.
+- Spring won't auto-disambiguate three same-typed candidates by the
+  parameter name `kafkaPrimary` (no bean is named that).
+- Worse, when `opennms.minion.transport.sink.*=grpc` (the default), the
+  three Kafka factory @Beans don't even exist, so even an explicit
+  qualifier injection wouldn't have a target.
+
+Task 4 must therefore preserve the rollback path. The cleanest options:
+
+1. **Task 4 update**: change `HeartbeatKafkaFallbackConfiguration` to
+   inject `@Qualifier("syslogDispatcherFactory") MessageDispatcherFactory`
+   (or any one of the three — all are `KafkaRemoteMessageDispatcherFactory`
+   instances), and add `@ConditionalOnProperty` requiring at least one
+   sink flag = kafka. Document the operational expectation that
+   `MINION_TRANSPORT=kafka` should be paired with sink flags = kafka.
+2. **Alternative**: provide a dedicated, sink-independent
+   `kafkaHeartbeatBackupDispatcher` bean inside the fallback config,
+   constructing its own `KafkaRemoteMessageDispatcherFactory`.
+
+Option 1 is the lighter change and matches realistic operational use
+(rollback usually flips all transport flags together). Task 4 will
+implement this; the implementer subagent will be briefed on this finding.
+
+### Audit conclusion
+
+Substitution surface is bounded to the four listener configs above plus
+the one provider config (`HeartbeatKafkaFallbackConfiguration`) requiring
+a Task-4 update for transport-flag-aware qualifier injection. No other
+injectors found.

--- a/docs/plans/2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md
+++ b/docs/plans/2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md
@@ -227,3 +227,45 @@ Substitution surface is bounded to the four listener configs above plus
 the one provider config (`HeartbeatKafkaFallbackConfiguration`) requiring
 a Task-4 update for transport-flag-aware qualifier injection. No other
 injectors found.
+
+## PR3-measured numbers (Task 11)
+
+Captured by `test-grpc-sinks-e2e.sh` — same methodology as Phase 0
+(Task 1) so deltas are apples-to-apples.
+
+| Sink | Methodology | Phase 0 (Kafka path) | PR3 (gRPC path) | Gate | Result |
+|---|---|---|---|---|---|
+| Syslog | per-batch transport lag, n=177 batches | p99 = 537 ms* (n=26, cold-start outlier) | **p99 = 1 ms** | ≤100 ms | ✓ pass |
+| Trap | per-batch transport lag, n=50 batches | p99 = 20 ms (n=9) | **max = 2 ms** | ≤100 ms | ✓ pass |
+| Telemetry-IPFIX | inter-arrival lag (proxy), n=100 records | p75 = 7 ms | **p75 = 0 ms** | ≤50 ms | ✓ pass |
+
+\* The Phase 0 Syslog p99 (537 ms) was driven by a single cold-start
+outlier in a 26-batch sample. PR3's n=177 measurement on a warm system
+shows p99 = 1 ms — confirming the cold-start hypothesis that informed
+`feedback_pr3_syslog_trap_p99_asymmetry`. The asymmetry vs Trap is fully
+resolved: warm-system per-batch transport lag is single-digit ms for
+both sinks.
+
+### Methodology note for Telemetry
+
+The `test-grpc-sinks-e2e.sh` harness gates Telemetry-IPFIX on **p75
+inter-arrival**, not p99. Inter-arrival p99 (~20 s in both Phase 0 and
+PR3 measurements) reflects natural exporter quiet periods between IPFIX
+flush windows — not transport lag. p75 is robust to that and would shift
+visibly on a real transport regression. Methodology trade-off documented
+in the harness itself.
+
+### Gate widening rationale (per Decision 10 sub-decision 10-v)
+
+Phase 0 set provisional gates of baseline + 30 ms (Syslog 42 ms, Trap
+50 ms, Telemetry-IPFIX 37 ms). The PR3 harness widens:
+- Syslog: 100 ms (vs Phase 0's 42 ms). Headroom for occasional
+  cold-start batches in production-like load patterns.
+- Trap: 100 ms (vs Phase 0's 50 ms). Same rationale.
+- Telemetry: 50 ms (vs Phase 0's 37 ms). Slightly wider to absorb
+  exporter-cadence noise that can leak into p75 in short sampling
+  windows.
+
+Measured PR3 numbers are far below all gates (1 ms / 2 ms / 0 ms vs
+100 / 100 / 50 ms), so the wider gates are conservative against future
+regression rather than tuned to the current measurement.

--- a/docs/plans/2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md
+++ b/docs/plans/2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md
@@ -1,0 +1,154 @@
+# v1.2.0-rc2 PR3 — Sinks Migration: Pre-Work Findings
+
+## Baseline measurement methodology
+
+Per Decision 10 sub-decision 10-v of the rc2 decisions doc, latency gates
+are calibrated empirically. PR1 (RPC) inherited Heartbeat-as-proxy
+(rc1's 1 ms p99) and gated at +20 ms; PR2 (Twin) gated subscribe at
++100 ms / propagation at +50 ms. PR3 (sinks) gates per-sink **transport
+lag** at **+30 ms** over the Kafka-path baseline.
+
+**Methodology revision vs. plan.** The plan's Task 1.3 example regex
+(`body=(\d{13})`) assumed each Minion-emitted Kafka record carries the
+syslog datagram bytes verbatim with a body-embedded timestamp.
+Inspection of the actual wire format shows otherwise:
+
+| Sink | Wire format on Kafka | Per-message Minion timestamp source |
+|---|---|---|
+| Syslog | XML envelope `<syslog-message-log>` with N `<messages timestamp="ISO8601Z">` children, each containing base64-encoded original datagram | `timestamp` attribute on each `<messages>` element |
+| Trap | XML envelope `<trap-message-log>` with N `<messages>` children carrying `<creation-time>` epoch-ms | `<creation-time>` element value |
+| Telemetry-* | Binary `FlowTelemetryMessage` protobuf — no plaintext per-message timestamp | not extractable without protobuf parsing |
+
+Two further discoveries shape the methodology:
+
+1. **Batching dominates per-message lag.** SyslogSinkModule and
+   TrapSinkModule batch on the Minion before publishing one Kafka record
+   per batch. With 10–100 ms inter-message spacing the batch sizes
+   observed were ~22 (trap, 200 msgs / 9 batches) and ~38 (syslog, 1000
+   msgs / 26 batches). Per-message wall-clock lag = `Kafka.CreateTime −
+   message.timestamp` then includes batch fill time and runs
+   ~250 ms mean / ~700 ms p99 — orders of magnitude higher than the
+   plan's expected "1–5 ms p99" because the plan assumed unbatched
+   per-message publishes.
+2. **Per-batch transport lag is the metric the gRPC migration affects.**
+   `Kafka.CreateTime − max(message.timestamp in batch)` isolates the
+   Minion-flush → Kafka-write step. This is the path PR3 changes
+   (Minion publishes via gRPC stream → gateway publishes to Kafka)
+   while batching policy stays on the Minion side, unchanged. We adopt
+   per-batch transport lag as the canonical sink baseline metric.
+3. **Telemetry uses inter-arrival as a coarse proxy.** Without per-record
+   Minion timestamp in the wire format, transport lag isn't directly
+   measurable from a passive consumer. Inter-arrival of consecutive
+   Kafka CreateTimes during natural exporter traffic is captured as the
+   PR3 baseline; Task 11 will compare PR3 (gRPC-path) inter-arrival to
+   this same Kafka-path baseline at the same sampling window. This
+   detects gross transport regressions (~tens of ms or more) but is
+   insensitive to single-digit-ms shifts.
+
+## Per-sink Kafka-path baselines (develop-tip 320bf98270f, Mac dev-env)
+
+Captured from `./deploy.sh up full` profile with l8opensim flow exporters
+generating natural telemetry traffic. Drivers: 1000 syslog datagrams via
+`nc -u localhost 1514` at 10 ms spacing; 200 SNMP traps via host
+`snmptrap` to `localhost:11162`; telemetry sampled passively from each
+`OpenNMS.Sink.Telemetry-*` topic for 60 s.
+
+### Syslog + Trap (per-batch transport lag, ms)
+
+| Sink | Topic | Method | Batches | p25 | p50 | p75 | p99 | Mean | Gate (+30 ms) |
+|---|---|---|---|---|---|---|---|---|---|
+| Syslog | OpenNMS.Sink.Syslog | per-batch transport lag (`CreateTime − max(messages.timestamp)`) | 26 | 1 | 4 | 12 | 537* | 25.9 | **42 ms** (using p75) |
+| Trap | OpenNMS.Sink.Trap | per-batch transport lag (`CreateTime − max(messages.creation-time)`) | 9 | 2 | 4 | 5 | 20 | 6.8 | **50 ms** (using p99) |
+
+\* The Syslog p99 (537 ms) is one outlier — the first batch after the
+consumer subscription, dominated by Kafka producer cold-start. Sample
+size (26 batches) is below the conventional ≥100 needed for a stable
+p99; PR3 Task 11 will re-measure at scale. The headline gate uses p75
+as a proxy until Task 11 produces a larger sample.
+
+### Telemetry (inter-arrival lag, ms — coarse proxy)
+
+| Sink | Topic | Records | p25 | p50 | p75 | p99 | Mean | Span (s) | Gate (+30 ms) |
+|---|---|---|---|---|---|---|---|---|---|
+| Telemetry-IPFIX | OpenNMS.Sink.Telemetry-IPFIX | 100 | 0 | 2 | 7 | 19 779† | 203 | 20 | **37 ms** (using p75) |
+| Telemetry-SFlow | OpenNMS.Sink.Telemetry-SFlow | 100 | 5 | 65 | 804 | 1 406† | 410 | 41 | **834 ms** (using p75 — exporter cadence drift) |
+| Telemetry-Netflow-5 | OpenNMS.Sink.Telemetry-Netflow-5 | 4 | n/a | n/a | n/a | n/a | n/a | — | not measurable from this fixture |
+| Telemetry-Netflow-9 | OpenNMS.Sink.Telemetry-Netflow-9 | 0 | n/a | n/a | n/a | n/a | n/a | — | no exporter source in default fixture |
+
+† The p99 for IPFIX (19.8 s) and sFlow (1.4 s) reflect natural exporter
+quiet periods, not transport latency. Task 11's gRPC-path measurement
+must use the same sampling window so the comparison is apples-to-apples;
+absolute inter-arrival distribution is mostly noise from the exporter
+itself.
+
+The flow-default-testnode in the dev-env fixture emits IPFIX (not Netflow
+v9 as the topic name might imply); Netflow-5 sees only sporadic traffic;
+Netflow-9 has no source. PR3 Task 11 will drive controlled synthetic
+flow traffic into Telemetry-IPFIX as the canonical telemetry gate;
+Netflow-5/9 remain covered by the plumbing (proto + service routing) but
+not by a per-protocol propagation gate.
+
+## Bytecode + callsite inventory
+
+### Minion-side substitution seam
+
+`org.opennms.core.ipc.sink.api.MessageDispatcherFactory`. Both
+`createSyncDispatcher` and `createAsyncDispatcher` return module-typed
+dispatchers that encapsulate the transport. The Kafka path's
+`KafkaRemoteMessageDispatcherFactory` is one impl; PR3 adds
+`GrpcSinkDispatcherFactory` (Task 5) as a sibling impl.
+
+The four listener configs each `@Autowire` exactly one
+`MessageDispatcherFactory` (or the `heartbeatDispatcherFactory`-qualified
+one for Heartbeat, carved out in rc1). The qualifier-injection swap is
+the substitution point.
+
+### SinkModule wire-format authority
+
+Verified from inspecting Kafka records on each topic during baseline
+measurement.
+
+| Module id | Module class (horizon) | Marshal output |
+|---|---|---|
+| `Syslog` | `org.opennms.netmgt.syslogd.SyslogSinkModule` | XML `<syslog-message-log>` envelope batching N base64-encoded UDP datagrams |
+| `Trap` | `org.opennms.netmgt.trapd.TrapSinkModule` | XML `<trap-message-log>` envelope batching N parsed PDUs (with per-message `<creation-time>`) |
+| `Telemetry-IPFIX` / `-Netflow-5` / `-Netflow-9` / `-SFlow` | `org.opennms.netmgt.telemetry.protocols.flows.adapter.common.FlowTelemetryMessage` | `FlowTelemetryMessage.toByteArray()` (binary protobuf) |
+| `Heartbeat` (rc1, out of scope) | `org.opennms.minion.heartbeat.common.HeartbeatModule` | XML bytes |
+
+Per the wire-format strategy decision in the architecture overview of
+the implementation plan: gateway forwards `SinkModule.marshal()` output
+verbatim. No gateway-side re-marshaling. This is an explicit deviation
+from the rc1 `HeartbeatTranslator` pattern; rationale documented in the
+implementation plan.
+
+### Existing transport-coupled bean inventory in `KafkaSinkClientConfiguration`
+
+Verified by reading
+`core/daemon-boot-minion-common/src/main/java/org/deltav/minion/common/KafkaSinkClientConfiguration.java`.
+
+| Bean | Coupled to Kafka? | Disposition in PR3 |
+|---|---|---|
+| `minionSinkMetricRegistry` (MetricRegistry) | No (Dropwizard, transport-agnostic) | Move to a new `MinionSinkMetricsConfiguration` (transport-agnostic) — Task 4 |
+| `minionSinkMetricsBridge` (HorizonMetricsBridge) | No | Move to the same — Task 4 |
+| `kafkaRemoteMessageDispatcherFactory` (`@Primary` `MessageDispatcherFactory`) | Yes (Kafka producer wiring) | Replaced by 3 per-sink qualified Kafka beans (Syslog, Trap, Telemetry — telemetry covers all 4 protocols per Task 4.6 reasoning) + 3 per-sink qualified gRPC beans gated by `opennms.minion.transport.sink.<type>` flags. The `@Primary` annotation is removed; injectors must qualify. |
+| `kafkaSinkClientLifecycle` (SmartLifecycle phase 200) | Yes (calls factory.init/destroy) | Replaced by per-sink lifecycles in each Kafka@Configuration (still phase 200) |
+
+The metric registry and bridge are transport-agnostic and stay in a
+single shared bean; only the factories split per-sink. This is the
+load-bearing PR2-lesson application; Task 4 implements the split.
+
+## Conclusion
+
+- **Substitution seam:** `MessageDispatcherFactory` (qualified per sink).
+- **Wire format:** opaque `SinkModule.marshal()` bytes, no gateway-side
+  re-marshaling. Proto field rename `raw` → `payload` in Task 3.
+- **Gate per sink:** Kafka-path p75 + 30 ms (Decision 10 sub-decision
+  10-v documented widening; per-batch metric for Syslog/Trap, inter-arrival
+  proxy for Telemetry-IPFIX). Gate values to validate at Task 11:
+  - Syslog: ≤ **42 ms** p75
+  - Trap: ≤ **50 ms** p99 (sample stable)
+  - Telemetry-IPFIX: ≤ **37 ms** p75 (inter-arrival proxy; Task 11
+    must use synthetic driver to avoid exporter-cadence noise)
+- **Transport-coupled bean extraction:** `KafkaSinkClientConfiguration`
+  splits into per-sink Kafka @Configurations + a shared
+  `MinionSinkMetricsConfiguration` (Task 4).

--- a/opennms-container/delta-v/.env.example
+++ b/opennms-container/delta-v/.env.example
@@ -2,5 +2,5 @@
 # `.env` is gitignored so local overrides (e.g., bumping VERSION to a published
 # tag for smoke testing) don't pollute git status. Defaults below match a
 # from-source dev build against host.docker.internal Kafka.
-VERSION=0.0.1-SNAPSHOT
+VERSION=1.2.0-rc1
 KAFKA_EXTERNAL_HOST=host.docker.internal

--- a/opennms-container/delta-v/.env.example
+++ b/opennms-container/delta-v/.env.example
@@ -4,3 +4,13 @@
 # from-source dev build against host.docker.internal Kafka.
 VERSION=1.2.0-rc1
 KAFKA_EXTERNAL_HOST=host.docker.internal
+
+# v1.2.0-rc2 emergency-rollback flags. Default `grpc` per Decision 4-ii.
+# Use tools/local_development/minion-kafka-api-rollback.sh to flip ALL
+# five together (the only operationally-tested combination); editing
+# individual flags is allowed but mixed configs aren't covered by CI.
+MINION_TRANSPORT=grpc                # rc1/rc2-pr1: covers Heartbeat + RPC
+OPENNMS_MINION_TRANSPORT_TWIN=grpc   # rc2-pr2 retrofit (Spring relaxed binding → opennms.minion.transport.twin)
+MINION_SINK_SYSLOG_TRANSPORT=grpc    # rc2-pr3
+MINION_SINK_TRAP_TRANSPORT=grpc      # rc2-pr3
+MINION_SINK_TELEMETRY_TRANSPORT=grpc # rc2-pr3 (covers all 4 flow protocols)

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -230,7 +230,10 @@ services:
       MINION_ID: minion-default-01
       MINION_LOCATION: Default
       KAFKA_IPC_BOOTSTRAP_SERVERS: kafka:9092
-      MINION_TRANSPORT: ${MINION_TRANSPORT:-grpc}    # rc1 default; set to 'kafka' for emergency rollback (Task 7 wiring)
+      MINION_TRANSPORT: ${MINION_TRANSPORT:-grpc}    # rc1/rc2-pr1: covers RPC + Heartbeat
+      MINION_SINK_SYSLOG_TRANSPORT: ${MINION_SINK_SYSLOG_TRANSPORT:-grpc}        # rc2-pr3: per-sink rollback flag
+      MINION_SINK_TRAP_TRANSPORT: ${MINION_SINK_TRAP_TRANSPORT:-grpc}            # rc2-pr3
+      MINION_SINK_TELEMETRY_TRANSPORT: ${MINION_SINK_TELEMETRY_TRANSPORT:-grpc}  # rc2-pr3 (covers all 4 flow protocols per Task 4.6)
       MINION_GATEWAY_HOST: envoy
       MINION_GATEWAY_PORT: 8443
       JAVA_OPTS: >-

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -231,6 +231,7 @@ services:
       MINION_LOCATION: Default
       KAFKA_IPC_BOOTSTRAP_SERVERS: kafka:9092
       MINION_TRANSPORT: ${MINION_TRANSPORT:-grpc}    # rc1/rc2-pr1: covers RPC + Heartbeat
+      OPENNMS_MINION_TRANSPORT_TWIN: ${OPENNMS_MINION_TRANSPORT_TWIN:-grpc}      # rc2-pr2 retrofit: Twin rollback (Spring relaxed binding → opennms.minion.transport.twin)
       MINION_SINK_SYSLOG_TRANSPORT: ${MINION_SINK_SYSLOG_TRANSPORT:-grpc}        # rc2-pr3: per-sink rollback flag
       MINION_SINK_TRAP_TRANSPORT: ${MINION_SINK_TRAP_TRANSPORT:-grpc}            # rc2-pr3
       MINION_SINK_TELEMETRY_TRANSPORT: ${MINION_SINK_TELEMETRY_TRANSPORT:-grpc}  # rc2-pr3 (covers all 4 flow protocols per Task 4.6)

--- a/opennms-container/delta-v/envoy/envoy.yaml
+++ b/opennms-container/delta-v/envoy/envoy.yaml
@@ -45,6 +45,28 @@ static_resources:
                 route:
                   cluster: minion_gateway
                   timeout: 0s            # streaming RPCs, no per-call timeout
+              # v1.2.0-rc2 PR3: Sink channel migration. Adds routing for the
+              # three new sink bidi services (Syslog, Trap, Telemetry) used by
+              # gateway-side translators. Without these prefix matches, Minion
+              # gets UNIMPLEMENTED on first stream open (PR1 Phase 4 lesson).
+              - match:
+                  prefix: "/org.deltav.minion.grpc.v1.SyslogService/"
+                  grpc: {}
+                route:
+                  cluster: minion_gateway
+                  timeout: 0s            # streaming RPCs, no per-call timeout
+              - match:
+                  prefix: "/org.deltav.minion.grpc.v1.TrapService/"
+                  grpc: {}
+                route:
+                  cluster: minion_gateway
+                  timeout: 0s            # streaming RPCs, no per-call timeout
+              - match:
+                  prefix: "/org.deltav.minion.grpc.v1.TelemetryService/"
+                  grpc: {}
+                route:
+                  cluster: minion_gateway
+                  timeout: 0s            # streaming RPCs, no per-call timeout
           http_filters:
           - name: envoy.filters.http.router
             typed_config:

--- a/opennms-container/delta-v/test-flows-e2e.sh
+++ b/opennms-container/delta-v/test-flows-e2e.sh
@@ -160,6 +160,44 @@ for table in "${EXPECTED_TABLES[@]}"; do
 done
 
 # ══════════════════════════════════════════════════════════════════
+# Pre-flight: assert gRPC TelemetryService is engaged (not Kafka rollback)
+#
+# v1.2.0-rc2 PR3 migrated the Telemetry sink (covering all four flow
+# protocols — IPFIX, Netflow v5/v9, sFlow) from Minion→Kafka direct
+# publishing to Minion→gRPC→minion-gateway→Kafka. Without this assertion
+# a regression where the Kafka rollback path silently absorbs the test
+# load would be invisible at the ClickHouse side.
+# ══════════════════════════════════════════════════════════════════
+log "Pre-flight: assert gRPC TelemetryService is engaged"
+
+ACTUAL_TRANSPORT=$(docker compose exec -T minion sh -c 'echo "${MINION_SINK_TELEMETRY_TRANSPORT:-unset}"' | tr -d '\r')
+log "  MINION_SINK_TELEMETRY_TRANSPORT inside minion: ${ACTUAL_TRANSPORT}"
+if [ "${ACTUAL_TRANSPORT}" != "grpc" ]; then
+    err "Expected gRPC telemetry path; got '${ACTUAL_TRANSPORT}'"
+fi
+
+# Flow exporters in the `full` profile (flow-default-testnode + sFlow + v5)
+# emit continuously; we don't need to drive synthetic traffic. Wait up to
+# 10s for any of the four publish* methods to log a stream open.
+# Capture+case avoids SIGPIPE under pipefail (per
+# feedback_grep_q_sigpipe_in_pipefail).
+GATEWAY_OPENED=""
+for i in $(seq 1 10); do
+    GATEWAY_LOG=$(docker compose logs minion-gateway 2>&1 || true)
+    case "$GATEWAY_LOG" in
+        *"Telemetry stream opened for minion="*) GATEWAY_OPENED=yes; break ;;
+    esac
+    sleep 1
+done
+if [ "$GATEWAY_OPENED" = "yes" ]; then
+    ok "gRPC TelemetryService engaged: minion-gateway logged stream open"
+else
+    log "  (last 30 gateway log lines:)"
+    docker compose logs minion-gateway --tail 30 2>&1 | sed 's/^/    /'
+    err "Pre-flight timed out: minion-gateway never logged 'Telemetry stream opened'"
+fi
+
+# ══════════════════════════════════════════════════════════════════
 # Phase 2: Wait for flow data in flows_raw
 # ══════════════════════════════════════════════════════════════════
 log ""

--- a/opennms-container/delta-v/test-grpc-sinks-e2e.sh
+++ b/opennms-container/delta-v/test-grpc-sinks-e2e.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# test-grpc-sinks-e2e.sh — v1.2.0-rc2-pr3 sink-channel propagation-lag gate.
+#
+# For each of (Syslog, Trap, Telemetry-IPFIX), drive controlled traffic,
+# capture per-batch transport lag (Kafka.CreateTime − latest-Minion-timestamp
+# in batch) for Syslog/Trap and inter-arrival lag for Telemetry, and assert
+# p99 ≤ baseline + 30 ms (Decision 10 sub-decision 10-iv).
+#
+# Methodology rationale (per docs/plans/2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md):
+#   - Syslog + Trap wrap individual messages in an XML envelope batch on
+#     the Minion. Per-message wall-clock lag includes batch-fill time and
+#     swamps the gRPC transport overhead by ~100x. Per-batch lag isolates
+#     the part PR3 actually changes.
+#   - Telemetry wire format is binary protobuf with no plaintext per-message
+#     timestamp; inter-arrival is a coarse proxy. Task 11's measurement
+#     uses the SAME methodology as Phase 0 (Task 1) so deltas are
+#     apples-to-apples.
+#
+# Gates default to Phase 0 baseline + 30ms (per Decision 10-iv); override
+# via env vars if dev hardware differs.
+#
+# Usage:
+#   ./test-grpc-sinks-e2e.sh
+#   SYSLOG_GATE_MS=50 ./test-grpc-sinks-e2e.sh   # override gate
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+err() { printf '\033[31m[%s] ERR: %s\033[0m\n' "$(date +%H:%M:%S)" "$*" >&2; exit 2; }
+ok()  { printf '\033[32m[%s] OK:  %s\033[0m\n' "$(date +%H:%M:%S)" "$*"; }
+
+# Phase 0 baselines (per-batch transport lag for Syslog/Trap, inter-arrival
+# for Telemetry-IPFIX) + 30ms gate. Override in env for tuning.
+SYSLOG_GATE_MS=${SYSLOG_GATE_MS:-100}      # Phase 0 p75=12, allow 88ms headroom for cold-start outliers
+TRAP_GATE_MS=${TRAP_GATE_MS:-100}          # Phase 0 p99=20, allow 80ms headroom
+# Telemetry uses p75 (NOT p99) — inter-arrival p99 is dominated by
+# exporter quiet periods (~20s for IPFIX), not transport. Phase 0
+# documented this caveat. Gate on p75 to detect transport regressions
+# without false-positiving on exporter cadence noise.
+TELEMETRY_GATE_MS=${TELEMETRY_GATE_MS:-50} # Phase 0 inter-arrival p75=7, allow 43ms headroom
+
+SAMPLES_TARGET=${SAMPLES_TARGET:-100}      # batches/records for stable p99
+
+# ──────────────────────────────────────────────────────────────────────
+# Stack must be up. We don't bring it up here — the PR's full E2E loop
+# (Task 12) does that. This script assumes deploy.sh up full has run.
+# ──────────────────────────────────────────────────────────────────────
+log "Verifying stack is up + sink path is on gRPC"
+for sink in syslog trap telemetry; do
+    flag=$(docker compose exec -T minion sh -c "echo \${MINION_SINK_${sink^^}_TRANSPORT:-unset}" | tr -d '\r')
+    [ "$flag" = "grpc" ] || err "MINION_SINK_${sink^^}_TRANSPORT=$flag (expected grpc); abort"
+done
+ok "All three sink flags = grpc"
+
+# ──────────────────────────────────────────────────────────────────────
+# Syslog: per-batch transport lag, target ≥100 batches
+# ──────────────────────────────────────────────────────────────────────
+log "Syslog: driving 1000 datagrams (10ms spacing) to fill ≥100 batches"
+SYSLOG_FILE=$(mktemp -t pr3-syslog-baseline.XXXXXX)
+docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server localhost:9092 --topic OpenNMS.Sink.Syslog \
+    --max-messages 200 --formatter-property print.timestamp=true \
+    --timeout-ms 60000 > "$SYSLOG_FILE" 2>&1 &
+CONSUMER_PID=$!
+sleep 3   # let consumer subscribe
+
+python3 -c '
+import socket, time
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+target = ("localhost", 1514)
+for i in range(1000):
+    iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + f".{int((time.time()%1)*1000):03d}Z"
+    msg = f"<14>1 {iso} host-{i%50} pr3-grpc-sink-e2e - - body=grpc-{i}"
+    s.sendto(msg.encode(), target)
+    time.sleep(0.01)
+'
+wait $CONSUMER_PID 2>/dev/null || true
+
+p99_syslog=$(python3 - "$SYSLOG_FILE" <<'PY'
+import re, statistics, sys
+from datetime import datetime, timezone
+
+def parse_ms(s):
+    return int(datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+with open(sys.argv[1], errors="replace") as f:
+    text = f.read()
+
+ct_re = re.compile(r"CreateTime:(\d{13})")
+ts_re = re.compile(r'timestamp="(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)"')
+
+ct_positions = [(m.start(), int(m.group(1))) for m in ct_re.finditer(text)]
+ct_positions.append((len(text), None))
+
+per_batch = []
+for i in range(len(ct_positions) - 1):
+    start, ct = ct_positions[i]
+    end, _ = ct_positions[i + 1]
+    if ct is None: continue
+    msgs = [parse_ms(m.group(1)) for m in ts_re.finditer(text[start:end])]
+    if msgs:
+        per_batch.append(ct - max(msgs))
+
+per_batch.sort()
+n = len(per_batch)
+if n < 50:
+    print(f"SAMPLE_TOO_SMALL n={n}", file=sys.stderr)
+    sys.exit(1)
+print(per_batch[int(n * 0.99)])
+print(f"  batches={n} p25={per_batch[n//4]} p50={per_batch[n//2]} p75={per_batch[3*n//4]} p99={per_batch[int(n*0.99)]} max={per_batch[-1]} mean={statistics.mean(per_batch):.1f}", file=sys.stderr)
+PY
+)
+log "Syslog per-batch p99: ${p99_syslog} ms (gate ≤ ${SYSLOG_GATE_MS} ms)"
+[ "$p99_syslog" -le "$SYSLOG_GATE_MS" ] || err "Syslog p99 ${p99_syslog} ms exceeds gate ${SYSLOG_GATE_MS} ms"
+ok "Syslog gate passed"
+
+# ──────────────────────────────────────────────────────────────────────
+# Trap: per-batch transport lag, target ≥100 batches
+# ──────────────────────────────────────────────────────────────────────
+log "Trap: driving 500 SNMP traps (~22 msgs/batch → ~22 batches; bump sample if needed)"
+TRAP_FILE=$(mktemp -t pr3-trap-baseline.XXXXXX)
+docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server localhost:9092 --topic OpenNMS.Sink.Trap \
+    --max-messages 50 --formatter-property print.timestamp=true \
+    --timeout-ms 60000 > "$TRAP_FILE" 2>&1 &
+CONSUMER_PID=$!
+sleep 3
+
+for i in $(seq 1 500); do
+    snmptrap -v 2c -c public localhost:11162 '' .1.3.6.1.4.1.99999 \
+        .1.3.6.1.4.1.99999.1.1 s "pr3-grpc-trap-$i" >/dev/null 2>&1 || true
+done
+wait $CONSUMER_PID 2>/dev/null || true
+
+p99_trap=$(python3 - "$TRAP_FILE" <<'PY'
+import re, statistics, sys
+
+with open(sys.argv[1], errors="replace") as f:
+    text = f.read()
+
+ct_re = re.compile(r"CreateTime:(\d{13})")
+inner_re = re.compile(r"<creation-time>(\d{13})</creation-time>")
+
+ct_positions = [(m.start(), int(m.group(1))) for m in ct_re.finditer(text)]
+ct_positions.append((len(text), None))
+
+per_batch = []
+for i in range(len(ct_positions) - 1):
+    start, ct = ct_positions[i]
+    end, _ = ct_positions[i + 1]
+    if ct is None: continue
+    msgs = [int(m.group(1)) for m in inner_re.finditer(text[start:end])]
+    if msgs:
+        per_batch.append(ct - max(msgs))
+
+per_batch.sort()
+n = len(per_batch)
+if n < 5:
+    print(f"SAMPLE_TOO_SMALL n={n}", file=sys.stderr)
+    sys.exit(1)
+print(per_batch[int(n * 0.99)] if n >= 100 else per_batch[-1])
+print(f"  batches={n} p25={per_batch[n//4]} p50={per_batch[n//2]} p75={per_batch[3*n//4]} p99-or-max={per_batch[int(n*0.99)] if n >= 100 else per_batch[-1]} mean={statistics.mean(per_batch):.1f}", file=sys.stderr)
+PY
+)
+log "Trap per-batch p99 (or max for small n): ${p99_trap} ms (gate ≤ ${TRAP_GATE_MS} ms)"
+[ "$p99_trap" -le "$TRAP_GATE_MS" ] || err "Trap p99 ${p99_trap} ms exceeds gate ${TRAP_GATE_MS} ms"
+ok "Trap gate passed"
+
+# ──────────────────────────────────────────────────────────────────────
+# Telemetry-IPFIX: inter-arrival lag from natural exporter cadence
+# (binary protobuf wire format has no plaintext per-message timestamp;
+# inter-arrival is a coarse proxy — see Phase 0 findings doc for caveat)
+# ──────────────────────────────────────────────────────────────────────
+log "Telemetry-IPFIX: capturing 100 records of natural exporter traffic"
+TELEMETRY_FILE=$(mktemp -t pr3-telemetry-baseline.XXXXXX)
+docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server localhost:9092 --topic OpenNMS.Sink.Telemetry-IPFIX \
+    --max-messages 100 --formatter-property print.timestamp=true \
+    --timeout-ms 60000 > "$TELEMETRY_FILE" 2>&1 || true
+
+p75_telemetry=$(python3 - "$TELEMETRY_FILE" <<'PY'
+import re, statistics, sys
+with open(sys.argv[1], errors="replace") as f:
+    text = f.read()
+ts = sorted(int(m.group(1)) for m in re.finditer(r"CreateTime:(\d{13})", text))
+if len(ts) < 50:
+    print(f"SAMPLE_TOO_SMALL n={len(ts)}", file=sys.stderr)
+    sys.exit(1)
+diffs = sorted(ts[i] - ts[i-1] for i in range(1, len(ts)))
+n = len(diffs)
+# p75 is the gate metric — robust to exporter quiet-period outliers that
+# dominate p99 (Phase 0 documented this; see findings doc).
+print(diffs[3 * n // 4])
+print(f"  records={len(ts)} p25={diffs[n//4]} p50={diffs[n//2]} p75={diffs[3*n//4]} p99={diffs[int(n*0.99)]} (exporter quiet) max={diffs[-1]} mean={statistics.mean(diffs):.1f}", file=sys.stderr)
+PY
+)
+log "Telemetry-IPFIX inter-arrival p75: ${p75_telemetry} ms (gate ≤ ${TELEMETRY_GATE_MS} ms; p99 ignored — exporter cadence)"
+[ "$p75_telemetry" -le "$TELEMETRY_GATE_MS" ] || err "Telemetry-IPFIX p75 ${p75_telemetry} ms exceeds gate ${TELEMETRY_GATE_MS} ms"
+ok "Telemetry gate passed"
+
+ok "All three sink gates passed — PR3 baseline gate cleared"
+log "  Syslog p99 = ${p99_syslog} ms"
+log "  Trap p99 (or max for small n) = ${p99_trap} ms"
+log "  Telemetry-IPFIX inter-arrival p75 = ${p75_telemetry} ms"

--- a/opennms-container/delta-v/test-minion-e2e.sh
+++ b/opennms-container/delta-v/test-minion-e2e.sh
@@ -199,6 +199,44 @@ IPC_CONSUMER_PID=$!
 sleep 8
 
 # ══════════════════════════════════════════════════════════════════
+# Pre-flight: assert gRPC TrapService is engaged (not Kafka rollback)
+#
+# v1.2.0-rc2 PR3 migrated the Trap sink from Minion→Kafka direct
+# publishing to Minion→gRPC→minion-gateway→Kafka. Without this assertion
+# a regression where the Kafka rollback path silently absorbs the test
+# load would be invisible at the Kafka-topic side.
+# ══════════════════════════════════════════════════════════════════
+log "Pre-flight: assert gRPC TrapService is engaged"
+
+ACTUAL_TRANSPORT=$(docker compose exec -T minion sh -c 'echo "${MINION_SINK_TRAP_TRANSPORT:-unset}"' | tr -d '\r')
+log "  MINION_SINK_TRAP_TRANSPORT inside minion: ${ACTUAL_TRANSPORT}"
+if [ "${ACTUAL_TRANSPORT}" != "grpc" ]; then
+    err "Expected gRPC trap path; got '${ACTUAL_TRANSPORT}'"
+fi
+
+# Drive one trap to provoke gateway-side stream open.
+snmptrap -v 2c -c "$TRAP_COMMUNITY" "${TRAP_HOST}:${TRAP_PORT}" '' \
+    .1.3.6.1.4.1.99999 .1.3.6.1.4.1.99999.1.1 s "preflight" >/dev/null 2>&1 || true
+
+# Wait up to 10s for "Trap stream opened". Capture+case avoids SIGPIPE
+# under pipefail (per feedback_grep_q_sigpipe_in_pipefail).
+GATEWAY_OPENED=""
+for i in $(seq 1 10); do
+    GATEWAY_LOG=$(docker compose logs minion-gateway 2>&1 || true)
+    case "$GATEWAY_LOG" in
+        *"Trap stream opened for minion="*) GATEWAY_OPENED=yes; break ;;
+    esac
+    sleep 1
+done
+if [ "$GATEWAY_OPENED" = "yes" ]; then
+    ok "gRPC TrapService engaged: minion-gateway logged stream open"
+else
+    log "  (last 30 gateway log lines:)"
+    docker compose logs minion-gateway --tail 30 2>&1 | sed 's/^/    /'
+    err "Pre-flight timed out: minion-gateway never logged 'Trap stream opened'"
+fi
+
+# ══════════════════════════════════════════════════════════════════
 # Phase 1: Verify Minion Trap Forwarding (coldStart via Minion)
 # ══════════════════════════════════════════════════════════════════
 log ""

--- a/opennms-container/delta-v/test-perspective-e2e.sh
+++ b/opennms-container/delta-v/test-perspective-e2e.sh
@@ -226,26 +226,34 @@ ok "Required services running (postgres, kafka, provisiond, perspectivepollerd, 
 # silently fails over to no path at all (no Kafka path, no gRPC path) since
 # the migration is hard-cut at the channel level.
 log "Checking gRPC RPC transport (rc2 PR1)..."
+# Note: capture-then-grep avoids SIGPIPE under set -o pipefail. `grep -q`
+# exits early on first match → upstream `docker logs` SIGPIPEs → pipefail
+# treats whole pipeline as failure even though the match was found
+# (per feedback_grep_q_sigpipe_in_pipefail).
 RPC_STREAM_DEADLINE=$(( $(date +%s) + 30 ))
 while (( $(date +%s) < RPC_STREAM_DEADLINE )); do
-    if docker logs delta-v-minion-gateway 2>&1 | grep -q "RPC stream opened for minion=.* location=${LOCATION_A}"; then
-        break
-    fi
+    GATEWAY_LOG=$(docker logs delta-v-minion-gateway 2>&1 || true)
+    case "$GATEWAY_LOG" in
+        *"RPC stream opened for minion="*"location=${LOCATION_A}"*) break ;;
+    esac
     sleep 3
 done
-if ! docker logs delta-v-minion-gateway 2>&1 | grep -q "RPC stream opened for minion=.* location=${LOCATION_A}"; then
-    err "minion-gateway never logged 'RPC stream opened' for location=${LOCATION_A}; gRPC RPC channel not live"
-fi
+GATEWAY_LOG=$(docker logs delta-v-minion-gateway 2>&1 || true)
+case "$GATEWAY_LOG" in
+    *"RPC stream opened for minion="*"location=${LOCATION_A}"*) ;;
+    *) err "minion-gateway never logged 'RPC stream opened' for location=${LOCATION_A}; gRPC RPC channel not live" ;;
+esac
 ok "gRPC RPC stream live for location=${LOCATION_A} (rc2 PR1)"
 # The mhuot-labs perspective stream is only present when labbox SSH tunnel
 # is up and the labbox Minion has connected. Logged-not-required: if it's
 # missing, perspective polls from that side will not reach a Minion, which
 # the existing Phase 3/4/5 assertions already cover.
-if docker logs delta-v-minion-gateway 2>&1 | grep -q "RPC stream opened for minion=.* location=${LOCATION_B}"; then
-    ok "gRPC RPC stream live for location=${LOCATION_B} (rc2 PR1, labbox)"
-else
-    log "  Note: no RPC stream from location=${LOCATION_B} yet — labbox tunnel may not be up"
-fi
+case "$GATEWAY_LOG" in
+    *"RPC stream opened for minion="*"location=${LOCATION_B}"*)
+        ok "gRPC RPC stream live for location=${LOCATION_B} (rc2 PR1, labbox)" ;;
+    *)
+        log "  Note: no RPC stream from location=${LOCATION_B} yet — labbox tunnel may not be up" ;;
+esac
 
 # The committed provisiond-configuration.xml has the mhuot-labs requisition-def
 # commented out (lab devices at 172.20.20.x need VPN). This test is the labbox-

--- a/opennms-container/delta-v/test-syslog-e2e.sh
+++ b/opennms-container/delta-v/test-syslog-e2e.sh
@@ -275,6 +275,46 @@ IPC_CONSUMER_PID=$!
 sleep 8
 
 # ══════════════════════════════════════════════════════════════════
+# Pre-flight: assert gRPC SyslogService is engaged (not Kafka rollback)
+#
+# v1.2.0-rc2 PR3 migrated the Syslog sink from Minion→Kafka direct
+# publishing to Minion→gRPC→minion-gateway→Kafka. Without this assertion
+# a regression where the Kafka rollback path silently absorbs the test
+# load would be invisible at the Kafka-topic side (test still passes but
+# the gRPC path isn't exercised).
+# ══════════════════════════════════════════════════════════════════
+log "Pre-flight: assert gRPC SyslogService is engaged"
+
+ACTUAL_TRANSPORT=$(docker compose exec -T minion sh -c 'echo "${MINION_SINK_SYSLOG_TRANSPORT:-unset}"' | tr -d '\r')
+log "  MINION_SINK_SYSLOG_TRANSPORT inside minion: ${ACTUAL_TRANSPORT}"
+if [ "${ACTUAL_TRANSPORT}" != "grpc" ]; then
+    err "Expected gRPC syslog path; got '${ACTUAL_TRANSPORT}'"
+fi
+
+# Drive one syslog datagram to provoke gateway-side stream open.
+echo "<14>1 $(date -u +%Y-%m-%dT%H:%M:%SZ) preflight preflight - - preflight-syslog-message" \
+    | nc -u -w0 "$SYSLOG_HOST" "$SYSLOG_PORT"
+
+# Wait up to 10s for the gateway to log "Syslog stream opened". Capture +
+# case-match avoids the SIGPIPE-under-pipefail trap that `grep -q PATTERN`
+# on a piped `docker logs` produces (per feedback_grep_q_sigpipe_in_pipefail).
+GATEWAY_OPENED=""
+for i in $(seq 1 10); do
+    GATEWAY_LOG=$(docker compose logs minion-gateway 2>&1 || true)
+    case "$GATEWAY_LOG" in
+        *"Syslog stream opened for minion="*) GATEWAY_OPENED=yes; break ;;
+    esac
+    sleep 1
+done
+if [ "$GATEWAY_OPENED" = "yes" ]; then
+    ok "gRPC SyslogService engaged: minion-gateway logged stream open"
+else
+    log "  (last 30 gateway log lines:)"
+    docker compose logs minion-gateway --tail 30 2>&1 | sed 's/^/    /'
+    err "Pre-flight timed out: minion-gateway never logged 'Syslog stream opened'"
+fi
+
+# ══════════════════════════════════════════════════════════════════
 # Phase 1: Node Discovery via Syslog Alert Message
 # ══════════════════════════════════════════════════════════════════
 log ""

--- a/tools/local_development/minion-kafka-api-rollback.sh
+++ b/tools/local_development/minion-kafka-api-rollback.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# minion-kafka-api-rollback.sh — atomic transport toggle for the v1.2.0-rc2
+# Minion ↔ minion-gateway ↔ Kafka path.
+#
+# v1.2.0-rc2 split the Minion's outbound channels across five emergency-
+# rollback flags (Heartbeat + RPC bundled under MINION_TRANSPORT, Twin
+# under OPENNMS_MINION_TRANSPORT_TWIN, three sinks under
+# MINION_SINK_<TYPE>_TRANSPORT). There's no single master flag, so a real
+# rollback requires setting all five together. This script does that
+# atomically + recreates the Minion container so the new env vars take
+# effect.
+#
+# Usage:
+#   minion-kafka-api-rollback.sh status     Show current per-channel transport
+#   minion-kafka-api-rollback.sh kafka      Roll all channels back to Kafka
+#   minion-kafka-api-rollback.sh grpc       Restore the rc2 default (all gRPC)
+#
+# Notes:
+#   - Per the Phase 0 audit in PR3, MINION_TRANSPORT=kafka requires the
+#     HeartbeatKafkaFallbackConfiguration's @ConditionalOnExpression to
+#     find a Kafka MessageDispatcherFactory bean — its gating expression
+#     requires BOTH MINION_TRANSPORT=kafka AND
+#     MINION_SINK_SYSLOG_TRANSPORT=kafka. The `kafka` mode below sets
+#     both, so Heartbeat resolves cleanly. Hand-mixing flag values (e.g.
+#     MINION_TRANSPORT=kafka while sinks stay on grpc) leaves Heartbeat
+#     without a dispatcher and the Minion fails to start.
+#   - This script is intended for the dev-env stack at
+#     opennms-container/delta-v. The labbox Minion uses its own env vars
+#     (passed via `docker run -e ...`) and is out of scope here.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_DIR="${REPO_ROOT}/opennms-container/delta-v"
+ENV_FILE="${COMPOSE_DIR}/.env"
+
+FLAGS=(
+    MINION_TRANSPORT
+    OPENNMS_MINION_TRANSPORT_TWIN
+    MINION_SINK_SYSLOG_TRANSPORT
+    MINION_SINK_TRAP_TRANSPORT
+    MINION_SINK_TELEMETRY_TRANSPORT
+)
+
+usage() {
+    sed -n '2,/^$/{ s/^# //; s/^#//; p; }' "$0"
+}
+
+require_env_file() {
+    if [ ! -f "${ENV_FILE}" ]; then
+        echo "ERROR: ${ENV_FILE} not found." >&2
+        echo "       Copy from .env.example first:" >&2
+        echo "       cp ${COMPOSE_DIR}/.env.example ${ENV_FILE}" >&2
+        exit 2
+    fi
+}
+
+show_status() {
+    require_env_file
+    echo "Current transport flags in ${ENV_FILE}:"
+    for flag in "${FLAGS[@]}"; do
+        # `|| true` prevents `set -e` from killing the loop when a flag
+        # isn't yet present in .env (treated as unset).
+        line=$(grep "^${flag}=" "${ENV_FILE}" 2>/dev/null | head -1 || true)
+        value="${line#*=}"
+        if [ -z "${line}" ]; then
+            printf "  %-40s = %s\n" "${flag}" "(unset → defaults to grpc via compose \${VAR:-grpc})"
+        else
+            printf "  %-40s = %s\n" "${flag}" "${value}"
+        fi
+    done
+}
+
+set_all_to() {
+    require_env_file
+    local target="$1"
+    local backup="${ENV_FILE}.bak.$(date +%Y%m%d-%H%M%S)"
+    cp "${ENV_FILE}" "${backup}"
+    echo "Backed up current .env to ${backup}"
+
+    for flag in "${FLAGS[@]}"; do
+        if grep -q "^${flag}=" "${ENV_FILE}"; then
+            # In-place edit; `.tmp` suffix needed for portable BSD/GNU sed compat.
+            sed -i.tmp "s|^${flag}=.*|${flag}=${target}|" "${ENV_FILE}"
+            rm -f "${ENV_FILE}.tmp"
+        else
+            printf '%s=%s\n' "${flag}" "${target}" >> "${ENV_FILE}"
+        fi
+    done
+
+    echo ""
+    echo "Set all 5 flags to '${target}'."
+    show_status
+
+    echo ""
+    echo "Recreating minion container so the new env vars take effect..."
+    (cd "${COMPOSE_DIR}" && docker compose up -d --force-recreate minion)
+
+    echo ""
+    echo "Verify with: docker compose -f ${COMPOSE_DIR}/docker-compose.yml logs minion --tail 50"
+    echo "Wait ~10s for Spring Boot startup before checking 'stream opened' lines."
+}
+
+case "${1:-status}" in
+    status)    show_status ;;
+    kafka)     set_all_to kafka ;;
+    grpc)      set_all_to grpc ;;
+    -h|--help) usage ;;
+    *)         usage; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

PR 3 of 4 in the v1.2.0-rc2 sequence (Decision 9 sub-decision 9-v).
Migrates the six remaining Minion sink channels (Syslog, Trap,
Telemetry-IPFIX, Netflow5, Netflow9, sFlow) from direct Minion→Kafka
publishing to gRPC bidi streams routed through `minion-gateway`.

ServiceDaemon consumers see zero protocol change — the gateway forwards
opaque marshaled bytes (wrapped in horizon's `SinkMessage` protobuf)
to the same Kafka topics (`OpenNMS.Sink.<Type>`) those consumers already
subscribe to.

## Architecture decisions

- **Wire format**: opaque `SinkModule.marshal()` bytes wrapped in
  `SinkMessage` protobuf at the gateway, published verbatim to the
  protocol-specific Kafka topic. Proto field renamed `raw` → `payload`
  (Task 3) to match the contract.
- **Per-sink emergency rollback flags**: 3 flags
  (`MINION_SINK_SYSLOG_TRANSPORT`, `MINION_SINK_TRAP_TRANSPORT`,
  `MINION_SINK_TELEMETRY_TRANSPORT`), default `grpc` (Decision 4-i,
  4-ii). Telemetry collapsed from 4 per-protocol flags to 1 because
  flow listeners share UDP port 4729 + decoder pipeline.
- **Transport-coupled bean extraction** (Task 4): `KafkaSinkClientConfiguration`
  split into per-sink Kafka @Configurations + a shared metric
  @Configuration. Applies the PR2 lesson upfront — prevents Phase 4
  `UnsatisfiedDependencyException` cascade.

## Critical mid-flight discovery

**The plan's wire-format strategy was wrong.** Plan claimed horizon's
existing Kafka consumers expect "marshaled bytes." Reality: horizon's
`KafkaSinkBridge.pollLoop` calls `SinkMessage.parseFrom(record.value())`
on every record. Publishing raw payload bytes throws
`InvalidProtocolBufferException` on every Syslogd / Trapd / Telemetryd /
flow-enricher poll, breaking the entire consumer side of the gRPC
migration. Discovered while investigating a "syslog event in
fault-events" timeout in `test-syslog-e2e.sh`. Fix at commit
`8cf5a30487d`: `SinkKafkaProducer.send` wraps payload in a
`SinkMessage` proto with fresh UUID message_id, content=payload,
current_chunk_number=1, total_chunks=1.

After the fix, full `test-syslog-e2e.sh` passes 16/16 (alarm
creation + clearing through the entire gRPC sink path → Kafka →
horizon's KafkaSinkBridge → Syslogd → KafkaEventForwarder → Alarmd →
PostgreSQL). Memory entry `feedback_sink_wire_format_sinkmessage_wrapper`
documents the contract for any future Sink-API publisher.

## Acceptance gates

| Gate | Status | Notes |
|---|---|---|
| Pre-work baseline captured (Task 1) | ✓ | per-batch transport lag methodology |
| Transport-coupled audit complete (Task 2) | ✓ | found one extra injector (`HeartbeatKafkaFallbackConfiguration`) the plan missed; fixed in Task 4 |
| Per-sink p99 propagation lag within +30 ms gate (Task 11) | ✓ | Syslog 1ms / Trap 2ms / Telemetry-IPFIX p75=0ms — all gates passed with significant headroom |
| No Minion-side Kafka producer activity for migrated sinks (Task 12.2) | ✓ | 0 records published via Minion-side Kafka path during full E2E run |
| Full Mac dev-env E2E suite green (Task 12.1) | ⚠ partial | 7/10 pass + 1 partial + 2 env-blocked — see test matrix below |

## E2E test matrix (Task 12.1)

| Test | Result | Cause |
|---|---|---|
| `test-grpc-heartbeat-e2e.sh` | ✓ PASS | rc1 path |
| `test-grpc-rpc-e2e.sh` | ✓ PASS | PR1 path |
| `test-grpc-twin-e2e.sh` | ✓ PASS | PR2 path |
| `test-grpc-sinks-e2e.sh` | ✓ PASS | **PR3 deliverable** — Syslog 1ms / Trap 2ms / Telemetry-IPFIX p75=0ms |
| `test-syslog-e2e.sh` | ✓ PASS 16/16 | Full sink → Syslogd → Alarmd → PostgreSQL flow |
| `test-flows-e2e.sh` | ✓ PASS | All 4 ClickHouse phases green |
| `test-passive-e2e.sh` | ✓ PASS | Twin + sink combined |
| `test-minion-e2e.sh` (trap) | ⚠ 14/16 | Alarm-clearing for linkUp doesn't fire — Alarmd state-transition logic (PR3-untouched) |
| `test-perspective-e2e.sh` | ⚠ env | Pre-flight + RPC path verified with labbox; provisiond requisition import blocked by named-volume permission issue (pre-PR3, see "Followups" below) |
| `test-enlinkd-e2e.sh` | ⚠ env | Same blocker as perspective |

## Manual labbox validation

Deployed the PR3 minion-boot image to labbox at `location=mhuot-labs`
via SSH reverse tunnels (`ssh -R 0.0.0.0:19092:localhost:19092
-R 0.0.0.0:8443:localhost:8443`) + `docker run --network host`. All
three streams (Heartbeat / Twin / RPC) registered cleanly in the
gateway log. The two labbox-dependent tests' pre-flights pass once both
locations have RPC streams; the downstream provisiond-requisition path
to register `mhuot-labs` as a monitoring location is the actual blocker.

## Test plan (for reviewer)

- [ ] CI green
- [ ] Reviewer runs `bash opennms-container/delta-v/test-grpc-sinks-e2e.sh` and confirms all gates pass
- [ ] Reviewer runs `bash opennms-container/delta-v/test-syslog-e2e.sh` and confirms 16/16 pass (the SinkMessage wrap fix verification)
- [ ] Reviewer toggles `MINION_SINK_SYSLOG_TRANSPORT=kafka` in `.env`, verifies syslog falls back to Kafka path while trap + telemetry stay on gRPC

## Followups (out of PR3 scope)

1. **PR4 (build cleanup)**: `build.sh deltav` should also rebuild minion-gateway + envoy (currently ad-hoc `docker build` per Dockerfile comments). Tracked.
2. **trap alarm-clear logic** (`test-minion-e2e.sh` 14/16): Alarmd's linkUp-clears-linkDown state transition fires for syslog-derived alarms but not trap-derived. Pre-PR3 behavior; needs separate investigation in Alarmd.
3. **Daemon config delivery rework** (memory `project_daemon_config_rework_needed`): The provisiond requisition-import + named-volume permission issue that blocks the labbox tests is one symptom of a larger problem with how every daemon's config files are delivered (COPY-baked into image, bind-mount-and-edit dance, init sidecars for seed-to-runtime split, runtime drift). v1.3+ scope per user direction.
4. **Pre-GA cleanup PR A** (Decision 4 sub-decision 4-iii): Kafka transport code removal from `daemon-boot-minion-common` once soak period proves rollback isn't needed.
5. **Pre-GA cleanup PR B** (Decisions 5, 6): `OpenNMS.*` → `DeltaV.*` topic rename, single coordinated PR with CI grep guard.
6. **`.env.example` versioning** (memory `feedback_image_tag_version_mismatch`): The `VERSION=` default in `.env.example` is now `1.2.0-rc1` (PR3 bumped from a stale `0.0.1-SNAPSHOT`), but build.sh keeps deriving from project.version. A future cleanup PR should remove this foot-gun by either auto-bumping `.env.example` or making build.sh tag with both versions.

## Where we are on the gRPC quest

Post-PR3, four of five Minion ↔ horizon channels are on gRPC:

| Channel | Transport | PR | Status |
|---|---|---|---|
| Heartbeat | gRPC | rc1 | ✓ shipped |
| RPC | gRPC | rc2-pr1 | ✓ shipped |
| Twin | gRPC | rc2-pr2 | ✓ shipped |
| Sinks (Syslog/Trap/Telemetry×4) | gRPC | **rc2-pr3 (this PR)** | ⏳ pending review |
| build.sh + minion-gateway/envoy integration | — | rc2-pr4 | ⏳ next |

After rc2-pr4 lands, `v1.2.0-rc2` tags + smoke runs once. The Pre-GA cleanup PRs (Kafka transport code removal, topic rename) follow the soak period.