### PR TITLE
fix(perspective-app-init): poll for monitoring locations instead of one-shot check

### DIFF
--- a/opennms-container/delta-v/perspective-app-init/init.sh
+++ b/opennms-container/delta-v/perspective-app-init/init.sh
@@ -54,16 +54,27 @@ while [ -z "$ifservice_id" ]; do
 done
 log "Found ifservice id=${ifservice_id} for ${SERVICE_NAME}"
 
-# 2. Verify both perspective monitoring locations exist (Default is always
-#    present from db-init; l8opensim-lab appears once minion-lab registers).
-loc_count=$(psql_q "
-    SELECT count(*) FROM monitoringlocations WHERE id IN ('${LOCATION_A}', '${LOCATION_B}')
-")
-if [ "${loc_count:-0}" -ne 2 ]; then
-    log "FAIL: expected both monitoring locations (${LOCATION_A}, ${LOCATION_B}); found ${loc_count}"
-    log "      ensure minion-lab is running and has registered with the gateway"
-    exit 1
-fi
+# 2. Wait for both perspective monitoring locations to exist. Default is
+#    present from db-init immediately; l8opensim-lab appears only once
+#    minion-lab has registered with the gateway — which lags behind
+#    minion-lab's container healthcheck (the depends_on gate), so poll for
+#    it rather than assuming it is already there.
+log "Waiting for monitoring locations ${LOCATION_A}, ${LOCATION_B} (timeout ${WAIT_TIMEOUT}s)..."
+deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+loc_count=0
+while [ "${loc_count:-0}" -ne 2 ]; do
+    if [ "$(date +%s)" -gt "$deadline" ]; then
+        log "FAIL: expected both monitoring locations (${LOCATION_A}, ${LOCATION_B}); found ${loc_count} within ${WAIT_TIMEOUT}s"
+        log "      ensure minion-lab is running and has registered with the gateway"
+        exit 1
+    fi
+    loc_count=$(psql_q "
+        SELECT count(*) FROM monitoringlocations WHERE id IN ('${LOCATION_A}', '${LOCATION_B}')
+    " 2>/dev/null || echo 0)
+    if [ "${loc_count:-0}" -ne 2 ]; then
+        sleep "$POLL_INTERVAL"
+    fi
+done
 log "Both monitoring locations present: ${LOCATION_A}, ${LOCATION_B}"
 
 # 3. Idempotently provision application + mappings.


### PR DESCRIPTION
## Summary

`perspective-app-init` `depends_on: minion-lab` with `condition: service_healthy`. But minion-lab passing its container healthcheck and minion-lab finishing registration of its `l8opensim-lab` monitoring location in PostgreSQL are two different moments — the DB registration lags behind the healthcheck.

The init script's location check was a **one-shot** count. When it ran in that gap it saw only `Default` and failed:

```
FAIL: expected both monitoring locations (Default, l8opensim-lab); found 1
```

`perspective-app-init` exits 1 → `perspectivepollerd` (which `depends_on perspective-app-init: service_completed_successfully`) is left stuck in `Created` and never starts. Observed on a fresh `--profile full` smoke bring-up.

## Fix

Replace the one-shot check with a bounded poll loop — the same pattern step 1 already uses to wait for the `ifservices` row. It polls every `POLL_INTERVAL` and only fails if both locations haven't appeared within `WAIT_TIMEOUT` (300s default).

## Test plan

- [ ] Fresh `--profile full` bring-up — `perspective-app-init` exits `0` even when it starts before minion-lab's location registers; `perspectivepollerd` starts on its own
- [ ] Genuine missing-location case still fails after the timeout (not a silent hang)

> Note: takes effect once the `perspective-app-init` image is rebuilt — i.e. the next tag.