### PR TITLE
feat(v1.2.0): PerspectivePollerd Phase 3 publisher to deltav-timeseries

### DIFF
--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -238,6 +238,21 @@
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Phase 3: publish per-poll response-time records to the
+             deltav-timeseries Kafka topic. Mirrors the Pollerd publisher
+             from PR #220 — same wire contract (TimeseriesBatch protobuf),
+             same Spring Cloud Stream binder, distinguished by
+             ProducerType.PRODUCER_PERSPECTIVE_POLLERD. -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.deltav-kafka-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-stream-kafka</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/InstrumentedPerspectivePollerd.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/InstrumentedPerspectivePollerd.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.perspectivepoller.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.netmgt.collection.api.CollectionAgentFactory;
+import org.opennms.netmgt.collection.api.PersisterFactory;
+import org.opennms.netmgt.config.PollerConfig;
+import org.opennms.netmgt.dao.api.ApplicationDao;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.perspectivepoller.PerspectivePolledService;
+import org.opennms.netmgt.perspectivepoller.PerspectivePollerd;
+import org.opennms.netmgt.perspectivepoller.PerspectiveServiceTracker;
+import org.opennms.netmgt.poller.LocationAwarePollerClient;
+import org.opennms.netmgt.poller.PollStatus;
+import org.opennms.netmgt.threshd.api.ThresholdingService;
+
+/**
+ * Subclass of horizon's {@link PerspectivePollerd} that adds delta-v
+ * instrumentation by overriding {@code persistResponseTimeData}, the only
+ * public per-poll callback exposed by horizon's PerspectivePollerd.
+ *
+ * <p>Per call, in order:
+ * <ol>
+ *   <li>Delegates to {@code super.persistResponseTimeData(...)} — preserves
+ *       horizon's RRD-style persistence (no-op when the perspective service
+ *       has no {@code RrdRepository} configured).</li>
+ *   <li>Increments {@code deltav_perspective_polls_completed_total} tagged
+ *       by {@code perspective}, {@code location}, and {@code result}.</li>
+ *   <li>Records {@code deltav_perspective_poll_duration_seconds} from the
+ *       poll's measured response time.</li>
+ *   <li>If {@link PerspectiveResponseTimePublisher} is wired (Phase 3
+ *       enabled), forwards the sample to the {@code deltav-timeseries}
+ *       Kafka topic.</li>
+ * </ol>
+ *
+ * <p>Per {@code feedback_rpc_timeout_no_outages}, this seam fires only on
+ * RPC-successful polls — the horizon PollJob's exception branch never
+ * reaches {@code persistResponseTimeData}, so RPC infrastructure failures
+ * are correctly excluded from poll counters.
+ */
+public class InstrumentedPerspectivePollerd extends PerspectivePollerd {
+
+    private final MeterRegistry meterRegistry;
+    private final PerspectiveResponseTimePublisher publisher;
+    private final Timer pollDuration;
+
+    public InstrumentedPerspectivePollerd(SessionUtils sessionUtils,
+                                          MonitoringLocationDao monitoringLocationDao,
+                                          PollerConfig pollerConfig,
+                                          MonitoredServiceDao monitoredServiceDao,
+                                          LocationAwarePollerClient locationAwarePollerClient,
+                                          ApplicationDao applicationDao,
+                                          CollectionAgentFactory collectionAgentFactory,
+                                          PersisterFactory persisterFactory,
+                                          EventForwarder eventForwarder,
+                                          ThresholdingService thresholdingService,
+                                          OutageDao outageDao,
+                                          TracerRegistry tracerRegistry,
+                                          PerspectiveServiceTracker tracker,
+                                          MeterRegistry meterRegistry,
+                                          PerspectiveResponseTimePublisher publisher) {
+        super(sessionUtils, monitoringLocationDao, pollerConfig, monitoredServiceDao,
+                locationAwarePollerClient, applicationDao, collectionAgentFactory,
+                persisterFactory, eventForwarder, thresholdingService, outageDao,
+                tracerRegistry, tracker);
+        this.meterRegistry = meterRegistry;
+        this.publisher = publisher;
+        this.pollDuration = meterRegistry.timer(PerspectivePollerdDomainMetrics.POLL_DURATION);
+    }
+
+    @Override
+    public void persistResponseTimeData(PerspectivePolledService polledService, PollStatus pollStatus) {
+        try {
+            super.persistResponseTimeData(polledService, pollStatus);
+        } finally {
+            recordPoll(polledService, pollStatus);
+            if (publisher != null) {
+                publisher.publish(polledService, pollStatus);
+            }
+        }
+    }
+
+    private void recordPoll(PerspectivePolledService polledService, PollStatus status) {
+        if (polledService == null) {
+            return;
+        }
+        String perspective = polledService.getPerspectiveLocation() != null
+                ? polledService.getPerspectiveLocation() : "Default";
+        String residentLocation = polledService.getResidentLocation() != null
+                ? polledService.getResidentLocation() : "Default";
+        String result = status != null && status.getStatusName() != null
+                ? status.getStatusName().toLowerCase() : "unknown";
+        meterRegistry.counter(PerspectivePollerdDomainMetrics.POLLS_COMPLETED,
+                PerspectivePollerdDomainMetrics.TAG_PERSPECTIVE, perspective,
+                PerspectivePollerdDomainMetrics.TAG_LOCATION, residentLocation,
+                PerspectivePollerdDomainMetrics.TAG_RESULT, result).increment();
+        if (status != null && status.getResponseTime() != null
+                && !Double.isNaN(status.getResponseTime())) {
+            pollDuration.record((long) (status.getResponseTime() * 1_000_000.0),
+                    java.util.concurrent.TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDaemonConfiguration.java
@@ -49,6 +49,7 @@ import org.opennms.netmgt.perspectivepoller.PerspectivePollerd;
 import org.opennms.netmgt.perspectivepoller.PerspectiveServiceTracker;
 import org.opennms.netmgt.poller.LocationAwarePollerClient;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -131,20 +132,29 @@ public class PerspectivePollerdDaemonConfiguration {
     }
 
     /**
-     * The PerspectivePollerd daemon.
+     * The PerspectivePollerd daemon — wired as {@link InstrumentedPerspectivePollerd}
+     * so per-poll {@code deltav_perspective_*} counters fire and (when
+     * {@code deltav.perspective.timeseries.enabled=true}) response-time
+     * samples publish to the {@code deltav-timeseries} Kafka topic.
+     *
+     * <p>The bean's declared type stays {@link PerspectivePollerd} so
+     * downstream consumers ({@link AnnotationBasedEventListenerAdapter},
+     * the SmartLifecycle wrapper) bind unchanged.</p>
      *
      * <p>Constructor parameter 9 ({@code eventForwarder}) is typed as
      * {@code EventForwarder}, but {@code EventIpcManager} extends
      * {@code EventForwarder}, so passing the EventIpcManager bean is valid.
-     * Spring resolves by type compatibility.</p>
-     *
-     * <p>The forwarder slot is wrapped with {@link CountingPerspectiveEventForwarder}
+     * The forwarder slot is wrapped with {@link CountingPerspectiveEventForwarder}
      * so per-perspective lifecycle UEIs (nodeLostService /
-     * nodeRegainedService) are surfaced at {@code /actuator/prometheus}
-     * as {@code deltav_perspective_*} counters. The unwrapped
-     * {@code EventIpcManager} bean is still used by the
+     * nodeRegainedService) surface at {@code /actuator/prometheus}. The
+     * unwrapped {@code EventIpcManager} bean is still used by the
      * {@code AnnotationBasedEventListenerAdapter} beans for inbound
      * subscription registration.</p>
+     *
+     * <p>The publisher is supplied via {@link ObjectProvider} because
+     * {@link PerspectivePollerdTimeseriesConfiguration} is gated on a
+     * daemon-scoped flag; when disabled, no bean is registered and Phase 3
+     * publishing is a no-op.</p>
      */
     @Bean
     public PerspectivePollerd perspectivePollerd(
@@ -161,13 +171,16 @@ public class PerspectivePollerdDaemonConfiguration {
             OutageDao outageDao,
             TracerRegistry tracerRegistry,
             PerspectiveServiceTracker perspectiveServiceTracker,
-            io.micrometer.core.instrument.MeterRegistry meterRegistry) {
+            io.micrometer.core.instrument.MeterRegistry meterRegistry,
+            ObjectProvider<PerspectiveResponseTimePublisher> publisherProvider) {
         EventForwarder countingForwarder =
                 new CountingPerspectiveEventForwarder(eventIpcManager, meterRegistry);
-        return new PerspectivePollerd(sessionUtils, monitoringLocationDao, pollerConfig,
+        PerspectiveResponseTimePublisher publisher = publisherProvider.getIfAvailable();
+        return new InstrumentedPerspectivePollerd(sessionUtils, monitoringLocationDao, pollerConfig,
                 monitoredServiceDao, locationAwarePollerClient, applicationDao,
                 collectionAgentFactory, persisterFactory, countingForwarder,
-                thresholdingService, outageDao, tracerRegistry, perspectiveServiceTracker);
+                thresholdingService, outageDao, tracerRegistry, perspectiveServiceTracker,
+                meterRegistry, publisher);
     }
 
     /**

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDomainMetrics.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdDomainMetrics.java
@@ -21,16 +21,14 @@ package org.deltav.netmgt.perspectivepoller.boot;
  * Names become {@code deltav_perspective_*} at {@code /actuator/prometheus}
  * after Micrometer's dot-to-underscore flattening.
  *
- * <p>Architecture note (vs pollerd): horizon's {@code PerspectivePollerd}
- * uses a Quartz-based scheduler and a private {@code lambda$execute$0}
- * inside {@code PerspectivePollJob} as its per-poll callback. There is no
- * public {@code PollContext}-equivalent seam to subclass without modifying
- * horizon source. As a result, beta2 instrumentation is bounded to the
- * {@code EventForwarder} wrap (outage UEI counting) — the same pattern
- * applied to discovery's daemon. Per-poll response-time {@code deltav_*}
- * counters and Phase 3 Kafka publishing for perspective polls require a
- * deeper hook (e.g., a wrapping {@code PersisterFactory}) and are tracked
- * as a post-beta2 follow-up.
+ * <p>Instrumentation seam: {@link InstrumentedPerspectivePollerd} overrides
+ * horizon's {@code persistResponseTimeData(PerspectivePolledService, PollStatus)}
+ * (called once per RPC-successful poll completion from
+ * {@code PerspectivePollJob.execute()}). RPC-level failures (timeouts,
+ * disconnects) never reach this seam — see {@code feedback_rpc_timeout_no_outages}.
+ *
+ * <p>The {@code EventForwarder} wrap ({@link CountingPerspectiveEventForwarder})
+ * supplies the outage UEI counters; that path remains unchanged.
  */
 public final class PerspectivePollerdDomainMetrics {
 
@@ -39,4 +37,11 @@ public final class PerspectivePollerdDomainMetrics {
     public static final String EVENTS_FORWARDED          = "deltav.perspective.events.forwarded";
     public static final String SERVICE_LOST_TOTAL        = "deltav.perspective.service.lost";
     public static final String SERVICE_REGAINED_TOTAL    = "deltav.perspective.service.regained";
+
+    public static final String POLLS_COMPLETED           = "deltav.perspective.polls.completed";
+    public static final String POLL_DURATION             = "deltav.perspective.poll.duration";
+
+    static final String TAG_LOCATION    = "location";
+    static final String TAG_PERSPECTIVE = "perspective";
+    static final String TAG_RESULT      = "result";
 }

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdTimeseriesConfiguration.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectivePollerdTimeseriesConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.perspectivepoller.boot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+/**
+ * Phase 3: publishes per-poll response-time records for PerspectivePollerd to
+ * the {@code deltav-timeseries} Kafka topic, mirroring the Pollerd publisher
+ * shipped in PR #220 with {@code ProducerType.PRODUCER_PERSPECTIVE_POLLERD}
+ * to disambiguate origin.
+ *
+ * <p>The enable flag is daemon-scoped — {@code deltav.perspective.timeseries.enabled}
+ * — and intentionally distinct from Pollerd's {@code deltav.timeseries.enabled}.
+ * The two daemons must remain independently togglable.
+ *
+ * <p>The topic itself is shared infrastructure (both daemons emit to the same
+ * {@code deltav-timeseries} topic for prometheus-writer to consume). The
+ * {@link NewTopic} declaration here is defensive: whichever daemon starts
+ * first creates it, subsequent declarations are no-ops via
+ * {@code TopicAlreadyExistsException}. Tuning knobs (partitions, retention)
+ * follow the same first-declarer-wins semantics; operators changing them
+ * should keep both daemons' values consistent.
+ */
+@Configuration
+@ConditionalOnProperty(name = "deltav.perspective.timeseries.enabled", havingValue = "true")
+public class PerspectivePollerdTimeseriesConfiguration {
+
+    @Bean
+    public NewTopic deltavTimeseriesTopic(
+            @Value("${deltav.perspective.timeseries.partitions:16}") int partitions,
+            @Value("${deltav.perspective.timeseries.replication-factor:1}") short replicationFactor,
+            @Value("${deltav.perspective.timeseries.retention-days:1}") int retentionDays) {
+        return TopicBuilder.name("deltav-timeseries")
+                .partitions(partitions)
+                .replicas(replicationFactor)
+                .config("retention.ms", String.valueOf(retentionDays * 24L * 3600_000L))
+                .config("compression.type", "lz4")
+                .build();
+    }
+
+    @Bean
+    public PerspectiveResponseTimePublisher perspectiveResponseTimePublisher(StreamBridge streamBridge,
+                                                                             MeterRegistry meterRegistry) {
+        return new PerspectiveResponseTimePublisher(streamBridge, meterRegistry);
+    }
+}

--- a/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectiveResponseTimePublisher.java
+++ b/core/daemon-boot-perspectivepollerd/src/main/java/org/deltav/netmgt/perspectivepoller/boot/PerspectiveResponseTimePublisher.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.perspectivepoller.boot;
+
+import java.nio.charset.StandardCharsets;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import org.deltav.timeseries.proto.Attribute;
+import org.deltav.timeseries.proto.AttributeGroup;
+import org.deltav.timeseries.proto.AttributeType;
+import org.deltav.timeseries.proto.ProducerType;
+import org.deltav.timeseries.proto.Resource;
+import org.deltav.timeseries.proto.TimeseriesBatch;
+import org.opennms.netmgt.perspectivepoller.PerspectivePolledService;
+import org.opennms.netmgt.poller.PollStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Publishes per-poll response-time samples for PerspectivePollerd to the
+ * {@code deltav-timeseries} Kafka topic as {@link TimeseriesBatch} protobuf
+ * records, keyed by {@code "{perspective}@{nodeId}"}.
+ *
+ * <p>Mirrors the wire shape of {@code PollResultPublisher} (the Pollerd
+ * counterpart), with two distinguishing fields:
+ * <ul>
+ *   <li>{@link ProducerType#PRODUCER_PERSPECTIVE_POLLERD} so the consumer
+ *       can disambiguate from direct Pollerd records when the same node /
+ *       service is polled by both daemons.</li>
+ *   <li>{@code location} is set to {@link PerspectivePolledService#getPerspectiveLocation()}
+ *       — the Minion vantage point that ran the poll. Perspective polling's
+ *       whole point is the same service measured from multiple locations;
+ *       encoding the perspective in {@code location} produces a clean
+ *       per-vantage-point series in VictoriaMetrics.</li>
+ * </ul>
+ *
+ * <p>Error-isolated: never throws. Failures bump
+ * {@code deltav_timeseries_batches_failed_total} and the poll callback
+ * continues unaffected.
+ */
+public class PerspectiveResponseTimePublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PerspectiveResponseTimePublisher.class);
+    static final String BINDING_NAME = "publishTimeseries-out-0";
+    static final String GROUP_NAME = "response-time";
+    static final String ATTRIBUTE_NAME = "response";
+    static final String RESOURCE_TYPE = "monitoredService";
+    static final String PRODUCER_LABEL = "perspectivepollerd";
+
+    private final StreamBridge streamBridge;
+    private final MeterRegistry meterRegistry;
+
+    public PerspectiveResponseTimePublisher(StreamBridge streamBridge, MeterRegistry meterRegistry) {
+        this.streamBridge = streamBridge;
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void publish(PerspectivePolledService polledService, PollStatus status) {
+        if (polledService == null || status == null) {
+            return;
+        }
+        Double responseTime = status.getResponseTime();
+        if (responseTime == null || Double.isNaN(responseTime)) {
+            return;
+        }
+        String perspective = polledService.getPerspectiveLocation() != null
+                ? polledService.getPerspectiveLocation() : "Default";
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            TimeseriesBatch batch = buildBatch(polledService, status, responseTime, perspective);
+            byte[] payload;
+            try {
+                payload = batch.toByteArray();
+            } catch (RuntimeException ex) {
+                LOG.warn("Serialization failed for node {} svc {} perspective {}; dropping",
+                        polledService.getNodeId(), polledService.getServiceName(), perspective, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", perspective, "producer", PRODUCER_LABEL,
+                        "reason", "serialization_error").increment();
+                return;
+            }
+            byte[] key = (perspective + "@" + polledService.getNodeId()).getBytes(StandardCharsets.UTF_8);
+            Message<byte[]> message = MessageBuilder.withPayload(payload)
+                    .setHeader(KafkaHeaders.KEY, key)
+                    .build();
+            boolean sent;
+            try {
+                sent = streamBridge.send(BINDING_NAME, message);
+            } catch (RuntimeException ex) {
+                LOG.warn("streamBridge.send threw for node {} svc {} perspective {}",
+                        polledService.getNodeId(), polledService.getServiceName(), perspective, ex);
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", perspective, "producer", PRODUCER_LABEL,
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+            if (!sent) {
+                meterRegistry.counter("deltav_timeseries_batches_failed_total",
+                        "location", perspective, "producer", PRODUCER_LABEL,
+                        "reason", "kafka_send_error").increment();
+                return;
+            }
+            meterRegistry.counter("deltav_timeseries_batches_published_total",
+                    "location", perspective, "producer", PRODUCER_LABEL).increment();
+        } finally {
+            sample.stop(Timer.builder("deltav_timeseries_publish_duration_seconds")
+                    .tags("location", perspective, "producer", PRODUCER_LABEL)
+                    .register(meterRegistry));
+        }
+    }
+
+    private TimeseriesBatch buildBatch(PerspectivePolledService svc, PollStatus status,
+                                       double responseTimeMs, String perspective) {
+        long timestampMs = status.getTimestamp() != null
+                ? status.getTimestamp().getTime()
+                : System.currentTimeMillis();
+        String resourceId = "node[" + svc.getNodeId() + "].monitoredService["
+                + svc.getServiceName() + "]";
+        Attribute responseAttr = Attribute.newBuilder()
+                .setName(ATTRIBUTE_NAME)
+                .setNumeric(responseTimeMs)
+                .setType(AttributeType.ATTRIBUTE_TYPE_GAUGE)
+                .build();
+        AttributeGroup group = AttributeGroup.newBuilder()
+                .setName(GROUP_NAME)
+                .addAttributes(responseAttr)
+                .build();
+        Resource resource = Resource.newBuilder()
+                .setResourceId(resourceId)
+                .setType(RESOURCE_TYPE)
+                .setInstance(svc.getServiceName() != null ? svc.getServiceName() : "")
+                .addGroups(group)
+                .build();
+        return TimeseriesBatch.newBuilder()
+                .setTimestampMs(timestampMs)
+                .setNodeId(svc.getNodeId())
+                .setLocation(perspective)
+                .setCollectionPackage(svc.getServiceName() != null ? svc.getServiceName() : "")
+                .setProducer(ProducerType.PRODUCER_PERSPECTIVE_POLLERD)
+                .addResources(resource)
+                .build();
+    }
+}

--- a/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
@@ -14,6 +14,36 @@ spring:
     properties:
       hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
       hibernate.archive.autodetection: none
+  # KafkaAdmin (which provisions deltavTimeseriesTopic in
+  # PerspectivePollerdTimeseriesConfiguration when enabled) binds to
+  # spring.kafka.bootstrap-servers. The topic is shared with Pollerd; whichever
+  # daemon starts first creates it.
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+  cloud:
+    stream:
+      bindings:
+        publishTimeseries-out-0:
+          destination: deltav-timeseries
+          producer:
+            partition-count: ${DELTAV_PERSPECTIVE_TIMESERIES_PARTITIONS:16}
+            use-native-encoding: true
+      kafka:
+        binder:
+          brokers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+          auto-create-topics: true
+        bindings:
+          publishTimeseries-out-0:
+            producer:
+              configuration:
+                key.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                value.serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+                compression.type: lz4
+                linger.ms: 50
+                batch.size: 65536
+                acks: all
+                enable.idempotence: true
+                max.in.flight.requests.per.connection: 5
 
 opennms:
   home: ${OPENNMS_HOME:/opt/deltav}
@@ -37,3 +67,13 @@ management:
     web:
       exposure:
         include: health,prometheus
+
+# Phase 3 publisher knob — daemon-scoped, intentionally distinct from Pollerd's
+# `deltav.timeseries.enabled` so the two daemons can be toggled independently.
+deltav:
+  perspective:
+    timeseries:
+      enabled: ${DELTAV_PERSPECTIVE_TIMESERIES_ENABLED:false}
+      partitions: ${DELTAV_PERSPECTIVE_TIMESERIES_PARTITIONS:16}
+      replication-factor: ${DELTAV_PERSPECTIVE_TIMESERIES_REPLICATION_FACTOR:1}
+      retention-days: ${DELTAV_PERSPECTIVE_TIMESERIES_RETENTION_DAYS:1}

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -687,6 +687,10 @@ services:
       OPENNMS_TSID_NODE_ID: "7"
       OPENNMS_RPC_KAFKA_ENABLED: "true"
       OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      # Phase 3: publish per-poll response-time records to deltav-timeseries
+      # Kafka topic. Daemon-scoped flag — independent of Pollerd's
+      # DELTAV_TIMESERIES_ENABLED so the two can be toggled separately.
+      DELTAV_PERSPECTIVE_TIMESERIES_ENABLED: ${DELTAV_PERSPECTIVE_TIMESERIES_ENABLED:-true}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 10s


### PR DESCRIPTION
## Summary

- Closes the Phase 3 gap for PerspectivePollerd — per-poll response-time records now publish to the `deltav-timeseries` Kafka topic, completing the latency integration with VictoriaMetrics that was deferred in beta2.
- Mirrors the Pollerd PR #220 wire contract; distinguished by `ProducerType.PRODUCER_PERSPECTIVE_POLLERD` (already reserved in the protobuf enum).
- Enable flag `deltav.perspective.timeseries.enabled` is **daemon-scoped** — intentionally not the same name as Pollerd's `deltav.timeseries.enabled`. The two daemons must remain independently togglable.

## Approach

The instrumentation seam is `InstrumentedPerspectivePollerd`, a subclass of horizon's `PerspectivePollerd` that overrides `persistResponseTimeData(PerspectivePolledService, PollStatus)` — the only public per-poll callback exposed by horizon's daemon. The override:

1. Delegates to `super.persistResponseTimeData(...)` — preserves horizon's RRD-style persistence path.
2. Increments `deltav_perspective_polls_completed_total` and records `deltav_perspective_poll_duration_seconds` (closes the Phase 2 deferral noted in `PerspectivePollerdDomainMetrics`).
3. Forwards the sample to `PerspectiveResponseTimePublisher` when the conditional bean is wired (Phase 3).

Per `feedback_rpc_timeout_no_outages`, the seam fires only on RPC-successful polls — horizon's `PerspectivePollJob` exception branch never reaches `persistResponseTimeData`, so RPC infrastructure failures are correctly excluded from poll counters.

## Wire shape

`TimeseriesBatch` protobuf records, identical envelope to Pollerd's, with two distinguishing fields:
- `producer = PRODUCER_PERSPECTIVE_POLLERD` (consumer disambiguates origin when both daemons poll the same node/service)
- `location = polledService.getPerspectiveLocation()` (encodes the Minion vantage point — the whole point of perspective polling)

Resource ID `node[N].monitoredService[svc]` matches Pollerd's; perspective discrimination lives in the `location` field, producing a clean per-vantage-point series.

## Files

- **New:** `PerspectiveResponseTimePublisher.java` (publisher, mirrors Pollerd's `PollResultPublisher`)
- **New:** `InstrumentedPerspectivePollerd.java` (subclass + override)
- **New:** `PerspectivePollerdTimeseriesConfiguration.java` (`@ConditionalOnProperty(deltav.perspective.timeseries.enabled)`)
- **Modified:** `PerspectivePollerdDaemonConfiguration.java` (wires the subclass via `ObjectProvider`)
- **Modified:** `PerspectivePollerdDomainMetrics.java` (drops the deferral note, adds `POLLS_COMPLETED` / `POLL_DURATION` constants)
- **Modified:** `application.yml` (Spring Cloud Stream binder config + `deltav.perspective.timeseries.*` knobs)
- **Modified:** `pom.xml` (adds `deltav-kafka-contracts` + `spring-cloud-starter-stream-kafka`)
- **Modified:** `docker-compose.yml` (`DELTAV_PERSPECTIVE_TIMESERIES_ENABLED` env var, defaults true)

## Test plan

- [x] Local docker compose `full,metrics` profile — perspectivepollerd boots clean, no Spring binding errors
- [x] `deltav-timeseries` Kafka topic provisioned at startup
- [x] `deltav_perspective_poll_duration_seconds` exposed at `/actuator/prometheus` (count=0 since dev compose has no perspective applications seeded)
- [ ] **Smoke VM (rc3 cycle):** verify `deltav_timeseries_batches_published_total{producer="perspectivepollerd"}` increments after first perspective poll; spot-check VictoriaMetrics for the new series
- [ ] **Followup PR:** extend `test-perspective-e2e.sh` (or add a new test-timeseries-perspective-e2e.sh) to assert end-to-end record flow with seeded perspective application

## Notes

- Topic-tuning knobs (partitions, replication-factor, retention-days) follow first-declarer-wins semantics — both Pollerd and PerspectivePollerd declare the same `NewTopic`. Operators changing them should keep both daemons' values consistent.
- Pollerd's `deltav.timeseries.enabled` flag is a candidate for a future rename to `deltav.pollerd.timeseries.enabled` for naming consistency. Tracked separately, not blocking.