### PR TITLE
feat(v1.2.0): wire DroolsAlarmContext + EventProxy adapter in alarmd

### DIFF
--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -18,17 +18,30 @@ package org.deltav.netmgt.alarmd.boot;
 
 
 
+import java.io.File;
+
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.persistence.EntityManagerFactory;
 
 import org.deltav.core.daemon.common.SpringServiceDaemonSmartLifecycle;
+import org.hibernate.SessionFactory;
 import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
 import org.opennms.netmgt.alarmd.Alarmd;
 import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
 import org.opennms.netmgt.alarmd.AlarmPersister;
 import org.opennms.netmgt.alarmd.AlarmPersisterImpl;
 import org.opennms.netmgt.alarmd.NorthbounderManager;
+import org.opennms.netmgt.alarmd.drools.AlarmService;
+import org.opennms.netmgt.alarmd.drools.AlarmTicketerService;
+import org.opennms.netmgt.alarmd.drools.DefaultAlarmService;
+import org.opennms.netmgt.alarmd.drools.DefaultAlarmTicketerService;
+import org.opennms.netmgt.alarmd.drools.DroolsAlarmContext;
 import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.events.api.EventSubscriptionService;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Log;
 import org.opennms.netmgt.model.AlarmAssociation;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.OnmsAlarm;
@@ -51,11 +64,13 @@ import org.opennms.netmgt.model.jakarta.converter.NodeTypeConverter;
 import org.opennms.netmgt.model.jakarta.converter.OnmsSeverityConverter;
 import org.opennms.netmgt.model.jakarta.converter.PrimaryTypeConverter;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
 import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Spring Boot @Configuration that wires all Alarmd beans.
@@ -186,14 +201,19 @@ public class AlarmdConfiguration {
     }
 
     /**
-     * No-op EventProxy — Alarmd's NorthbounderManager uses this to send events
-     * for northbound interface state changes. Not needed until NBI integration.
+     * Bridges horizon's older {@link EventProxy} interface to delta-v's
+     * {@link EventForwarder} (KafkaEventForwarder) bean. Used by
+     * {@link NorthbounderManager} to send NBI state-change events, and by
+     * any horizon code path that resolves the {@code eventProxy} bean by
+     * name. Per {@code feedback_horizon_parallel_vs_additive}, EventProxy
+     * and EventForwarder are parallel abstractions — until horizon source
+     * deletes EventProxy entirely, an in-process delegate is the right fix.
      */
     @Bean(name = "eventProxy")
