### PR TITLE
docs(v1.2.0-rc2-pr4): plan-authoring kickoff for build cleanup

### DIFF
--- a/docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-plan-authoring-kickoff.md
+++ b/docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-plan-authoring-kickoff.md
@@ -1,0 +1,114 @@
+# Next session: v1.2.0-rc2 PR4 — build cleanup, plan-authoring
+
+**This is the plan-authoring kickoff for v1.2.0-rc2 PR4.** PR1 (RPC), PR2 (Twin), and PR3 (Sinks) all shipped. After PR4 lands, `v1.2.0-rc2` tags + smoke runs once.
+
+This session **writes the PR4 implementation plan** — it does not implement. The deliverable is `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md` (and an implementation-kickoff next-session prompt for the session that follows).
+
+---
+
+## Where we are
+
+Four of five Minion ↔ horizon channels are on gRPC after PR3:
+
+| Channel | Transport | Shipped in | Status |
+|---|---|---|---|
+| Heartbeat | gRPC | rc1 | ✓ |
+| RPC | gRPC | rc2-pr1 (#236) | ✓ |
+| Twin | gRPC | rc2-pr2 (#239) | ✓ |
+| Sinks (Syslog/Trap/Telemetry×4) | gRPC | rc2-pr3 (#244) | ✓ |
+| build.sh + minion-gateway/envoy integration | — | **rc2-pr4 (this plan)** | ⏳ |
+
+PR3 caught a critical wire-format bug ([`SinkMessage` proto wrapping](../../../core/minion-gateway/src/main/java/org/deltav/gateway/sink/SinkKafkaProducer.java)) that would have shipped silent-broken if user hadn't mandated investigating the Syslogd consumer-side path. Fix at commit `8cf5a30487d`. Memory: `feedback_sink_wire_format_sinkmessage_wrapper`.
+
+PR3 also surfaced operational pain points that PR4 fixes:
+
+1. **`build.sh deltav` doesn't rebuild minion-gateway or envoy.** Operators must `docker build -f opennms-container/delta-v/minion-gateway/Dockerfile core/minion-gateway/` and `docker build opennms-container/delta-v/envoy/` ad-hoc per the Dockerfile comments. PR3 had to do this manually multiple times during Phase 4 verification.
+2. **Tag mismatch chronic** (memory `feedback_image_tag_version_mismatch`). `build.sh` derives `$VERSION` from `pom.xml` (`1.2.0-rc1`) and tags `deltav/<name>:1.2.0-rc1` + `:latest`; `.env` reads its own `VERSION` line. PR3 bumped `.env.example` to `1.2.0-rc1` but the underlying foot-gun (any version bump leaves stale 0.0.1-SNAPSHOT cached images) remains.
+3. **Minion-gateway Dockerfile EXPOSE port** says `50051` (legacy) but the actual gRPC server listens on `9090` (`o.s.g.s.lifecycle.GrpcServerLifecycle: gRPC Server started, listening on address: [/[0:0:0:0:0:0:0:0]:9090]`). The `EXPOSE` directive is documentation only (doesn't affect connectivity), but it's misleading.
+
+---
+
+## Your task — write `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md`
+
+Follow the structure of the prior rc2 plans:
+- `docs/plans/2026-04-26-v1.2.0-rc2-pr1-rpc-implementation-plan.md`
+- `docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md`
+- `docs/plans/2026-04-28-v1.2.0-rc2-pr3-sinks-implementation-plan.md`
+
+Each is structured: Goal / Architecture overview / File structure / Phase 0 pre-work / Phase 1-N implementation tasks / Acceptance criteria / References.
+
+**Concrete PR4 scope** (estimated 2-4 commits per the rc2 kickoff):
+
+1. **`build.sh deltav` extension to include minion-gateway + envoy.** Add `do_minion_gateway_image()` and `do_envoy_image()` functions modeled on `do_db_init_image()` (which is already present in build.sh). Each invokes the appropriate `docker build` with the project version, tags both `$VERSION` and `:latest`. Wire both into the `deltav` mode.
+2. **Dockerfile EXPOSE fix in minion-gateway.** `EXPOSE 50051 8080` → `EXPOSE 9090 8080` (gRPC port + actuator). Pure documentation change; no behavior impact, but stops misleading future operators.
+3. **Optional: investigate the version-tag chronic issue** (memory `feedback_image_tag_version_mismatch`). Two clean fixes worth choosing between in the plan:
+   - (a) `build.sh` also tags with whatever `.env`'s `VERSION` is (so a stale `.env` works against fresh builds)
+   - (b) `build.sh` writes the resolved `$VERSION` back into `.env` after a successful build
+   - (c) Standardize on `:latest` everywhere in `.env` and skip versioned tags entirely
+   Pick one with rationale OR explicitly defer to a separate PR if scope creep is a concern.
+
+The plan should NOT include sink/Twin/RPC migration scope — those all shipped. PR4 is purely about build hygiene.
+
+**Phase 0 pre-work** for PR4 should be small but should include:
+- Bytecode/file inventory: which Dockerfiles need rebuilding, where they live, what build args they take
+- Verification of the `EXPOSE 9090` vs `EXPOSE 50051` claim against the running gateway image
+- Any other build-script callers that hard-code the current behavior (CI scripts, smoke tooling, etc.)
+
+---
+
+## Read first
+
+- [PR3 PR description](https://github.com/pbrane/delta-v/pull/244) — the "Followups (out of PR3 scope)" section enumerates what PR4 should address
+- [rc2 master decisions](../../plans/2026-04-26-v1.2.0-rc2-decisions.md), specifically Decision 9 (4-PR sequence) and Decision 9-iv (PR4 scope)
+- [rc1 build.sh integration kickoff](2026-04-25-v1.2.0-rc1-implementation-plan-kickoff.md) for the prior plan-authoring template
+- The `build.sh` script itself: `opennms-container/delta-v/build.sh`. Read `do_db_init_image()` as the canonical "ad-hoc image add to deltav mode" template.
+- The two Dockerfiles: `opennms-container/delta-v/minion-gateway/Dockerfile` and `opennms-container/delta-v/envoy/Dockerfile`. Both have "Build (ad-hoc until wired into build.sh)" comments — those are the PR4 to-fix markers.
+- Memory `feedback_image_tag_version_mismatch` for the chronic tag issue context
+- Memory `feedback_spring_boot_repackage_needs_clean` for the related `clean install` discipline
+
+---
+
+## Specific instructions for the plan author
+
+- **Don't relitigate Decision 9.** PR4 is the fourth and final rc2 PR. After it merges, tag + smoke. Pre-GA cleanup PRs (Kafka transport removal, topic rename) come after.
+- **Keep the plan tight.** PR3's plan was 3094 lines because it covered 6 sinks × 4 phases. PR4 should be much shorter — maybe 500-800 lines, 4-6 tasks across 2 phases.
+- **Test methodology**: PR4 doesn't add new code paths, just fixes build hygiene. The success criteria is "fresh `git clone` + `./build.sh deltav` + `./deploy.sh up` produces a working stack with no manual `docker build` steps." That's the headline acceptance test.
+- **Don't add gRPC service work, sink work, or anything operationally invasive.** PR4 is exclusively about making the build script catch up to what the migration code already does.
+- **Per `feedback_never_pr_opennms`**: the implementation kickoff you write at the end MUST instruct the implementing session to use `--repo pbrane/delta-v --base develop` for `gh pr create`.
+
+---
+
+## Output of this session
+
+1. `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md` — the full PR4 implementation plan (Phases 0-N, tasks, files to modify, verification)
+2. `docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-implementation-kickoff.md` — a brief implementation kickoff for the session that executes the plan, following the structure of `2026-04-28-v1.2.0-rc2-pr3-implementation-kickoff.md`
+3. A single commit on a new feature branch `docs/v1.2.0-rc2-pr4-build-cleanup-plan` off freshly-pulled develop, opening a docs PR per the established cadence
+
+---
+
+## After PR4 plan ships
+
+- **PR4 implementation session** — execute the plan. Per Decision 9's sequential cadence, this is a separate session.
+- **`v1.2.0-rc2` tag** after PR4 merges (per Decision 9 sub-decision 9-iv)
+- **Smoke test** on UTM VM via existing `smoker.sh` (memory `reference_smoke_test_procedure`)
+- **Pre-GA cleanup PR A** (Decision 4-iii): Kafka transport code removal once soak proves rollback isn't needed. Memory `feedback_image_tag_version_mismatch` and `project_daemon_config_rework_needed` are also v1.3+ candidates that may bundle here or stay separate.
+- **Pre-GA cleanup PR B** (Decisions 5, 6): `OpenNMS.*` → `DeltaV.*` topic rename, single coordinated PR with CI grep guard added.
+
+---
+
+## Open invariants
+
+- `feedback_never_pr_opennms` — CRITICAL — `--repo pbrane/delta-v` always
+- `feedback_pull_before_branching` — pull develop before creating the docs/v1.2.0-rc2-pr4-build-cleanup-plan branch
+- `feedback_image_tag_version_mismatch` — the chronic issue PR4 may or may not choose to fix; acknowledge it
+- `feedback_spring_boot_repackage_needs_clean` — relevant for any new `do_*_image` function that depends on a Maven artifact
+- `feedback_smoke_vm_release_only` — smoke is post-tag, not part of PR4
+
+---
+
+## References
+
+- PR3 merged at commit `13bbb87af1c` (2026-05-04)
+- Develop tip at PR4 plan authoring: `13bbb87af1c`
+- Horizon BOM: `1.2.0-rc1` (verify in pom.xml at session start)
+- Open PR not related to rc2: `pbrane/delta-v#225` (OpenTelemetry tracing overlay) — out of PR4 scope


### PR DESCRIPTION
## Summary

Kickoff prompt for the PR4 plan-authoring session. After PR3 (#244) merged at \`13bbb87af1c\`, four of five Minion-horizon channels are on gRPC. PR4 closes the build-hygiene gap that PR3 surfaced:

- \`build.sh deltav\` doesn't rebuild minion-gateway or envoy (currently ad-hoc \`docker build\` per Dockerfile comments — PR3 had to do this manually multiple times during Phase 4 verification)
- minion-gateway's Dockerfile EXPOSEs the legacy gRPC port (\`50051\` vs the actual \`9090\`)
- chronic image-tag-vs-.env-VERSION mismatch (memory \`feedback_image_tag_version_mismatch\`) — optional but worth considering as part of PR4

The kickoff briefs the next session to write the PR4 implementation plan + an implementation kickoff for the session that follows, matching the cadence used for PR1/PR2/PR3 plans.

## Scope estimate

PR4 is intentionally narrow:
- Estimated 2-4 commits, 500-800 line plan
- 4-6 tasks across 2 phases
- Headline acceptance: \`git clone\` + \`./build.sh deltav\` + \`./deploy.sh up\` produces a working stack with no manual \`docker build\` steps

## Test plan

- [ ] Reviewer reads the kickoff and confirms the scope matches Decision 9-iv intent
- [ ] No code changes — pure docs