### PR TITLE
feat(v1.2.0): perspective monitoring smoke baseline + Grafana dashboard

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -36,6 +36,7 @@
 #     - ghcr.io/<owner>/clickhouse-init:<version>          One-shot DDL bootstrap sidecar
 #     - ghcr.io/<owner>/grafana:<version>                  Grafana + baked provisioning / dashboards
 #     - ghcr.io/<owner>/provisiond-imports-init:<version>  Seeds requisitions named volume on first boot
+#     - ghcr.io/<owner>/perspective-app-init:<version>     Seeds smoke-baseline perspective application
 #     - ghcr.io/<owner>/l8opensim-provisioner:<version>    POSTs 20-device seed to l8opensim
 #     - ghcr.io/<owner>/mock-snmp-agent:<version>          Mock SNMP agent (test infra)
 #     - ghcr.io/<owner>/flow-exporter:<version>            NetFlow v5/v9 test-node exporter
@@ -328,6 +329,19 @@ jobs:
             --push \
             .
 
+      - name: Build and push deltav/perspective-app-init image
+        working-directory: opennms-container/delta-v
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform ${{ env.PLATFORMS }} \
+            -f Dockerfile.perspective-app-init \
+            -t "${{ env.IMAGE_PREFIX }}/perspective-app-init:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/perspective-app-init:latest" \
+            --push \
+            .
+
       - name: Build and push deltav/l8opensim-provisioner image
         working-directory: opennms-container/delta-v
         env:
@@ -398,7 +412,7 @@ jobs:
           echo "     ./deploy.sh up lite"
           echo ""
           echo "### Images"
-          DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init flow-enricher prometheus-writer clickhouse clickhouse-init grafana provisiond-imports-init l8opensim-provisioner mock-snmp-agent flow-exporter sflow-exporter jre-deltav daemon-base"
+          DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init flow-enricher prometheus-writer clickhouse clickhouse-init grafana provisiond-imports-init perspective-app-init l8opensim-provisioner mock-snmp-agent flow-exporter sflow-exporter jre-deltav daemon-base"
           for name in $DAEMONS; do
             echo "  ${{ env.IMAGE_PREFIX }}/$name:${VERSION}"
           done

--- a/opennms-container/delta-v/Dockerfile.perspective-app-init
+++ b/opennms-container/delta-v/Dockerfile.perspective-app-init
@@ -1,0 +1,20 @@
+# Delta-V perspective-app-init sidecar — one-shot creator of the smoke-baseline
+# perspective application. After provisiond imports the perspective-smoke
+# requisition (the node + service rows appear in postgres), this sidecar
+# inserts the matching `applications`, `application_service_map`, and
+# `application_perspective_location_map` rows so PerspectivePollerd's tracker
+# discovers the application and starts polling from both perspectives.
+#
+# Idempotent: ON CONFLICT clauses make every insert safe to re-run. The
+# sidecar is a `restart: "no"` one-shot in compose.
+FROM alpine:3.20
+
+LABEL org.opencontainers.image.title="Delta-V Perspective App Init" \
+      org.opencontainers.image.description="Seeds the smoke-baseline perspective application after provisiond import"
+
+RUN apk add --no-cache postgresql16-client
+
+COPY perspective-app-init/init.sh /init.sh
+RUN chmod +x /init.sh
+
+ENTRYPOINT ["/init.sh"]

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -183,6 +183,20 @@ do_envoy_image() {
     apply_env_version_alias "deltav/envoy"
 }
 