-    public org.opennms.netmgt.events.api.EventProxy eventProxy() {
-        return new org.opennms.netmgt.events.api.EventProxy() {
-            @Override public void send(org.opennms.netmgt.xml.event.Event event) {}
-            @Override public void send(org.opennms.netmgt.xml.event.Log eventLog) {}
+    public EventProxy eventProxy(EventForwarder eventForwarder) {
+        return new EventProxy() {
+            @Override public void send(Event event) { eventForwarder.sendNow(event); }
+            @Override public void send(Log eventLog) { eventForwarder.sendNow(eventLog); }
         };
     }
 
@@ -202,12 +222,91 @@ public class AlarmdConfiguration {
         return new NorthbounderManager();
     }
 
+    /**
+     * Exposes the Hibernate {@link SessionFactory} as a bean for
+     * {@link DroolsAlarmContext}'s {@code @Autowired SessionFactory} field.
+     * Spring Boot auto-configures an {@link EntityManagerFactory} via
+     * {@code spring-boot-starter-data-jpa}; Hibernate's SessionFactory is
+     * the underlying instance reachable via {@code unwrap}.
+     */
+    @Bean
+    public SessionFactory sessionFactory(EntityManagerFactory emf) {
+        return emf.unwrap(SessionFactory.class);
+    }
+
+    /**
+     * {@link TransactionTemplate} bean — DroolsAlarmContext autowires this
+     * concrete type (not the {@link TransactionOperations} interface).
+     * Sharing the same instance across both bean definitions is fine
+     * because TransactionTemplate is thread-safe.
+     */
+    @Bean
+    public TransactionTemplate transactionTemplate(
+            org.springframework.transaction.PlatformTransactionManager txManager) {
+        return new TransactionTemplate(txManager);
+    }
+
+    /**
+     * Drools facade for the Right-Hand-Side actions in alarmd / situations
+     * rules: clear, ack, escalate, set-severity, etc. Backs DroolsAlarmContext.
+     */
+    @Bean
+    public AlarmService alarmService() {
+        return new DefaultAlarmService();
+    }
+
+    /**
+     * Drools facade for ticketer integration (createTicket / updateTicket
+     * / closeTicket events). Publishes troubleTicket/* UEIs through the
+     * existing {@link EventForwarder}; the actual ticket-system dispatch
+     * happens in a future Kafka consumer per
+     * {@code project_external_alarm_integrations_as_kafka_consumers}.
+     * Until that consumer ships, ticket events flow to Kafka but are not
+     * consumed; that is harmless (no rules require ticket round-trip).
+     */
+    @Bean
+    public AlarmTicketerService alarmTicketerService() {
+        return new DefaultAlarmTicketerService();
+    }
+
+    /**
+     * Drools KieSession context that runs alarmd.drl + situations.drl on
+     * every alarm-lifecycle callback (created / cleared / acked / etc.).
+     * Without this bean, alarmd is "store and forget": alarms persist but
+     * never auto-clear, escalate, or archive.
+     *
+     * <p>The rules folder is baked into the alarmd container via
+     * {@code alarmd-overlay/etc/alarmd/drools-rules.d/} (bundled here from
+     * horizon's {@code opennms-base-assembly/.../drools-rules.d}). Default
+     * resolution via {@code DroolsAlarmContext#getDefaultRulesFolder()}
+     * relies on {@code ConfigFileConstants.getHome()} which reads the
+     * {@code opennms.home} system property; we pass the path explicitly to
+     * avoid that brittle indirection.</p>
+     */
+    @Bean
+    public DroolsAlarmContext droolsAlarmContext(
+            @Value("${opennms.home:/opt/deltav}") String opennmsHome) {
+        File rulesFolder = new File(opennmsHome, "etc/alarmd/drools-rules.d");
+        return new DroolsAlarmContext(rulesFolder);
+    }
+
+    /**
+     * <p>The Alarmd daemon — wired with DroolsAlarmContext for full alarm
+     * lifecycle automation. The 5th constructor argument ({@code MessageBus})
+     * stays {@code null}: in delta-v's containerized deployment model,
+     * horizon's reload-config IPC has no analog (config reload = container
+     * recreate), and horizon's own {@code Alarmd.onInit()} tolerates a null
+     * MessageBus by logging a single warning. The next horizon dep bump
+     * will drop the parameter entirely (see
+     * {@code project_horizon_alarmd_messagebus_removal}).</p>
+     */
     @Bean
     public Alarmd alarmd(AlarmPersister alarmPersister,
                          AlarmLifecycleListenerManager alarmLifecycleListenerManager,
-                         NorthbounderManager northbounderManager) {
+                         NorthbounderManager northbounderManager,
+                         DroolsAlarmContext droolsAlarmContext) {
         return new Alarmd(alarmPersister, alarmLifecycleListenerManager, northbounderManager,
-                null, null);
+                droolsAlarmContext, null /* MessageBus — see javadoc */);
     }
 
     @Bean

--- a/opennms-container/delta-v/alarmd-overlay/etc/alarmd/drools-rules.d/alarmd.drl
+++ b/opennms-container/delta-v/alarmd-overlay/etc/alarmd/drools-rules.d/alarmd.drl
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.drools;
+
+import java.util.Date;
+import org.kie.api.time.SessionClock;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
+
+global org.opennms.netmgt.alarmd.drools.AlarmService alarmService;
+
+declare org.opennms.netmgt.model.OnmsAlarm
+    @role(event)
+    @timestamp(lastUpdateTime)
+end
+
+rule "cosmicClear"
+  salience 100
+  when
+    $sessionClock : SessionClock()
+    $clear : OnmsAlarm(alarmType == OnmsAlarm.RESOLUTION_TYPE)
+    $trigger : OnmsAlarm(alarmType == OnmsAlarm.PROBLEM_TYPE, severity.isGreaterThanOrEqual(OnmsSeverity.NORMAL), reductionKey == $clear.clearKey, lastEventTime <= $clear.lastEventTime)
+  then
+    alarmService.clearAlarm($trigger, new Date($sessionClock.getCurrentTime()));
+end
+
+rule "unclear"
+  when
+    $sessionClock : SessionClock()
+    $trigger : OnmsAlarm(alarmType == OnmsAlarm.PROBLEM_TYPE,
+                         severity == OnmsSeverity.CLEARED, lastEvent != null,
+                         OnmsSeverity.get(lastEvent.getEventSeverity()).isGreaterThan(OnmsSeverity.CLEARED),
+                         lastEventTime > lastAutomationTime)
+  then
+    alarmService.unclearAlarm($trigger, new Date($sessionClock.getCurrentTime()));
+end
+
+/*
+  An example of how the alarm severity can be made to automatically increase over time.
+  This rule is purposely commented out and disabled by default.
+
+rule "escalation"
+  when
+    $sessionClock : SessionClock()
+    $alarm : OnmsAlarm((alarmType == OnmsAlarm.PROBLEM_TYPE || alarmType == OnmsAlarm.PROBLEM_WITHOUT_RESOLUTION_TYPE) &&
+                         OnmsSeverity.WARNING.isLessThanOrEqual(severity) &&
+                         OnmsSeverity.CRITICAL.isGreaterThan(severity) &&
+                         serviceType != null &&
+                         alarmAckTime == null)
+    not( OnmsAlarm( this == $alarm ) over window:time( 1h ) )
+  then
+    alarmService.escalateAlarm($alarm, new Date($sessionClock.getCurrentTime()));
+end
+*/
+
+rule "cleanUp"
+  salience 0
+  when
+    $sessionClock : SessionClock()
+    $alarm : OnmsAlarm(severity.isLessThanOrEqual(OnmsSeverity.NORMAL) &&
+                       alarmAckTime == null &&
+                       (TTicketState == null || TTicketState == TroubleTicketState.CLOSED || TTicketState == TroubleTicketState.CANCELLED))
+    not( OnmsAlarm( this == $alarm ) over window:time( 5m ) )
+  then
+    alarmService.deleteAlarm($alarm);
+end
+
+rule "fullCleanUp"
+  salience 0
+  when
+    $sessionClock : SessionClock()
+    $alarm : OnmsAlarm(severity.isLessThanOrEqual(OnmsSeverity.NORMAL) &&
+                        (TTicketState == null || TTicketState == TroubleTicketState.CLOSED || TTicketState == TroubleTicketState.CANCELLED))
+    not( OnmsAlarm( this == $alarm ) over window:time( 1d ) )
+  then
+    alarmService.deleteAlarm($alarm);
+end
+
+rule "GC"
+  salience 0
+  when
+    $sessionClock : SessionClock()
+    $alarm : OnmsAlarm(alarmAckTime == null)
+    not( OnmsAlarm( this == $alarm ) over window:time( 3d ) )
+  then
+    alarmService.deleteAlarm($alarm);
+end
+
+rule "fullGC"
+  salience 0
+  when
+    $sessionClock : SessionClock()
+    $alarm : OnmsAlarm()
+    not( OnmsAlarm( this == $alarm ) over window:time( 8d ) )
+  then
+    alarmService.deleteAlarm($alarm);
+end
+
+rule "createTickets"
+  enabled false
+  when
+    $sessionClock : SessionClock()
+    $ticketer : AlarmTicketerService(isTicketingEnabled() == true)
+    $alarm : OnmsAlarm(severity.isGreaterThan(OnmsSeverity.CLEARED) &&
+                       (alarmType == OnmsAlarm.PROBLEM_TYPE || alarmType == OnmsAlarm.PROBLEM_WITHOUT_RESOLUTION_TYPE) &&
+                       alarmAckUser == null &&
+                       TTicketState == null)
+    not( OnmsAlarm( this == $alarm ) over window:time( 15m ) )
+  then
+    alarmService.acknowledgeAlarm($alarm, new Date($sessionClock.getCurrentTime()));
+    $ticketer.createTicket($alarm, new Date($sessionClock.getCurrentTime()));
+end
+
+rule "createCriticalTicket"
+  enabled false
+  when
+    $sessionClock : SessionClock()
+    $ticketer : AlarmTicketerService(isTicketingEnabled() == true)
+    $alarm : OnmsAlarm(severity == OnmsSeverity.CRITICAL &&
+                       (alarmType == OnmsAlarm.PROBLEM_TYPE || alarmType == OnmsAlarm.PROBLEM_WITHOUT_RESOLUTION_TYPE) &&
+                       alarmAckUser == null &&
+                       TTicketState == null)
+    not( OnmsAlarm( this == $alarm ) over window:time( 5m ) )
+  then
+    alarmService.acknowledgeAlarm($alarm, new Date($sessionClock.getCurrentTime()));
+    $ticketer.createTicket($alarm, new Date($sessionClock.getCurrentTime()));
+end
+
+/*
+  When changing window times, ensure that they are compatible with other rules.
+  For example: when window time for updateTickets is less than cleanUp rule,
+  it may not cleanUp all the alarms that are getting updated with UpdateTickets rule.
+*/
+  
+rule "updateTickets"
+  enabled false
+  when
+    $sessionClock : SessionClock()
+    $ticketer : AlarmTicketerService(isTicketingEnabled() == true)
+    $alarm : OnmsAlarm(severity.isGreaterThan(OnmsSeverity.CLEARED) &&
+                       (alarmType == OnmsAlarm.PROBLEM_TYPE || alarmType == OnmsAlarm.PROBLEM_WITHOUT_RESOLUTION_TYPE) &&
+                       TTicketState != null)
+    not( OnmsAlarm( this == $alarm ) over window:time( 15m ) )
+  then
+    $ticketer.updateTicket($alarm, new Date($sessionClock.getCurrentTime()));
+end
+
+rule "closeClearedAlarmTickets"
+  enabled false
+  when
+    $sessionClock : SessionClock()
+    $ticketer : AlarmTicketerService(isTicketingEnabled() == true)
+    $alarm : OnmsAlarm(severity == OnmsSeverity.CLEARED &&
+                       TTicketState == TroubleTicketState.OPEN)
+    not( OnmsAlarm( this == $alarm ) over window:time( 15m ) )
+  then
+    $ticketer.closeTicket($alarm, new Date($sessionClock.getCurrentTime()));
+end
+
+rule "clearAlarmsForClosedTickets"
+  enabled false
+  when
+    $sessionClock : SessionClock()
+    AlarmTicketerService(isTicketingEnabled() == true)
+    $alarm : OnmsAlarm(severity.isGreaterThan(OnmsSeverity.CLEARED) &&
+                       (alarmType == OnmsAlarm.PROBLEM_TYPE || alarmType == OnmsAlarm.PROBLEM_WITHOUT_RESOLUTION_TYPE) &&
+                       TTicketState == TroubleTicketState.CLOSED)
+  then
+    alarmService.clearAlarm($alarm, new Date($sessionClock.getCurrentTime()));
+end

--- a/opennms-container/delta-v/alarmd-overlay/etc/alarmd/drools-rules.d/situations.drl
+++ b/opennms-container/delta-v/alarmd-overlay/etc/alarmd/drools-rules.d/situations.drl
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.drools;
+
+import java.util.Date;
+import java.util.List;
+import org.kie.api.time.SessionClock;
+import org.opennms.netmgt.model.OnmsAcknowledgment;
+import org.opennms.netmgt.model.AckAction;
+import org.opennms.netmgt.model.AlarmAssociation;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
+import java.util.LinkedList;
+
+global org.opennms.netmgt.alarmd.drools.AlarmService alarmService;
+
+declare org.opennms.netmgt.model.OnmsAlarm
+    @role(event)
+    @timestamp(lastUpdateTime)
+end
+
+rule "setSituationSeverityToMaxAlarmSeverity"
+  when
+    $sessionClock : SessionClock()
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds )
+    $relatedAlarms : LinkedList() from collect( OnmsAlarm($relatedAlarmIds contains id) )
+    $maxSeverity : OnmsSeverity( isLessThanOrEqual(OnmsSeverity.NORMAL) ) from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
+    OnmsAlarm( this == $situation, severity != $maxSeverity )
+  then
+    alarmService.setSeverity($situation, $maxSeverity, new Date($sessionClock.getCurrentTime()));
+end
+
+rule "escalateSituationSeverity"
+  when
+    $sessionClock : SessionClock()
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds )
+    $relatedAlarms : LinkedList() from collect( OnmsAlarm($relatedAlarmIds contains id) )
+    $maxSeverity : OnmsSeverity( isGreaterThan(OnmsSeverity.NORMAL) ) from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
+    OnmsAlarm( this == $situation, severity != OnmsSeverity.escalate($maxSeverity) )
+  then
+    alarmService.setSeverity($situation, OnmsSeverity.escalate($maxSeverity), new Date($sessionClock.getCurrentTime()));
+end
+
+rule "SituationHasBeenAcknowledged"
+  when
+    $sessionClock : SessionClock()
+    // The Situation has been Acknowledged.
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == true )
+    // There is an ACKNOWLEDGE ack in working memory.
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE)
+    // There are NO alarm ACKs after the Situation ACK.
+    $relatedAlarmAcks : LinkedList( size == 0 ) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackTime > $situationAck.getAckTime() ) )
+    // There is at least one related alarm that is not acknowledged and it was correlated before the Situation ACK.
+    $relatedAlarms : LinkedList( size > 0 ) from collect( OnmsAlarm($relatedAlarmIds contains id, isAcknowledged() == false ) )
+    // There is a related alarm that is unacknowleged
+    $relatedAlarm : OnmsAlarm($relatedAlarmIds contains id, $unAkedAlarmId : id, isAcknowledged() == false )
+    // The UN-ACK time for that alarm is prior to the Situation ACK
+    $unAcknowledgment : OnmsAcknowledgment(refId == $unAkedAlarmId, ackAction == AckAction.UNACKNOWLEDGE, ackTime < $situationAck.getAckTime() )
+    // The association time of that alarm is before the ACK time on the situation
+    $unAkedRelatedAlarmAssociation : AlarmAssociation(situationAlarm == $situation, $unAcknowledgment.refId == relatedAlarm.getId(), mappedTime < $situationAck.getAckTime() )
+  then
+    Date acknowledgeTime = new Date($sessionClock.getCurrentTime());
+    // Acknowledge all of the alarms in one go or we will trigger more rule evaluations
+    for (int i=0; i < $relatedAlarms.size(); i++) {
+       alarmService.acknowledgeAlarm((OnmsAlarm)$relatedAlarms.get(i), acknowledgeTime);
+    }
+end
+
+rule "SituationHasBeenUnAcknowledged"
+  when
+    $sessionClock : SessionClock()
+    // The Situation has been Unacknowledged (or was never Acknowledged)
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == false )
+    // Un-Ack'd and Non-Ack'd Alarms will have an UNACKNOWLEDGE ack in working memory.
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.UNACKNOWLEDGE)
+    // There are NO alarm ACKs after the Situation ACK
+    $relatedAlarmAcks : LinkedList( size == 0 ) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.ACKNOWLEDGE, ackTime > $situationAck.getAckTime() ) )
+    // There is NO NAK on any of the Related Alarms BEFORE the Situation NAK - it would have triggered the Situation NAK and should not be propagated.
+    $triggeringNaks : LinkedList( size == 0 ) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime < $situationAck.getAckTime() ) )
+    // The list of Alarms to Un-Acknowledge
+    $relatedAlarms : LinkedList( size > 0 ) from collect (OnmsAlarm($relatedAlarmIds contains id, isAcknowledged() == true) )
+  then
+    Date acknowledgeTime = new Date($sessionClock.getCurrentTime());
+    for (int i=0; i < $relatedAlarms.size(); i++) {
+        alarmService.unacknowledgeAlarm((OnmsAlarm)$relatedAlarms.get(i), acknowledgeTime);
+    }
+end
+
+rule "AllRelatedAlarmsAcknowledged"
+  when
+    $sessionClock : SessionClock()
+    // The Situation has been Unacknowledged (or was never Acknowledged)
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == false )
+    // Un-Ack'd and Non-Ack'd Alarms will have an UNACKNOWLEDGE ack in working memory.
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.UNACKNOWLEDGE)
+    // All the relatedAlarms are Acknowledged.
+    List(size == $relatedAlarmIds.size) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.ACKNOWLEDGE ) )
+    // There is at least one alarm ACK after the Situation ACK.
+    $triggeringAlarmAcks : LinkedList( size > 0 ) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.ACKNOWLEDGE, ackTime > $situationAck.getAckTime() ) )
+  then
+   	alarmService.acknowledgeAlarm((OnmsAlarm)$situation, new Date($sessionClock.getCurrentTime()));
+end
+
+rule "newAlarmsUnAcknowledgesSituation"
+  when
+    $sessionClock : SessionClock()
+    // There is an Acknowledged Situation.
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == true )
+    // The Situation Acknowledgment is in Working Memory.
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE )
+    // There is at least one un-Acknowledgment for one of the related alarms with a time after the Situation was acknowledged.
+    $unAkedRelatedAlarms : LinkedList(size > 0) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime > $situationAck.getAckTime() ) )
+  then
+   	alarmService.unacknowledgeAlarm($situation, new Date($sessionClock.getCurrentTime()));
+end
+
+rule "oldAlarmsUnAcknowledgesSituation"
+  when
+    $sessionClock : SessionClock()
+    // There is an Acknowledged Situation.
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == true )
+    // The Situation Acknowledgment is in Working Memory.
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE )
+    // There is a related alarm that is unacknowleged
+    // The UN-ACK time for that alarm is prior to the Situation ACK
+    $unAcknowledgment : OnmsAcknowledgment($relatedAlarmIds contains refId, $unAkedAlarmId : refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime < $situationAck.getAckTime() )
+    // The association time of that alarm is later than the ACK time on the situation
+	$unAkedRelatedAlarmAssociation : AlarmAssociation(situationAlarm == $situation, $unAcknowledgment.refId == relatedAlarm.getId(), mappedTime > $situationAck.getAckTime() )
+  then
+   	alarmService.unacknowledgeAlarm($situation, new Date($sessionClock.getCurrentTime()));
+end

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -741,7 +741,10 @@ services:
       kafka:
         condition: service_healthy
     environment:
