### PR TITLE
docs(plans): next-session prompt for v1.2.0 GA plan execution

### DIFF
--- a/docs/superpowers/next-session-prompts/2026-05-16-v1.2.0-ga-execution-kickoff.md
+++ b/docs/superpowers/next-session-prompts/2026-05-16-v1.2.0-ga-execution-kickoff.md
@@ -1,0 +1,77 @@
+# Next-Session Prompt: v1.2.0 GA Finalization — Execution
+
+Use this prompt to start a new Claude session that **executes** the v1.2.0 GA
+finalization plan. The planning session is done; this session writes code,
+opens PRs, and drives the release to the `v1.2.0` GA tag.
+
+## What to do
+
+Execute the implementation plan at
+`docs/plans/2026-05-16-v1.2.0-ga-finalization-implementation.md` task-by-task.
+
+Drive it with the `superpowers:subagent-driven-development` skill (recommended
+by the plan header — fresh subagent per task, two-stage review between tasks).
+`superpowers:executing-plans` is the alternative if you prefer inline batch
+execution.
+
+The companion design spec is
+`docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md` — read it
+first for the GA cut line and the reasoning behind the rename.
+
+## Where things stand (paste verbatim into the new session)
+
+The planning session (2026-05-16) reconciled the v1.2.0 state: all four release
+tracks are functionally complete. The design + plan were approved and merged in
+**PR #279**. `develop` is synced; current tag is `v1.2.0-rc3.1`.
+
+**GA cut line (already decided — do not re-litigate):**
+- **GA-blocking:** topic rename only — de-legacy `OpenNMS.*` / `opennms-*` Kafka
+  topic prefixes on RPC, Twin, and event topics to `DeltaV.*` / `deltav-*`.
+- **Deferred to v1.3:** Default-location retirement, Minion image slimming,
+  dashboard actuator-metrics gap.
+
+**The 8 tasks:** (1) topic-rename audit → (2) PR A event topics → (3) PR B
+RPC/Twin topics → (4) rc4 cut + smoke → (5) GA promotion → (6) GA smoke →
+(7) release notes → (8) reconcile the master release plan.
+
+## Critical execution notes
+
+- **Task 1 is a gate.** The audit determines whether PR B (Task 3) is a
+  delta-v-only change or needs a companion `pbrane/delta-v-horizon` PR + BOM
+  bump. Do not start Task 3 until the audit verdict (A or B) is recorded.
+- **The topic rename is a breaking change.** No mixed-version interoperability;
+  GA upgrade requires a full-stack restart. This must land in the release notes
+  (Task 7).
+- **rc4 smoke is a hard gate.** Task 4 ends with a UTM VM smoke run; Task 5 (GA
+  promotion) only proceeds if rc4 smoke is green. The smoke runs are **manual
+  steps the user performs on the UTM VM** — pause and hand off at those steps
+  per `reference_smoke_test_procedure` (use `--profile full`).
+- Tag pushes (Tasks 4, 5) trigger the image-publish workflow and cannot be
+  cancelled cleanly — verify everything before tagging. A partial/transient
+  publish failure is often just a re-run, not a re-publish.
+
+## Workflow guards
+
+- **Never PR against `OpenNMS/*`** — always `--repo pbrane/delta-v` (or
+  `pbrane/delta-v-horizon`). See `feedback_never_pr_opennms`.
+- **Never commit to `develop`/`main`** — feature branches + PRs only.
+- **Pull `develop` before branching.**
+- **Build with `./mvnw`**; `./mvnw clean install` when a shared module
+  (`daemon-common`, `minion-gateway`) changes — plain `install` re-uses the
+  stale repackaged fat jar.
+- **Never bulk-`sed` version strings** — use `mvn versions:set`.
+- Bump `opennms-container/delta-v/.env.example` with every `project.version`
+  bump; re-tag auxiliary images on version bumps.
+- Smoke VM = release validation only; dev/local validation is docker-compose on
+  the Mac.
+
+## Related memory items
+
+`project_v1_2_ga_finalization` (the cut-line decision + plan pointers),
+`project_sink_topic_rename`, `feedback_never_pr_opennms`,
+`feedback_feature_branches`, `feedback_pull_before_branching`,
+`feedback_no_blind_sed_versions`, `feedback_image_tag_version_mismatch`,
+`feedback_auxiliary_image_retag_on_version_bump`,
+`feedback_build_sh_and_gha_must_match`, `feedback_spring_boot_repackage_needs_clean`,
+`feedback_delayed_tag_workflow_trigger`, `feedback_gh_packages_cached_notfound`,
+`reference_smoke_test_procedure`.


### PR DESCRIPTION
Execution kickoff prompt for the v1.2.0 GA finalization plan merged in #279. Drives subagent-driven execution of the 8-task run to the v1.2.0 GA tag.