### PR TITLE
feat(v1.2.0-rc2/4): build pipeline cleanup — minion-gateway + envoy in build.sh, EXPOSE fix, .env-tag alias

### DIFF
--- a/docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md
+++ b/docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md
@@ -566,34 +566,36 @@ After the `docker build ... -f Dockerfile.minion-boot ...` block (around line 23
 
 This is the only test that exercises the alias logic — Phase-0 Task 1.5 confirmed the live `.env` matches POM, so without forcing, the helper is a no-op.
 
+The original plan tried to test the helper in isolation by sourcing `build.sh`. That approach is broken: `build.sh:349` ends with `main "$@"` which re-triggers the full pipeline on source. The cleanest reliable test is to force the mismatch, run the actual `./build.sh deltav` flow once, and verify aliases appear on multiple images. This naturally overlaps with the Task 6.2 build but is kept as a separate task to keep the alias-logic test distinct from the headline-criterion test (so a failure in one doesn't mask a failure in the other).
+
 ```bash
-# Backup .env, force a mismatch, build one image, verify alias, restore.
+# Force mismatch in .env, run full ./build.sh deltav, verify aliases, restore.
 cd opennms-container/delta-v
 cp .env .env.task5-bak
-sed -i.tmp 's/^VERSION=.*/VERSION=test-alias-9.9.9/' .env
-rm .env.tmp
+sed -i.tmp 's/^VERSION=.*/VERSION=test-alias-9.9.9/' .env && rm .env.tmp
 
-# Build a single small image to exercise the alias path
-( cd "$(git rev-parse --show-toplevel)" && ./opennms-container/delta-v/build.sh ) >/dev/null 2>&1 || true
-# Fall back to direct invocation if `./build.sh` (full pipeline) is too slow:
-bash -c 'cd "$(git rev-parse --show-toplevel)" && source opennms-container/delta-v/build.sh && SCRIPT_DIR=opennms-container/delta-v REPO_ROOT=$PWD VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout) do_envoy_image'
+# Run the canonical pipeline. Aliases the post-build $VERSION images
+# to deltav/<name>:test-alias-9.9.9 via apply_env_version_alias.
+./build.sh deltav 2>&1 | tee /tmp/pr4-task5.log
 
-# Verify the alias was created
-docker images deltav/envoy --format "  {{.Repository}}:{{.Tag}}" | grep "test-alias-9.9.9"
+# Verify the alias appeared on at least two distinct images:
+# envoy (pure docker build path) and minion-gateway (Maven + docker build path).
+docker images deltav/envoy --format "{{.Repository}}:{{.Tag}}" | grep "deltav/envoy:test-alias-9.9.9"
+docker images deltav/minion-gateway --format "{{.Repository}}:{{.Tag}}" | grep "deltav/minion-gateway:test-alias-9.9.9"
 
-# Restore
+# Restore .env (option (a) is non-destructive: file is unchanged from pre-test state).
 mv .env.task5-bak .env
 
-# Cleanup the alias tag so we don't pollute the local image cache
-docker rmi deltav/envoy:test-alias-9.9.9
+# Cleanup all test-alias tags so the local image cache stays tidy.
+docker images --format "{{.Repository}}:{{.Tag}}" | grep ":test-alias-9.9.9" | xargs -I{} docker rmi {}
 ```
 
 Expected:
-- `docker images` line `deltav/envoy:test-alias-9.9.9` is present after the build.
-- `.env` is restored byte-for-byte (option (a) does NOT mutate `.env`).
-- Cleanup removes the test alias.
+- Both `grep` lines find a match (alias was applied to envoy and minion-gateway).
+- `.env` is restored byte-for-byte (verify with `git diff opennms-container/delta-v/.env` — should be empty since `.env` is gitignored, but no working-tree change).
+- Cleanup removes every `:test-alias-9.9.9` tag from the local image cache.
 
-If the alias is not present, the helper has a typo or wasn't called; debug before committing.
+If either alias is absent, the helper has a typo or wasn't called from that image's `do_*_image` function; debug before committing.
 
 - [ ] **Step 5.7: Commit**
 

--- a/docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md
+++ b/docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md
@@ -1,0 +1,98 @@
+# v1.2.0-rc2 PR4 — Pre-Work Findings
+
+> **Sibling to:** [`2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md`](./2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md)
+> **Generated:** 2026-05-04 during Phase 0 Task 1 of the PR4 implementation session.
+> **Develop tip at capture:** `2f088e38866` (`Merge pull request #247 from pbrane/docs/v1.2.0-rc2-pr4-build-cleanup-plan`)
+
+This document captures the four facts the implementation depends on so a Phase-1 reviewer doesn't have to re-derive them: (a) which Dockerfiles need to be wired in, (b) what build context each takes, (c) what the actual gRPC port is, (d) whether anything else (CI, smoke tooling) hardcodes the current behavior in a way PR4 would break.
+
+---
+
+## Dockerfiles to wire in
+
+| Dockerfile | Build context | Maven involvement | Output image |
+|---|---|---|---|
+| `opennms-container/delta-v/minion-gateway/Dockerfile` | `core/minion-gateway/` | Yes — `./mvnw -pl core/minion-gateway -am -DskipTests install` produces `target/org.opennms.core.minion-gateway-${VERSION}.jar` which the Dockerfile `COPY`s as `minion-gateway.jar` | `deltav/minion-gateway:${VERSION}` + `:latest` |
+| `opennms-container/delta-v/envoy/Dockerfile` | `opennms-container/delta-v/envoy/` | None — pure `docker build .` from the directory | `deltav/envoy:${VERSION}` + `:latest` |
+
+Both Dockerfiles open with a header comment about the daemon's purpose, then a `# Build (ad-hoc until wired into build.sh):` block documenting the manual command. Tasks 2-4 wire both in and remove those build comments.
+
+## EXPOSE port mismatch — confirmed
+
+| Source of truth | Port | Verified at |
+|---|---|---|
+| `core/minion-gateway/src/main/resources/application.yml:6` (`spring.grpc.server.port`) | **9090** | `port: 9090             # h2c plaintext within compose network; TLS terminated at Envoy in front` |
+| `opennms-container/delta-v/envoy/envoy.yaml:87` (cluster upstream) | **9090** | `socket_address: { address: minion-gateway, port_value: 9090 }` |
+| `opennms-container/delta-v/minion-gateway/Dockerfile:30` (current) | **50051** (legacy from rc1 design draft) | `EXPOSE 50051 8080` |
+
+The actuator port `8080` is correct. The gRPC port should be `9090`. EXPOSE is documentation only (Docker doesn't enforce; compose doesn't publish), but the mismatch misleads operators reading the Dockerfile during connectivity debugging. Task 4 fixes to `EXPOSE 9090 8080`.
+
+## Other callers
+
+Search command:
+
+```
+grep -rn "docker build.*minion-gateway\|docker build.*envoy" --include="*.sh" --include="*.md" --include="*.yml"
+```
+
+Matches found are exclusively in **historical plan and kickoff documents**:
+
+- `docs/plans/2026-04-27-v1.2.0-rc2-pr2-twin-implementation-plan.md` — Task 15 manual rebuild instructions
+- `docs/plans/2026-04-26-v1.2.0-rc1-implementation-plan.md` — rc1 manual build steps
+- `docs/superpowers/next-session-prompts/2026-04-28-v1.2.0-rc2-pr2-implementation-kickoff.md` — Phase 4 reminders
+- `docs/superpowers/next-session-prompts/2026-04-28-v1.2.0-rc2-pr3-implementation-kickoff.md` — Phase 4 reminders
+- `docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-plan-authoring-kickoff.md` — the prompt that motivated this PR
+- The PR4 plan itself (`docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md`)
+- The two Dockerfile comments PR4 removes
+
+**No CI scripts, no runtime scripts, no test harness scripts** reference these manual build commands. Safe to wire into `build.sh` and remove the Dockerfile comments without breaking anything else.
+
+The historical plan/kickoff matches are intentional artifacts of how PR1-3 were executed; not retroactively updated.
+
+## `compute-shared-libs.sh` independence
+
+```
+grep -n "minion-gateway\|envoy" opennms-container/delta-v/compute-shared-libs.sh
+# (no matches)
+```
+
+Confirms `compute-shared-libs.sh` operates on the 12 daemon-boot modules only. minion-gateway and envoy live entirely outside its scope (analogous to `do_db_init_image`, `do_flow_enricher_image`, `do_prometheus_writer_image`). The plan's "Files NOT modified" assumption holds.
+
+## `.env` ↔ `pom.xml` version state
+
+| Source | VERSION value |
+|---|---|
+| `pom.xml` (`./mvnw help:evaluate -Dexpression=project.version`) | **`1.2.0-rc1`** |
+| `opennms-container/delta-v/.env.example` | **`1.2.0-rc1`** |
+| `opennms-container/delta-v/.env` (in main checkout) | `1.2.0-rc1` (matches) |
+| `opennms-container/delta-v/.env` (in PR4 worktree) | **does not exist** (gitignored; worktree is fresh) |
+
+All three live values are in sync today. Task 5's tag-alias logic is a no-op when they match, which is why Step 5.6 explicitly forces a mismatch (`VERSION=test-alias-9.9.9`) to exercise the alias code path.
+
+### Surprising-but-not-blocking finding: fresh worktree has no `.env`
+
+`.env` is gitignored (`.gitignore` excludes it; `.env.example` is the tracked template). A freshly created git worktree therefore lacks `.env`, and any `./build.sh deltav` or `./deploy.sh up` invocation in the worktree will fail interpolating `${VERSION}` until the operator runs:
+
+```
+cp opennms-container/delta-v/.env.example opennms-container/delta-v/.env
+```
+
+This is **already the documented setup step** (`.env.example:1` says "Copy this file to `.env` ..."), but Task 5.6 and Task 6.2 both implicitly assume `.env` exists. The implementation session adds this `cp` step before exercising those tasks. No plan change required — just operator awareness.
+
+This is also a useful fresh-clone-experience signal: a brand-new clone hits the same issue. The `.env.example` comment block is the only documentation. Out of PR4 scope to add a `.env` auto-bootstrap to `build.sh` (would be option-(b)-ish surprise behavior on a config file); flag as a future hygiene candidate if it bites operators.
+
+---
+
+## Conclusion
+
+All four pre-work checks pass. The plan's assumptions hold:
+
+1. ✓ Two Dockerfiles to wire in; one needs Maven, one doesn't.
+2. ✓ EXPOSE 50051 → 9090 mismatch confirmed against `application.yml` + `envoy.yaml`.
+3. ✓ No external callers hardcode the current behavior; only historical plan docs reference the manual commands.
+4. ✓ `compute-shared-libs.sh` independence verified.
+5. ✓ `.env` ↔ POM versions in sync at session start; Task 5.6's forced-mismatch is the only path that triggers the alias logic.
+
+One operational note added: copy `.env.example` → `.env` before `./build.sh deltav` in the fresh worktree. Documented in setup step at start of Task 5.6 / Task 6.2.
+
+Phase 1 (Tasks 2-5) cleared to start.

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -29,6 +29,24 @@ VERSION="$(cd "$REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version 
 log() { echo "==> $*"; }
 err() { echo "ERROR: $*" >&2; exit 1; }
 
+# Tag the just-built image with the .env-declared VERSION too, if it differs
+# from the resolved POM $VERSION. Resolves the chronic foot-gun where pom.xml
+# bumps but .env doesn't, causing `docker compose up` to fail with
+# "pull access denied" against the now-stale .env tag.
+# Non-destructive: writes only to the local Docker daemon's tag namespace,
+# never modifies .env. See feedback_image_tag_version_mismatch.
+apply_env_version_alias() {
+    local image_name="$1"   # e.g. "deltav/minion-gateway"
+    local env_file="$SCRIPT_DIR/.env"
+    [ -f "$env_file" ] || return 0
+    local env_version
+    env_version=$(grep '^VERSION=' "$env_file" | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'")
+    if [ -n "$env_version" ] && [ "$env_version" != "$VERSION" ]; then
+        docker tag "${image_name}:${VERSION}" "${image_name}:${env_version}"
+        log "  also tagged: ${image_name}:${env_version} (from .env, differs from POM $VERSION)"
+    fi
+}
+
 # Detect daemon-boot modules whose source is newer than their target JAR and
 # rebuild them in-place. Guards against the "stale JAR" failure mode where
 # `do_deltav_images` stages a weeks-old JAR into a freshly-built Docker image,
@@ -135,6 +153,7 @@ do_db_init_image() {
     ./mvnw -B -f core/db-init/pom.xml -DskipTests package
     cd "$REPO_ROOT/core/db-init"
     docker build -t "deltav/db-init:$VERSION" -t "deltav/db-init:latest" .
+    apply_env_version_alias "deltav/db-init"
 }
 
 do_minion_gateway_image() {
@@ -149,6 +168,7 @@ do_minion_gateway_image() {
         -t "deltav/minion-gateway:latest" \
         -f "$SCRIPT_DIR/minion-gateway/Dockerfile" \
         "$REPO_ROOT/core/minion-gateway/"
+    apply_env_version_alias "deltav/minion-gateway"
 }
 
 do_envoy_image() {
@@ -160,6 +180,7 @@ do_envoy_image() {
         -t "deltav/envoy:$VERSION" \
         -t "deltav/envoy:latest" \
         .
+    apply_env_version_alias "deltav/envoy"
 }
 
 do_flow_enricher_image() {
@@ -168,6 +189,7 @@ do_flow_enricher_image() {
     ./mvnw -B -f core/flow-enricher/pom.xml -DskipTests package
     cd "$REPO_ROOT/core/flow-enricher"
     docker build -t "deltav/flow-enricher:$VERSION" -t "deltav/flow-enricher:latest" .
+    apply_env_version_alias "deltav/flow-enricher"
 }
 
 do_prometheus_writer_image() {
@@ -176,6 +198,7 @@ do_prometheus_writer_image() {
     ./mvnw -B -f core/prometheus-writer/pom.xml -DskipTests package
     cd "$REPO_ROOT/core/prometheus-writer"
     docker build -t "deltav/prometheus-writer:$VERSION" -t "deltav/prometheus-writer:latest" .
+    apply_env_version_alias "deltav/prometheus-writer"
 }
 
 do_jre_image() {
@@ -221,6 +244,7 @@ do_deltav_images() {
         -t "deltav/daemon-base:$VERSION" \
         -t "deltav/daemon-base:latest" \
         .
+    apply_env_version_alias "deltav/daemon-base"
 
     # Phase 3: Build per-daemon images
     local daemon_names="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd"
@@ -236,6 +260,7 @@ do_deltav_images() {
             -t "deltav/$name:$VERSION" \
             -t "deltav/$name:latest" \
             .
+        apply_env_version_alias "deltav/$name"
     done
 
     # --- Stage Minion Boot fat JAR ---
@@ -255,6 +280,7 @@ do_deltav_images() {
         -t "deltav/minion-boot:$VERSION" \
         -t "deltav/minion-boot:latest" \
         .
+    apply_env_version_alias "deltav/minion-boot"
 
     # Clean up staging
     rm -rf "$SCRIPT_DIR/staging"

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -137,6 +137,20 @@ do_db_init_image() {
     docker build -t "deltav/db-init:$VERSION" -t "deltav/db-init:latest" .
 }
 
+do_minion_gateway_image() {
+    log "Building minion-gateway image (deltav/minion-gateway:$VERSION)..."
+    cd "$REPO_ROOT"
+    # Use -pl ... -am install (not -f pom.xml package) because minion-gateway
+    # depends on org.opennms.core.minion-grpc-contracts; Spring Boot repackage
+    # needs the contracts JAR present in ~/.m2 (feedback_spring_boot_repackage_needs_clean).
+    ./mvnw -B -pl core/minion-gateway -am -DskipTests install
+    docker build \
+        -t "deltav/minion-gateway:$VERSION" \
+        -t "deltav/minion-gateway:latest" \
+        -f "$SCRIPT_DIR/minion-gateway/Dockerfile" \
+        "$REPO_ROOT/core/minion-gateway/"
+}
+
 do_flow_enricher_image() {
     log "Building flow-enricher image (deltav/flow-enricher:$VERSION)..."
     cd "$REPO_ROOT"
@@ -257,8 +271,15 @@ do_deltav_images() {
     # built as a standalone image rather than sharing daemon-base.
     do_prometheus_writer_image
 
+    # --- Build minion-gateway (gRPC ingress translator for Minion-facing surface) ---
+    # minion-gateway sits between Envoy and the internal Kafka topics, translating
+    # gRPC bidi calls from Minions into Kafka publishes. Built standalone (like
+    # db-init / flow-enricher / prometheus-writer) because its dependency profile
+    # is Spring gRPC + protobuf rather than the horizon-derived daemon stack.
+    do_minion_gateway_image
+
     log "Delta-V images built:"
-    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer" | sort | head -25
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway" | sort | head -25
 }
 
 

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -151,6 +151,17 @@ do_minion_gateway_image() {
         "$REPO_ROOT/core/minion-gateway/"
 }
 
+do_envoy_image() {
+    log "Building envoy image (deltav/envoy:$VERSION)..."
+    # Pure Docker build — Envoy is the upstream image plus envoy.yaml + curl
+    # (for the docker-compose healthcheck). No Maven involvement.
+    cd "$SCRIPT_DIR/envoy"
+    docker build \
+        -t "deltav/envoy:$VERSION" \
+        -t "deltav/envoy:latest" \
+        .
+}
+
 do_flow_enricher_image() {
     log "Building flow-enricher image (deltav/flow-enricher:$VERSION)..."
     cd "$REPO_ROOT"
@@ -278,8 +289,13 @@ do_deltav_images() {
     # is Spring gRPC + protobuf rather than the horizon-derived daemon stack.
     do_minion_gateway_image
 
+    # --- Build envoy (gRPC ingress in front of minion-gateway) ---
+    # envoyproxy/envoy:1.30.4 + envoy.yaml + curl (compose healthcheck needs it).
+    # No Maven; pure docker build.
+    do_envoy_image
+
     log "Delta-V images built:"
-    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway" | sort | head -25
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy" | sort | head -25
 }
 
 

--- a/opennms-container/delta-v/envoy/Dockerfile
+++ b/opennms-container/delta-v/envoy/Dockerfile
@@ -3,12 +3,6 @@
 # rc1 posture: h2c plaintext on :8443 inside the compose network. TLS
 # termination on this listener arrives in rc2 (per Phase 0 Decision 4).
 # Long-lived bidi streams: stream/route timeouts disabled (Decision 3).
-#
-# Build (ad-hoc until wired into build.sh):
-#   docker build \
-#     -t deltav/envoy:${VERSION} \
-#     -t deltav/envoy:latest \
-#     opennms-container/delta-v/envoy/
 
 FROM envoyproxy/envoy:v1.30.4
 

--- a/opennms-container/delta-v/minion-gateway/Dockerfile
+++ b/opennms-container/delta-v/minion-gateway/Dockerfile
@@ -5,14 +5,6 @@
 # the corresponding Kafka topic publish. Plaintext h2c in rc1; TLS is
 # terminated upstream by Envoy in v1.2.0+ and on the listener directly
 # in rc2.
-#
-# Build (ad-hoc until wired into build.sh):
-#   ./mvnw -pl core/minion-gateway -am clean install -DskipTests
-#   docker build \
-#     -t deltav/minion-gateway:${VERSION} \
-#     -t deltav/minion-gateway:latest \
-#     -f opennms-container/delta-v/minion-gateway/Dockerfile \
-#     core/minion-gateway/
 
 ARG JRE_BASE=deltav/jre-deltav:21
 FROM ${JRE_BASE}
@@ -27,6 +19,6 @@ WORKDIR ${APP_HOME}
 
 COPY target/org.opennms.core.minion-gateway-*.jar ${APP_HOME}/minion-gateway.jar
 
-EXPOSE 50051 8080
+EXPOSE 9090 8080
 
 ENTRYPOINT ["java", "-jar", "/opt/deltav/minion-gateway/minion-gateway.jar"]


### PR DESCRIPTION
## Summary

Completes v1.2.0-rc2 by fixing build hygiene. After this merges, `v1.2.0-rc2` tags + smoke runs once on the UTM VM (Decision 9-iv).

- `./build.sh deltav` now builds every image `docker-compose.yml` references — adds `do_minion_gateway_image()` and `do_envoy_image()` modeled on `do_db_init_image()` / `do_flow_enricher_image()`. Operators no longer have to follow the ad-hoc Dockerfile-comment instructions.
- `minion-gateway/Dockerfile` `EXPOSE 50051` → `EXPOSE 9090` (docs-only, but stops misleading future operators; verified against `application.yml:6` + `envoy.yaml:87`).
- Mitigates the chronic `.env` ↔ `pom.xml` version-tag mismatch (`feedback_image_tag_version_mismatch`) via **option (a)**: every built image is also aliased to the `.env`-declared `VERSION` if it differs from the resolved POM version. **Non-destructive** — never modifies `.env`. Options (b) (rewrite `.env`) and (c) (`:latest` only) considered and rejected; rationale in the plan's architecture overview.
- Removes the now-stale `# Build (ad-hoc until wired into build.sh)` comment blocks from both Dockerfiles.

## Plan + decision context

- Plan: `docs/plans/2026-05-04-v1.2.0-rc2-pr4-build-cleanup-implementation-plan.md` (merged via #247)
- Pre-work findings: `docs/plans/2026-05-04-v1.2.0-rc2-pr4-pre-work-findings.md` (added in this PR)
- Implementation kickoff: `docs/superpowers/next-session-prompts/2026-05-04-v1.2.0-rc2-pr4-implementation-kickoff.md`
- rc2 master decisions: `docs/plans/2026-04-26-v1.2.0-rc2-decisions.md` (Decision 9 sub-decision 9-iv)

## Commits

| SHA | Subject |
|---|---|
| `16ae1f3c0d3` | docs(v1.2.0-rc2-pr4): pre-work findings for build cleanup |
| `2dc1e8f3a94` | docs(v1.2.0-rc2-pr4): refine Step 5.6 test to drop broken source-build.sh trick |
| `e79e359a914` | feat(v1.2.0-rc2-pr4): add do_minion_gateway_image to build.sh |
| `c772942aaec` | feat(v1.2.0-rc2-pr4): add do_envoy_image to build.sh |
| `2e6619eccc1` | fix(v1.2.0-rc2-pr4): correct minion-gateway EXPOSE + drop stale build comments |
| `23d81f828d7` | feat(v1.2.0-rc2-pr4): tag built images with .env VERSION too (option a) |

## Test plan

- [x] `bash -n build.sh` syntax-clean after every commit
- [x] **Forced .env mismatch test (Step 5.6):** `VERSION=test-alias-9.9.9` in `.env`, ran `./build.sh deltav`, all 19 built images received the alias tag (12 per-daemon + daemon-base + minion-boot + db-init + flow-enricher + prometheus-writer + minion-gateway + envoy). `.env` restored byte-for-byte (`diff` clean).
- [x] **Headline acceptance (Step 6.2):** removed `deltav/minion-gateway:1.2.0-rc1`, `:latest`, `deltav/envoy:1.2.0-rc1`, `:latest` from local cache, ran `./build.sh deltav`, both tags reborn, `./deploy.sh up full` brought all 23 services to `(healthy)` with no manual `docker build`.
- [x] **EXPOSE fix verified:** `docker inspect deltav/minion-gateway:1.2.0-rc1 --format '{{json .Config.ExposedPorts}}'` → `{\"8080/tcp\":{},\"9090/tcp\":{}}` (no `50051/tcp`).
- [x] **Regression-check E2E gates:**
    - PR1 RPC (`test-grpc-rpc-e2e.sh`): PASS — gRPC RPC channel live, counters incrementing
    - PR2 Twin (`test-grpc-twin-e2e.sh`): PASS — Twin stream opened + SUBSCRIBE observed
    - PR3 Sinks (`test-grpc-sinks-e2e.sh`): PASS — Syslog p99=18ms, Trap p99=10ms, Telemetry IPFIX p75=0ms (all under gates)
    - Syslog end-to-end (`test-syslog-e2e.sh`): PASS — 16/16 (alarm create + clear)
    - Minion+Trap end-to-end (`test-minion-e2e.sh`): PASS — 16/16 (alarm create + clear via Minion path)
- [ ] Perspective / enlinkd / flows gates not run this session — runtime is unchanged in PR4 (build-script only) so the 5 gates above are sufficient regression evidence. flow-testnodes hit pre-existing `172.18.0.x` IP race (kickoff documented).

## Plan refinement landed in this PR

`2dc1e8f3a94` replaces Task 5.6's original test (which tried to source `build.sh` to call `do_envoy_image` in isolation — broken because `build.sh:349` ends with `main \"$@\"` re-triggering the full pipeline) with a simpler canonical-flow test: force the `.env` mismatch, run `./build.sh deltav` once, verify aliases on at least two distinct images. Per the kickoff's "apply per-task review fixes inline" rule.

## Surprising-but-not-blocking finding from pre-work

Fresh `git worktree` (and equivalently fresh `git clone`) lacks `.env` — it's gitignored, with `.env.example` as the tracked template. Operators must `cp .env.example .env` before `./build.sh deltav` or `./deploy.sh up`. Already documented at `.env.example:1`. Out of PR4 scope to add an auto-bootstrap to `build.sh` (would be option-(b)-shaped surprise behavior on a config file). Flagged in the findings doc as a future hygiene candidate.

## Out of scope (explicit)

- No protobuf, gRPC, or Java code changes
- No transport flag changes (defaults remain `grpc`)
- No Kafka topic rename (Decisions 5/6 — separate pre-GA cleanup PR)
- No Kafka transport code removal (Decision 4-iii — separate pre-GA cleanup PR after soak)
- No CI workflow changes