-      JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=256m"
+      # Heap 1g → 1.5g for Drools: KieSession baseline ~50–200MB, plus a
+      # snapshot of all active alarms loaded at startup. Sized for typical
+      # 100s–1000s active-alarm deployments; very large sites may need more.
+      JAVA_OPTS: "-Xms512m -Xmx1536m -XX:MaxMetaspaceSize=256m"
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
       SPRING_DATASOURCE_USERNAME: opennms
       SPRING_DATASOURCE_PASSWORD: opennms


### PR DESCRIPTION
## Summary

Closes the largest user-visible alarm-lifecycle gap in delta-v (`project_alarmd_alarm_lifecycle_gap`). Without Drools wired, alarmd was "store and forget" — alarms persisted but never auto-cleared, escalated, or archived. This PR makes the alarm-lifecycle automation that horizon's `.drl` rules encode actually run.

Builds on PR #257 (AcknowledgmentDaoJpa).

## Three pieces

### 1. Drools rule bundle
- **`alarmd.drl`** (197 lines) — alarm reduction + auto-clear by reduction key
- **`situations.drl`** (158 lines) — situation correlation rules

Both copied verbatim from horizon's `opennms-base-assembly/.../drools-rules.d/` (no Maven placeholders to resolve). Baked into the alarmd container at `/opt/deltav/etc/alarmd/drools-rules.d/` via `alarmd-overlay/etc/`.

