### PR TITLE
fix(v1.2.0-rc2): pass JRE_BASE build-arg to minion-gateway image build

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -248,12 +248,17 @@ jobs:
         # Build context is core/minion-gateway/ so the Dockerfile's
         # `COPY target/org.opennms.core.minion-gateway-*.jar` resolves against the
         # Maven-built fat JAR from the "Compile all modules" step.
+        # JRE_BASE override mirrors the daemon-base step's JRE_IMAGE override —
+        # without it, BuildKit tries to pull the unprefixed default
+        # `deltav/jre-deltav:21` from docker.io and fails (the local-only tag
+        # build.sh produces is not on a public registry).
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           docker buildx build \
             --platform ${{ env.PLATFORMS }} \
             -f opennms-container/delta-v/minion-gateway/Dockerfile \
+            --build-arg "JRE_BASE=${{ env.IMAGE_PREFIX }}/jre-deltav:21" \
             -t "${{ env.IMAGE_PREFIX }}/minion-gateway:${VERSION}" \
             -t "${{ env.IMAGE_PREFIX }}/minion-gateway:latest" \
             --push \


### PR DESCRIPTION
## Summary

Follow-up to #250. PR #250 added the minion-gateway image step to `delta-v-build-images.yml` but didn't pass `--build-arg JRE_BASE=...`. The Dockerfile defaults to `ARG JRE_BASE=deltav/jre-deltav:21` (no registry prefix → BuildKit resolves to `docker.io/deltav/jre-deltav:21`). That tag is local-only — produced by `build.sh`'s `do_jre_image` and never pushed publicly. Result: workflow_dispatch run [25383724961](https://github.com/pbrane/delta-v/actions/runs/25383724961) failed at *Build and push minion-gateway image* with `pull access denied` on the `FROM ${JRE_BASE}` line.

## Fix

Add `--build-arg "JRE_BASE=${{ env.IMAGE_PREFIX }}/jre-deltav:21"` to the minion-gateway step. Mirrors the `daemon-base` step's `JRE_IMAGE` override at line 161 (different arg name because the two Dockerfiles use different ARG names — `daemon-base` uses `JRE_IMAGE`, `minion-gateway` uses `JRE_BASE`).

The JRE image is already published at `ghcr.io/pbrane/jre-deltav:21` by the workflow's earlier *Build and push JRE base image* step.

`envoy` step is unaffected — its `FROM envoyproxy/envoy:v1.30.4` is a public image. Envoy didn't run in the failed dispatch because workflow steps fail-fast at minion-gateway.

## Rollout

After merge, re-trigger workflow_dispatch on develop:

```
gh workflow run delta-v-build-images.yml --ref develop --repo pbrane/delta-v
```

Verify both images afterwards:

```
docker manifest inspect ghcr.io/pbrane/minion-gateway:1.2.0-rc2
docker manifest inspect ghcr.io/pbrane/envoy:1.2.0-rc2
```

## Test plan

- [ ] CI passes (Build and Analyze + CodeQL + label)
- [ ] After merge, dispatched workflow run succeeds end-to-end
- [ ] Both minion-gateway:1.2.0-rc2 and envoy:1.2.0-rc2 manifests resolve from ghcr.io/pbrane