### PR TITLE
chore: bump version 1.2.0-rc2 → 1.2.0-rc2.1

### DIFF
--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/horizon-metric-bridge/pom.xml
+++ b/core/horizon-metric-bridge/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-grpc-contracts/pom.xml
+++ b/core/minion-grpc-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2</version>
+        <version>1.2.0-rc2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/opennms-container/delta-v/.env.example
+++ b/opennms-container/delta-v/.env.example
@@ -2,7 +2,7 @@
 # `.env` is gitignored so local overrides (e.g., bumping VERSION to a published
 # tag for smoke testing) don't pollute git status. Defaults below match a
 # from-source dev build against host.docker.internal Kafka.
-VERSION=1.2.0-rc2
+VERSION=1.2.0-rc2.1
 KAFKA_EXTERNAL_HOST=host.docker.internal
 
 # v1.2.0-rc2 emergency-rollback flags. Default `grpc` per Decision 4-ii.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>1.2.0-rc2</version>
+  <version>1.2.0-rc2.1</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>


### PR DESCRIPTION
## Summary

Mechanical version bump for `v1.2.0-rc2.1` — a fix-pack tag rolling up the three follow-ups merged after `v1.2.0-rc2`:

- PR #250 — `fix(v1.2.0-rc2): add minion-gateway + envoy image steps to GHA workflow` (the rc2 tag-push workflow missed two images)
- PR #251 — `fix(v1.2.0-rc2): pass JRE_BASE build-arg to minion-gateway image build` (minion-gateway FROM resolved against unpublished docker.io/deltav default)
- PR #252 — `fix(v1.2.0-rc2): close DNS search-domain leakage that caused flow gaps` (Envoy STRICT_DNS AAAA leak + dns_search hardening across all 32 services)

Smoke on rc2 was signed off, but the home-network DNS issue and the GHA gaps are real bugs that benefit from a clean tag. rc2.1 is that clean tag — semantically "rc2 with three small fixes," not a fresh rc cycle.

## Mechanical changes

- 28 `pom.xml` files: `1.2.0-rc2` → `1.2.0-rc2.1` via `./mvnw versions:set -DnewVersion=1.2.0-rc2.1 -DgenerateBackupPoms=false -DprocessAllModules=true`
- `opennms-container/delta-v/.env.example`: `VERSION=1.2.0-rc2` → `VERSION=1.2.0-rc2.1` per `feedback_image_tag_version_mismatch`

## After this merges

- Tag `v1.2.0-rc2.1` (annotated, unsigned, like rc1/rc2) on the merge commit
- GHA `delta-v-build-images.yml` triggers on the tag push and publishes the full 27-image set (now including minion-gateway + envoy thanks to PRs #250/#251)
- Existing rc2 smoke procedure works unchanged; just point `IMG_TAG=1.2.0-rc2.1` and `GIT_REF=v1.2.0-rc2.1`

## Out of scope

- No code changes, no new features, no transport changes
- Just the prerequisite for the rc2.1 tag