### PR TITLE
docs(v1.2.0-rc2/4): implementation plan + kickoff for build cleanup

### DIFF
--- a/docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md
+++ b/docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md
@@ -1,0 +1,797 @@
+# v1.2.0-rc2 PR4 — Build Pipeline Cleanup: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `./build.sh deltav` produce every Docker image that `docker-compose.yml` references, so that a fresh `git clone` + `./build.sh deltav` + `./deploy.sh up` yields a working stack with no manual `docker build` steps. Fix the `EXPOSE` port mismatch in `minion-gateway/Dockerfile`. Mitigate the chronic `.env` ↔ `pom.xml` version-tag drift (`feedback_image_tag_version_mismatch`) by tagging built images with both the resolved POM version and the `.env`-declared version.
+
+**Architecture:** Two new `do_<image>_image()` functions added to `opennms-container/delta-v/build.sh`, modeled on the existing `do_db_init_image()` and `do_flow_enricher_image()` templates. Both wired into `do_deltav_images()` so the canonical `./build.sh deltav` mode covers them. Minion-gateway's Maven build uses `-pl core/minion-gateway -am install` (not the per-module `-f pom.xml package` form db-init uses) because minion-gateway depends on `org.opennms.core.minion-grpc-contracts` and per `feedback_spring_boot_repackage_needs_clean` the Spring Boot fat-jar repackage requires the dependency JAR to be `install`ed first. Envoy has no Maven module so its `do_envoy_image()` is a pure `docker build`. Dockerfile fix is a 1-line change. Tag-mismatch mitigation adds a single conditional `docker tag` step that reads `.env`'s `VERSION` line and tags the built image with that value alongside the POM-derived `$VERSION`.
+
+**Tech Stack:** Bash 5.x, Docker BuildKit, Maven 3.x via `./mvnw` wrapper, the same JDK 21 / Spring Boot 4.0.3 / Envoy 1.30.4 versions already in use. No Java code changes. No Spring config changes. No protobuf or gRPC contract changes.
+
+**Scope boundary:** This plan covers **PR4 only** (build hygiene). Per Decision 9 of the rc2 master decisions doc, this is the fourth and final rc2 PR. PR1 (RPC), PR2 (Twin), PR3 (Sinks) all shipped at PRs #236, #239, #244 respectively. After PR4 merges, `v1.2.0-rc2` tags and smoke runs on the UTM VM. No new code paths, no transport migration work, no protocol changes are in scope here.
+
+---
+
+## Architecture overview specific to PR4
+
+### Current state (post-PR3)
+
+`build.sh deltav` builds:
+1. Daemon-base shared layer (`Dockerfile.daemon-base`)
+2. 12 per-daemon images (`Dockerfile.daemon-per`, one per `daemon_names` entry)
+3. minion-boot image (`Dockerfile.minion-boot`)
+4. db-init image (`do_db_init_image()`)
+5. flow-enricher image (`do_flow_enricher_image()`)
+6. prometheus-writer image (`do_prometheus_writer_image()`)
+
+Total: 16 images. Each tagged `:$VERSION` and `:latest`.
+
+`build.sh deltav` does **not** build:
+- minion-gateway image (`docker-compose.yml:171` references it)
+- envoy image (`docker-compose.yml:190` references it)
+
+Operators are forced to invoke the comments at the top of each Dockerfile (`opennms-container/delta-v/minion-gateway/Dockerfile:9-15`, `opennms-container/delta-v/envoy/Dockerfile:7-11`) ad-hoc. PR3's Phase 4 verification rebuilt these manually multiple times. A fresh-clone operator following only `./build.sh deltav` + `./deploy.sh up` hits "pull access denied for deltav/minion-gateway" and "pull access denied for deltav/envoy" — both required by docker-compose, neither produced by the canonical pipeline.
+
+### Target state (post-PR4)
+
+`build.sh deltav` builds **18 images** — the existing 16 plus minion-gateway and envoy. The headline acceptance criterion ("fresh `git clone` + `./build.sh deltav` + `./deploy.sh up` produces a working stack with zero manual `docker build` steps") now holds.
+
+### Minion-gateway Maven build wrinkle
+
+`do_db_init_image()` builds db-init with:
+
+```bash
+./mvnw -B -f core/db-init/pom.xml -DskipTests package
+```
+
+This works for db-init because db-init's compile-time deps are all third-party (Liquibase, Spring Boot starters) — already resolvable from `~/.m2/repository` or Central. No reactor sibling needs to be `install`ed first.
+
+minion-gateway is different. Its `pom.xml` declares a dependency on `org.opennms.core.minion-grpc-contracts` (a sibling reactor module). A `-f core/minion-gateway/pom.xml package` invocation will fail or pick up a stale jar: per `feedback_spring_boot_repackage_needs_clean`, Spring Boot's `repackage` goal needs the dependency artifact present in the local repo or the resulting fat jar will silently re-use whatever was last `install`ed (potentially a stale rc1 build).
+
+The correct invocation is:
+
+```bash
+./mvnw -B -pl core/minion-gateway -am -DskipTests install
+```
+
+`-pl ... -am` builds the module *and* its reactor dependencies; `install` (not `package`) puts each into `~/.m2/repository` so Spring Boot's repackage finds them.
+
+### Envoy build (no Maven involvement)
+
+Envoy is pure `docker build`. The Dockerfile (`opennms-container/delta-v/envoy/Dockerfile`) has a build context that is the directory itself — the file `envoy.yaml` sits next to the Dockerfile and is `COPY`'d in. No Maven, no JAR staging, no `compute-shared-libs.sh` interaction.
+
+```bash
+docker build -t deltav/envoy:$VERSION -t deltav/envoy:latest opennms-container/delta-v/envoy/
+```
+
+### EXPOSE port mismatch
+
+`opennms-container/delta-v/minion-gateway/Dockerfile:30` declares `EXPOSE 50051 8080`. Verified against running config:
+
+| Source of truth | Port |
+|---|---|
+| `core/minion-gateway/src/main/resources/application.yml:6` (`spring.grpc.server.port`) | **9090** |
+| `opennms-container/delta-v/envoy/envoy.yaml:87` (cluster upstream) | **9090** |
+| Dockerfile `EXPOSE` directive | 50051 (legacy from rc1 design draft) |
+
+The actuator port `8080` is correct. The gRPC port should be `9090`. The `EXPOSE` directive is documentation only — Docker doesn't enforce it for connectivity, and `docker-compose.yml` doesn't publish either port to the host (the gateway is only reachable from inside the compose network via Envoy). The fix is a 1-line change to keep future operators from following a misleading EXPOSE.
+
+### Tag-mismatch chronic issue (option a — tag with both)
+
+`feedback_image_tag_version_mismatch` (filed two months ago, recurring): `build.sh` derives `$VERSION` from `pom.xml` via `./mvnw help:evaluate -Dexpression=project.version` (`build.sh:27`). `.env` declares its own `VERSION=` line, which `docker-compose.yml` interpolates into every `image:` reference. Whenever `pom.xml` bumps but `.env`/`.env.example` doesn't, `./build.sh deltav` produces images tagged `:$NEW_VERSION` while `docker compose up` tries to pull `:$OLD_VERSION` and fails with "pull access denied for deltav/<name>".
+
+PR3 partially mitigated by bumping `.env.example` to `1.2.0-rc1`. The underlying foot-gun remains because the contract is "`.env` must be hand-bumped per release."
+
+Three options were enumerated in the plan-authoring kickoff:
+- **(a)** `build.sh` also tags with whatever `.env`'s `VERSION` is (so a stale `.env` works against fresh builds).
+- **(b)** `build.sh` writes the resolved `$VERSION` back into `.env` after a successful build.
+- **(c)** Standardize on `:latest` everywhere in `.env` and skip versioned tags entirely.
+
+**Decision: option (a).** Rationale:
+
+| Option | Drawback | Why rejected / accepted |
+|---|---|---|
+| (a) | Local image-cache pollution: if operator pinned `.env=published-tag-X` for smoke testing then runs `./build.sh deltav` from a source tree, fresh local binaries get re-tagged as `published-tag-X`. | **Accepted.** Non-destructive (writes only to local Docker daemon's tag namespace, never to disk). Doesn't modify `.env`. Doesn't break smoke pinning when build.sh is *not* re-run from source. The `:latest` tag already has identical clobber semantics, and operators are accustomed to it. The end-of-build `log` line will print every tag created so the substitution is visible. |
+| (b) | Build script silently rewrites a config file. Surprising side effect. Worse: when an operator pins `.env=published-tag-X` for smoke testing and accidentally runs `./build.sh deltav`, their pin is destroyed without warning. | **Rejected.** Mutates files on disk; surprising; defeats the smoke-pinning use case `.env.example` documents. |
+| (c) | Loses the smoke-test-with-pinned-published-tag use case `.env.example:4` documents. Smoke tests on UTM VM run via the smoke-procedure (`reference_smoke_test_procedure.md`) which uses `GIT_REF` + `IMG_TAG` env vars rather than `.env`, but `.env`'s `VERSION` is still the public escape hatch for "pull a published tag locally." | **Rejected.** Forfeits a documented, intentional use case. |
+
+Option (a) is the smallest delta to current behavior, doesn't block (b) or (c) being adopted later, and resolves the headline failure mode (`pull access denied` after a version bump).
+
+Implementation sketch:
+
+```bash
+# In do_minion_gateway_image / do_envoy_image / do_db_init_image / do_flow_enricher_image / do_prometheus_writer_image:
+docker build -t "deltav/<name>:$VERSION" -t "deltav/<name>:latest" ...
+
+# After the build, if .env exists and declares a different VERSION, alias:
+local env_version=""
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    env_version=$(grep '^VERSION=' "$SCRIPT_DIR/.env" | head -1 | cut -d= -f2)
+fi
+if [ -n "$env_version" ] && [ "$env_version" != "$VERSION" ]; then
+    docker tag "deltav/<name>:$VERSION" "deltav/<name>:$env_version"
+    log "  also tagged: deltav/<name>:$env_version (from .env)"
+fi
+```
+
+A small helper function `apply_env_version_alias()` wraps this so each `do_*_image` function calls it once after `docker build`. See Task 5.
+
+### What PR4 explicitly does NOT do
+
+- No protobuf changes. PR3 finalized sink wire formats; PR4 doesn't touch `.proto` files.
+- No Java code changes. Pure build/Dockerfile/bash.
+- No change to the per-channel transport flags (`MINION_TRANSPORT`, `OPENNMS_MINION_TRANSPORT_TWIN`, `MINION_SINK_*_TRANSPORT`). All defaults remain `grpc`.
+- No new container in `docker-compose.yml`. Both minion-gateway and envoy have been there since rc1.
+- No CI workflow changes. CircleCI doesn't build the local-dev images.
+- No Kafka topic rename (Decisions 5/6 — separate pre-GA cleanup PR).
+- No Kafka transport code removal from `daemon-boot-minion-common` (Decision 4 sub-decision 4-iii — separate pre-GA cleanup PR after soak).
+
+---
+
+## File structure
+
+### New files
+
+- `docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md` — Phase 0 inventory + verification record.
+
+### Modified files
+
+- `opennms-container/delta-v/build.sh` — add `do_minion_gateway_image()`, `do_envoy_image()`, `apply_env_version_alias()` helper; wire both image functions into `do_deltav_images()`; update the closing `docker images | grep -E ...` line in `do_deltav_images()` to include `minion-gateway` and `envoy`.
+- `opennms-container/delta-v/minion-gateway/Dockerfile` — `EXPOSE 50051 8080` → `EXPOSE 9090 8080`; remove the now-stale "Build (ad-hoc until wired into build.sh)" comment block.
+- `opennms-container/delta-v/envoy/Dockerfile` — remove the now-stale "Build (ad-hoc until wired into build.sh)" comment block.
+
+### Files NOT modified
+
+- `core/minion-gateway/pom.xml` — already correct.
+- `core/minion-gateway/src/main/resources/application.yml` — already binds gRPC to 9090.
+- `opennms-container/delta-v/envoy/envoy.yaml` — upstream cluster already points at `minion-gateway:9090`.
+- `opennms-container/delta-v/docker-compose.yml` — no service definitions change; only image-build pipeline catches up.
+- `.env`, `.env.example` — option (a) is non-destructive: build script aliases the tag, doesn't rewrite the file.
+- `tools/local_development/minion-kafka-api-rollback.sh` — only references the runtime path, not the build path.
+- All `test-*-e2e.sh` scripts — they consume images, they don't build them.
+- `compute-shared-libs.sh` — operates on the 12 daemon-boot modules only; minion-gateway and envoy are out of scope.
+
+---
+
+## Phase 0 — Pre-work (Task 1)
+
+Pre-work captures the verification baseline that subsequent tasks depend on. Mirrors the structure of PR1/PR2/PR3 Phase 0 work but is materially smaller because PR4 doesn't introduce new latency surfaces.
+
+### Task 1: Pre-work findings doc
+
+**Files:**
+- Create: `docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md`
+
+**Rationale:** Captures the four facts the implementation depends on so a Phase-1 reviewer doesn't have to re-derive them: (a) which Dockerfiles need to be wired in, (b) what build context each takes, (c) what the actual gRPC port is, (d) whether anything else (CI, smoke tooling) hardcodes the current behavior in a way PR4 would break.
+
+- [ ] **Step 1.1: Inventory the two Dockerfiles**
+
+Run:
+
+```bash
+ls -la opennms-container/delta-v/minion-gateway/Dockerfile opennms-container/delta-v/envoy/Dockerfile
+head -20 opennms-container/delta-v/minion-gateway/Dockerfile
+head -20 opennms-container/delta-v/envoy/Dockerfile
+```
+
+Expected:
+- Both files exist.
+- Minion-gateway Dockerfile has the comment block `# Build (ad-hoc until wired into build.sh):` followed by the manual command.
+- Envoy Dockerfile has an analogous comment block.
+
+Capture in findings doc:
+
+```markdown
+## Dockerfiles to wire in
+
+| Dockerfile | Build context | Maven involvement | Output image |
+|---|---|---|---|
+| `opennms-container/delta-v/minion-gateway/Dockerfile` | `core/minion-gateway/` | Yes — `./mvnw -pl core/minion-gateway -am -DskipTests install` produces `target/org.opennms.core.minion-gateway-${VERSION}.jar` which the Dockerfile `COPY`s as `minion-gateway.jar` | `deltav/minion-gateway:${VERSION}` + `:latest` |
+| `opennms-container/delta-v/envoy/Dockerfile` | `opennms-container/delta-v/envoy/` | None — pure `docker build .` from the directory | `deltav/envoy:${VERSION}` + `:latest` |
+```
+
+- [ ] **Step 1.2: Verify the EXPOSE 9090 vs 50051 claim against running config**
+
+Run:
+
+```bash
+grep -n "spring.grpc.server.port\|port:" core/minion-gateway/src/main/resources/application.yml
+grep -n "minion-gateway, port_value" opennms-container/delta-v/envoy/envoy.yaml
+grep -n "EXPOSE" opennms-container/delta-v/minion-gateway/Dockerfile
+```
+
+Expected:
+- `application.yml` shows `port: 9090`
+- `envoy.yaml` shows `port_value: 9090`
+- Dockerfile `EXPOSE` shows `50051 8080`
+
+Capture verbatim in findings doc under heading `## EXPOSE port mismatch — confirmed`. The fix is a 1-line change in Task 4.
+
+- [ ] **Step 1.3: Inventory other callers of the build commands PR4 wires in**
+
+Run:
+
+```bash
+grep -rn "docker build.*minion-gateway\|docker build.*envoy" --include="*.sh" --include="*.md" --include="*.yml" 2>/dev/null
+```
+
+Expected: matches in
+- `opennms-container/delta-v/minion-gateway/Dockerfile` (the comment we're about to remove)
+- `opennms-container/delta-v/envoy/Dockerfile` (the comment we're about to remove)
+- Any docs referencing the manual build command
+
+Capture in findings doc under `## Other callers`. None should be CI scripts; if any are, flag them — those would also need updating.
+
+- [ ] **Step 1.4: Check for stale comments in `compute-shared-libs.sh` referencing minion-gateway**
+
+Run:
+
+```bash
+grep -n "minion-gateway\|envoy" opennms-container/delta-v/compute-shared-libs.sh
+```
+
+Expected: no matches. `compute-shared-libs.sh` operates on the 12 daemon-boot modules only; minion-gateway has its own dependency profile and isn't part of the daemon-base sharing layer (analogous to db-init, flow-enricher, prometheus-writer per `do_deltav_images()` comments). If matches surface, the plan's "Files NOT modified" assumption is wrong and `compute-shared-libs.sh` needs review — flag and stop.
+
+- [ ] **Step 1.5: Capture the current `.env` ↔ `pom.xml` version state**
+
+Run:
+
+```bash
+./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
+echo
+grep '^VERSION=' opennms-container/delta-v/.env opennms-container/delta-v/.env.example
+```
+
+Capture both values verbatim. As of plan authoring (`2026-05-04`):
+- POM version: `1.2.0-rc1`
+- `.env` VERSION: `1.2.0-rc1`
+- `.env.example` VERSION: `1.2.0-rc1`
+
+All three are in sync now. Task 5's tag-alias logic is a no-op when they match; the test for it (Step 5.6) explicitly forces a mismatch to exercise the alias code path.
+
+- [ ] **Step 1.6: Commit the findings doc**
+
+```bash
+git add docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md
+git commit -m "docs(v1.2.0-rc2-pr4): pre-work findings for build cleanup"
+```
+
+---
+
+## Phase 1 — Implementation (Tasks 2-5)
+
+### Task 2: Add `do_minion_gateway_image()` to build.sh
+
+**Files:**
+- Modify: `opennms-container/delta-v/build.sh:138-146` region (immediately after `do_db_init_image`, before `do_flow_enricher_image`)
+
+**Rationale:** Mirror the existing `do_db_init_image()` shape — `log` line, Maven build, `docker build` with double-tag — but use `-pl core/minion-gateway -am install` (not `-f pom.xml package`) per the architecture overview's "Minion-gateway Maven build wrinkle" section, and use the absolute Dockerfile path (`-f $SCRIPT_DIR/minion-gateway/Dockerfile`) with `core/minion-gateway/` as the build context (the existing Dockerfile-comment convention).
+
+- [ ] **Step 2.1: Add the function**
+
+Insert into `opennms-container/delta-v/build.sh` immediately after the closing `}` of `do_db_init_image()` (line ~138), before `do_flow_enricher_image()`:
+
+```bash
+do_minion_gateway_image() {
+    log "Building minion-gateway image (deltav/minion-gateway:$VERSION)..."
+    cd "$REPO_ROOT"
+    # Use -pl ... -am install (not -f pom.xml package) because minion-gateway
+    # depends on org.opennms.core.minion-grpc-contracts; Spring Boot repackage
+    # needs the contracts JAR present in ~/.m2 (feedback_spring_boot_repackage_needs_clean).
+    ./mvnw -B -pl core/minion-gateway -am -DskipTests install
+    docker build \
+        -t "deltav/minion-gateway:$VERSION" \
+        -t "deltav/minion-gateway:latest" \
+        -f "$SCRIPT_DIR/minion-gateway/Dockerfile" \
+        "$REPO_ROOT/core/minion-gateway/"
+}
+```
+
+- [ ] **Step 2.2: Wire into `do_deltav_images()`**
+
+In `do_deltav_images()` (currently ends around line 261), after the `do_prometheus_writer_image` call and before the closing `log "Delta-V images built:"` line, add:
+
+```bash
+    # --- Build minion-gateway (gRPC ingress translator for Minion-facing surface) ---
+    # minion-gateway sits between Envoy and the internal Kafka topics, translating
+    # gRPC bidi calls from Minions into Kafka publishes. Built standalone (like
+    # db-init / flow-enricher / prometheus-writer) because its dependency profile
+    # is Spring gRPC + protobuf rather than the horizon-derived daemon stack.
+    do_minion_gateway_image
+```
+
+- [ ] **Step 2.3: Update the closing `docker images` grep filter**
+
+In `do_deltav_images()`'s closing `docker images --format ... | grep -E "..."` line, add `|minion-gateway` to the alternation. Final grep pattern:
+
+```
+"daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway"
+```
+
+- [ ] **Step 2.4: Smoke-test the function in isolation**
+
+Run:
+
+```bash
+cd opennms-container/delta-v
+bash -n build.sh                    # syntax check
+( source build.sh; declare -F do_minion_gateway_image )    # function defined
+```
+
+Expected:
+- `bash -n` exits 0.
+- Second command echoes `do_minion_gateway_image`.
+
+(End-to-end smoke deferred to Task 6; this step just catches typos.)
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add opennms-container/delta-v/build.sh
+git commit -m "feat(v1.2.0-rc2-pr4): add do_minion_gateway_image to build.sh
+
+Wires minion-gateway Docker build into ./build.sh deltav so a fresh
+clone produces every image docker-compose.yml references. Uses
+-pl ... -am install (not -f pom.xml package) because minion-gateway
+depends on minion-grpc-contracts and Spring Boot repackage needs the
+sibling JAR installed.
+
+Refs feedback_spring_boot_repackage_needs_clean."
+```
+
+---
+
+### Task 3: Add `do_envoy_image()` to build.sh
+
+**Files:**
+- Modify: `opennms-container/delta-v/build.sh` (insert after the new `do_minion_gateway_image()` from Task 2)
+
+**Rationale:** Envoy has no Maven involvement — pure `docker build` from `opennms-container/delta-v/envoy/`. Function shape is even simpler than `do_minion_gateway_image`.
+
+- [ ] **Step 3.1: Add the function**
+
+Insert immediately after the closing `}` of `do_minion_gateway_image()`:
+
+```bash
+do_envoy_image() {
+    log "Building envoy image (deltav/envoy:$VERSION)..."
+    # Pure Docker build — Envoy is the upstream image plus envoy.yaml + curl
+    # (for the docker-compose healthcheck). No Maven involvement.
+    cd "$SCRIPT_DIR/envoy"
+    docker build \
+        -t "deltav/envoy:$VERSION" \
+        -t "deltav/envoy:latest" \
+        .
+}
+```
+
+- [ ] **Step 3.2: Wire into `do_deltav_images()`**
+
+In `do_deltav_images()`, immediately after the `do_minion_gateway_image` call from Task 2:
+
+```bash
+    # --- Build envoy (gRPC ingress in front of minion-gateway) ---
+    # envoyproxy/envoy:1.30.4 + envoy.yaml + curl (compose healthcheck needs it).
+    # No Maven; pure docker build.
+    do_envoy_image
+```
+
+- [ ] **Step 3.3: Update the closing `docker images` grep filter**
+
+Add `|envoy` to the alternation. Final grep pattern:
+
+```
+"daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy"
+```
+
+- [ ] **Step 3.4: Smoke-test the function**
+
+```bash
+cd opennms-container/delta-v
+bash -n build.sh
+( source build.sh; declare -F do_envoy_image )
+```
+
+Expected: `bash -n` exits 0; function name echoed.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add opennms-container/delta-v/build.sh
+git commit -m "feat(v1.2.0-rc2-pr4): add do_envoy_image to build.sh
+
+Wires envoy Docker build into ./build.sh deltav. Pure docker build
+(no Maven). Completes the set of images docker-compose.yml references."
+```
+
+---
+
+### Task 4: Fix `EXPOSE` port mismatch in minion-gateway Dockerfile + remove stale build comments
+
+**Files:**
+- Modify: `opennms-container/delta-v/minion-gateway/Dockerfile:9-15` (remove "Build (ad-hoc until wired into build.sh)" comment block)
+- Modify: `opennms-container/delta-v/minion-gateway/Dockerfile:30` (`EXPOSE 50051 8080` → `EXPOSE 9090 8080`)
+- Modify: `opennms-container/delta-v/envoy/Dockerfile:7-11` (remove analogous build comment block)
+
+**Rationale:** `EXPOSE` is documentation-only (Docker doesn't enforce it; compose doesn't publish it to the host), but it currently misleads operators reading the Dockerfile to debug connectivity. The application binds gRPC on `9090` (`application.yml:6`) and Envoy connects to `minion-gateway:9090` (`envoy.yaml:87`), per Phase 0 Task 1.2 verification. The "Build (ad-hoc until wired into build.sh)" comment blocks become stale once Tasks 2 + 3 land.
+
+- [ ] **Step 4.1: Fix the EXPOSE directive**
+
+Edit `opennms-container/delta-v/minion-gateway/Dockerfile` line 30:
+
+```dockerfile
+# before
+EXPOSE 50051 8080
+
+# after
+EXPOSE 9090 8080
+```
+
+- [ ] **Step 4.2: Remove the stale build comment in minion-gateway Dockerfile**
+
+Delete lines 9-15 of `opennms-container/delta-v/minion-gateway/Dockerfile` (the block beginning `# Build (ad-hoc until wired into build.sh):`). The header comment about the daemon's purpose (lines 1-8) stays. Result: lines 1-8 are immediately followed by the `ARG JRE_BASE=...` line.
+
+- [ ] **Step 4.3: Remove the stale build comment in envoy Dockerfile**
+
+Delete lines 7-11 of `opennms-container/delta-v/envoy/Dockerfile` (the block beginning `# Build (ad-hoc until wired into build.sh):`). The header comment about the listener's purpose (lines 1-6) stays. Result: lines 1-6 are immediately followed by `FROM envoyproxy/envoy:v1.30.4`.
+
+- [ ] **Step 4.4: Verify no other Dockerfiles reference the legacy 50051 port**
+
+```bash
+grep -rn "50051" opennms-container/delta-v/ core/minion-gateway/ 2>/dev/null
+```
+
+Expected: no matches. If matches surface (e.g., a stale port comment in `application.yml`), flag and fix before commit.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add opennms-container/delta-v/minion-gateway/Dockerfile opennms-container/delta-v/envoy/Dockerfile
+git commit -m "fix(v1.2.0-rc2-pr4): correct minion-gateway EXPOSE + drop stale build comments
+
+EXPOSE 50051 was a legacy from the rc1 design draft; minion-gateway
+binds gRPC on 9090 (application.yml + envoy.yaml). EXPOSE is docs-only
+(Docker doesn't enforce; compose doesn't publish), but the wrong value
+misleads operators debugging connectivity.
+
+Also removes the 'Build (ad-hoc until wired into build.sh)' comment
+blocks from both Dockerfiles now that ./build.sh deltav covers them."
+```
+
+---
+
+### Task 5: Add `apply_env_version_alias()` helper for tag-mismatch mitigation (option a)
+
+**Files:**
+- Modify: `opennms-container/delta-v/build.sh` (add `apply_env_version_alias()` helper near top; call from each `do_*_image` function and from the daemon-base / per-daemon / minion-boot blocks inside `do_deltav_images`)
+
+**Rationale:** Per the architecture overview's "Tag-mismatch chronic issue" section, option (a) is the smallest non-destructive fix to `feedback_image_tag_version_mismatch`. The helper reads `.env`'s `VERSION=` line once, compares to the resolved POM `$VERSION`, and aliases the just-built image to the `.env` value if they differ. Called once per built image so the alias is present everywhere docker-compose looks.
+
+- [ ] **Step 5.1: Add the helper function**
+
+Insert into `opennms-container/delta-v/build.sh` immediately after the global `err()` line (around line 30):
+
+```bash
+# Tag the just-built image with the .env-declared VERSION too, if it differs
+# from the resolved POM $VERSION. Resolves the chronic foot-gun where pom.xml
+# bumps but .env doesn't, causing `docker compose up` to fail with
+# "pull access denied" against the now-stale .env tag.
+# Non-destructive: writes only to the local Docker daemon's tag namespace,
+# never modifies .env. See feedback_image_tag_version_mismatch.
+apply_env_version_alias() {
+    local image_name="$1"   # e.g. "deltav/minion-gateway"
+    local env_file="$SCRIPT_DIR/.env"
+    [ -f "$env_file" ] || return 0
+    local env_version
+    env_version=$(grep '^VERSION=' "$env_file" | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'")
+    if [ -n "$env_version" ] && [ "$env_version" != "$VERSION" ]; then
+        docker tag "${image_name}:${VERSION}" "${image_name}:${env_version}"
+        log "  also tagged: ${image_name}:${env_version} (from .env, differs from POM $VERSION)"
+    fi
+}
+```
+
+- [ ] **Step 5.2: Call the helper from every `do_*_image` function**
+
+For each of:
+- `do_db_init_image()`
+- `do_flow_enricher_image()`
+- `do_prometheus_writer_image()`
+- `do_minion_gateway_image()` (added in Task 2)
+- `do_envoy_image()` (added in Task 3)
+
+Add `apply_env_version_alias` as the **last line of the function body** (after the `docker build`). Examples:
+
+```bash
+# do_db_init_image — final line
+    docker build -t "deltav/db-init:$VERSION" -t "deltav/db-init:latest" .
+    apply_env_version_alias "deltav/db-init"
+}
+
+# do_minion_gateway_image — final line
+    docker build \
+        -t "deltav/minion-gateway:$VERSION" \
+        -t "deltav/minion-gateway:latest" \
+        -f "$SCRIPT_DIR/minion-gateway/Dockerfile" \
+        "$REPO_ROOT/core/minion-gateway/"
+    apply_env_version_alias "deltav/minion-gateway"
+}
+```
+
+- [ ] **Step 5.3: Call the helper from the daemon-base build inside `do_deltav_images()`**
+
+Inside `do_deltav_images()`, immediately after the `docker build --no-cache -f Dockerfile.daemon-base ...` block (around line 198):
+
+```bash
+    docker build --no-cache \
+        -f Dockerfile.daemon-base \
+        -t "deltav/daemon-base:$VERSION" \
+        -t "deltav/daemon-base:latest" \
+        .
+    apply_env_version_alias "deltav/daemon-base"
+```
+
+- [ ] **Step 5.4: Call the helper from the per-daemon loop inside `do_deltav_images()`**
+
+Inside the `for name in $daemon_names` loop, after the `docker build -f Dockerfile.daemon-per ...` block (around line 213):
+
+```bash
+        docker build \
+            -f Dockerfile.daemon-per \
+            --build-arg "VERSION=$VERSION" \
+            --build-arg "DAEMON_NAME=$name" \
+            --build-arg "MAIN_CLASS=$main_class" \
+            -t "deltav/$name:$VERSION" \
+            -t "deltav/$name:latest" \
+            .
+        apply_env_version_alias "deltav/$name"
+    done
+```
+
+- [ ] **Step 5.5: Call the helper from the minion-boot block inside `do_deltav_images()`**
+
+After the `docker build ... -f Dockerfile.minion-boot ...` block (around line 232):
+
+```bash
+    docker build \
+        --build-arg "VERSION=$VERSION" \
+        -f Dockerfile.minion-boot \
+        -t "deltav/minion-boot:$VERSION" \
+        -t "deltav/minion-boot:latest" \
+        .
+    apply_env_version_alias "deltav/minion-boot"
+```
+
+- [ ] **Step 5.6: Test the alias code path with a forced mismatch**
+
+This is the only test that exercises the alias logic — Phase-0 Task 1.5 confirmed the live `.env` matches POM, so without forcing, the helper is a no-op.
+
+```bash
+# Backup .env, force a mismatch, build one image, verify alias, restore.
+cd opennms-container/delta-v
+cp .env .env.task5-bak
+sed -i.tmp 's/^VERSION=.*/VERSION=test-alias-9.9.9/' .env
+rm .env.tmp
+
+# Build a single small image to exercise the alias path
+( cd "$(git rev-parse --show-toplevel)" && ./opennms-container/delta-v/build.sh ) >/dev/null 2>&1 || true
+# Fall back to direct invocation if `./build.sh` (full pipeline) is too slow:
+bash -c 'cd "$(git rev-parse --show-toplevel)" && source opennms-container/delta-v/build.sh && SCRIPT_DIR=opennms-container/delta-v REPO_ROOT=$PWD VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout) do_envoy_image'
+
+# Verify the alias was created
+docker images deltav/envoy --format "  {{.Repository}}:{{.Tag}}" | grep "test-alias-9.9.9"
+
+# Restore
+mv .env.task5-bak .env
+
+# Cleanup the alias tag so we don't pollute the local image cache
+docker rmi deltav/envoy:test-alias-9.9.9
+```
+
+Expected:
+- `docker images` line `deltav/envoy:test-alias-9.9.9` is present after the build.
+- `.env` is restored byte-for-byte (option (a) does NOT mutate `.env`).
+- Cleanup removes the test alias.
+
+If the alias is not present, the helper has a typo or wasn't called; debug before committing.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add opennms-container/delta-v/build.sh
+git commit -m "feat(v1.2.0-rc2-pr4): tag built images with .env VERSION too (option a)
+
+Mitigates feedback_image_tag_version_mismatch: when pom.xml bumps but
+.env hasn't been hand-bumped, build.sh now also tags every built image
+with the .env-declared VERSION so 'docker compose up' against a stale
+.env still resolves.
+
+Non-destructive: writes only to the local Docker daemon's tag
+namespace, never modifies .env. The :latest tag already has identical
+clobber semantics, and operators can pin .env to a published tag for
+smoke testing as long as they don't re-run build.sh from source.
+
+Options (b) (rewrite .env) and (c) (':latest' only) were considered
+and rejected; rationale in the implementation plan."
+```
+
+---
+
+## Phase 2 — Acceptance test + PR (Task 6)
+
+### Task 6: Headline acceptance test + open PR
+
+**Files:**
+- No file changes. The headline acceptance is a build/run procedure.
+
+**Rationale:** PR4's success criterion per the kickoff prompt is *"fresh `git clone` + `./build.sh deltav` + `./deploy.sh up` produces a working stack with no manual `docker build` steps."* This is the only end-to-end test that exercises Tasks 2-5 together. After it passes, open the PR.
+
+- [ ] **Step 6.1: Verify the existing E2E suite is still green on the working tree**
+
+PR4 doesn't change any runtime code paths, so the existing E2E gates from PR1/PR2/PR3 should pass unchanged. This step is a regression check.
+
+```bash
+cd opennms-container/delta-v
+./build.sh deltav
+./deploy.sh up
+sleep 90
+docker compose ps
+```
+
+Expected: all 16+2 = 18 containers `Up (healthy)` after ~90 seconds. Capture the output.
+
+```bash
+./test-grpc-rpc-e2e.sh         # PR1's gate
+./test-grpc-twin-e2e.sh        # PR2's gate
+./test-grpc-sinks-e2e.sh       # PR3's gate
+./test-syslog-e2e.sh
+./test-minion-e2e.sh
+./test-flows-e2e.sh
+./test-perspective-e2e.sh
+./test-enlinkd-e2e.sh
+```
+
+Expected: all green. If any fail, the failure is unrelated to PR4 (no runtime code changed) — investigate as a regression check before opening PR4.
+
+- [ ] **Step 6.2: Headline acceptance — fresh clone simulation**
+
+The strongest version of this test uses a fresh `git clone` into a scratch directory. A faster proxy that exercises the same code path is to remove the local `deltav/minion-gateway` and `deltav/envoy` images, prune the build cache for those Dockerfiles, then rebuild via `./build.sh deltav` and bring the stack up.
+
+```bash
+cd opennms-container/delta-v
+docker compose down
+docker rmi deltav/minion-gateway:1.2.0-rc1 deltav/minion-gateway:latest 2>/dev/null || true
+docker rmi deltav/envoy:1.2.0-rc1 deltav/envoy:latest 2>/dev/null || true
+docker images deltav/minion-gateway deltav/envoy
+```
+
+Expected: empty (no `deltav/minion-gateway` or `deltav/envoy` image present).
+
+```bash
+./build.sh deltav 2>&1 | tee /tmp/pr4-build.log
+```
+
+Expected:
+- Log includes `==> Building minion-gateway image (deltav/minion-gateway:1.2.0-rc1)...`
+- Log includes `==> Building envoy image (deltav/envoy:1.2.0-rc1)...`
+- Final image listing shows `deltav/minion-gateway:1.2.0-rc1` and `deltav/envoy:1.2.0-rc1` alongside the other 16 images.
+
+```bash
+docker images deltav/minion-gateway deltav/envoy
+```
+
+Expected: both images present, fresh `CREATED` timestamp.
+
+```bash
+./deploy.sh up
+sleep 90
+docker compose ps | grep -E "minion-gateway|envoy"
+```
+
+Expected: both `Up (healthy)`. The headline acceptance criterion is satisfied: the canonical pipeline produced both images and they boot cleanly.
+
+- [ ] **Step 6.3: Spot-check the EXPOSE fix landed in the new image**
+
+```bash
+docker inspect deltav/minion-gateway:1.2.0-rc1 --format '{{json .Config.ExposedPorts}}'
+```
+
+Expected: `{"8080/tcp":{},"9090/tcp":{}}` (or equivalent). NOT `50051/tcp`.
+
+- [ ] **Step 6.4: Tear down the test stack**
+
+```bash
+cd opennms-container/delta-v
+./deploy.sh down
+```
+
+- [ ] **Step 6.5: Restore any working-tree drift before commit**
+
+Per `feedback_provisiond_requisition_drift`, E2E runs may leave `provisiond-overlay/etc/imports/*.xml` dirty with runtime `last-import=` writes. Restore:
+
+```bash
+git status
+git checkout opennms-container/delta-v/provisiond-overlay/etc/imports/ 2>/dev/null || true
+git status
+```
+
+Expected: working tree clean except for PR4's intended changes.
+
+- [ ] **Step 6.6: Open the PR**
+
+Per `feedback_never_pr_opennms`: `--repo pbrane/delta-v --base develop` always.
+
+```bash
+gh pr create --repo pbrane/delta-v --base develop \
+    --title "feat(v1.2.0-rc2/4): build pipeline cleanup — minion-gateway + envoy in build.sh, EXPOSE fix, .env-tag alias" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Completes v1.2.0-rc2 by fixing build hygiene:
+
+- `./build.sh deltav` now builds every image `docker-compose.yml` references — adds `do_minion_gateway_image()` and `do_envoy_image()` modeled on `do_db_init_image()`.
+- `minion-gateway/Dockerfile` `EXPOSE 50051` → `EXPOSE 9090` (docs-only, but stops misleading future operators; verified against `application.yml:6` + `envoy.yaml:87`).
+- Mitigates the chronic `.env` ↔ `pom.xml` version-tag mismatch (`feedback_image_tag_version_mismatch`) via option (a): every built image is also aliased to the `.env`-declared `VERSION` if it differs from the resolved POM version. Non-destructive.
+- Removes the now-stale `# Build (ad-hoc until wired into build.sh)` comment blocks from both Dockerfiles.
+
+After this merges, `v1.2.0-rc2` tags + smoke runs on UTM VM per `reference_smoke_test_procedure`.
+
+## Plan + decision context
+
+- Plan: `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md`
+- Pre-work findings: `docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md`
+- rc2 master decisions: `docs/plans/2026-04-26-v1.2.0-rc2-decisions.md` (Decision 9 sub-decision 9-iv: rc2 tag cut after PR4 merges)
+
+## Test plan
+
+- [ ] `docker rmi deltav/minion-gateway:* deltav/envoy:*` then `./build.sh deltav` reproduces both images
+- [ ] `docker compose ps` shows both `Up (healthy)`
+- [ ] `docker inspect deltav/minion-gateway --format '{{json .Config.ExposedPorts}}'` shows `9090/tcp`, not `50051/tcp`
+- [ ] All PR1/PR2/PR3 E2E gates still green: `test-grpc-rpc-e2e.sh`, `test-grpc-twin-e2e.sh`, `test-grpc-sinks-e2e.sh`, `test-syslog-e2e.sh`, `test-minion-e2e.sh`, `test-flows-e2e.sh`, `test-perspective-e2e.sh`, `test-enlinkd-e2e.sh`
+- [ ] Forced `.env` VERSION mismatch test (Task 5.6) confirms `apply_env_version_alias` writes the alias
+
+## Out of scope (explicit)
+
+- No protobuf, gRPC, or Java code changes
+- No transport flag changes (defaults remain `grpc`)
+- No Kafka topic rename (Decisions 5/6 — separate pre-GA cleanup PR)
+- No Kafka transport code removal (Decision 4-iii — separate pre-GA cleanup PR after soak)
+EOF
+)"
+```
+
+Capture the PR URL in the session output.
+
+---
+
+## Acceptance criteria
+
+- [ ] All Phase 0–2 tasks complete.
+- [ ] Pre-work findings doc (`docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md`) committed.
+- [ ] `./build.sh deltav` produces 18 images: existing 16 plus `deltav/minion-gateway:$VERSION` and `deltav/envoy:$VERSION`.
+- [ ] `docker inspect deltav/minion-gateway --format '{{json .Config.ExposedPorts}}'` shows `9090/tcp` and `8080/tcp`, NOT `50051/tcp`.
+- [ ] Both `# Build (ad-hoc until wired into build.sh)` comment blocks removed from the two Dockerfiles.
+- [ ] `apply_env_version_alias` helper exists and is called from every `do_*_image` function plus the daemon-base, per-daemon, and minion-boot build blocks inside `do_deltav_images`.
+- [ ] Forced-mismatch test (Step 5.6) confirms the alias logic works without modifying `.env`.
+- [ ] Headline acceptance (Step 6.2) passes: removing the local `minion-gateway` + `envoy` images, then running `./build.sh deltav` followed by `./deploy.sh up`, brings the full stack to `Up (healthy)` without any manual `docker build` invocations.
+- [ ] All PR1/PR2/PR3 E2E gates still pass (regression check, Task 6.1).
+- [ ] Working tree clean (no `provisiond-overlay/etc/imports/` drift) before commit.
+- [ ] PR opened against `pbrane/delta-v --base develop` with title prefix `feat(v1.2.0-rc2/4):` per Decision 9 sub-decision 9-v.
+
+---
+
+## References
+
+- **rc2 master decisions:** `docs/plans/2026-04-26-v1.2.0-rc2-decisions.md` (Decision 9, sub-decisions 9-i through 9-v)
+- **PR4 plan-authoring kickoff:** `docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-plan-authoring-kickoff.md`
+- **PR3 plan + findings (immediate predecessor):** `docs/plans/2026-04-28-v1.2.0-rc2-pr3-sinks-implementation-plan.md` + `2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md`
+- **PR3 PR (the wire-format-bug post-mortem motivating PR4's hygiene work):** https://github.com/pbrane/delta-v/pull/244
+- **Memory invariants this plan applies:**
+  - `feedback_never_pr_opennms` — CRITICAL — `--repo pbrane/delta-v` always
+  - `feedback_pull_before_branching` — pull develop before creating the implementation branch
+  - `feedback_spring_boot_repackage_needs_clean` — minion-gateway needs `-pl ... -am install`, not `-f pom.xml package`
+  - `feedback_image_tag_version_mismatch` — chronic two-month-old issue; PR4 mitigates via option (a)
+  - `feedback_smoke_vm_release_only` — smoke is post-tag, not part of PR4
+  - `feedback_provisiond_requisition_drift` — restore working tree before commit
+- **Develop tip at PR4 plan authoring:** `2de571fe541` (`Merge pull request #246 from pbrane/fix/v1.2.0-rc2-provisiond-imports-perm-self-heal`)
+- **Project version at PR4 plan authoring:** `1.2.0-rc1` (POM `project.version`; matches `.env` and `.env.example`)

--- a/docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-implementation-kickoff.md
+++ b/docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-implementation-kickoff.md
@@ -1,0 +1,166 @@
+# Next session: v1.2.0-rc2 PR4 — Build pipeline cleanup implementation
+
+**This is the implementation kickoff for v1.2.0-rc2 PR4.** PR1 (RPC, #236), PR2 (Twin, #239), and PR3 (Sinks, #244) all shipped. PR4 is the fourth and final rc2 PR — pure build hygiene. After PR4 merges, `v1.2.0-rc2` tags + smoke runs once on the UTM VM.
+
+This session is for **execution only** — no design, no plan changes. The plan at `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md` is the spec; the rc2 decisions doc Decision 9 (4-PR sequence; rc2 tag cut after PR4 merges) is the architectural anchor.
+
+**Read first** — these are not optional preamble:
+
+- [PR4 implementation plan](../../plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md) — the 6-task spec.
+- [rc2 decisions doc](../../plans/2026-04-26-v1.2.0-rc2-decisions.md) — locked design. Decisions most relevant to PR4:
+  - **Decision 9 sub-decision 9-iv** — `v1.2.0-rc2` tag is cut after PR4 merges; PR4 closes the rc2 acceptance criteria.
+  - **Decision 9 sub-decision 9-v** — PR title format `feat(v1.2.0-rc2/N): <subject>`. PR4 → `feat(v1.2.0-rc2/4): build pipeline cleanup ...`.
+  **Do not relitigate.**
+- [PR3 plan](../../plans/2026-04-28-v1.2.0-rc2-pr3-sinks-implementation-plan.md) — execution cadence reference and the source of the operational pain points PR4 fixes.
+- [PR3 PR #244](https://github.com/pbrane/delta-v/pull/244) — code reference for the ad-hoc minion-gateway/envoy build commands PR4 wires in.
+- Memory invariants: `feedback_never_pr_opennms`, `feedback_pull_before_branching`, `feedback_spring_boot_repackage_needs_clean`, `feedback_image_tag_version_mismatch`, `feedback_smoke_vm_release_only`, `feedback_provisiond_requisition_drift`, `feedback_clean_m2_between_branches`.
+
+---
+
+## Where we are (post-PR3)
+
+| Track | Status |
+|---|---|
+| Heartbeat sink — gRPC | ✅ rc1 |
+| RPC channel — gRPC | ✅ rc2 PR1 (#236) |
+| Twin API — gRPC | ✅ rc2 PR2 (#239) |
+| Syslog / Trap / Telemetry sinks — gRPC | ✅ rc2 PR3 (#244) |
+| `build.sh deltav` integrates minion-gateway + envoy + EXPOSE fix + tag-mismatch mitigation | ⏳ this session — rc2 PR4 |
+| `v1.2.0-rc2` tag + smoke | ⏳ after PR4 |
+
+---
+
+## What PR4 is and what it isn't
+
+**Is:**
+- 6-task plan, ~5 commits expected.
+- Modifies one bash file (`opennms-container/delta-v/build.sh`) and two Dockerfiles (`opennms-container/delta-v/minion-gateway/Dockerfile`, `opennms-container/delta-v/envoy/Dockerfile`).
+- Creates one pre-work findings doc.
+- Headline acceptance: a fresh `git clone` + `./build.sh deltav` + `./deploy.sh up` produces a working stack with zero manual `docker build` invocations.
+
+**Isn't:**
+- Not a code migration. No Java, no protobuf, no gRPC contracts, no Spring config, no transport-flag changes.
+- Not a smoke run. Smoke is post-tag, not part of PR4 (`feedback_smoke_vm_release_only`).
+- Not a Kafka topic rename (Decision 5/6 — separate pre-GA cleanup PR).
+- Not a Kafka transport code removal (Decision 4-iii — separate pre-GA cleanup PR after soak).
+- Not a CI workflow change. CircleCI doesn't build the local-dev images.
+
+---
+
+## Workflow
+
+1. **Worktree isolation** per `superpowers:using-git-worktrees`: create `.worktrees/v1.2.0-rc2-pr4-build-cleanup` off freshly-fetched develop. Branch name `feat/v1.2.0-rc2-pr4-build-cleanup`.
+2. **Pull develop first** (`feedback_pull_before_branching`). The PR4 plan-authoring PR (this session's docs PR) should have merged before this implementation session fires — verify develop's tip includes `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md` before branching.
+3. **Clear stale `.m2` SNAPSHOTs** between PR3 and PR4 branches per `feedback_clean_m2_between_branches`.
+4. **Bite-sized execution per the plan's Phase 0 → Phase 1 → Phase 2 task sequence.**
+5. **Two-stage review per code task** (spec compliance reviewer subagent first, then code quality reviewer subagent). PR4 is small enough that inline code review by a single reviewer is also acceptable — judgment call, but err toward two-stage given the chronic nature of `feedback_image_tag_version_mismatch`.
+6. **Per-phase checkpoints**: stop after Phase 0 (Task 1), Phase 1 (Tasks 2-5), Phase 2 (Task 6) for human review.
+7. **Headline acceptance test (Task 6.2) is the merge gate.** No PR opens until the fresh-clone simulation passes.
+
+---
+
+## Specific PR4 nuances vs PR1/PR2/PR3
+
+- **No new latency surface.** PR1/PR2/PR3 each had a Phase 0 baseline + post-implementation gate measurement. PR4 doesn't change runtime code so there's nothing to baseline against. The Phase 0 task is a verification + inventory only.
+- **No protobuf changes.** PR3 finalized sink wire formats. PR4 doesn't touch `.proto` files or regenerate stubs.
+- **No transport flag changes.** All `MINION_TRANSPORT`, `OPENNMS_MINION_TRANSPORT_TWIN`, `MINION_SINK_*_TRANSPORT` defaults remain `grpc`.
+- **Tag-mismatch decision baked into the plan.** Per the plan's "Tag-mismatch chronic issue" section, option (a) is chosen with documented rationale. **Do not switch to option (b) or (c) mid-execution** without re-discussion — both have known regressions for the smoke-pinning use case `.env.example` documents.
+- **The Dockerfile EXPOSE fix is documentation-only.** Docker doesn't enforce EXPOSE for connectivity, and `docker-compose.yml` doesn't publish the gateway ports to the host. The fix exists to stop misleading future operators reading the Dockerfile during connectivity debugging. Don't expand scope to "expose 9090 from compose" or similar — the runtime path goes Minion → Envoy → minion-gateway, and exposing the gateway externally would defeat that.
+- **Maven build wrinkle.** `do_minion_gateway_image()` uses `./mvnw -B -pl core/minion-gateway -am -DskipTests install`, NOT the `-f core/minion-gateway/pom.xml package` form `do_db_init_image()` uses. The reason is `feedback_spring_boot_repackage_needs_clean`: minion-gateway depends on `org.opennms.core.minion-grpc-contracts`, and Spring Boot's repackage goal needs the contracts JAR `install`ed in `~/.m2` or the resulting fat jar will silently re-use a stale build. **If a reviewer suggests "match db-init exactly with `-f pom.xml package`", point them at the architecture overview's "Minion-gateway Maven build wrinkle" section.**
+
+---
+
+## Phase boundaries (per-phase checkpoint stops)
+
+Stop and report to the user after each phase ends. User reviews before proceeding to the next phase.
+
+| Phase | Tasks | Output |
+|---|---|---|
+| 0 — Pre-work | 1 | Pre-work findings doc with verification of EXPOSE 9090, Dockerfile inventory, `.env`/POM version state |
+| 1 — Implementation | 2-5 | `do_minion_gateway_image` + `do_envoy_image` + Dockerfile fixes + `apply_env_version_alias` helper. 4 commits. |
+| 2 — Acceptance + PR | 6 | Fresh-clone simulation passes; all PR1/PR2/PR3 E2E gates green; PR opened. |
+
+---
+
+## What NOT to do in this session
+
+- **Don't relitigate Decision 9.** PR4 is the fourth and final rc2 PR. After it merges, tag + smoke. No fifth PR; no scope expansion.
+- **Don't change the plan.** Apply per-task review fixes inline (the plan anticipates this); but architectural pivots (e.g., switching tag-mismatch from option (a) to (b)) belong to a future planning session, not mid-execution.
+- **Don't push to `OpenNMS/opennms`.** `--repo pbrane/delta-v --base develop` always (`feedback_never_pr_opennms`).
+- **Don't start implementation on develop.** Use the worktree's feature branch `feat/v1.2.0-rc2-pr4-build-cleanup`.
+- **Don't bundle the topic rename** (`OpenNMS.*` → `DeltaV.*`). Per Decision 5 — that's a separate pre-GA cleanup PR.
+- **Don't bundle Kafka transport code removal** from `daemon-boot-minion-common`. Per Decision 4-iii — that's a separate pre-GA cleanup PR after rc2 soak.
+- **Don't tag or smoke in this session.** Per Decision 9-iv, the rc2 tag is cut *after* PR4 merges — that's a separate operation, not part of the implementation session.
+- **Don't cut scope on Task 5.** The tag-mismatch helper is the only piece that addresses a chronic 2-month-old foot-gun; reviewers who think it's overengineered should be pointed at `feedback_image_tag_version_mismatch` and the architecture overview's option-(a)-vs-(b)-vs-(c) table.
+- **Don't move minion-gateway's Dockerfile into `core/minion-gateway/`.** It currently lives at `opennms-container/delta-v/minion-gateway/Dockerfile` deliberately (different from db-init/flow-enricher). PR4 keeps the file where it is; restructuring is out of scope.
+
+---
+
+## Phase 2 reminders (will surface during the headline acceptance test)
+
+- **Image rebuild discipline now self-heals.** Once Tasks 2-3 land, `./build.sh deltav` rebuilds minion-gateway + envoy. The PR3-era manual `docker build` workflow goes away.
+- **Provisiond requisition drift.** Per `feedback_provisiond_requisition_drift` — the headline acceptance test (Task 6.2) brings up the full stack; E2E gates in Task 6.1 may leave `provisiond-overlay/etc/imports/*.xml` dirty. Restore with `git checkout` before the final commit (Task 6.5 is the explicit step).
+- **Compose IP race on flow testnodes.** `test-flows-e2e.sh` may fail to bring up testnodes due to `172.18.0.20-22` static-IP collisions. Pre-existing; not a PR4 regression. If it fails on the regression-check step, retry once before flagging.
+- **`grep -q` under `pipefail`.** Per `feedback_grep_q_sigpipe_in_pipefail` — `docker logs | grep -q PATTERN` returns SIGPIPE (141) on match, which `set -o pipefail` treats as failure. PR4's plan has no `grep -q` usages but be alert during reviewer-suggested fixes.
+
+---
+
+## Branch + workflow for THIS session
+
+- **Pull develop first** (`feedback_pull_before_branching`). Verify develop's tip includes the PR4 plan-authoring PR's merge commit before branching.
+- **Create worktree** at `.worktrees/v1.2.0-rc2-pr4-build-cleanup` on branch `feat/v1.2.0-rc2-pr4-build-cleanup`.
+- **Clear stale `.m2` SNAPSHOTs** between PR3 and PR4 branches (`feedback_clean_m2_between_branches`).
+- Per-task implementation per the plan's bite-sized steps.
+- Per-phase checkpoint with user.
+- After Task 6.2 (headline acceptance green), Task 6.6 opens the PR.
+
+---
+
+## Open invariants
+
+- `feedback_never_pr_opennms` — CRITICAL — `--repo pbrane/delta-v --base develop` always.
+- `feedback_pull_before_branching` — fresh-fetched develop before worktree creation.
+- `feedback_spring_boot_repackage_needs_clean` — load-bearing for Task 2's Maven invocation; don't switch to `-f pom.xml package`.
+- `feedback_image_tag_version_mismatch` — the chronic issue Task 5 mitigates via option (a). Don't drop Task 5 from PR4.
+- `feedback_smoke_vm_release_only` — Mac dev for verification; smoke VM is post-tag, not in this session.
+- `feedback_provisiond_requisition_drift` — restore working tree before commit (Task 6.5).
+- `feedback_clean_m2_between_branches` — clear stale SNAPSHOTs after worktree creation.
+
+---
+
+## Acceptance criteria (working list — refined during Phase 2 + Task 6)
+
+- [ ] All Phase 0–2 tasks complete with reviewer subagent(s) approving each code task.
+- [ ] Pre-work findings doc (`docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md`) committed with the four verification captures (Dockerfile inventory, EXPOSE port verification, other-callers inventory, `.env`/POM version state).
+- [ ] `./build.sh deltav` produces 18 images (existing 16 + minion-gateway + envoy).
+- [ ] `docker inspect deltav/minion-gateway --format '{{json .Config.ExposedPorts}}'` shows `9090/tcp` and `8080/tcp`, NOT `50051/tcp`.
+- [ ] `apply_env_version_alias` helper called from every `do_*_image` plus the daemon-base, per-daemon, and minion-boot build blocks.
+- [ ] Forced `.env` mismatch test (Step 5.6) confirms the alias is created and `.env` is restored byte-for-byte.
+- [ ] Headline acceptance (Step 6.2) passes: removing local `minion-gateway` + `envoy` images, then running `./build.sh deltav` followed by `./deploy.sh up`, brings the full stack to `Up (healthy)` with no manual `docker build`.
+- [ ] All PR1/PR2/PR3 E2E gates pass on the PR4 branch (regression check, Task 6.1).
+- [ ] No working-tree drift (Task 6.5 restored anything that drifted).
+- [ ] PR opened against `pbrane/delta-v --base develop` with title `feat(v1.2.0-rc2/4): build pipeline cleanup — minion-gateway + envoy in build.sh, EXPOSE fix, .env-tag alias`.
+- [ ] PR body documents the option-(a)-rejected-(b/c) decision so reviewers don't re-open the question.
+
+---
+
+## After PR4 ships
+
+- **`v1.2.0-rc2` tag** on the merge commit (per Decision 9-iv).
+- **Smoke test** on UTM VM via `reference_smoke_test_procedure`. Validates the no-git-clone contract end-to-end against the published `1.2.0-rc2` images.
+- **Pre-GA cleanup PR A** (Decision 4-iii): Kafka transport code removal from `daemon-boot-minion-common` + per-channel emergency flag removal + 17 ActiveMQ + 15 ServiceMix bundle purge. Subject to soak findings; if any per-channel rollback was exercised during soak, that channel's removal slips.
+- **Pre-GA cleanup PR B** (Decisions 5, 6): `OpenNMS.*` → `DeltaV.*` topic rename, single coordinated PR, CI grep guard added.
+
+---
+
+## References
+
+- **PR4 implementation plan:** `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md`
+- **PR4 plan-authoring kickoff:** `docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-plan-authoring-kickoff.md`
+- **rc2 decisions doc:** `docs/plans/2026-04-26-v1.2.0-rc2-decisions.md` (Decision 9 sub-decisions 9-i through 9-v)
+- **PR1 plan + findings:** `docs/plans/2026-04-26-v1.2.0-rc2-pr1-rpc-implementation-plan.md` + `2026-04-26-v1.2.0-rc2-pr1-pre-work-findings.md`
+- **PR2 plan:** `docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md`
+- **PR3 plan + findings:** `docs/plans/2026-04-28-v1.2.0-rc2-pr3-sinks-implementation-plan.md` + `2026-04-28-v1.2.0-rc2-pr3-pre-work-findings.md`
+- **PR1/PR2/PR3 PRs:** https://github.com/pbrane/delta-v/pull/236, /pull/239, /pull/244
+- **Develop tip at PR4 plan authoring:** `2de571fe541` (`Merge pull request #246 from pbrane/fix/v1.2.0-rc2-provisiond-imports-perm-self-heal`)
+- **Project version at PR4 plan authoring:** `1.2.0-rc1` (POM `project.version`; `.env` and `.env.example` in sync — verify at session start)


### PR DESCRIPTION
## Summary

Authors the v1.2.0-rc2 PR4 implementation plan and the implementation-session kickoff prompt. PR4 is the fourth and final rc2 PR; after it merges, `v1.2.0-rc2` tags + smoke runs once on the UTM VM (Decision 9-iv).

- **Plan:** `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md` — 797 lines, 6 tasks across 3 phases (Phase 0 pre-work / Phase 1 implementation / Phase 2 acceptance + PR). Within the 500-800 line target the plan-authoring kickoff set.
- **Kickoff:** `docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-implementation-kickoff.md` — 166 lines, mirrors PR3's structure.

## PR4 scope (from the plan-authoring kickoff)

1. `./build.sh deltav` extension to include `minion-gateway` + `envoy` (currently ad-hoc per Dockerfile comments).
2. `minion-gateway/Dockerfile` `EXPOSE 50051` -> `EXPOSE 9090` (verified against `application.yml:6` + `envoy.yaml:87` during plan authoring).
3. Tag-mismatch chronic issue (`feedback_image_tag_version_mismatch`) mitigation -- **option (a) chosen** with rationale in the plan: tag built images with both POM `$VERSION` and `.env`-declared VERSION. Non-destructive (writes only to local Docker daemon's tag namespace, never modifies `.env`); preserves the smoke-pinning use case `.env.example` documents. Options (b) (rewrite `.env`) and (c) (`:latest` only) considered and rejected; rationale table in the plan's Architecture Overview section.

## Load-bearing decisions baked in (don't relitigate during implementation)

- **Minion-gateway Maven invocation** uses `./mvnw -B -pl core/minion-gateway -am -DskipTests install`, NOT the `-f core/minion-gateway/pom.xml package` form `do_db_init_image()` uses. Reason per `feedback_spring_boot_repackage_needs_clean`: minion-gateway depends on `org.opennms.core.minion-grpc-contracts`, and Spring Boot's repackage needs the contracts JAR `install`ed in `~/.m2`.
- **Dockerfile EXPOSE fix is documentation-only.** Don't expand scope to "expose 9090 from compose" -- the runtime path goes Minion -> Envoy -> minion-gateway, and exposing the gateway externally would defeat that.
- **Minion-gateway Dockerfile stays at `opennms-container/delta-v/minion-gateway/Dockerfile`** (deliberately separate from `core/minion-gateway/`, unlike `db-init`/`flow-enricher`). PR4 keeps it where it is; restructuring is out of scope.
- **PR4 does not bundle Kafka topic rename** (Decision 5/6) or **Kafka transport code removal** (Decision 4-iii) -- those are pre-GA cleanup PRs separate from rc2.

## Test plan

- [x] Plan reads as a self-contained spec (no placeholders, all bash snippets complete, all file paths absolute).
- [x] Kickoff prompt cites all relevant memory invariants (`feedback_never_pr_opennms`, `feedback_pull_before_branching`, `feedback_spring_boot_repackage_needs_clean`, `feedback_image_tag_version_mismatch`, `feedback_smoke_vm_release_only`, `feedback_provisiond_requisition_drift`, `feedback_clean_m2_between_branches`).
- [x] Plan's tag-mismatch decision documents why (a) was picked and what (b) and (c) would lose.
- [x] EXPOSE 9090 vs 50051 claim verified during plan authoring (`application.yml:6` and `envoy.yaml:87` both bind 9090).
- [x] Plan's headline acceptance criterion (Task 6.2) is the merge gate for the implementation PR.

## Out of scope (explicit)

- No build.sh changes in this PR -- this is the docs PR; the implementation PR happens in a separate session.
- No protobuf, gRPC, or Java code changes anywhere.
- No transport flag changes.

## After this docs PR merges

Per Decision 9 sub-decision 9-i (PRs land sequentially):

1. PR4 implementation session executes the plan -> opens `feat(v1.2.0-rc2/4): build pipeline cleanup ...` PR.
2. After PR4 implementation merges, `v1.2.0-rc2` tag is cut.
3. Smoke test on UTM VM via `reference_smoke_test_procedure`.
4. Pre-GA cleanup PR A (Kafka transport code removal, after soak).
5. Pre-GA cleanup PR B (`OpenNMS.*` -> `DeltaV.*` topic rename, single coordinated PR).