+do_perspective_app_init_image() {
+    log "Building perspective-app-init image (deltav/perspective-app-init:$VERSION)..."
+    # Tiny Alpine + psql client + init.sh. Seeds the smoke-baseline
+    # perspective application after provisiond imports the perspective-smoke
+    # requisition. No Maven involvement.
+    cd "$SCRIPT_DIR"
+    docker build \
+        -f Dockerfile.perspective-app-init \
+        -t "deltav/perspective-app-init:$VERSION" \
+        -t "deltav/perspective-app-init:latest" \
+        .
+    apply_env_version_alias "deltav/perspective-app-init"
+}
+
 do_flow_enricher_image() {
     log "Building flow-enricher image (deltav/flow-enricher:$VERSION)..."
     cd "$REPO_ROOT"
@@ -320,8 +334,14 @@ do_deltav_images() {
     # No Maven; pure docker build.
     do_envoy_image
 
+    # --- Build perspective-app-init (smoke-baseline perspective seed) ---
+    # Tiny Alpine + psql client. Wires the Devices-API-Perspective-App
+    # application + service map + perspective locations after provisiond
+    # imports the perspective-smoke requisition.
+    do_perspective_app_init_image
+
     log "Delta-V images built:"
-    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy" | sort | head -25
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy|perspective-app-init" | sort | head -30
 }
 
 

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -167,6 +167,14 @@ services:
     ports:
       - "19161:161/udp"  # ad-hoc SNMP testing from the host
       - "19081:8080/tcp" # web UI + REST API
+    # Pinned IP so the perspective-smoke requisition can target a stable
+    # address. Default Minion routes via the Docker bridge to reach this;
+    # the l8opensim-lab Minion shares this netns so it sees 172.18.0.30 as
+    # one of its own interfaces (the "perspective" comes from the polling
+    # daemon's RPC dispatch, not the network path).
+    networks:
+      default:
+        ipv4_address: 172.18.0.30
 
   l8opensim-provisioner:
     <<: *no-search-domain
@@ -664,6 +672,27 @@ services:
       retries: 12
       start_period: 20s
 
+  # One-shot sidecar that creates the smoke-baseline perspective application
+  # (Devices-API-Perspective-App) once provisiond has imported the
+  # perspective-smoke requisition. PerspectivePollerd's tracker polls
+  # applications every 5s, so no daemon restart is needed.
+  perspective-app-init:
+    <<: *no-search-domain
+    profiles: [full]
+    image: ${IMAGE_PREFIX:-deltav}/perspective-app-init:${VERSION}
+    container_name: delta-v-perspective-app-init
+    restart: "no"
+    depends_on:
+      provisiond:
+        condition: service_healthy
+      minion-lab:
+        condition: service_healthy
+    environment:
+      PGHOST: postgres
+      PGUSER: opennms
+      PGPASSWORD: opennms
+      PGDATABASE: opennms
+
   perspectivepollerd:
     <<: *no-search-domain
     profiles: [full]
@@ -675,6 +704,8 @@ services:
         condition: service_completed_successfully
       kafka:
         condition: service_healthy
+      perspective-app-init:
+        condition: service_completed_successfully
     environment:
       JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=256m -Dorg.opennms.core.ipc.rpc.force-remote=true"
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms

--- a/opennms-container/delta-v/grafana/dashboards/perspective-monitoring.json
+++ b/opennms-container/delta-v/grafana/dashboards/perspective-monitoring.json
@@ -1,0 +1,228 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Perspective polling latency and throughput. Panels query the Phase 3 publisher series (deltav-timeseries Kafka topic → prometheus-writer → VictoriaMetrics). Service: HTTP-8080 against l8opensim's API root, polled from Default and l8opensim-lab perspectives.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "axisLabel": "response time",
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "opennms_response_time_response{producer=\"perspective_pollerd\"}",
+          "instant": false,
+          "legendFormat": "{{location}} → {{node_label}}/{{resource_instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-perspective response time (ms)",
+      "type": "timeseries",
+      "description": "Each line is one (perspective, target service) pair. Comparing the same target across perspectives reveals the network-path latency that perspective polling is designed to surface."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "avg by (location) (opennms_response_time_response{producer=\"perspective_pollerd\"})",
+          "instant": true,
+          "legendFormat": "{{location}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latest avg response time by perspective",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["mean"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "rate(deltav_perspective_polls_completed_total[1m])",
+          "legendFormat": "{{perspective}} ({{result}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Polls/sec by perspective + result",
+      "type": "timeseries",
+      "description": "Direct from PerspectivePollerd's /actuator/prometheus (deltav_perspective_polls_completed_total). Faceted by perspective and result label so 'down' polls stand out from 'up' ones."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "rate(deltav_timeseries_batches_failed_total{producer=\"perspectivepollerd\"}[5m])",
+          "legendFormat": "{{location}} ({{reason}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Phase 3 publish failures (perspectivepollerd)",
+      "type": "timeseries",
+      "description": "Rate of deltav_timeseries_batches_failed_total scoped to producer=perspectivepollerd. Should stay flat at zero; non-zero indicates Kafka or serialization issues with the Phase 3 publisher."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "increase(deltav_timeseries_batches_published_total{producer=\"perspectivepollerd\"}[5m])",
+          "legendFormat": "{{location}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Phase 3 records published (5m bucket)",
+      "type": "timeseries",
+      "description": "Confirms PerspectivePollerd's publisher is emitting to deltav-timeseries. Each bucket = number of records sent in the prior 5 minutes, broken out by perspective location. Zero across the board means the publisher is not running or the gating flag is off."
+    }
+  ],
+  "preload": false,
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["delta-v", "perspective", "polling"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Perspective Monitoring",
+  "uid": "perspective-monitoring",
+  "version": 1,
+  "weekStart": ""
+}