### 2. Bean wiring (`AlarmdConfiguration.java`)
- **`DefaultAlarmService`** — Drools facade for clear/ack/escalate RHS actions
- **`DefaultAlarmTicketerService`** — Drools facade for ticketing RHS. Publishes `troubleTicket/*` UEIs to Kafka. Future ticket-consumer (per `project_external_alarm_integrations_as_kafka_consumers`) dispatches to JIRA/RT/etc.
- **`DroolsAlarmContext`** — with explicit `rulesFolder` (avoids reliance on `ConfigFileConstants.getHome()` reading `opennms.home` system property)
- **`SessionFactory`** — unwrapped from `EntityManagerFactory`. Required by `DroolsAlarmContext`'s `@Autowired SessionFactory` (used for Hibernate lazy-init in alarm-snapshot processing)
- **`TransactionTemplate`** — concrete-typed bean. `DroolsAlarmContext` autowires the impl class, not the `TransactionOperations` interface

The `Alarmd` bean factory now passes `DroolsAlarmContext` as the 4th constructor arg (was `null`). The 5th arg `MessageBus` stays `null` with a javadoc explaining why — no analog in delta-v's containerized deployment model. Horizon source-fix to drop the parameter entirely is queued at `project_horizon_alarmd_messagebus_removal`.

