### PR TITLE
feat: perspective/poller dashboard filters + multi-service seed + cold-start fix

### DIFF
--- a/opennms-container/delta-v/grafana/dashboards/perspective-monitoring.json
+++ b/opennms-container/delta-v/grafana/dashboards/perspective-monitoring.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Perspective polling latency and throughput. Panels query the Phase 3 publisher series (deltav-timeseries Kafka topic → prometheus-writer → VictoriaMetrics). Service: HTTP-8080 against l8opensim's API root, polled from Default and l8opensim-lab perspectives.",
+  "description": "Perspective polling latency and throughput. Panels query the Phase 3 publisher series (deltav-timeseries Kafka topic → prometheus-writer → VictoriaMetrics). Services HTTP-8080 (l8opensim API root) and Google-Search, polled from the Default and l8opensim-lab perspectives. Use the Perspective and Service dropdowns to scope the view.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -50,7 +50,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "opennms_response_time_response{producer=\"perspective_pollerd\"}",
+          "expr": "opennms_response_time_response{producer=\"perspective_pollerd\", location=~\"$location\", resource_instance=~\"$service\"}",
           "instant": false,
           "legendFormat": "{{location}} → {{node_label}}/{{resource_instance}}",
           "refId": "A"
@@ -91,8 +91,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "avg by (location) (opennms_response_time_response{producer=\"perspective_pollerd\"})",
-          "instant": true,
+          "expr": "avg by (location) (opennms_response_time_response{producer=\"perspective_pollerd\", location=~\"$location\", resource_instance=~\"$service\"})",
+          "instant": false,
           "legendFormat": "{{location}}",
           "refId": "A"
         }
@@ -127,7 +127,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "rate(deltav_perspective_polls_completed_total[1m])",
+          "expr": "rate(deltav_perspective_polls_completed_total{perspective=~\"$location\"}[1m])",
           "legendFormat": "{{perspective}} ({{result}})",
           "refId": "A"
         }
@@ -168,7 +168,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "rate(deltav_timeseries_batches_failed_total{producer=\"perspectivepollerd\"}[5m])",
+          "expr": "rate(deltav_timeseries_batches_failed_total{producer=\"perspectivepollerd\", location=~\"$location\"}[5m])",
           "legendFormat": "{{location}} ({{reason}})",
           "refId": "A"
         }
@@ -203,7 +203,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "increase(deltav_timeseries_batches_published_total{producer=\"perspectivepollerd\"}[5m])",
+          "expr": "increase(deltav_timeseries_batches_published_total{producer=\"perspectivepollerd\", location=~\"$location\"}[5m])",
           "legendFormat": "{{location}}",
           "refId": "A"
         }
@@ -217,7 +217,48 @@
   "refresh": "10s",
   "schemaVersion": 39,
   "tags": ["delta-v", "perspective", "polling"],