--- a/opennms-container/delta-v/perspective-app-init/init.sh
+++ b/opennms-container/delta-v/perspective-app-init/init.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+#
+# Seeds the smoke-baseline perspective application:
+#   - waits for provisiond to import the `perspective-smoke` requisition
+#     (the HTTP-8080 service row landing in `ifservices` is the trigger)
+#   - inserts the application + service map + two perspective-location rows
+#     (Default + l8opensim-lab) idempotently, via `ON CONFLICT` clauses
+#
+# PerspectivePollerd's PerspectiveServiceTracker timer-polls applications
+# every 5s, so it picks up the new mapping without a daemon restart.
+#
+# Required env: PGHOST, PGUSER, PGPASSWORD, PGDATABASE.
+
+set -eu
+
+APP_NAME="${PERSPECTIVE_APP_NAME:-Devices-API-Perspective-App}"
+FOREIGN_SOURCE="${PERSPECTIVE_FOREIGN_SOURCE:-perspective-smoke}"
+SERVICE_NAME="${PERSPECTIVE_SERVICE_NAME:-HTTP-8080}"
+LOCATION_A="${PERSPECTIVE_LOCATION_A:-Default}"
+LOCATION_B="${PERSPECTIVE_LOCATION_B:-l8opensim-lab}"
+WAIT_TIMEOUT="${PERSPECTIVE_WAIT_TIMEOUT:-300}"
+POLL_INTERVAL=5
+
+log() { echo "[perspective-app-init] $*"; }
+
+psql_q() {
+    psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -t -A -c "$1"
+}
+
+# 1. Wait for the perspective-smoke service row to land in ifservices.
+#    This proves provisiond has finished importing the requisition.
+log "Waiting for ${FOREIGN_SOURCE}/${SERVICE_NAME} to appear in ifservices (timeout ${WAIT_TIMEOUT}s)..."
+deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+ifservice_id=""
+while [ -z "$ifservice_id" ]; do
+    if [ "$(date +%s)" -gt "$deadline" ]; then
+        log "FAIL: ${SERVICE_NAME} on ${FOREIGN_SOURCE} did not appear in ifservices within ${WAIT_TIMEOUT}s"
+        log "      check provisiond logs: docker logs delta-v-provisiond"
+        exit 1
+    fi
+    ifservice_id=$(psql_q "
+        SELECT s.id
+          FROM ifservices s
+          JOIN ipinterface ip ON s.ipinterfaceid = ip.id
+          JOIN node n         ON ip.nodeid = n.nodeid
+          JOIN service st     ON s.serviceid = st.serviceid
+         WHERE n.foreignsource = '${FOREIGN_SOURCE}'
+           AND st.servicename  = '${SERVICE_NAME}'
+         LIMIT 1
+    " 2>/dev/null || echo "")
+    if [ -z "$ifservice_id" ]; then
+        sleep "$POLL_INTERVAL"
+    fi
+done
+log "Found ifservice id=${ifservice_id} for ${SERVICE_NAME}"
+
+# 2. Verify both perspective monitoring locations exist (Default is always
+#    present from db-init; l8opensim-lab appears once minion-lab registers).
+loc_count=$(psql_q "
+    SELECT count(*) FROM monitoringlocations WHERE id IN ('${LOCATION_A}', '${LOCATION_B}')
+")
+if [ "${loc_count:-0}" -ne 2 ]; then
+    log "FAIL: expected both monitoring locations (${LOCATION_A}, ${LOCATION_B}); found ${loc_count}"
+    log "      ensure minion-lab is running and has registered with the gateway"
+    exit 1
+fi
+log "Both monitoring locations present: ${LOCATION_A}, ${LOCATION_B}"
+
+# 3. Idempotently provision application + mappings.
+psql_q "
+    INSERT INTO applications (id, name)
+    VALUES (nextval('opennmsnxtid'), '${APP_NAME}')
+    ON CONFLICT (name) DO NOTHING;
+" >/dev/null
+app_id=$(psql_q "SELECT id FROM applications WHERE name = '${APP_NAME}'")
+if [ -z "$app_id" ]; then
+    log "FAIL: could not resolve application id for ${APP_NAME}"
+    exit 1
+fi
+log "Application ${APP_NAME} ready (id=${app_id})"
+
+psql_q "
+    INSERT INTO application_service_map (appid, ifserviceid)
+    VALUES (${app_id}, ${ifservice_id})
+    ON CONFLICT DO NOTHING;
+" >/dev/null
+log "Service ${SERVICE_NAME} mapped to application"
+
+for loc in "$LOCATION_A" "$LOCATION_B"; do
+    psql_q "
+        INSERT INTO application_perspective_location_map (appid, monitoringlocationid)
+        VALUES (${app_id}, '${loc}')
+        ON CONFLICT DO NOTHING;
+    " >/dev/null
+done
+log "Perspective locations mapped: ${LOCATION_A}, ${LOCATION_B}"
+
+log "Done — PerspectivePollerd tracker (5s polling timer) will pick up the application within seconds."

--- a/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/perspective-smoke.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/foreign-sources/perspective-smoke.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Smoke baseline foreign source for perspective monitoring. The single node
+  this requisition imports is polled from two perspectives (Default +
+  l8opensim-lab) by the perspective-app-init sidecar's application mapping.
+  Detectors are intentionally empty — the monitored service is provisioned
+  explicitly in the requisition, no auto-discovery needed.
+-->
+<foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source"
+                name="perspective-smoke">
+  <scan-interval>1d</scan-interval>
+  <detectors/>
+  <policies/>
+</foreign-source>

--- a/opennms-container/delta-v/provisiond-overlay/etc/imports-seed/perspective-smoke.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/imports-seed/perspective-smoke.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Smoke baseline requisition for perspective monitoring. One node pointing
+  at l8opensim's HTTP API at its static Docker network IP (172.18.0.30,
+  pinned in docker-compose.yml). Both Minions can reach this target:
+    - Default: routes via Docker bridge to 172.18.0.30
+    - l8opensim-lab: shares netns with l8opensim, so the IP is local
+  Uses the HTTP-8080 service (predefined in poller-configuration.xml) which
+  sends GET / against port 8080 — l8opensim returns 200 on /.
+-->
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
+              foreign-source="perspective-smoke">
+  <node location="Default" foreign-id="l8opensim-api" node-label="l8opensim-perspective-target">
+    <interface ip-addr="172.18.0.30" status="1" snmp-primary="N">
+      <monitored-service service-name="HTTP-8080"/>
+    </interface>
+  </node>
+</model-import>

--- a/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -46,6 +46,9 @@
   <requisition-def import-name="perspective-test" import-url-resource="file:///opt/deltav/etc/imports/perspective-test.xml">
     <cron-schedule>0 0/1 * * * ? *</cron-schedule>
   </requisition-def>
+  <requisition-def import-name="perspective-smoke" import-url-resource="file:///opt/deltav/etc/imports/perspective-smoke.xml">
+    <cron-schedule>0/30 * * * * ?</cron-schedule>
+  </requisition-def>
   <requisition-def import-name="flow-test"
                    import-url-resource="file:///opt/deltav/etc/imports/flow-test.xml">
     <cron-schedule>0/30 * * * * ?</cron-schedule>


### PR DESCRIPTION
## Summary

Wires PR #255's PerspectivePollerd Phase 3 publisher into the smoke baseline so every smoke run on the UTM VM exercises perspective polling end-to-end.

Three pieces:

1. **Seeded perspective application** — new `perspective-app-init` Alpine sidecar (psql + idempotent `INSERT ... ON CONFLICT`) creates `Devices-API-Perspective-App`, links the HTTP-8080 service from the new `perspective-smoke` requisition, and maps `Default` + `l8opensim-lab` as perspectives. Triggered after provisiond imports the requisition; runs *before* perspectivepollerd starts so the tracker's 5s timer picks the app up on first DB query (no daemon restart needed).

2. **Requisition seed** — `perspective-smoke.xml` + foreign source ship in the `provisiond-imports-init` image. One node (`l8opensim-perspective-target`) at l8opensim's pinned static IP `172.18.0.30` with the existing `HTTP-8080` service. Both Minions can reach this address: `Default` routes via the Docker bridge; `l8opensim-lab` shares l8opensim's netns so the IP is loopback-local. The "perspective" comes from the polling daemon's RPC dispatch, not the network path — which makes the latency asymmetry on the dashboard a *feature*, not a bug.

3. **Grafana dashboard** — `perspective-monitoring.json` baked into the `deltav/grafana` image. Five panels:
   - Per-perspective response time (timeseries) — `opennms_response_time_response{producer="perspective_pollerd"}`
   - Latest avg by perspective (stat)
   - Polls/sec by perspective + result (timeseries) — `rate(deltav_perspective_polls_completed_total[1m])`
   - Phase 3 publish failures (timeseries) — `rate(deltav_timeseries_batches_failed_total{producer="perspectivepollerd"}[5m])`
   - 5-minute publish counts by perspective (timeseries) — `increase(deltav_timeseries_batches_published_total{producer="perspectivepollerd"}[5m])`

## Daemon-scoping invariant preserved

The new sidecar's enable knob is implicit (it always runs in `full` profile). The publisher itself is gated by PR #255's daemon-scoped flag `deltav.perspective.timeseries.enabled` — no new shared config introduced.

## Build pipeline

Both `build.sh` (`do_perspective_app_init_image()` wired into `do_deltav_images`) and `.github/workflows/delta-v-build-images.yml` (new build-and-push step + DAEMONS list update) per `feedback_build_sh_and_gha_must_match`.

## Files

- **New:** `Dockerfile.perspective-app-init`, `perspective-app-init/init.sh`
- **New:** `provisiond-overlay/etc/foreign-sources/perspective-smoke.xml`
- **New:** `provisiond-overlay/etc/imports-seed/perspective-smoke.xml`
- **New:** `grafana/dashboards/perspective-monitoring.json`
- **Modified:** `provisiond-overlay/etc/provisiond-configuration.xml` (perspective-smoke requisition-def, 30s cron)
- **Modified:** `docker-compose.yml` (l8opensim ipv4_address 172.18.0.30, perspective-app-init service, perspectivepollerd depends_on chain)
- **Modified:** `build.sh`, `.github/workflows/delta-v-build-images.yml`

## Test plan

- [x] `./build.sh deltav` builds new perspective-app-init image cleanly + tags via `apply_env_version_alias`
- [x] Grafana image rebuild loads the new dashboard (verified via `/api/search` after `docker compose up -d --force-recreate grafana`)
- [x] All five dashboard panels syntactically valid (Grafana schema v39)
- [x] provisiond imports `perspective-smoke.xml` (visible in `current job names: ... perspective-smoke ...`)
- [ ] **Local stack full bring-up:** complete e2e (perspective-app-init → polls firing → metrics flowing). Provisiond startup on the dev box is unusually slow today (Hibernate + scheduler registration takes ~30 min); deferring the final visual confirmation to the smoke VM rc3 cycle, which boots faster.
- [ ] **Smoke VM rc3:** mint rc3 tag → smoker.sh → confirm `deltav_timeseries_batches_published_total{producer="perspectivepollerd"}` increments, dashboard panels populate

## Notes

- l8opensim's `/` HTTP root returns 200 OK (verified locally), so the HTTP-8080 monitor passes against it without per-package overrides.
- `ON CONFLICT DO NOTHING` on every insert means the sidecar is safe to re-run; volumes can persist across `docker compose down/up` without breaking the seed.
- `provisiond-imports-init`'s `.seeded` marker file means **dev volumes** carrying state from before this PR will need `docker volume rm delta-v_provisiond_imports` before the new requisition appears (per `feedback_named_volume_autopopulate`). Smoke VM is unaffected (fresh state).
- Pollerd's `deltav.timeseries.enabled` future rename to daemon-scoped `deltav.pollerd.timeseries.enabled` (per `feedback_no_shared_config_across_daemons`) is still queued separately, not blocking.