### PR TITLE
fix(v1.2.0-rc2.2): mirror l8opensim to pbrane GHCR + bump to rc2.2

### DIFF
--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/horizon-metric-bridge/pom.xml
+++ b/core/horizon-metric-bridge/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-grpc-contracts/pom.xml
+++ b/core/minion-grpc-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc2.1</version>
+        <version>1.2.0-rc2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/opennms-container/delta-v/.env.example
+++ b/opennms-container/delta-v/.env.example
@@ -2,7 +2,7 @@
 # `.env` is gitignored so local overrides (e.g., bumping VERSION to a published
 # tag for smoke testing) don't pollute git status. Defaults below match a
 # from-source dev build against host.docker.internal Kafka.
-VERSION=1.2.0-rc2.1
+VERSION=1.2.0-rc2.2
 KAFKA_EXTERNAL_HOST=host.docker.internal
 
 # v1.2.0-rc2 emergency-rollback flags. Default `grpc` per Decision 4-ii.

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -121,8 +121,13 @@ services:
 
   l8opensim:
     <<: *no-search-domain
-    # Pinned to the digest validated in Task 1 spike. Update deliberately.
-    image: ghcr.io/labmonkeys-space/l8opensim@sha256:714b83cbdda904dd748bc850cb6f6977815dbfece0ca1393ded22eb24fe61b07
+    # Pinned to a digest under our control. Mirror of the labmonkeys-space
+    # build that was previously used (originally pinned to
+    # ghcr.io/labmonkeys-space/l8opensim@sha256:714b83cbdda9...). The upstream
+    # package was made non-public during rc2 smoke validation, breaking
+    # `docker compose pull` for downstream consumers; we mirror to
+    # ghcr.io/pbrane/ to remove the third-party SPOF. Update deliberately.
+    image: ghcr.io/pbrane/l8opensim@sha256:aec42138a627adc30a0f845ad73a5b96d6ca9e6987de343cb3eb80770bd4e3cf
     container_name: delta-v-l8opensim
     profiles: [lite, full, metrics]
     cap_add:

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>1.2.0-rc2.1</version>
+  <version>1.2.0-rc2.2</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>


### PR DESCRIPTION
## Summary

`ghcr.io/labmonkeys-space/l8opensim` was made non-public sometime between the rc2 image-build workflow run and the rc2.1 smoke run, breaking `docker compose pull` for downstream consumers with `error from registry: denied`.

Smoke VM `smoker.sh` failure (excerpted):
```
✘ Image ghcr.io/labmonkeys-space/l8opensim@sha256:714b83cbdda904dd748bc850cb6f6977815dbfece0ca1393ded22eb24fe61b07 Error error fro...
Error response from daemon: error from registry: denied
```

The image is not in `labmonkeys-space`'s public package list any longer (only `charts/*` and `nl6` remain public there), and there is no public source repo to rebuild from. **Resolution:** mirror the locally cached image to `ghcr.io/pbrane/l8opensim` and re-pin `docker-compose.yml` to a digest under our control.

## Changes

1. **Mirror push** (already done): `ghcr.io/pbrane/l8opensim:1.2.0-rc2.1` + `:latest` published from cached layers (original digest `sha256:714b83cb...`). New mirrored manifest digest: `sha256:aec42138a627adc30a0f845ad73a5b96d6ca9e6987de343cb3eb80770bd4e3cf`.
2. **`docker-compose.yml:120`**: pin updated from `ghcr.io/labmonkeys-space/l8opensim@sha256:714b83cb...` to `ghcr.io/pbrane/l8opensim@sha256:aec42138...`. Comment updated to document the mirroring rationale.
3. **Version bump**: `1.2.0-rc2.1` → `1.2.0-rc2.2` across 28 poms + `.env.example`. Cuts a fresh tag so the smoke VM has a clean target.

## Single-platform caveat (follow-up tracked)

The original digest `714b83cb...` was a multi-platform manifest list (linux/amd64 + linux/arm64). The local cache on the mirror-push host had only the arm64 variant, so the new digest `aec42138...` is single-platform arm64. The smoke VM is `aarch64` (verified via `uname -m` against `192.168.64.2`) so the mirror works for current smoke. A multi-arch republish is a future follow-up — file as a v1.2 hardening item if linux/amd64 testing is needed.

## Rollout

After this merges:
1. Tag `v1.2.0-rc2.2` (annotated) on the merge commit
2. GHA `delta-v-build-images.yml` triggers and publishes 27 fresh `:1.2.0-rc2.2` images
3. Re-run smoker.sh on UTM VM with `IMG_TAG=1.2.0-rc2.2` + `GIT_REF=v1.2.0-rc2.2` — should pull cleanly

## Out of scope

- Multi-arch republish (single-platform arm64 covers the smoke VM; amd64 is follow-up)
- Replacing l8opensim with an alternative simulator (architectural decision, not a fix)
- Reaching out to labmonkeys-space to restore public access (not under our control)