### PR TITLE
docs(plans): v1.2.0 GA finalization design + implementation plan

### DIFF
--- a/docs/plans/2026-05-16-v1.2.0-ga-finalization-implementation.md
+++ b/docs/plans/2026-05-16-v1.2.0-ga-finalization-implementation.md
@@ -1,0 +1,546 @@
+# Delta-V v1.2.0 GA Finalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the remaining legacy `OpenNMS.*` / `opennms-*` Kafka topics to a `DeltaV.*` / `deltav-*` prefix, then cut and ship the `v1.2.0` GA release.
+
+**Architecture:** Two rename PRs (event topics first as a low-risk pure-config change; RPC + Twin topics second, scope gated by an upfront audit) merge to `develop`, followed by a release-candidate cut (`rc4`) that smoke-validates the breaking change, then promotion to the `v1.2.0` GA tag with a final smoke run.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.3, Maven (`./mvnw`), Apache Kafka, Docker Compose, GitHub Actions image publishing, `gh` CLI against `pbrane/delta-v`.
+
+**Design reference:** `docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md`
+
+---
+
+## Workflow guards (apply to every task)
+
+- **Never open PRs against `OpenNMS/*`.** Always `gh pr create --repo pbrane/delta-v --base develop ...` (or `--repo pbrane/delta-v-horizon` for horizon).
+- **Never commit to `develop`/`main`.** Every change is a feature branch + PR.
+- **Pull `develop` before branching:** `git checkout develop && git pull --ff-only origin develop`.
+- **Build with `./mvnw`**, not `compile.pl` (delta-v has no `compile.pl`).
+- **Clean builds across branch switches:** when a shared module (`daemon-common`, `minion-gateway`) changes, downstream needs `./mvnw clean install` — a plain `install` re-uses the stale repackaged fat jar.
+- **Never bulk-`sed` version strings.** Use `mvn versions:set`.
+- **Tag pushes trigger the image-publish workflow and cannot be cancelled cleanly.** Verify everything before tagging.
+
+---
+
+## File Structure
+
+**Audit artifact (Task 1):**
+- Create: `docs/plans/2026-05-16-topic-rename-audit.md` — the topic inventory + RPC/Twin prefix-mechanism finding.
+
+**PR A — event topic rename (Task 2):** production config defaults, per-daemon `application.yml`, vestigial `.cfg` files, unit-test constants, E2E test scripts, docs.
+
+**PR B — RPC + Twin topic rename (Task 3):** `minion-gateway` dispatcher/publisher classes, the daemon-side RPC/Twin prefix mechanism (delta-v config or — contingency — a `pbrane/delta-v-horizon` change + BOM bump), docs.
+
+**Release mechanics (Tasks 4–8):** `pom.xml` versions (via `mvn versions:set`), `opennms-container/delta-v/.env.example`, `build.sh` / `.github/workflows/delta-v-build-images.yml`, release notes, the master release plan doc.
+
+---
+
+## Task 1: Topic-rename audit
+
+Produces the inventory and the one open scoping decision (RPC/Twin daemon-side prefix mechanism). No production code changes.
+
+**Files:**
+- Create: `docs/plans/2026-05-16-topic-rename-audit.md`
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+git checkout -b docs/topic-rename-audit
+```
+
+- [ ] **Step 2: Confirm the event-topic reference inventory**
+
+Run and capture the output:
+
+```bash
+rg -n 'opennms-fault-events|opennms-ipc-events' --glob '!**/target/**'
+```
+
+Classify every hit into: (a) **live production config** — `core/daemon-common/.../KafkaEventTransportConfiguration.java` `@Value` defaults and `core/daemon-boot-*/src/main/resources/application.yml`; (b) **vestigial Karaf `.cfg`** — `opennms-container/delta-v/*-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg` (Karaf is removed; Spring Boot daemons read `application.yml`, not `.cfg`); (c) **unit-test constants** — `core/event-forwarder-kafka/src/test/...`; (d) **E2E test scripts** — `opennms-container/delta-v/test-*.sh`; (e) **docs** — `README.md`, `GEMINI.md`, `opennms-container/delta-v/README.md`.
+
+- [ ] **Step 3: Verify the `.cfg` files are vestigial**
+
+Confirm no Spring Boot daemon loads `org.opennms.core.event.forwarder.kafka.cfg`:
+
+```bash
+rg -rn 'forwarder.kafka.cfg|\.cfg' core/daemon-common/src/main core/daemon-boot-*/src/main
+```
+
+Expected: no code path reads the `.cfg` PID file. Record the conclusion — if vestigial, PR A deletes them; if live, PR A renames their contents.
+
+- [ ] **Step 4: Determine the RPC/Twin daemon-side topic-prefix mechanism**
+
+The minion-gateway side is delta-v code (`RpcChannelDispatcher`, `RpcResponsePublisher`, `TwinChannelDispatcher`, `TwinStateCache`). The daemon side constructs `<prefix>.<location>.rpc-request` via horizon's `KafkaRpc*` / `KafkaTwin*` client. Test the hypothesis that `prefix` is the standard OpenNMS instance-id system property:
+
+```bash
+# Search the horizon JARs on the classpath for the prefix source
+rg -rn 'instance.id|TOPIC_PREFIX|rpc-request' ~/.m2/repository/org/opennms 2>/dev/null | head -20
+# Search delta-v daemon configs for any existing instance-id / kafka-rpc setting
+rg -rn 'instance.id|ipc.kafka|rpc' core/daemon-boot-pollerd/src/main/resources core/daemon-common/src/main/resources
+```
+
+Record the finding as one of:
+- **(A) Config-overridable** — the prefix is a system property (e.g. `org.opennms.instance.id`, default `OpenNMS`) or Spring property. PR B is delta-v-only: set the property + update the minion-gateway regexes.
+- **(B) Horizon-hardcoded** — the prefix is a compiled-in constant. PR B needs a companion `pbrane/delta-v-horizon` PR plus a horizon BOM bump in delta-v.
+
+- [ ] **Step 5: Reconcile the rc3.1-smoke Sink-topic observation**
+
+The rc3.1 smoke reported `DeltaV.Sink.*` topics, but the code uses a terse `n.*` Sink scheme (`n.Heartbeat`, `n.Telemetry-IPFIX`). Confirm which is on the wire:
+
+```bash
+rg -rn 'DeltaV\.Sink|"n\.' core/minion-gateway/src/main core/daemon-sink-kafka/src/main
+```
+
+Record the actual Sink topic names. They are **out of scope** for this rename (the `n.*`-vs-`DeltaV.*` inconsistency is a v1.3 cosmetic item) — this step only documents the truth so the rename does not accidentally touch them.
+
+- [ ] **Step 6: Write the audit document**
+
+Create `docs/plans/2026-05-16-topic-rename-audit.md` containing: the classified event-topic inventory (Step 2), the `.cfg` vestigial/live verdict (Step 3), the RPC/Twin prefix verdict A or B (Step 4), and the Sink-topic truth (Step 5). This document is the input to Tasks 2 and 3.
+
+- [ ] **Step 7: Commit and open PR**
+
+```bash
+git add docs/plans/2026-05-16-topic-rename-audit.md
+git commit -m "docs(plans): topic-rename audit for v1.2.0 GA"
+git push -u origin docs/topic-rename-audit
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "docs(plans): topic-rename audit for v1.2.0 GA" \
+  --body "Topic inventory + RPC/Twin prefix-mechanism finding feeding the v1.2.0 GA topic rename. See docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md."
+```
+
+---
+
+## Task 2: PR A — event topic rename
+
+Rename `opennms-fault-events` → `deltav-fault-events` and `opennms-ipc-events` → `deltav-ipc-events`. Pure delta-v config; no horizon dependency.
+
+**Files:**
+- Modify: `core/daemon-common/src/main/java/org/deltav/core/daemon/common/KafkaEventTransportConfiguration.java:55,58`
+- Modify: `core/daemon-boot-alarmd/src/main/resources/application.yml:41`
+- Modify: `core/daemon-boot-bsmd/src/main/resources/application.yml:41`
+- Modify: `core/daemon-boot-collectd/src/main/resources/application.yml:59-60`
+- Modify: `core/daemon-boot-discovery/src/main/resources/application.yml:31`
+- Modify: `core/daemon-boot-enlinkd/src/main/resources/application.yml:25-26`
+- Modify: `core/daemon-boot-eventtranslator/src/main/resources/application.yml:35`
+- Modify: `core/daemon-boot-perspectivepollerd/src/main/resources/application.yml:56-57`
+- Modify: `core/daemon-boot-pollerd/src/main/resources/application.yml:54-55`
+- Modify: `core/daemon-boot-provisiond/src/main/resources/application.yml:71`
+- Modify: `core/daemon-boot-syslogd/src/main/resources/application.yml:31`
+- Modify: `core/daemon-boot-telemetryd/src/main/resources/application.yml:26-27`
+- Modify: `core/daemon-boot-trapd/src/main/resources/application.yml:31`
+- Modify or Delete (per Task 1 Step 3): `opennms-container/delta-v/{provisiond,pollerd-daemon,collectd,enlinkd,syslogd,bsmd,trapd,discovery}-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg`
+- Modify: `core/event-forwarder-kafka/src/test/java/org/deltav/core/event/forwarder/kafka/KafkaEventForwarderTest.java:47-48`
+- Modify: `core/event-forwarder-kafka/src/test/java/org/deltav/core/event/forwarder/kafka/KafkaEventSubscriptionServiceTest.java:54`
+- Modify: `opennms-container/delta-v/test-e2e.sh:166,172`, `test-minion-e2e.sh:187,193`, `test-passive-e2e.sh:361,367`, `test-perspective-e2e.sh:186`, `test-syslog-e2e.sh:264,270`, `test-minion-rpc-e2e.sh:138`
+- Modify: `README.md:114,122,159,160`, `GEMINI.md:71`, `opennms-container/delta-v/README.md:10,204`
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+git checkout -b feat/rename-event-topics-deltav
+```
+
+- [ ] **Step 2: Rename the production config defaults**
+
+In `core/daemon-common/.../KafkaEventTransportConfiguration.java`:
+
+```java
+    @Value("${opennms.kafka.event-topic:deltav-fault-events}")
+    // ... line 58:
+    @Value("${opennms.kafka.ipc-topic:deltav-ipc-events}")
+```
+
+- [ ] **Step 3: Rename the per-daemon `application.yml` defaults**
+
+In each of the 13 `core/daemon-boot-*/src/main/resources/application.yml` files listed above, change the `:`-default inside the `${...}` expansion:
+
+```yaml
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:deltav-ipc-events}
+```
+
+(Some files have only `event-topic`; apply each line as it exists in that file.)
+
+- [ ] **Step 4: Handle the vestigial `.cfg` files**
+
+If Task 1 Step 3 found them vestigial, delete all 8:
+
+```bash
+git rm opennms-container/delta-v/*-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+```
+
+If Task 1 found them live, instead edit each: `topic.name=deltav-fault-events`, `ipc.topic.name=deltav-ipc-events`.
+
+- [ ] **Step 5: Update the unit-test constants**
+
+In `KafkaEventForwarderTest.java`:
+
+```java
+    private static final String FAULT_TOPIC = "deltav-fault-events";
+    private static final String IPC_TOPIC = "deltav-ipc-events";
+```
+
+In `KafkaEventSubscriptionServiceTest.java`:
+
+```java
+    private static final String TOPIC = "deltav-fault-events";
+```
+
+- [ ] **Step 6: Build daemon-common and run the event-forwarder tests**
+
+Run: `./mvnw -q clean install -pl core/event-forwarder-kafka,core/daemon-common -am -DskipITs`
+Expected: BUILD SUCCESS; `KafkaEventForwarderTest` and `KafkaEventSubscriptionServiceTest` PASS.
+
+- [ ] **Step 7: Commit the code + config rename**
+
+```bash
+git add -A
+git commit -m "feat: rename event Kafka topics to deltav-fault-events / deltav-ipc-events"
+```
+
+- [ ] **Step 8: Update the E2E test scripts**
+
+In each `opennms-container/delta-v/test-*.sh` listed above, replace `--topic opennms-fault-events` with `--topic deltav-fault-events` and `--topic opennms-ipc-events` with `--topic deltav-ipc-events`.
+
+- [ ] **Step 9: Update the docs**
+
+In `README.md`, `GEMINI.md`, and `opennms-container/delta-v/README.md`, replace the `opennms-fault-events` / `opennms-ipc-events` literals with the new names.
+
+- [ ] **Step 10: Commit the test-script + doc updates**
+
+```bash
+git add -A
+git commit -m "test,docs: align E2E scripts and docs with renamed event topics"
+```
+
+- [ ] **Step 11: Rebuild images and run the event-path E2E suite on docker-compose (Mac)**
+
+```bash
+cd opennms-container/delta-v
+# build.sh fails as a backgrounded harness command — run detached from a foreground call
+./build.sh deltav
+docker compose up -d
+./test-e2e.sh && ./test-syslog-e2e.sh && ./test-passive-e2e.sh && ./test-minion-e2e.sh
+```
+
+Expected: each script PASSES. These exercise the event topics end-to-end (event create → Kafka → alarm). A failure here means a topic name was missed.
+
+- [ ] **Step 12: Push and open PR A**
+
+```bash
+git push -u origin feat/rename-event-topics-deltav
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "feat: rename event Kafka topics to deltav-* prefix" \
+  --body "PR A of the v1.2.0 GA topic rename. Renames opennms-fault-events/opennms-ipc-events to deltav-fault-events/deltav-ipc-events. Pure delta-v config; breaking change (see design doc). E2E suite green on docker-compose."
+```
+
+---
+
+## Task 3: PR B — RPC + Twin topic rename
+
+Rename `OpenNMS.<location>.rpc-request` → `DeltaV.<location>.rpc-request`, `OpenNMS.rpc-response` → `DeltaV.rpc-response`, and `OpenNMS.twin.*` → `DeltaV.twin.*`. **Scope depends on the Task 1 Step 4 verdict.**
+
+**Files (minion-gateway side, always):**
+- Modify: `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java:74,77`
+- Modify: `core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponsePublisher.java:43`
+- Modify: `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java:71` (+ javadoc lines 34, 41 region)
+- Modify: `core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java:33` (javadoc)
+- Modify: `core/minion-gateway/pom.xml:99` (description javadoc)
+- Modify: `README.md:167-168`, `opennms-container/delta-v/test-enlinkd-e2e.sh:194`, `opennms-container/delta-v/test-minion-rpc-e2e.sh:388`
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+git checkout -b feat/rename-rpc-twin-topics-deltav
+```
+
+- [ ] **Step 2 (contingency — only if Task 1 verdict was B, horizon-hardcoded): land the horizon change first**
+
+In a `pbrane/delta-v-horizon` clone, change the `KafkaRpc*` / `KafkaTwin*` topic-prefix constant from `OpenNMS` to a configurable property defaulting to `DeltaV`. Open that PR with `gh pr create --repo pbrane/delta-v-horizon`, get it merged, note the new published horizon JAR version, and bump `<horizon.version>` in delta-v's root `pom.xml`. If the verdict was A (config-overridable), skip this step.
+
+- [ ] **Step 3: Set the daemon-side prefix to `DeltaV`**
+
+Per the Task 1 verdict: if A, set the instance-id / prefix property to `DeltaV` in the shared daemon config (`core/daemon-common/src/main/resources/` or each daemon `application.yml`, as the audit located it) and in `core/minion-gateway/src/main/resources/application.yml`. If B, the horizon default from Step 2 already provides it; confirm no per-daemon override pins `OpenNMS`.
+
+- [ ] **Step 4: Update the minion-gateway RPC topic references**
+
+In `RpcChannelDispatcher.java`:
+
+```java
+    private static final Pattern RPC_REQUEST_TOPIC = Pattern.compile("DeltaV\\.(.*)\\.rpc-request");
+    // ... and the @KafkaListener annotation:
+        topicPattern = "DeltaV\\..*\\.rpc-request",
+```
+
+In `RpcResponsePublisher.java`:
+
+```java
+        @Value("${minion-gateway.rpc.response-topic:DeltaV.rpc-response}") String responseTopic) {
+```
+
+Update the javadoc `{@code OpenNMS.*}` references in both files to `DeltaV.*`.
+
+- [ ] **Step 5: Update the minion-gateway Twin topic references**
+
+In `TwinChannelDispatcher.java`:
+
+```java
+        topicPattern = "DeltaV\\.twin\\.response\\..*",
+```
+
+Update the `{@code OpenNMS.twin.response.<location>}` javadoc in `TwinChannelDispatcher.java`, `TwinStateCache.java`, and the `pom.xml:99` description to `DeltaV.twin.response.<location>`. If a Twin **request** topic literal (`OpenNMS.twin.request`) exists in code, rename it to `DeltaV.twin.request`.
+
+- [ ] **Step 6: Build the gateway and affected daemons**
+
+Run: `./mvnw -q clean install -pl core/minion-gateway -am -DskipITs`
+Expected: BUILD SUCCESS. Then run any `RpcChannelDispatcher` / `TwinChannelDispatcher` unit tests present:
+`./mvnw -q test -pl core/minion-gateway`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat: rename RPC and Twin Kafka topics to DeltaV.* prefix"
+```
+
+- [ ] **Step 8: Update docs and RPC/Twin-referencing test scripts**
+
+In `README.md:167-168` rename `OpenNMS.twin.response` / `OpenNMS.twin.request`. In `test-enlinkd-e2e.sh:194` (comment) and `test-minion-rpc-e2e.sh:388` (log string) update the `OpenNMS.<loc>.rpc-request` references to `DeltaV.<loc>.rpc-request`.
+
+```bash
+git add -A
+git commit -m "docs,test: align docs and E2E scripts with renamed RPC/Twin topics"
+```
+
+- [ ] **Step 9: Rebuild images and run the RPC/Twin E2E suite on docker-compose (Mac)**
+
+```bash
+cd opennms-container/delta-v
+./build.sh deltav
+docker compose up -d
+./test-minion-rpc-e2e.sh && ./test-enlinkd-e2e.sh && ./test-grpc-twin-e2e.sh && ./test-grpc-heartbeat-e2e.sh
+```
+
+Expected: each PASSES. These exercise the RPC path (Minion ↔ gateway ↔ daemon) and Twin sync end-to-end.
+
+- [ ] **Step 10: Push and open PR B**
+
+```bash
+git push -u origin feat/rename-rpc-twin-topics-deltav
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "feat: rename RPC and Twin Kafka topics to DeltaV.* prefix" \
+  --body "PR B of the v1.2.0 GA topic rename. Renames OpenNMS.<loc>.rpc-request/rpc-response and OpenNMS.twin.* to DeltaV.*. Breaking change. RPC/Twin E2E green on docker-compose. [If verdict B: depends on pbrane/delta-v-horizon PR #NNN + horizon BOM bump.]"
+```
+
+---
+
+## Task 4: Cut `v1.2.0-rc4`
+
+Version bump and release-candidate cut that smoke-validates the breaking topic rename. Picks up PR #277 (already merged to `develop`) automatically.
+
+**Files:**
+- Modify: every `pom.xml` carrying `1.2.0-rc3.1` (via `mvn versions:set`)
+- Modify: `opennms-container/delta-v/.env.example`
+
+- [ ] **Step 1: Confirm PR A and PR B are merged**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+gh pr list --repo pbrane/delta-v --state merged --limit 5
+```
+
+Expected: PR A and PR B appear merged. Confirm `git log --oneline -5` shows both rename commits and PR #277.
+
+- [ ] **Step 2: Branch and bump the version**
+
+```bash
+git checkout -b chore/v1.2.0-rc4
+./mvnw -q versions:set -DnewVersion=1.2.0-rc4 -DgenerateBackupPoms=false -DprocessAllModules=true
+```
+
+Expected: `grep -m1 '<version>' pom.xml` (the project version line, ~line 16) shows `1.2.0-rc4`.
+
+- [ ] **Step 3: Bump `.env.example`**
+
+In `opennms-container/delta-v/.env.example`, change `VERSION=1.2.0-rc3.1` to `VERSION=1.2.0-rc4`.
+
+- [ ] **Step 4: Verify the reactor builds**
+
+Run: `./mvnw -q clean install -DskipTests -DskipITs`
+Expected: BUILD SUCCESS across all modules.
+
+- [ ] **Step 5: Commit and merge via PR**
+
+```bash
+git add -A
+git commit -m "chore(v1.2.0): bump version to 1.2.0-rc4"
+git push -u origin chore/v1.2.0-rc4
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "chore(v1.2.0): bump version to 1.2.0-rc4" \
+  --body "rc4 cut: topic rename (PRs A+B) + PR #277. Smoke-validates the breaking topic rename before GA promotion."
+```
+
+Wait for merge.
+
+- [ ] **Step 6: Tag `v1.2.0-rc4`**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+git tag v1.2.0-rc4
+git push origin v1.2.0-rc4
+```
+
+This triggers the image-publish workflow. Monitor it:
+
+```bash
+gh run watch --repo pbrane/delta-v
+```
+
+Expected: all 26 images publish to GHCR.
+
+- [ ] **Step 7: Smoke-test rc4 on the UTM VM**
+
+Follow `reference_smoke_test_procedure` on the UTM VM at `~/delta-v-smoke`, with `GIT_REF=v1.2.0-rc4`, `IMG_TAG=1.2.0-rc4`, and `--profile full` (exercises perspectivepollerd).
+Expected: 28 nodes imported, Grafana reachable, all services healthy, `opennms_response_time_response{producer="pollerd"|"perspective_pollerd"}` in VictoriaMetrics, no false outages.
+
+- [ ] **Step 8: Gate**
+
+If the rc4 smoke is **green**, proceed to Task 5. If it surfaces a topic-rename defect, fix it via a feature branch + PR, cut `rc4.1`, and re-smoke before proceeding. Do not promote a red rc4 to GA.
+
+---
+
+## Task 5: Promote to `v1.2.0` GA
+
+Pure version-string promotion of the smoke-validated rc4 — no functional change.
+
+**Files:**
+- Modify: every `pom.xml` carrying `1.2.0-rc4`
+- Modify: `opennms-container/delta-v/.env.example`
+- Verify: `opennms-container/delta-v/build.sh`, `.github/workflows/delta-v-build-images.yml`
+
+- [ ] **Step 1: Branch and bump the version**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+git checkout -b chore/v1.2.0-ga
+./mvnw -q versions:set -DnewVersion=1.2.0 -DgenerateBackupPoms=false -DprocessAllModules=true
+```
+
+Expected: project version line shows `1.2.0`.
+
+- [ ] **Step 2: Bump `.env.example`**
+
+Change `VERSION=1.2.0-rc4` to `VERSION=1.2.0`.
+
+- [ ] **Step 3: Verify `build.sh` / GHA image-list parity**
+
+Confirm `opennms-container/delta-v/build.sh` and `.github/workflows/delta-v-build-images.yml` reference the same image set (they drift silently):
+
+```bash
+diff <(rg -o 'deltav/[a-z-]+' opennms-container/delta-v/build.sh | sort -u) \
+     <(rg -o 'deltav/[a-z-]+' .github/workflows/delta-v-build-images.yml | sort -u)
+```
+
+Expected: no difference. If they differ, reconcile before tagging.
+
+- [ ] **Step 4: Verify the reactor builds**
+
+Run: `./mvnw -q clean install -DskipTests -DskipITs`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit and merge via PR**
+
+```bash
+git add -A
+git commit -m "chore(v1.2.0): bump version to 1.2.0 (GA)"
+git push -u origin chore/v1.2.0-ga
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "chore(v1.2.0): bump version to 1.2.0 (GA)" \
+  --body "GA version promotion of the smoke-validated rc4. No functional change."
+```
+
+Wait for merge.
+
+- [ ] **Step 6: Tag `v1.2.0` and retag auxiliary images**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+git tag v1.2.0
+git push origin v1.2.0
+gh run watch --repo pbrane/delta-v
+```
+
+After the publish workflow completes, retag the auxiliary images that `build.sh deltav` does not rebuild (clickhouse, grafana, mock-snmp-agent, flow-exporter, sflow-exporter) to `1.2.0` per `feedback_auxiliary_image_retag_on_version_bump`.
+Expected: all 26 images present at tag `1.2.0` on GHCR.
+
+---
+
+## Task 6: GA smoke run
+
+- [ ] **Step 1: Smoke-test `v1.2.0` on the UTM VM**
+
+Follow `reference_smoke_test_procedure` with `GIT_REF=v1.2.0`, `IMG_TAG=1.2.0`, `--profile full`.
+Expected: 28 nodes imported, Grafana reachable, all services healthy, perspectivepollerd exercised, no false outages.
+
+- [ ] **Step 2: Record the result**
+
+If green, the release is shippable — proceed to Task 7. If red, the GA tag must be addressed (fix-forward to `v1.2.0` is not possible — a `v1.2.0.1`/`v1.2.1` patch cut would be needed); stop and escalate to the user.
+
+---
+
+## Task 7: GA release notes
+
+**Files:**
+- Create: the v1.2.0 release notes (location per the repo's release-notes convention — GitHub Release body and/or `docs/`).
+
+- [ ] **Step 1: Draft the release notes**
+
+Cover: the four-track v1.2.0 theme ("Delta-V runs well on Kubernetes" — self-contained images, Minion gRPC IPC, application observability, Pollerd/PerspectivePollerd response-time publishing); the **topic-rename breaking change** with explicit upgrade guidance (no mixed-version interoperability — full-stack restart required; old topics are abandoned, new topics auto-create); and the **known issue**: pollerd/perspective dashboards ship 3 "No Data" counter panels each (actuator→VictoriaMetrics scrape deferred to v1.3).
+
+- [ ] **Step 2: Publish**
+
+```bash
+gh release create v1.2.0 --repo pbrane/delta-v --title "Delta-V v1.2.0" --notes-file <notes-file>
+```
+
+(Or edit the release GitHub auto-created from the tag.)
+
+---
+
+## Task 8: Reconcile the master release plan
+
+**Files:**
+- Modify: `docs/plans/2026-04-23-v1.2.0-release-plan.md`
+
+- [ ] **Step 1: Update the release plan to final state**
+
+Replace the stale "Remaining" section (which lists rc1/rc2/GA as future) with the actual shipped history (rc1, rc2, rc2.1, rc2.2, rc3, rc3.1, rc4, `v1.2.0` GA), mark all four tracks DONE, and record the three v1.3-deferred items (Default-location retirement, Minion image slimming, dashboard actuator gap). Update the `v1.1.1 release notes: TBD` reference now that GA notes exist.
+
+- [ ] **Step 2: Commit via PR**
+
+```bash
+git checkout develop && git pull --ff-only origin develop
+git checkout -b docs/reconcile-v1.2.0-release-plan
+git add docs/plans/2026-04-23-v1.2.0-release-plan.md
+git commit -m "docs(plans): reconcile v1.2.0 release plan to GA-shipped state"
+git push -u origin docs/reconcile-v1.2.0-release-plan
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "docs(plans): reconcile v1.2.0 release plan to GA-shipped state" \
+  --body "Supersedes the stale Remaining section now that v1.2.0 GA has shipped."
+```
+
+---
+
+## Definition of Done
+
+- [ ] `v1.2.0` tagged on `pbrane/delta-v`.
+- [ ] 26 images published to GHCR at tag `1.2.0` (including retagged auxiliary images).
+- [ ] GA smoke green on the UTM VM (`--profile full`): 28 nodes, Grafana reachable, all services healthy, perspectivepollerd exercised.
+- [ ] GA release notes published, covering the topic-rename breaking change and the known dashboard-panel gap.
+- [ ] `docs/plans/2026-04-23-v1.2.0-release-plan.md` reconciled to final state.

--- a/docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md
+++ b/docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md
@@ -1,0 +1,204 @@
+# Delta-V v1.2.0 GA Finalization — Design
+
+> **Status:** Approved 2026-05-16. Supersedes the stale "Remaining" section of
+> `docs/plans/2026-04-23-v1.2.0-release-plan.md`. This document is the design;
+> the sequenced implementation plan is produced separately via `writing-plans`.
+
+## Purpose
+
+Enumerate the true remaining surface for the Delta-V v1.2.0 release, record the
+agreed GA-blocking vs. v1.3-deferred cut line, and define the run to the `v1.2.0`
+(GA) tag. The deliverable of the session that consumes this design is the
+finalization plan — not code.
+
+## Reconciled v1.2.0 state
+
+The master release plan's "Remaining" section is stale: it lists rc1/rc2/GA as
+future work, while the project has since cut rc1, rc2, rc2.1, rc2.2, rc3, and
+rc3.1 (current tag, 2026-05-16). All four release tracks are functionally
+complete:
+
+| Track | Status | Evidence |
+|---|---|---|
+| 1 — Self-contained images | ✅ DONE | alpha1–3 |
+| 2 — Minion gRPC IPC | ✅ DONE | gRPC migration (PR3) + Kafka removal (PR #260 — minion-gateway is the sole ingress) |
+| 3 — Application observability | ✅ DONE | beta1 (Scope A bridge) + beta2 (Scope B domain metrics) |
+| 4 — Pollerd/PerspectivePollerd response-time publishing | ✅ DONE | Pollerd (beta2), PerspectivePollerd (rc3); verified end-to-end on the rc3.1 smoke run |
+
+Track 2 is **not** "in its tail" — its load-bearing work (the gRPC migration and
+the removal of the Kafka rollback path) has landed. What the original release
+plan bundled into Track 2 were three *cleanup* items, not blockers of it; all
+three are deferred to v1.3 (see below).
+
+**Plan step:** update `docs/plans/2026-04-23-v1.2.0-release-plan.md` in place —
+replace the stale "Remaining" section with this reconciled state plus the GA run.
+
+## GA cut line
+
+Decided with the user during brainstorming 2026-05-16.
+
+### GA-blocking (the only feature work left)
+
+- **Topic rename** — remove legacy `OpenNMS.*` / `opennms-*` topic prefixes.
+
+### Deferred to v1.3
+
+- **Retire the "Default" Minion location** (`project_retire_default_minion`) —
+  not started; retargets 7 E2E scripts plus requisitions and removes
+  mock-snmp-agent. The win is architectural legibility, not a bug fix; no
+  forcing function.
+- **Minion ServiceMix/ActiveMQ bundle purge + image slimming**
+  (`project_minion_servicemix_activemq_cleanup`, `project_minion_image_slimming`)
+  — pure optimization (~50–100 MB off the 677 MB Minion image), no functional
+  gap. The gRPC track that was meant to carry it is already closed (PR #260).
+- **Dashboard actuator-metrics gap** (`project_dashboard_actuator_metrics_gap`)
+  — the pollerd/perspective Grafana dashboards each ship 3 counter panels that
+  permanently show "No Data" because `deltav_*` Micrometer counters never reach
+  VictoriaMetrics. GA ships with the dead panels as-is; the actuator→VM scrape
+  path is v1.3 work. Documented as a known issue in the GA release notes.
+
+### Already settled — no decision needed
+
+- **PR #277** (perspective-app-init retry loop + Google-Search seeding +
+  dashboard location/service filters) is merged to `develop`; the next cut
+  picks it up automatically.
+- **Issues #201 / #202 / #203** — open test-harness bugs. Confirmed
+  non-blocking: the release plan already classifies them as normal maintenance.
+  They stay open and are fixed independently of the GA run.
+- **PR #225** (optional OpenTelemetry tracing overlay) — DJ/Mike's tracing
+  track; out of scope for v1.2.0 GA.
+
+## GA-blocking work: the topic rename
+
+### Goal and target naming
+
+De-legacy substitution only. The gRPC migration already replaced the old
+`OpenNMS.Sink.*` topics with a terse `n.*` scheme (`n.Heartbeat`,
+`n.Telemetry-IPFIX`); that scheme is **left as-is**. The `n.*`-vs-`DeltaV.*`
+inconsistency is recorded as a v1.3 cosmetic cleanup, not GA work.
+
+| Topic class | Today | GA target |
+|---|---|---|
+| RPC request | `OpenNMS.<location>.rpc-request` | `DeltaV.<location>.rpc-request` |
+| RPC response | `OpenNMS.rpc-response` | `DeltaV.rpc-response` |
+| Twin | `OpenNMS.twin.response.<location>` (and the request topic) | `DeltaV.twin.*` |
+| Events | `opennms-fault-events`, `opennms-ipc-events` | `deltav-fault-events`, `deltav-ipc-events` |
+
+### Known topic surface
+
+- **Event topics** — delta-v config only. `@Value` defaults in
+  `core/daemon-common/.../KafkaEventTransportConfiguration.java`
+  (`opennms.kafka.event-topic`, `opennms.kafka.ipc-topic`), per-daemon
+  `application.yml` overrides (e.g. alarmd's `event-topic`), and docker-compose
+  `KAFKA_EVENT_TOPIC` environment entries.
+- **RPC topics** — minion-gateway side: a `@KafkaListener` `topicPattern` regex
+  in `RpcChannelDispatcher.java` (`OpenNMS\..*\.rpc-request`) and a `@Value`
+  default in `RpcResponsePublisher.java` (`OpenNMS.rpc-response`). Daemon side:
+  each daemon that issues RPC uses horizon's `KafkaRpc*` client, which
+  constructs `<prefix>.<location>.rpc-request`.
+- **Twin topics** — minion-gateway side: a `@KafkaListener` `topicPattern` regex
+  in `TwinChannelDispatcher.java` (`OpenNMS\.twin\.response\..*`) and
+  `TwinStateCache.java`. Daemon side: horizon's `KafkaTwin*` client.
+
+### The central scoping unknown
+
+For RPC and Twin, the topic prefix on the **daemon side** is constructed by
+horizon's `KafkaRpc*` / `KafkaTwin*` client code, not by delta-v. The
+finalization plan's first task is an audit that answers: is that prefix a
+delta-v-overridable configuration property, or hard-coded in horizon? The answer
+decides whether the RPC/Twin rename is a delta-v-only change or needs a
+companion `pbrane/delta-v-horizon` PR plus a horizon BOM bump in delta-v. The
+audit also reconciles the rc3.1-smoke `DeltaV.Sink.*` observation against the
+code's actual `n.*` Sink scheme.
+
+### Work breakdown
+
+- **Audit (no PR)** — produces the RPC/Twin scoping answer above.
+- **PR A — event topic rename** — pure delta-v config; mechanical, low risk;
+  lands independently of the audit.
+- **PR B — RPC + Twin topic rename** — minion-gateway `topicPattern` regexes and
+  `@Value` defaults plus the daemon-side client. Scope (delta-v-only vs.
+  delta-v + horizon) is set by the audit; may carry a companion horizon PR and a
+  BOM bump.
+
+### Breaking-change consequence
+
+Renaming Kafka topics is a breaking change. A v1.1.x → v1.2.0 in-place upgrade
+will not interoperate — old daemons keep consuming old topics while new ones
+produce to renamed topics. Topics auto-create on first produce, so no topic
+provisioning step is required, but mixed-version clusters are unsupported. GA
+requires a full-stack restart, which suits delta-v's all-or-nothing
+docker-compose deployment model. The GA release notes must call this out with
+explicit upgrade guidance.
+
+## Release mechanics and sequencing
+
+No firm dates. Order reflects dependencies and risk.
+
+1. **Audit** the topic surface — resolves PR B scope.
+2. **PR A** — event topic rename → merge to `develop`.
+3. **PR B** — RPC + Twin topic rename (plus a companion `pbrane/delta-v-horizon`
+   PR and a horizon BOM bump if the audit requires) → merge to `develop`.
+4. **Cut `v1.2.0-rc4`** — version bump `1.2.0-rc3.1` → `1.2.0-rc4` via
+   `mvn versions:set` (never bulk-sed); bump `.env.example`'s `VERSION`. The cut
+   picks up PR #277 (already merged) and the topic renames. Smoke on the UTM VM
+   per `reference_smoke_test_procedure`, `--profile full`.
+5. **Promote to GA** — only if the rc4 smoke is green. Version bump
+   `1.2.0-rc4` → `1.2.0` via `mvn versions:set` (no functional change between
+   rc4 and GA); bump `.env.example`; verify `build.sh` and
+   `.github/workflows/delta-v-build-images.yml` are in parity, and re-tag the
+   auxiliary images (clickhouse, grafana, mock-snmp-agent, flow/sflow exporters)
+   that `build.sh deltav` does not rebuild. Tag `v1.2.0`.
+6. **GA smoke** — UTM VM, `--profile full` (exercises perspectivepollerd),
+   per `reference_smoke_test_procedure`.
+7. **GA release notes** — cover the four-track v1.2.0 theme, the topic-rename
+   breaking change with upgrade guidance, and the known dashboard dead-panel
+   gap.
+8. **Reconcile the master release plan** — update
+   `docs/plans/2026-04-23-v1.2.0-release-plan.md` to final state.
+
+### Why an rc4 cut before GA
+
+The topic rename is a breaking change and the only feature work in the GA run;
+it deserves its own smoke validation before the `v1.2.0` tag becomes a
+version-string promotion of an already-smoked rc4. Going `rc3.1` → GA directly
+would tag GA on un-smoked breaking-change code.
+
+### Why PR A and PR B are split
+
+PR A (event topics) is pure delta-v config and low risk; splitting it out lets
+it land while the audit resolves PR B's scope, rather than blocking the whole
+rename on the horizon-dependency question.
+
+## Definition of done
+
+- `v1.2.0` tagged.
+- 26 images published to GHCR.
+- GA smoke green on the UTM VM (`--profile full`): 28 nodes imported, Grafana
+  reachable, all services healthy, perspectivepollerd exercised.
+- GA release notes published.
+- `docs/plans/2026-04-23-v1.2.0-release-plan.md` reconciled to final state.
+
+## Workflow constraints
+
+- Never open PRs against `OpenNMS/*` — delta-v and delta-v-horizon are forks.
+  Always `--repo pbrane/delta-v` (or `pbrane/delta-v-horizon`).
+- Never commit directly to `develop` / `main` — feature branches and PRs only.
+- Pull `develop` before branching.
+- Tag pushes trigger the image-publish workflow and cannot be easily cancelled.
+  A partial/transient publish failure is often just a re-run, not a re-publish.
+- Smoke VM = release validation only; dev/local validation is docker-compose on
+  the Mac.
+
+## Related memory items
+
+Release-scope: `project_v1_2_minion_kafka_removal`, `project_v1_2_minion_grpc_migration`,
+`project_sink_topic_rename`, `project_retire_default_minion`,
+`project_minion_servicemix_activemq_cleanup`, `project_minion_image_slimming`,
+`project_dashboard_actuator_metrics_gap`, `project_perspective_app_init_cold_start_race`.
+
+Workflow/release-mechanics: `feedback_never_pr_opennms`, `feedback_feature_branches`,
+`feedback_pull_before_branching`, `feedback_image_tag_version_mismatch`,
+`feedback_auxiliary_image_retag_on_version_bump`, `feedback_build_sh_and_gha_must_match`,
+`feedback_no_blind_sed_versions`, `feedback_delayed_tag_workflow_trigger`,
+`feedback_gh_packages_cached_notfound`, `reference_smoke_test_procedure`.


### PR DESCRIPTION
Reconciles the stale v1.2.0 release plan against actual state — all four
release tracks are functionally complete — and produces the run to the
\`v1.2.0\` GA tag.

## Deliverables
- **Design spec** \`docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md\` — reconciled state + agreed GA cut line.
- **Implementation plan** \`docs/plans/2026-05-16-v1.2.0-ga-finalization-implementation.md\` — 8-task sequenced run.

## GA cut line (agreed with maintainer)
- **GA-blocking:** topic rename only (\`OpenNMS.*\`/\`opennms-*\` → \`DeltaV.*\`/\`deltav-*\` on RPC, Twin, event topics).
- **Deferred to v1.3:** Default-location retirement, Minion image slimming, dashboard actuator-metrics gap.

## Run
audit → PR A (event topics) → PR B (RPC/Twin topics) → rc4 cut + smoke → GA promotion → GA smoke → release notes → reconcile master plan.

Docs-only change. No code touched.