### 3. `EventProxy` adapter (replaces no-op stub)
5-line delegate to the existing `EventForwarder` bean (`KafkaEventForwarder`). Per `feedback_horizon_parallel_vs_additive`, `EventProxy` and `EventForwarder` are parallel abstractions — an adapter is the right fix until horizon source deletes `EventProxy`. Used by `NorthbounderManager` and any horizon code path that resolves the `eventProxy` bean by name.

### Plus

- alarmd JVM heap bumped `-Xmx1g` → `-Xmx1536m` for Drools KieSession headroom (~50–200MB baseline + alarm snapshot loaded at startup). Sized for typical 100s–1000s active-alarm deployments.

## Maven dependencies

**No new deps needed.** Drools libs (drools-core, drools-compiler, drools-drl-parser, drools-kiesession, kie-api, mvel2, etc.) were already on alarmd's classpath transitively via horizon's `opennms-alarmd` JAR. Verified by `jar tf` against the alarmd boot fat jar — 11 Drools/Kie jars present in `BOOT-INF/lib/`.

## Files

- **New:** `opennms-container/delta-v/alarmd-overlay/etc/alarmd/drools-rules.d/alarmd.drl`
- **New:** `opennms-container/delta-v/alarmd-overlay/etc/alarmd/drools-rules.d/situations.drl`
- **Modified:** `core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java` (+106 lines: 5 new beans + EventProxy adapter)
- **Modified:** `opennms-container/delta-v/docker-compose.yml` (alarmd `JAVA_OPTS` heap bump)