-  "templating": { "list": [] },
+  "templating": {
+    "list": [
+      {
+        "current": { "text": ["All"], "value": ["$__all"] },
+        "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+        "definition": "label_values(opennms_response_time_response{producer=\"perspective_pollerd\"}, location)",
+        "includeAll": true,
+        "label": "Perspective",
+        "multi": true,
+        "name": "location",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(opennms_response_time_response{producer=\"perspective_pollerd\"}, location)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "text": ["All"], "value": ["$__all"] },
+        "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+        "definition": "label_values(opennms_response_time_response{producer=\"perspective_pollerd\"}, resource_instance)",
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(opennms_response_time_response{producer=\"perspective_pollerd\"}, resource_instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",

--- a/opennms-container/delta-v/grafana/dashboards/pollerd-monitoring.json
+++ b/opennms-container/delta-v/grafana/dashboards/pollerd-monitoring.json
@@ -50,7 +50,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "opennms_response_time_response{producer=\"pollerd\"}",
+          "expr": "opennms_response_time_response{producer=\"pollerd\", location=~\"$location\", resource_instance=~\"$service\"}",
           "instant": false,
           "legendFormat": "{{location}} → {{node_label}}/{{resource_instance}}",
           "refId": "A"
@@ -91,8 +91,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "avg by (location) (opennms_response_time_response{producer=\"pollerd\"})",
-          "instant": true,
+          "expr": "avg by (location) (opennms_response_time_response{producer=\"pollerd\", location=~\"$location\", resource_instance=~\"$service\"})",
+          "instant": false,
           "legendFormat": "{{location}}",
           "refId": "A"
         }
@@ -127,7 +127,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "rate(deltav_pollerd_polls_completed_total[1m])",
+          "expr": "rate(deltav_pollerd_polls_completed_total{location=~\"$location\"}[1m])",
           "legendFormat": "{{location}} ({{result}})",
           "refId": "A"
         }
@@ -168,7 +168,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "rate(deltav_timeseries_batches_failed_total{producer=\"pollerd\"}[5m])",
+          "expr": "rate(deltav_timeseries_batches_failed_total{producer=\"pollerd\", location=~\"$location\"}[5m])",
           "legendFormat": "{{location}} ({{reason}})",
           "refId": "A"
         }
@@ -203,7 +203,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-          "expr": "increase(deltav_timeseries_batches_published_total{producer=\"pollerd\"}[5m])",
+          "expr": "increase(deltav_timeseries_batches_published_total{producer=\"pollerd\", location=~\"$location\"}[5m])",
           "legendFormat": "{{location}}",
           "refId": "A"
         }
@@ -217,7 +217,48 @@
   "refresh": "10s",
   "schemaVersion": 39,
   "tags": ["delta-v", "pollerd", "polling"],
-  "templating": { "list": [] },
+  "templating": {
+    "list": [
+      {
+        "current": { "text": ["All"], "value": ["$__all"] },
+        "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+        "definition": "label_values(opennms_response_time_response{producer=\"pollerd\"}, location)",
+        "includeAll": true,
+        "label": "Location",
+        "multi": true,
+        "name": "location",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(opennms_response_time_response{producer=\"pollerd\"}, location)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "text": ["All"], "value": ["$__all"] },
+        "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+        "definition": "label_values(opennms_response_time_response{producer=\"pollerd\"}, resource_instance)",
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(opennms_response_time_response{producer=\"pollerd\"}, resource_instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",

--- a/opennms-container/delta-v/perspective-app-init/init.sh
+++ b/opennms-container/delta-v/perspective-app-init/init.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 #
 # Seeds the smoke-baseline perspective application:
-#   - waits for provisiond to import the `perspective-smoke` requisition
-#     (the HTTP-8080 service row landing in `ifservices` is the trigger)
-#   - inserts the application + service map + two perspective-location rows
-#     (Default + l8opensim-lab) idempotently, via `ON CONFLICT` clauses
+#   - waits for both perspective monitoring locations to register
+#   - waits for provisiond to import the requisition backing each perspective
+#     service (the service's row landing in `ifservices` is the trigger)
+#   - inserts the application + service maps + perspective-location rows
+#     idempotently, via `ON CONFLICT` clauses
 #
 # PerspectivePollerd's PerspectiveServiceTracker timer-polls applications
 # every 5s, so it picks up the new mapping without a daemon restart.
@@ -14,59 +15,80 @@
 set -eu
 
 APP_NAME="${PERSPECTIVE_APP_NAME:-Devices-API-Perspective-App}"
-FOREIGN_SOURCE="${PERSPECTIVE_FOREIGN_SOURCE:-perspective-smoke}"
-SERVICE_NAME="${PERSPECTIVE_SERVICE_NAME:-HTTP-8080}"
 LOCATION_A="${PERSPECTIVE_LOCATION_A:-Default}"
 LOCATION_B="${PERSPECTIVE_LOCATION_B:-l8opensim-lab}"
 WAIT_TIMEOUT="${PERSPECTIVE_WAIT_TIMEOUT:-300}"
 POLL_INTERVAL=5
 
-log() { echo "[perspective-app-init] $*"; }
+# Services to perspective-poll, as a space-separated list of
+# "<foreign-source>/<service-name>" pairs. Each is mapped into APP_NAME and
+# therefore polled from every perspective location listed above.
+PERSPECTIVE_SERVICES="${PERSPECTIVE_SERVICES:-perspective-smoke/HTTP-8080 perspective-test/Google-Search}"
+
+# Log to stderr so wait_for_ifservice's stdout carries only the id it echoes.
+log() { echo "[perspective-app-init] $*" >&2; }
 
 psql_q() {
     psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -t -A -c "$1"
 }
 
-# 1. Wait for the perspective-smoke service row to land in ifservices.
-#    This proves provisiond has finished importing the requisition.
-log "Waiting for ${FOREIGN_SOURCE}/${SERVICE_NAME} to appear in ifservices (timeout ${WAIT_TIMEOUT}s)..."
+# Wait for a service's ifservices row to appear -- this proves provisiond has
+# finished importing the requisition that carries it -- then echo its id.
+# Args: <foreign-source> <service-name>
+wait_for_ifservice() {
+    fs="$1"
+    svc="$2"
+    log "Waiting for ${fs}/${svc} to appear in ifservices (timeout ${WAIT_TIMEOUT}s)..."
+    deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+    id=""
+    while [ -z "$id" ]; do
+        id=$(psql_q "
+            SELECT s.id
+              FROM ifservices s
+              JOIN ipinterface ip ON s.ipinterfaceid = ip.id
+              JOIN node n         ON ip.nodeid = n.nodeid
+              JOIN service st     ON s.serviceid = st.serviceid
+             WHERE n.foreignsource = '${fs}'
+               AND st.servicename  = '${svc}'
+             LIMIT 1
+        " 2>/dev/null || echo "")
+        if [ -z "$id" ]; then
+            if [ "$(date +%s)" -gt "$deadline" ]; then
+                log "FAIL: ${svc} on ${fs} did not appear in ifservices within ${WAIT_TIMEOUT}s"
+                log "      check provisiond logs: docker logs delta-v-provisiond"
+                exit 1
+            fi
+            sleep "$POLL_INTERVAL"
+        fi
+    done
+    log "Found ifservice id=${id} for ${fs}/${svc}"
+    echo "$id"
+}
+
+# 1. Wait for both perspective monitoring locations to exist. Default is
+#    present from db-init; l8opensim-lab only appears once provisiond has
+#    imported the l8opensim-lab requisition, whose nodes are scanned through
+#    Minion RPC -- on a cold start that lags well behind provisiond becoming
+#    healthy, so this needs a retry loop just like the ifservices waits.
+log "Waiting for monitoring locations ${LOCATION_A}, ${LOCATION_B} (timeout ${WAIT_TIMEOUT}s)..."
 deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
-ifservice_id=""
-while [ -z "$ifservice_id" ]; do
-    if [ "$(date +%s)" -gt "$deadline" ]; then
-        log "FAIL: ${SERVICE_NAME} on ${FOREIGN_SOURCE} did not appear in ifservices within ${WAIT_TIMEOUT}s"
-        log "      check provisiond logs: docker logs delta-v-provisiond"
-        exit 1
-    fi
-    ifservice_id=$(psql_q "
-        SELECT s.id
-          FROM ifservices s
-          JOIN ipinterface ip ON s.ipinterfaceid = ip.id
-          JOIN node n         ON ip.nodeid = n.nodeid
-          JOIN service st     ON s.serviceid = st.serviceid
-         WHERE n.foreignsource = '${FOREIGN_SOURCE}'
-           AND st.servicename  = '${SERVICE_NAME}'
-         LIMIT 1
-    " 2>/dev/null || echo "")
-    if [ -z "$ifservice_id" ]; then
+loc_count=0
+while [ "${loc_count:-0}" -ne 2 ]; do
+    loc_count=$(psql_q "
+        SELECT count(*) FROM monitoringlocations WHERE id IN ('${LOCATION_A}', '${LOCATION_B}')
+    " 2>/dev/null || echo 0)
+    if [ "${loc_count:-0}" -ne 2 ]; then
+        if [ "$(date +%s)" -gt "$deadline" ]; then
+            log "FAIL: expected both monitoring locations (${LOCATION_A}, ${LOCATION_B}); found ${loc_count} within ${WAIT_TIMEOUT}s"
+            log "      ensure minion-lab is running and has registered with the gateway"
+            exit 1
+        fi
         sleep "$POLL_INTERVAL"
     fi
 done
-log "Found ifservice id=${ifservice_id} for ${SERVICE_NAME}"
-
-# 2. Verify both perspective monitoring locations exist (Default is always
-#    present from db-init; l8opensim-lab appears once minion-lab registers).
-loc_count=$(psql_q "
-    SELECT count(*) FROM monitoringlocations WHERE id IN ('${LOCATION_A}', '${LOCATION_B}')
-")
-if [ "${loc_count:-0}" -ne 2 ]; then
-    log "FAIL: expected both monitoring locations (${LOCATION_A}, ${LOCATION_B}); found ${loc_count}"
-    log "      ensure minion-lab is running and has registered with the gateway"
-    exit 1
-fi
 log "Both monitoring locations present: ${LOCATION_A}, ${LOCATION_B}"
 
-# 3. Idempotently provision application + mappings.
+# 2. Idempotently provision the application.
 psql_q "
     INSERT INTO applications (id, name)
     VALUES (nextval('opennmsnxtid'), '${APP_NAME}')
@@ -79,13 +101,21 @@ if [ -z "$app_id" ]; then
 fi
 log "Application ${APP_NAME} ready (id=${app_id})"
 
-psql_q "
-    INSERT INTO application_service_map (appid, ifserviceid)
-    VALUES (${app_id}, ${ifservice_id})
-    ON CONFLICT DO NOTHING;
-" >/dev/null
-log "Service ${SERVICE_NAME} mapped to application"
+# 3. Wait for each perspective service to import, then map it into the app.
+for pair in $PERSPECTIVE_SERVICES; do
+    fs=${pair%/*}
+    svc=${pair#*/}
+    ifservice_id=$(wait_for_ifservice "$fs" "$svc")
+    psql_q "
+        INSERT INTO application_service_map (appid, ifserviceid)
+        VALUES (${app_id}, ${ifservice_id})
+        ON CONFLICT DO NOTHING;
+    " >/dev/null
+    log "Service ${svc} (${fs}) mapped to application"
+done
 
+# 4. Map the perspective monitoring locations onto the application. Every
+#    mapped service is then polled from each of these perspectives.
 for loc in "$LOCATION_A" "$LOCATION_B"; do
     psql_q "
         INSERT INTO application_perspective_location_map (appid, monitoringlocationid)


### PR DESCRIPTION
## Summary

Polish for the perspective/poller observability dashboards plus a smoke-harness fix, all surfaced during the v1.2.0-rc3.1 smoke validation.

- **Dashboard filters** — `pollerd-monitoring` and `perspective-monitoring` each get **Location/Perspective** and **Service** template-variable dropdowns (multi-select, "All" default), populated via `label_values()` and wired into the panel queries so response-time panels can be scoped per location and per service.
- **Panel 2 fix** — the "latest avg response time" stat panels switched from instant to range queries. An instant query goes blank once the latest sample ages past the ~5m lookback window; a range query + `lastNotNull` survives gaps between polls.
- **perspective-app-init cold-start fix** — the monitoring-location check was a one-shot query with no retry. On a cold start it ran before provisiond finished importing the `l8opensim-lab` requisition, exited non-zero, and blocked `perspectivepollerd`. It now retries on the same `WAIT_TIMEOUT` deadline as the existing `ifservices` wait.
- **Multi-service perspective seed** — `perspective-app-init` is generalized to seed a `PERSPECTIVE_SERVICES` list instead of a single hard-coded service, and now seeds **Google-Search** alongside **HTTP-8080**, so the perspective dashboards exercise more than one service/location.

## Verified on the live smoke environment

- Both dashboards provision cleanly in Grafana with the new variables; filtering works (perspective response-time panel 2→1 series when scoped to `l8opensim-lab`).
- `perspective-app-init` re-run end-to-end: exit 0, both `HTTP-8080` and `Google-Search` mapped.
- After perspectivepollerd loads the full seed it perspective-polls Google-Search from both perspectives — VictoriaMetrics shows `opennms_response_time_response{producer="perspective_pollerd", resource_instance="Google-Search"}` for `Default` (~195ms) and `l8opensim-lab` (~219ms).

## Known follow-up (out of scope)

The "Polls/sec" and "Phase 3" counter panels on both dashboards still show "No data" — they query `deltav_*` Micrometer/actuator metrics that never reach VictoriaMetrics (the `deltav-timeseries` pipeline only carries measurement series). Deferred until the app-observability track lands an actuator→VM scrape path.

## Test plan

- [ ] Cold-start smoke run (`--profile full`) completes without a manual `up -d` re-run — `perspective-app-init` exits 0 on the first attempt.
- [ ] Perspective Monitoring dashboard: Perspective + Service dropdowns populate; selecting a value scopes the response-time panels.
- [ ] Pollerd Monitoring dashboard: Location + Service dropdowns populate and scope the panels.
- [ ] "Latest avg response time" stat panels render between polls (no "No data" flicker).