### PR TITLE
fix(compose): reserve static IPs from dynamic IPAM range

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -1016,10 +1016,18 @@ networks:
   # static IP-to-node mapping fails to attribute flows correctly in the
   # Grafana flow sources inventory panel. Subnet matches the historical
   # Docker default (172.18.0.0/16) so existing services aren't disturbed.
+  #
+  # ip_range confines DYNAMIC allocation to 172.18.1.0/24, keeping it clear
+  # of the static ipv4_address pins in 172.18.0.x (flow test nodes .20-.22,
+  # l8opensim .30). Without this, in a large-profile bring-up the dynamic
+  # allocator marches up from .2 and can hand a static-pinned IP to another
+  # container before the pinned service starts, failing it with
+  # "failed to set up container networking: Address already in use".
   default:
     name: delta-v_default
     ipam:
       driver: default
       config:
         - subnet: 172.18.0.0/16
+          ip_range: 172.18.1.0/24
           gateway: 172.18.0.1


### PR DESCRIPTION
## Summary

The `default` network declares a subnet but no `ip_range`, so Docker's dynamic IP allocator uses the whole `172.18.0.0/16` starting at `172.18.0.2`. Several services pin **static** `ipv4_address` values inside that range:

- flow test nodes — `172.18.0.20`, `.21`, `.22`
- l8opensim — `172.18.0.30`

In a large-profile bring-up (`--profile full --profile metrics`, ~33 containers) the dynamic allocator reaches the `.20–.30` band and can hand a pinned IP to another container before the pinned service starts. The pinned container then fails:

```
failed to set up container networking: Address already in use
```

The flow test nodes `depends_on: minion (healthy)` so they start last — they're the usual casualty. It's race-dependent (smaller profiles never reach `.20`), which is why it surfaces intermittently.

## Fix

Add `ip_range: 172.18.1.0/24` to the network's IPAM config. Dynamic allocation is confined to `172.18.1.x`; the `172.18.0.x` static reservations are untouched. Static `ipv4_address` pins remain valid anywhere in the `subnet` — `ip_range` only constrains automatic assignment.

## Test plan

- [ ] `docker compose --profile full --profile metrics up -d` — all flow test nodes start, no "Address already in use"
- [ ] `docker network inspect delta-v_default` — dynamic containers in `172.18.1.x`; testnodes at `172.18.0.20-.22`, l8opensim at `.30`