### PR TITLE
feat(v1.2.0): rename Kafka Sink topic prefix OpenNMS.Sink.* → DeltaV.Sink.*

### DIFF
--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/TelemetryListenerConfiguration.java
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.Configuration;
  * <p>When enabled, opens UDP port {@code opennms.minion.telemetry.port}
  * (default 4729) to receive Netflow v5/v9, IPFIX, and sFlow datagrams
  * and forwards each one to the appropriate
- * {@code OpenNMS.Sink.Telemetry-*} Kafka topic via the Sink API.</p>
+ * {@code DeltaV.Sink.Telemetry-*} Kafka topic via the Sink API.</p>
  *
  * <p>Lifecycle phase 400: listeners start last, after Sink client
  * (200) and RPC server (300) are ready. Matches the Trap and Syslog

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowSinkModule.java
@@ -29,7 +29,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 
 /**
  * Sink module that ships per-datagram {@link FlowTelemetryMessage}
- * envelopes to Kafka topic {@code OpenNMS.Sink.Telemetry-{protocol}}.
+ * envelopes to Kafka topic {@code DeltaV.Sink.Telemetry-{protocol}}.
  *
  * <p>Each UDP datagram received by {@code FlowUdpListener} becomes one
  * Kafka message. There is no aggregation in this first cut — the

--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowUdpListener.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/telemetry/FlowUdpListener.java
@@ -46,7 +46,7 @@ import io.netty.channel.socket.nio.NioDatagramChannel;
  * Netty-based UDP listener that receives flow protocol datagrams on a
  * single port, detects the protocol via {@link FlowProtocol#detect}, and
  * dispatches each datagram to a per-protocol {@link AsyncDispatcher}
- * targeting the {@code OpenNMS.Sink.Telemetry-{protocol}} Kafka topic.
+ * targeting the {@code DeltaV.Sink.Telemetry-{protocol}} Kafka topic.
  *
  * <p>Owns its own single-thread {@link NioEventLoopGroup}. The existing
  * Minion Trap listener uses horizon's {@code TrapListener} (internal

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/KafkaSinkBridge.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/KafkaSinkBridge.java
@@ -41,8 +41,9 @@ import org.springframework.beans.factory.InitializingBean;
 /**
  * Bridges Kafka Sink topic consumption to the {@link TelemetryMessageConsumerManager}.
  *
- * <p>In the Delta-V architecture, Minion forwards telemetry data to per-queue Kafka Sink
- * topics (e.g., {@code OpenNMS.Sink.Telemetry-Netflow-5}, {@code OpenNMS.Sink.Telemetry-IPFIX}).
+ * <p>In the Delta-V architecture, minion-gateway publishes Minion-forwarded telemetry data
+ * to per-queue Kafka Sink topics (e.g., {@code DeltaV.Sink.Telemetry-Netflow-5},
+ * {@code DeltaV.Sink.Telemetry-IPFIX}).
  * Each bridge instance consumes from one topic and dispatches to the consumer manager,
  * which delivers to the appropriate telemetry adapter.</p>
  *
@@ -106,7 +107,7 @@ public class KafkaSinkBridge implements InitializingBean, DisposableBean {
 
         final String bootstrapServers = System.getProperty(PROP_BOOTSTRAP_SERVERS, DEFAULT_BOOTSTRAP_SERVERS);
         final String groupId = System.getProperty(PROP_GROUP_ID, DEFAULT_GROUP_ID);
-        final String topic = "OpenNMS.Sink." + module.getId();
+        final String topic = "DeltaV.Sink." + module.getId();
         LOG.info("KafkaSinkBridge starting: topic={}, bootstrapServers={}, groupId={}", topic, bootstrapServers, groupId);
 
         Properties props = new Properties();

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetryMessageConsumerManager.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetryMessageConsumerManager.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.DisposableBean;
  *
  * <p>Unlike the single-module LocalMessageConsumerManager (used by Trapd/Syslogd),
  * this manager spawns a separate KafkaSinkBridge per registered SinkModule.
- * Each bridge consumes from its own Kafka topic (e.g., OpenNMS.Sink.Telemetry-Netflow-5).</p>
+ * Each bridge consumes from its own Kafka topic (e.g., DeltaV.Sink.Telemetry-Netflow-5).</p>
  *
  * <p>When {@code Telemetryd.start()} runs, it creates {@code TelemetrySinkModule} instances
  * per queue and registers consumers with this manager. The {@code startConsumingForModule()}

--- a/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydSinkConfiguration.java
+++ b/core/daemon-boot-telemetryd/src/main/java/org/deltav/netmgt/telemetry/boot/TelemetrydSinkConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
  * <p>Provides a {@link TelemetryMessageConsumerManager} that spawns one
  * {@link KafkaSinkBridge} per telemetry protocol
  * (Netflow-5, IPFIX, sFlow, etc.). Each bridge consumes from its own Kafka
- * Sink topic (e.g., OpenNMS.Sink.Telemetry-Netflow-5).</p>
+ * Sink topic (e.g., DeltaV.Sink.Telemetry-Netflow-5).</p>
  *
  * <p>The {@link LocalMessageDispatcherFactory} routes dispatched messages
  * directly to the consumer manager in-process -- no remote transport.</p>

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -17,7 +17,7 @@
     <name>OpenNMS :: Core :: Daemon Sink :: Kafka</name>
     <description>
         Shared Kafka Sink bridge infrastructure for Spring Boot daemon containers.
-        Consumes from Minion Sink topics (OpenNMS.Sink.*) and dispatches to local consumers.
+        Consumes from Minion Sink topics (DeltaV.Sink.*) and dispatches to local consumers.
     </description>
 
     <dependencies>

--- a/core/daemon-sink-kafka/src/main/java/org/deltav/core/daemon/sink/kafka/KafkaSinkBridge.java
+++ b/core/daemon-sink-kafka/src/main/java/org/deltav/core/daemon/sink/kafka/KafkaSinkBridge.java
@@ -37,9 +37,9 @@ import org.springframework.beans.factory.InitializingBean;
 /**
  * Bridges Kafka Sink topic consumption to the local {@link LocalMessageConsumerManager}.
  *
- * <p>Minion forwards messages (traps, syslogs, telemetry) to Kafka Sink topics
- * ({@code OpenNMS.Sink.{moduleId}}). This bridge consumes from that topic and
- * dispatches to the local consumer manager.</p>
+ * <p>minion-gateway publishes Minion-forwarded messages (traps, syslogs, telemetry)
+ * to Kafka Sink topics ({@code DeltaV.Sink.{moduleId}}). This bridge consumes from
+ * that topic and dispatches to the local consumer manager.</p>
  *
  * <p>Reusable by any daemon that consumes from Minion Sink topics.</p>
  */
