### PR TITLE
fix(v1.2.0-rc2): add minion-gateway + envoy steps to GHA build workflow

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -27,6 +27,8 @@
 #
 #   Infrastructure:
 #     - ghcr.io/<owner>/minion-boot:<version>              Spring Boot Minion
+#     - ghcr.io/<owner>/minion-gateway:<version>           gRPC ingress translator (Minion → Kafka)
+#     - ghcr.io/<owner>/envoy:<version>                    gRPC ingress in front of minion-gateway
 #     - ghcr.io/<owner>/db-init:<version>                  Liquibase schema migration
 #     - ghcr.io/<owner>/flow-enricher:<version>            Flow decode + enrich → ClickHouse
 #     - ghcr.io/<owner>/prometheus-writer:<version>        Metrics → Prometheus Remote Write
@@ -237,6 +239,37 @@ jobs:
             --platform ${{ env.PLATFORMS }} \
             -t "${{ env.IMAGE_PREFIX }}/prometheus-writer:${VERSION}" \
             -t "${{ env.IMAGE_PREFIX }}/prometheus-writer:latest" \
+            --push \
+            .
+
+      - name: Build and push minion-gateway image
+        # minion-gateway's Dockerfile lives at opennms-container/delta-v/minion-gateway/Dockerfile
+        # (not core/minion-gateway/, unlike db-init / flow-enricher / prometheus-writer).
+        # Build context is core/minion-gateway/ so the Dockerfile's
+        # `COPY target/org.opennms.core.minion-gateway-*.jar` resolves against the
+        # Maven-built fat JAR from the "Compile all modules" step.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -f opennms-container/delta-v/minion-gateway/Dockerfile \
+            -t "${{ env.IMAGE_PREFIX }}/minion-gateway:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/minion-gateway:latest" \
+            --push \
+            core/minion-gateway
+
+      - name: Build and push envoy image
+        # Pure docker build — Envoy is the upstream image plus envoy.yaml + curl.
+        # No Maven involvement.
+        working-directory: opennms-container/delta-v/envoy
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -t "${{ env.IMAGE_PREFIX }}/envoy:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/envoy:latest" \
             --push \
             .
 


### PR DESCRIPTION
## Summary

PR #248 (rc2 PR4) wired `minion-gateway` and `envoy` into the local `./build.sh deltav` pipeline but missed the corresponding GitHub Actions workflow at `.github/workflows/delta-v-build-images.yml`. Result: the `v1.2.0-rc2` tag-push workflow ([run #25381248326](https://github.com/pbrane/delta-v/actions/runs/25381248326)) successfully published **25 images** to `ghcr.io/pbrane/*` but `minion-gateway:1.2.0-rc2` and `envoy:1.2.0-rc2` are **absent** — smoke on UTM VM would fail when `docker compose pull` tries to fetch them.

## Fix

Adds two new steps to `delta-v-build-images.yml` after the `prometheus-writer` step, modeled on its shape:

- `minion-gateway`: uses `-f opennms-container/delta-v/minion-gateway/Dockerfile` with `core/minion-gateway` as build context (Dockerfile lives outside `core/` unlike db-init/flow-enricher/prometheus-writer).
- `envoy`: pure `docker buildx build` from `opennms-container/delta-v/envoy/`. No Maven.

Comment block at top of file updated to list both new images.

## Security review

Both new steps reference only:
- `steps.version.outputs.version` — derived from `pom.xml` via the workflow's "Extract version from POM" step (workflow-controlled, not user input).
- `env.PLATFORMS` / `env.IMAGE_PREFIX` — workflow-level env vars set in the `env:` block.

No `github.event.*` inputs (issue/PR titles/bodies, commit messages, head_ref, etc.). No injection surface.

## Rollout (no rc2 retag needed)

The workflow has `workflow_dispatch` enabled, and `develop`'s `pom.xml` is already at `1.2.0-rc2` (post-PR #249). After this merges:

```
gh workflow run delta-v-build-images.yml --ref develop --repo pbrane/delta-v
```

That run reads `1.2.0-rc2` from develop's POM and publishes `minion-gateway:1.2.0-rc2` + `envoy:1.2.0-rc2` to ghcr.io. The existing `v1.2.0-rc2` tag stays put. Per `feedback_delayed_tag_workflow_trigger`, no tag retraction footgun.

## Test plan

- [ ] CI passes (Build and Analyze + CodeQL + label)
- [ ] After merge, `gh workflow run delta-v-build-images.yml --ref develop` completes successfully
- [ ] `gh run view <id> --log | grep -oE 'ghcr.io/pbrane/(minion-gateway|envoy):1\\.2\\.0-rc2' | sort -u` shows both images
- [ ] `docker manifest inspect ghcr.io/pbrane/minion-gateway:1.2.0-rc2` resolves
- [ ] `docker manifest inspect ghcr.io/pbrane/envoy:1.2.0-rc2` resolves

## Lesson learned (will file as memory after this lands)

Build-hygiene PRs that add new images need to update **both** local `build.sh` AND `.github/workflows/delta-v-build-images.yml`. PR4's plan explicitly scoped CI workflow changes out — that decision was wrong. The two are separate definitions and drift silently.