## Test plan

- [x] `./mvnw -pl core/daemon-boot-alarmd -am clean install` — builds clean
- [x] `./mvnw -pl core/daemon-boot-alarmd test` — passes (no module-level tests; matches Pollerd / PerspectivePollerd pattern)
- [x] All 11 Drools/Kie jars confirmed shipping in alarmd boot fat jar
- [ ] **Local docker compose:** boot alarmd with new config, observe `Loading all alarms to seed Drools context.` log line, confirm no exceptions during KieBuilder rule compilation
- [ ] **Smoke VM rc3:** observe `deltav_alarmd_alarms_*` counters increment under alarm activity; spot-check that resolved alarms transition to CLEARED severity within rule-triggered windows

## Architectural context

This PR + PR #257 together complete the v1.2.0 alarm-lifecycle work originally outlined in `project_alarmd_alarm_lifecycle_gap`. Sibling decisions captured during this PR's brainstorm:

- `feedback_horizon_parallel_vs_additive` — when to fix in horizon vs adapter
- `project_horizon_alarmd_messagebus_removal` — followup horizon source-fix
- `project_external_alarm_integrations_as_kafka_consumers` — future v1.3+ replacement for removed Ackd / Ticketd / Northbounders

## Risk

- **First Drools KieSession build at startup may surface unexpected `.drl` compile errors** if delta-v's classpath has different versions of the model classes the rules reference. The .drl files use `OnmsAlarm`, `OnmsSeverity`, etc. which delta-v's `opennms-model-jakarta` provides. Both source the same horizon parent, so signatures should match — but worth watching at first runtime.
- **MessageBus is `null` by design.** Horizon's `Alarmd.onInit()` logs a single `WARN` ("MessageBus not available — Alarmd will not receive IPC events via MessageBus") and continues. Acceptable; not a regression (was already the case).