### PR TITLE
fix(ipc): adopt horizon 1.0.18 — RPC consumer startup-race fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Horizon JAR version (published by pbrane/delta-v-horizon) -->
-    <deltav.horizon.version>1.0.17</deltav.horizon.version>
+    <deltav.horizon.version>1.0.18</deltav.horizon.version>
 
     <!-- Spring Cloud release train (for flow-enricher / flow-aggregator) -->
     <spring-cloud.version>2025.1.1</spring-cloud.version>


### PR DESCRIPTION
## Summary

Bumps `deltav.horizon.version` 1.0.17 → 1.0.18 to adopt the `KafkaRpcClientFactory` fix from delta-v-horizon #20.

**The bug:** Horizon's `KafkaRpcClientFactory` started its `OpenNMS.rpc-response` consumer lazily and dispatched RPC requests without waiting for it to join its group. Joining + offset positioning takes ~3 s; with `auto.offset.reset=latest` (fresh random consumer group per boot) the consumer positions at the topic *tail*. The delta-v minion-gateway RPC path returns responses in ~60 ms — inside that 3 s window — so responses landed ahead of the consumer's start offset and were silently skipped, and the RPC timed out.

PerspectivePollerd produced no data: every perspective-poll RPC timed out. Pollerd hit the same race at startup (10 timeouts) but re-polls continuously and recovered; PerspectivePollerd's poll is scheduled once per application and never recovered.

**The fix (horizon #20):** `KafkaRpcClientFactory.startConsumingForModule()` now blocks the caller until the response consumer has joined and positioned its offsets (a `CountDownLatch` released from `ConsumerRebalanceListener.onPartitionsAssigned`). Only the first request waits (~one group-join). `auto.offset.reset` stays `latest`.

## Verification

Built delta-v daemon images against horizon 1.0.18 and deployed `perspectivepollerd` + `pollerd` to the smoke stack:

- `deltav_perspective_poll_duration_seconds_count`: 0 → 2
- Both perspectives (Default, l8opensim-lab) poll `result="up"`, **0** RPC timeouts
- Perspective response-time (`producer=perspective_pollerd`) now flowing to VictoriaMetrics
- Pollerd regression check: 0 RPC timeouts, healthy

## Test plan

- [ ] Reactor builds against horizon 1.0.18 (verified locally — full `clean install` SUCCESS).
- [ ] Smoke run confirms perspective polling produces data and pollerd is unaffected.