@@ -91,7 +91,7 @@ public class KafkaSinkBridge implements InitializingBean, DisposableBean {
         }
         if (closed.get()) return;
 
-        final String topic = "OpenNMS.Sink." + module.getId();
+        final String topic = "DeltaV.Sink." + module.getId();
         LOG.info("KafkaSinkBridge starting: topic={}, bootstrapServers={}, groupId={}",
                 topic, bootstrapServers, groupId);
 

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/DeserializedSinkMessage.java
@@ -31,7 +31,7 @@ import org.opennms.netmgt.telemetry.common.ipc.TelemetryProtos;
  * carry a {@code moduleId} field &mdash; its fields are {@code messageId},
  * {@code content}, {@code currentChunkNumber}, {@code totalChunks}, and
  * {@code tracingInfo}. The Sink IPC framework derives the module identifier
- * from the Kafka topic name ({@code OpenNMS.Sink.{moduleId}}; see
+ * from the Kafka topic name ({@code DeltaV.Sink.{moduleId}}; see
  * {@code KafkaSinkBridge} in {@code core/daemon-sink-kafka}).
  *
  * <p>The single-argument {@link SinkMessageDeserializer#deserialize(byte[])}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherApplication.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherApplication.java
@@ -24,7 +24,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * Entry point for the Delta-V flow-enricher service.
  *
  * <p>Spring Boot 4.0 + Spring Cloud Stream (Kafka binder) consumer that reads
- * raw flow telemetry from OpenNMS Sink topics, enriches each flow with node
+ * raw flow telemetry from Delta-V Sink topics, enriches each flow with node
  * lookup, locality, and SNMP-interface marking, and publishes enriched
  * FlowDocument protobuf messages to the {@code deltav-flows} topic — the
  * public contract topic for community downstream consumers.

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
@@ -57,12 +57,7 @@ import org.springframework.messaging.Message;
  *
  * <h2>Module ID extraction</h2>
  *
- * <p>The Kafka topic follows one of two naming schemes:
- * <ul>
- *   <li>{@code OpenNMS.Sink.<moduleId>} &mdash; when the Minion was configured
- *       against an upstream horizon-style broker</li>
- *   <li>{@code DeltaV.Sink.<moduleId>} &mdash; the delta-v-native prefix</li>
- * </ul>
+ * <p>The Kafka topic follows the scheme {@code DeltaV.Sink.<moduleId>}.
  * The prefix is stripped to yield a module ID such as
  * {@code Telemetry-Netflow-5}, which is used as the dispatch key into the
  * processor map. Any other prefix (including a missing header) causes the
@@ -101,7 +96,6 @@ public class FlowEnrichmentFunction {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlowEnrichmentFunction.class);
 
-    private static final String OPENNMS_SINK_PREFIX = "OpenNMS.Sink.";
     private static final String DELTAV_SINK_PREFIX = "DeltaV.Sink.";
 
     private final SinkMessageDeserializer deserializer;
@@ -271,9 +265,6 @@ public class FlowEnrichmentFunction {
     private static String extractModuleId(String topicName) {
         if (topicName == null) {
             return null;
-        }
-        if (topicName.startsWith(OPENNMS_SINK_PREFIX)) {
-            return topicName.substring(OPENNMS_SINK_PREFIX.length());
         }
         if (topicName.startsWith(DELTAV_SINK_PREFIX)) {
             return topicName.substring(DELTAV_SINK_PREFIX.length());

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/SinkMessageDeserializer.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * <p><strong>moduleId source:</strong> the {@link SinkMessage} envelope does
  * not carry a {@code moduleId} field; in the Sink IPC protocol the module
  * identifier is derived from the Kafka topic name
- * ({@code OpenNMS.Sink.{moduleId}}). Callers that know the topic should use
+ * ({@code DeltaV.Sink.{moduleId}}). Callers that know the topic should use
  * the {@link #deserialize(String, byte[])} overload to supply the moduleId
  * explicitly. The {@link #deserialize(byte[])} overload populates the
  * {@link DeserializedSinkMessage#moduleId() moduleId} field as {@code null}.

--- a/core/flow-enricher/src/main/resources/application.yml
+++ b/core/flow-enricher/src/main/resources/application.yml
@@ -15,11 +15,10 @@ spring:
     stream:
       bindings:
         # Multi-topic input: comma-separated destinations let one binding
-        # consume from all four flow Sink topics in parallel. Defaults to the
-        # legacy OpenNMS.Sink.* prefix until the DeltaV.Sink.* rename lands;
-        # operators can override the whole list via DELTAV_FLOWS_SINK_TOPICS.
+        # consume from all four flow Sink topics in parallel. Operators can
+        # override the whole list via DELTAV_FLOWS_SINK_TOPICS.
         enrichFlows-in-0:
-          destination: ${DELTAV_FLOWS_SINK_TOPICS:OpenNMS.Sink.Telemetry-Netflow-5,OpenNMS.Sink.Telemetry-Netflow-9,OpenNMS.Sink.Telemetry-IPFIX,OpenNMS.Sink.Telemetry-SFlow}
+          destination: ${DELTAV_FLOWS_SINK_TOPICS:DeltaV.Sink.Telemetry-Netflow-5,DeltaV.Sink.Telemetry-Netflow-9,DeltaV.Sink.Telemetry-IPFIX,DeltaV.Sink.Telemetry-SFlow}
           group: deltav-flow-enricher
         enrichFlows-out-0:
           destination: ${DELTAV_FLOWS_OUTPUT_TOPIC:deltav-flows}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
@@ -57,7 +57,7 @@ class FlowEnrichmentFunctionTest {
 
     private static final String EXPORTER_ADDRESS = "192.0.2.10";
     private static final String MINION_LOCATION = "Default";
-    private static final String NF5_TOPIC = "OpenNMS.Sink.Telemetry-Netflow-5";
+    private static final String NF5_TOPIC = "DeltaV.Sink.Telemetry-Netflow-5";
     private static final String NF5_MODULE_ID = "Telemetry-Netflow-5";
 
     private SinkMessageDeserializer deserializer;
@@ -141,7 +141,7 @@ class FlowEnrichmentFunctionTest {
         byte[] kafkaBytes = buildValidSinkMessageBytes();
 
         List<byte[]> result = function.processMessage(
-                messageWithTopic("OpenNMS.Sink.Telemetry-Made-Up", kafkaBytes));
+                messageWithTopic("DeltaV.Sink.Telemetry-Made-Up", kafkaBytes));
 
         assertThat(result).isEmpty();
     }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/integration/FlowEnrichmentStreamBinderIT.java
@@ -132,9 +132,9 @@ class FlowEnrichmentStreamBinderIT {
     // application.yml's enrichFlows-in-0.destination. The test binder
     // provisions one SubscribableChannel per entry, keyed by
     // "<destination>.destination".
-    private static final String NF5_DESTINATION = "OpenNMS.Sink.Telemetry-Netflow-5";
-    private static final String NF9_DESTINATION = "OpenNMS.Sink.Telemetry-Netflow-9";
-    private static final String IPFIX_DESTINATION = "OpenNMS.Sink.Telemetry-IPFIX";
+    private static final String NF5_DESTINATION = "DeltaV.Sink.Telemetry-Netflow-5";
+    private static final String NF9_DESTINATION = "DeltaV.Sink.Telemetry-Netflow-9";
+    private static final String IPFIX_DESTINATION = "DeltaV.Sink.Telemetry-IPFIX";
     // SFLOW_DESTINATION omitted because this IT does not drive raw sFlow
     // wire bytes through the enricher. The real SFlowUdpParser bean is
     // constructed in this context (via the LogPreservingThreadFactory shim)
@@ -333,7 +333,7 @@ class FlowEnrichmentStreamBinderIT {
     @Test
     void unknownTopicPrefixDropsMessage() throws Exception {
         // Use a destination the enricher is NOT bound to: the input side is
-        // bound to the four OpenNMS.Sink.* channels, so to exercise the
+        // bound to the four DeltaV.Sink.* channels, so to exercise the
         // "unknown prefix" branch we must send through one of the bound
         // destinations but with a header that carries a prefix the enricher
         // doesn't recognize. We do that by overriding RECEIVED_TOPIC on the

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -78,7 +78,7 @@
             </exclusions>
         </dependency>
         <!-- horizon's SinkMessageProto wire format on the daemon-facing
-             Kafka topics OpenNMS.Sink.<Type>. The gateway wraps the
+             Kafka topics DeltaV.Sink.&lt;Type&gt;. The gateway wraps the
              gRPC-delivered opaque payload bytes in a SinkMessage protobuf
              before publishing — horizon's KafkaSinkBridge.pollLoop calls
              SinkMessage.parseFrom(record.value()) and would throw

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/MinionGatewayApplication.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/MinionGatewayApplication.java
@@ -36,7 +36,7 @@ public class MinionGatewayApplication {
 
     /**
      * Bridges horizon's Dropwizard MetricRegistry (used by the Kafka producer
-     * republishing to OpenNMS.Sink.Heartbeat) into Micrometer so meters appear
+     * republishing to DeltaV.Sink.Heartbeat) into Micrometer so meters appear
      * at /actuator/prometheus under the "opennms_" prefix per
      * feedback_meter_naming_horizon_vs_deltav. Spring gRPC's native
      * Micrometer meters (grpc.server.*) are emitted directly without

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatKafkaProducer.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatKafkaProducer.java
@@ -33,7 +33,7 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Republishes translated Heartbeat records to {@code OpenNMS.Sink.Heartbeat}
+ * Republishes translated Heartbeat records to {@code DeltaV.Sink.Heartbeat}
  * so the existing horizon consumer keys correctly off identity.
  *
  * <p>Per {@code feedback_meter_naming_horizon_vs_deltav}, the publish counters

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatTranslator.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/kafka/HeartbeatTranslator.java
@@ -33,7 +33,7 @@ import java.time.format.DateTimeFormatter;
  */
 public final class HeartbeatTranslator {
 
-    public static final String TOPIC = "OpenNMS.Sink.Heartbeat";
+    public static final String TOPIC = "DeltaV.Sink.Heartbeat";
 
     private static final DateTimeFormatter ISO =
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC);

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SyslogGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/SyslogGrpcService.java
@@ -32,7 +32,7 @@ import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOC
 
 /**
  * Bidi-streaming gRPC SyslogService. Per-onNext: forwards opaque payload
- * bytes to {@code OpenNMS.Sink.Syslog} keyed by {@code <location>@<minion-id>}.
+ * bytes to {@code DeltaV.Sink.Syslog} keyed by {@code <location>@<minion-id>}.
  *
  * <p>Per Decision 6 (sinks are lossy by design): Kafka publish failures
  * log and continue; the gRPC stream is not torn down on a single
@@ -43,7 +43,7 @@ import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOC
 public class SyslogGrpcService extends SyslogServiceGrpc.SyslogServiceImplBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SyslogGrpcService.class);
-    private static final String TOPIC = "OpenNMS.Sink.Syslog";
+    private static final String TOPIC = "DeltaV.Sink.Syslog";
 
     private final SinkKafkaProducer producer;
 

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TelemetryGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TelemetryGrpcService.java
@@ -32,7 +32,7 @@ import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOC
 
 /**
  * Bidi-streaming gRPC TelemetryService. Four protocol-specific {@code publish*}
- * methods route opaque payload bytes to {@code OpenNMS.Sink.Telemetry-<proto>}
+ * methods route opaque payload bytes to {@code DeltaV.Sink.Telemetry-<proto>}
  * topics keyed by {@code <location>@<minion-id>}. Routing is by RPC method,
  * not by inspecting payload — the Minion picks the topic by calling the
  * matching method on the generated stub.
@@ -46,10 +46,10 @@ import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOC
 public class TelemetryGrpcService extends TelemetryServiceGrpc.TelemetryServiceImplBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(TelemetryGrpcService.class);
-    private static final String IPFIX_TOPIC = "OpenNMS.Sink.Telemetry-IPFIX";
-    private static final String NETFLOW5_TOPIC = "OpenNMS.Sink.Telemetry-Netflow-5";
-    private static final String NETFLOW9_TOPIC = "OpenNMS.Sink.Telemetry-Netflow-9";
-    private static final String SFLOW_TOPIC = "OpenNMS.Sink.Telemetry-SFlow";
+    private static final String IPFIX_TOPIC = "DeltaV.Sink.Telemetry-IPFIX";
+    private static final String NETFLOW5_TOPIC = "DeltaV.Sink.Telemetry-Netflow-5";
+    private static final String NETFLOW9_TOPIC = "DeltaV.Sink.Telemetry-Netflow-9";
+    private static final String SFLOW_TOPIC = "DeltaV.Sink.Telemetry-SFlow";
 
     private final SinkKafkaProducer producer;
 

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TrapGrpcService.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/sink/TrapGrpcService.java
@@ -32,7 +32,7 @@ import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOC
 
 /**
  * Bidi-streaming gRPC TrapService. Per-onNext: forwards opaque payload
- * bytes to {@code OpenNMS.Sink.Trap} keyed by {@code <location>@<minion-id>}.
+ * bytes to {@code DeltaV.Sink.Trap} keyed by {@code <location>@<minion-id>}.
  *
  * <p>Per Decision 6 (sinks are lossy by design): Kafka publish failures
  * log and continue; the gRPC stream is not torn down on a single
@@ -43,7 +43,7 @@ import static org.deltav.gateway.grpc.MinionIdentityServerInterceptor.MINION_LOC
 public class TrapGrpcService extends TrapServiceGrpc.TrapServiceImplBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(TrapGrpcService.class);
-    private static final String TOPIC = "OpenNMS.Sink.Trap";
+    private static final String TOPIC = "DeltaV.Sink.Trap";
 
     private final SinkKafkaProducer producer;
 

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceIT.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceIT.java
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
  * End-to-end IT: real-startup minion-gateway daemon, real Kafka broker
  * (Testcontainers), gRPC client publishes one Heartbeat with identity
  * metadata and asserts the matching record on
- * {@code OpenNMS.Sink.Heartbeat}.
+ * {@code DeltaV.Sink.Heartbeat}.
  *
  * <p>Uses the {@link ApplicationContextInitializer} pattern (rather than
  * {@code @DynamicPropertySource}) to start the Kafka container before the
@@ -130,7 +130,7 @@ class HeartbeatGrpcServiceIT {
         cp.put("value.deserializer", ByteArrayDeserializer.class);
 
         try (KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(cp)) {
-            consumer.subscribe(Collections.singletonList("OpenNMS.Sink.Heartbeat"));
+            consumer.subscribe(Collections.singletonList("DeltaV.Sink.Heartbeat"));
             List<ConsumerRecord<String, byte[]>> all = new java.util.ArrayList<>();
             long deadline = System.nanoTime() + Duration.ofSeconds(20).toNanos();
             while (all.isEmpty() && System.nanoTime() < deadline) {

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/grpc/HeartbeatGrpcServiceTest.java
@@ -95,7 +95,7 @@ class HeartbeatGrpcServiceTest {
         ArgumentCaptor<ProducerRecord<String, byte[]>> captor =
             ArgumentCaptor.forClass(ProducerRecord.class);
         org.mockito.Mockito.verify(mockProducer).send(captor.capture());
-        assertThat(captor.getValue().topic()).isEqualTo("OpenNMS.Sink.Heartbeat");
+        assertThat(captor.getValue().topic()).isEqualTo("DeltaV.Sink.Heartbeat");
         assertThat(captor.getValue().key()).isEqualTo("loc-DC1@minion-A");
 
         sender.onCompleted();

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/kafka/HeartbeatTranslatorTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/kafka/HeartbeatTranslatorTest.java
@@ -35,7 +35,7 @@ class HeartbeatTranslatorTest {
 
         var record = HeartbeatTranslator.toKafkaRecord(hb, "minion-A", "loc-DC1");
 
-        assertThat(record.topic()).isEqualTo("OpenNMS.Sink.Heartbeat");
+        assertThat(record.topic()).isEqualTo("DeltaV.Sink.Heartbeat");
         assertThat(record.key()).isEqualTo("loc-DC1@minion-A");
     }
 

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SinkKafkaProducerTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SinkKafkaProducerTest.java
@@ -39,13 +39,13 @@ class SinkKafkaProducerTest {
         SinkKafkaProducer producer = new SinkKafkaProducer(mock, metrics);
 
         CompletableFuture<Void> result = producer.send(
-            "OpenNMS.Sink.Syslog", "Default@minion-A", "payload-bytes".getBytes());
+            "DeltaV.Sink.Syslog", "Default@minion-A", "payload-bytes".getBytes());
 
         result.get(2, TimeUnit.SECONDS);
 
         assertThat(mock.history()).hasSize(1);
         ProducerRecord<String, byte[]> record = mock.history().get(0);
-        assertThat(record.topic()).isEqualTo("OpenNMS.Sink.Syslog");
+        assertThat(record.topic()).isEqualTo("DeltaV.Sink.Syslog");
         assertThat(record.key()).isEqualTo("Default@minion-A");
 
         // Published bytes must be a SinkMessage protobuf containing the payload —
@@ -67,7 +67,7 @@ class SinkKafkaProducerTest {
         SinkKafkaProducer producer = new SinkKafkaProducer(mock, metrics);
 
         CompletableFuture<Void> result = producer.send(
-            "OpenNMS.Sink.Syslog", "k", new byte[0]);
+            "DeltaV.Sink.Syslog", "k", new byte[0]);
 
         mock.errorNext(new RuntimeException("broker down"));
 

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SyslogGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/SyslogGrpcServiceTest.java
@@ -38,7 +38,7 @@ class SyslogGrpcServiceTest {
     @Test
     void onNext_publishesToOpenNmsSinkSyslogTopicWithIdentityKey() {
         SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
-        when(producer.send(eq("OpenNMS.Sink.Syslog"), eq("Default@minion-A"), argThat(b -> new String(b).equals("payload"))))
+        when(producer.send(eq("DeltaV.Sink.Syslog"), eq("Default@minion-A"), argThat(b -> new String(b).equals("payload"))))
             .thenReturn(CompletableFuture.completedFuture(null));
         SyslogGrpcService svc = new SyslogGrpcService(producer);
 
@@ -55,7 +55,7 @@ class SyslogGrpcServiceTest {
                 .build());
         });
 
-        verify(producer).send(eq("OpenNMS.Sink.Syslog"), eq("Default@minion-A"),
+        verify(producer).send(eq("DeltaV.Sink.Syslog"), eq("Default@minion-A"),
             argThat(b -> new String(b).equals("payload")));
     }
 

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TelemetryGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TelemetryGrpcServiceTest.java
@@ -38,7 +38,7 @@ class TelemetryGrpcServiceTest {
     @Test
     void publishIpfix_routesToIpfixTopicWithIdentityKey() {
         SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
-        when(producer.send(eq("OpenNMS.Sink.Telemetry-IPFIX"), eq("Default@minion-A"),
+        when(producer.send(eq("DeltaV.Sink.Telemetry-IPFIX"), eq("Default@minion-A"),
                            argThat(b -> new String(b).equals("ipfix-bytes"))))
             .thenReturn(CompletableFuture.completedFuture(null));
         TelemetryGrpcService svc = new TelemetryGrpcService(producer);
@@ -55,14 +55,14 @@ class TelemetryGrpcServiceTest {
                 .setPayload(ByteString.copyFromUtf8("ipfix-bytes")).build());
         });
 
-        verify(producer).send(eq("OpenNMS.Sink.Telemetry-IPFIX"), eq("Default@minion-A"),
+        verify(producer).send(eq("DeltaV.Sink.Telemetry-IPFIX"), eq("Default@minion-A"),
             argThat(b -> new String(b).equals("ipfix-bytes")));
     }
 
     @Test
     void publishNetflow5_routesToNetflow5TopicWithIdentityKey() {
         SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
-        when(producer.send(eq("OpenNMS.Sink.Telemetry-Netflow-5"), eq("Default@minion-A"),
+        when(producer.send(eq("DeltaV.Sink.Telemetry-Netflow-5"), eq("Default@minion-A"),
                            argThat(b -> new String(b).equals("nf5-bytes"))))
             .thenReturn(CompletableFuture.completedFuture(null));
         TelemetryGrpcService svc = new TelemetryGrpcService(producer);
@@ -79,14 +79,14 @@ class TelemetryGrpcServiceTest {
                 .setPayload(ByteString.copyFromUtf8("nf5-bytes")).build());
         });
 
-        verify(producer).send(eq("OpenNMS.Sink.Telemetry-Netflow-5"), eq("Default@minion-A"),
+        verify(producer).send(eq("DeltaV.Sink.Telemetry-Netflow-5"), eq("Default@minion-A"),
             argThat(b -> new String(b).equals("nf5-bytes")));
     }
 
     @Test
     void publishNetflow9_routesToNetflow9TopicWithIdentityKey() {
         SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
-        when(producer.send(eq("OpenNMS.Sink.Telemetry-Netflow-9"), eq("Default@minion-A"),
+        when(producer.send(eq("DeltaV.Sink.Telemetry-Netflow-9"), eq("Default@minion-A"),
                            argThat(b -> new String(b).equals("nf9-bytes"))))
             .thenReturn(CompletableFuture.completedFuture(null));
         TelemetryGrpcService svc = new TelemetryGrpcService(producer);
@@ -103,14 +103,14 @@ class TelemetryGrpcServiceTest {
                 .setPayload(ByteString.copyFromUtf8("nf9-bytes")).build());
         });
 
-        verify(producer).send(eq("OpenNMS.Sink.Telemetry-Netflow-9"), eq("Default@minion-A"),
+        verify(producer).send(eq("DeltaV.Sink.Telemetry-Netflow-9"), eq("Default@minion-A"),
             argThat(b -> new String(b).equals("nf9-bytes")));
     }
 
     @Test
     void publishSflow_routesToSflowTopicWithIdentityKey() {
         SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
-        when(producer.send(eq("OpenNMS.Sink.Telemetry-SFlow"), eq("Default@minion-A"),
+        when(producer.send(eq("DeltaV.Sink.Telemetry-SFlow"), eq("Default@minion-A"),
                            argThat(b -> new String(b).equals("sflow-bytes"))))
             .thenReturn(CompletableFuture.completedFuture(null));
         TelemetryGrpcService svc = new TelemetryGrpcService(producer);
@@ -127,7 +127,7 @@ class TelemetryGrpcServiceTest {
                 .setPayload(ByteString.copyFromUtf8("sflow-bytes")).build());
         });
 
-        verify(producer).send(eq("OpenNMS.Sink.Telemetry-SFlow"), eq("Default@minion-A"),
+        verify(producer).send(eq("DeltaV.Sink.Telemetry-SFlow"), eq("Default@minion-A"),
             argThat(b -> new String(b).equals("sflow-bytes")));
     }
 }

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TrapGrpcServiceTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/sink/TrapGrpcServiceTest.java
@@ -38,7 +38,7 @@ class TrapGrpcServiceTest {
     @Test
     void onNext_publishesToOpenNmsSinkTrapTopic() {
         SinkKafkaProducer producer = mock(SinkKafkaProducer.class);
-        when(producer.send(eq("OpenNMS.Sink.Trap"), eq("Default@minion-A"),
+        when(producer.send(eq("DeltaV.Sink.Trap"), eq("Default@minion-A"),
                            argThat(b -> new String(b).equals("trap-bytes"))))
             .thenReturn(CompletableFuture.completedFuture(null));
         TrapGrpcService svc = new TrapGrpcService(producer);
@@ -55,7 +55,7 @@ class TrapGrpcServiceTest {
                 .setPayload(ByteString.copyFromUtf8("trap-bytes")).build());
         });
 
-        verify(producer).send(eq("OpenNMS.Sink.Trap"), eq("Default@minion-A"),
+        verify(producer).send(eq("DeltaV.Sink.Trap"), eq("Default@minion-A"),
             argThat(b -> new String(b).equals("trap-bytes")));
     }
 }

--- a/core/minion-grpc-contracts/src/main/proto/syslog.proto
+++ b/core/minion-grpc-contracts/src/main/proto/syslog.proto
@@ -9,7 +9,7 @@ import "google/protobuf/timestamp.proto";
 
 // One marshaled syslog Sink-API message produced on the Minion by
 // SyslogSinkModule.marshal(SyslogConnection). The minion-gateway forwards
-// `payload` bytes verbatim to OpenNMS.Sink.Syslog; the existing horizon
+// `payload` bytes verbatim to DeltaV.Sink.Syslog; the existing horizon
 // Syslogd consumer calls SyslogSinkModule.unmarshal(bytes) and is unaware
 // of the gRPC hop.
 //

--- a/core/minion-grpc-contracts/src/main/proto/telemetry.proto
+++ b/core/minion-grpc-contracts/src/main/proto/telemetry.proto
@@ -25,7 +25,7 @@ message TelemetryAck {
 }
 
 // One method per protocol so minion-gateway routes to the correct
-// OpenNMS.Sink.Telemetry-* topic without inspecting payload.
+// DeltaV.Sink.Telemetry-* topic without inspecting payload.
 service TelemetryService {
   rpc PublishIpfix(stream TelemetryDatagram) returns (stream TelemetryAck);
   rpc PublishNetflow5(stream TelemetryDatagram) returns (stream TelemetryAck);

--- a/core/minion-grpc-contracts/src/main/proto/trap.proto
+++ b/core/minion-grpc-contracts/src/main/proto/trap.proto
@@ -9,7 +9,7 @@ import "google/protobuf/timestamp.proto";
 
 // One marshaled SNMP trap Sink-API message produced on the Minion by
 // TrapSinkModule.marshal(TrapInformationWrapper). The minion-gateway
-// forwards `payload` bytes verbatim to OpenNMS.Sink.Trap; horizon's
+// forwards `payload` bytes verbatim to DeltaV.Sink.Trap; horizon's
 // Trapd consumer calls TrapSinkModule.unmarshal(bytes) unchanged.
 message SnmpTrap {
   bytes payload = 1;                    // TrapSinkModule.marshal() output

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -839,8 +839,7 @@ services:
       SPRING_DATASOURCE_USERNAME: opennms
       SPRING_DATASOURCE_PASSWORD: opennms
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      # Sink topic prefix is OpenNMS.* until the DeltaV.* rename PR lands.
-      DELTAV_FLOWS_SINK_TOPICS: "OpenNMS.Sink.Telemetry-Netflow-5,OpenNMS.Sink.Telemetry-Netflow-9,OpenNMS.Sink.Telemetry-IPFIX,OpenNMS.Sink.Telemetry-SFlow"
+      DELTAV_FLOWS_SINK_TOPICS: "DeltaV.Sink.Telemetry-Netflow-5,DeltaV.Sink.Telemetry-Netflow-9,DeltaV.Sink.Telemetry-IPFIX,DeltaV.Sink.Telemetry-SFlow"
       DELTAV_FLOWS_OUTPUT_TOPIC: deltav-flows
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]

--- a/opennms-container/delta-v/test-flows-e2e.sh
+++ b/opennms-container/delta-v/test-flows-e2e.sh
@@ -7,7 +7,7 @@
 # materialized views (application, source_ip, conversation, dscp) are populated.
 #
 # Pipeline:
-#   softflowd/exporter → Telemetryd (UDP 9999) → Kafka OpenNMS.Sink.Flows →
+#   softflowd/exporter → Telemetryd (UDP 9999) → Kafka DeltaV.Sink.Flows →
 #   flow-enricher (enrich + split) → Kafka deltav-flows →
 #   ClickHouse Kafka engine (flows_kafka) → ingest MV → flows_raw →
 #   dimension MVs (flows_by_application_1m, flows_by_source_ip_1m,

--- a/opennms-container/delta-v/test-grpc-heartbeat-e2e.sh
+++ b/opennms-container/delta-v/test-grpc-heartbeat-e2e.sh
@@ -7,7 +7,7 @@
 #   1. Envoy cluster.minion_gateway.upstream_rq_total advances during
 #      Heartbeat traffic — Minion is publishing via gRPC, not Kafka.
 #   2. minion-gateway translates and republishes <MinionIdentityDTO>
-#      XML on OpenNMS.Sink.Heartbeat (matches horizon wire format).
+#      XML on DeltaV.Sink.Heartbeat (matches horizon wire format).
 #   3. gRPC-Heartbeat p99 RTT (CreateTime − payload <timestamp>) ≤
 #      Kafka baseline p99 + threshold (11 ms by default).
 #
@@ -219,10 +219,10 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════
-# Assertion 2: <MinionIdentityDTO> records on OpenNMS.Sink.Heartbeat
+# Assertion 2: <MinionIdentityDTO> records on DeltaV.Sink.Heartbeat
 # ══════════════════════════════════════════════════════════════════
 log ""
-log "Assertion 2: ≥2 <MinionIdentityDTO> records on OpenNMS.Sink.Heartbeat"
+log "Assertion 2: ≥2 <MinionIdentityDTO> records on DeltaV.Sink.Heartbeat"
 
 # 90s window covers ≥2 publishes at 30s heartbeat interval (with slack
 # for consumer-group rebalance). Default offset=latest skips historical
@@ -230,7 +230,7 @@ log "Assertion 2: ≥2 <MinionIdentityDTO> records on OpenNMS.Sink.Heartbeat"
 HEARTBEAT_SAMPLE="${TEST_TMPDIR}/heartbeats.sample"
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic OpenNMS.Sink.Heartbeat \
+    --topic DeltaV.Sink.Heartbeat \
     --max-messages 6 \
     --timeout-ms 90000 \
     > "$HEARTBEAT_SAMPLE" 2>/dev/null || true
@@ -260,7 +260,7 @@ else
 
     docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
         --bootstrap-server localhost:9092 \
-        --topic OpenNMS.Sink.Heartbeat \
+        --topic DeltaV.Sink.Heartbeat \
         --property print.timestamp=true \
         > "$HEARTBEATS_RAW" 2>&1 &
     CONSUMER_PID=$!

--- a/opennms-container/delta-v/test-grpc-sinks-e2e.sh
+++ b/opennms-container/delta-v/test-grpc-sinks-e2e.sh
@@ -56,7 +56,7 @@ log "Verifying stack is up"
 log "Syslog: driving 1000 datagrams (10ms spacing) to fill ≥100 batches"
 SYSLOG_FILE=$(mktemp -t pr3-syslog-baseline.XXXXXX)
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-    --bootstrap-server localhost:9092 --topic OpenNMS.Sink.Syslog \
+    --bootstrap-server localhost:9092 --topic DeltaV.Sink.Syslog \
     --max-messages 200 --formatter-property print.timestamp=true \
     --timeout-ms 60000 > "$SYSLOG_FILE" 2>&1 &
 CONSUMER_PID=$!
@@ -118,7 +118,7 @@ ok "Syslog gate passed"
 log "Trap: driving 500 SNMP traps (~22 msgs/batch → ~22 batches; bump sample if needed)"
 TRAP_FILE=$(mktemp -t pr3-trap-baseline.XXXXXX)
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-    --bootstrap-server localhost:9092 --topic OpenNMS.Sink.Trap \
+    --bootstrap-server localhost:9092 --topic DeltaV.Sink.Trap \
     --max-messages 50 --formatter-property print.timestamp=true \
     --timeout-ms 60000 > "$TRAP_FILE" 2>&1 &
 CONSUMER_PID=$!
@@ -172,7 +172,7 @@ ok "Trap gate passed"
 log "Telemetry-IPFIX: capturing 100 records of natural exporter traffic"
 TELEMETRY_FILE=$(mktemp -t pr3-telemetry-baseline.XXXXXX)
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-    --bootstrap-server localhost:9092 --topic OpenNMS.Sink.Telemetry-IPFIX \
+    --bootstrap-server localhost:9092 --topic DeltaV.Sink.Telemetry-IPFIX \
     --max-messages 100 --formatter-property print.timestamp=true \
     --timeout-ms 60000 > "$TELEMETRY_FILE" 2>&1 || true
 

--- a/opennms-container/delta-v/test-minion-e2e.sh
+++ b/opennms-container/delta-v/test-minion-e2e.sh
@@ -178,7 +178,7 @@ log "Starting Kafka event consumers..."
 # Watch the Sink topic to verify Minion → Trapd forwarding
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic OpenNMS.Sink.Trap \
+    --topic DeltaV.Sink.Trap \
     > "$SINK_LOG" 2>/dev/null &
 SINK_CONSUMER_PID=$!
 

--- a/opennms-container/delta-v/test-syslog-e2e.sh
+++ b/opennms-container/delta-v/test-syslog-e2e.sh
@@ -5,7 +5,7 @@
 # Sends syslog messages through the Minion and verifies alarm creation/clearing
 # in PostgreSQL and REST API.
 #
-# Flow: Host → Minion (UDP 1514) → Kafka Sink (OpenNMS.Sink.Syslog) →
+# Flow: Host → Minion (UDP 1514) → Kafka Sink (DeltaV.Sink.Syslog) →
 #       Syslogd KafkaSinkBridge → SyslogSinkConsumer → ConvertToEvent →
 #       KafkaEventForwarder (enriches alarm-data from eventconf) →
 #       Kafka fault-events → Alarmd → PostgreSQL
@@ -255,7 +255,7 @@ log "Starting Kafka event consumers..."
 # Watch the Syslog Sink topic to verify Minion → Syslogd forwarding
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic OpenNMS.Sink.Syslog \
+    --topic DeltaV.Sink.Syslog \
     > "$SINK_LOG" 2>/dev/null &
 SINK_CONSUMER_PID=$!
 


### PR DESCRIPTION
## Summary

Atomic rename of the Minion→daemon Kafka topic prefix. Now that PR #260 made minion-gateway the **sole producer** to these topics, the rename surface is fully delta-v code (no horizon coupling), and producer + consumers can switch in lockstep within one PR.

**Why:** avoid topic name collisions in organizations transitioning from Horizon → Delta-V, align the topic namespace with the project name, and unblock the future flow-processor spec.

## Scope (38 files, +75 / -85)

**Producer — 4 hardcoded constants in minion-gateway:**
- `TrapGrpcService`, `SyslogGrpcService`, `HeartbeatTranslator`, `TelemetryGrpcService` (4 telemetry topics)

**Consumer — 2 prefix constants in the Kafka→Sink bridges:**
- `daemon-sink-kafka/KafkaSinkBridge` (used by trapd, syslogd, alarmd, eventtranslator, etc.)
- `daemon-boot-telemetryd/KafkaSinkBridge` (telemetryd's own copy)

**flow-enricher (Spring Cloud Stream):**
- `FlowEnrichmentFunction`: dropped the placeholder dual-prefix support; only `DELTAV_SINK_PREFIX` remains
- `application.yml`: destination default now `DeltaV.Sink.Telemetry-*`
- `docker-compose.yml`: `DELTAV_FLOWS_SINK_TOPICS` env var literal updated

**Tests + e2e scripts:** 7 minion-gateway tests, 2 flow-enricher tests, 5 e2e shell scripts (find/replace).

**Comments / docs:** 6 javadoc refs, 3 `.proto` file comments, 2 pom descriptions.

## Out of scope

- Horizon `core/ipc/sink/kafka/` — pre-built JARs; prefix is fully constructed in delta-v code (verified by reading both bridge sources). No horizon change needed.
- Existing Kafka data on the broker — `down -v` wipes the volume; topic auto-create handles the new prefix on first publish.

## E2E suite results (matches PR #260 baseline exactly)

| Test | Result |
|---|---|
| `test-grpc-heartbeat-e2e.sh` | ✅ 4/4 PASS — p99 6ms (gate ≤101ms), 3 `<MinionIdentityDTO>` records on `DeltaV.Sink.Heartbeat` |
| `test-grpc-twin-e2e.sh` | ✅ PASS |
| `test-grpc-sinks-e2e.sh` | ✅ 3/3 gates passed (Syslog, Trap, Telemetry-IPFIX) |
| `test-minion-e2e.sh` (Trapd) | ✅ 16/16 — full Minion→`DeltaV.Sink.Trap`→Trapd→Alarm path |
| `test-syslog-e2e.sh` | ✅ 16/16 — full Cisco syslog→Alarm path on new topic |
| `test-flows-e2e.sh` | ⚠️ 17/19 — IPFIX flowing end-to-end through `DeltaV.Sink.Telemetry-IPFIX`; 2 V9/SFLOW failures are the **same docker-compose IP-allocation race that hit PR #260** (flow-enricher and prometheus-writer claim 172.18.0.20/21 before flow-default and flow-sflow exporters get scheduled). Pre-existing test-environment race, not caused by this PR. |
| `test-passive-e2e.sh` | ⚠️ 16/2 — alarm create + clear PASS; 2 outage-table latency timeouts. **Identical failure mode to PR #260** — pre-existing Pollerd outage flake. |

The two flaky failures are byte-for-byte identical to PR #260 — that's the expected baseline for develop right now.

## Validation pattern caveat

During this PR's verification I hit one self-inflicted issue worth flagging for future work:
- An earlier `build.sh deltav` invocation silently failed (Docker daemon connection cancelled mid-context-transfer) but exited 0. The script doesn't propagate that error. Result: gateway image was stale and the first heartbeat run failed with `UNKNOWN_TOPIC_OR_PARTITION` for the new topics. Diagnosed by `docker history` showing a 3-hour-old COPY layer despite a fresh local jar. Re-running build.sh from the correct directory produced the right image.
- Lesson: trust `docker history` over `gh exit 0` for image freshness — added to memory.

## Test plan
- [x] `./mvnw clean install -DskipTests` (full reactor, exit 0)
- [x] `./build.sh deltav` (verified image freshness via `docker history` + `unzip -p ... | strings | grep Sink`)
- [x] `docker compose --profile full up -d` + verify all 22 services healthy
- [x] All 7 e2e scripts on the gRPC path
- [x] CI must pass before merge