### PR TITLE
feat: rename event Kafka topics to deltav-* prefix

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -68,7 +68,7 @@ cd opennms-container/delta-v
 
 *   **Spring Patterns**: Strictly use **constructor injection**; NEVER use `@Autowired` on fields.
 *   **Persistence**: Use `opennms-model-jakarta` and Hibernate 7 for new services. Legacy `opennms-model` (javax.persistence) is incompatible with the new stack.
-*   **IPC**: All inter-service communication must use Kafka topics (`opennms-fault-events`, `opennms-ipc-events`).
+*   **IPC**: All inter-service communication must use Kafka topics (`deltav-fault-events`, `deltav-ipc-events`).
 *   **Git Rules**: Never create PRs against `OpenNMS/*`. Use `--repo pbrane/delta-v` for all `gh pr create` commands.
 *   **Coding Style**: Adhere to existing patterns in `daemon-boot-*` modules. Exclude ServiceMix Spring 4.2.x bundles in POMs for Boot 4 modules.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ OpenNMS Horizon is an enterprise-grade open-source network monitoring platform. 
 ```
 Minion → Kafka Sink → Trapd/Syslogd
                           ↓
-            KafkaEventForwarder → opennms-fault-events (Kafka)
+            KafkaEventForwarder → deltav-fault-events (Kafka)
                                         ↓
                         ┌───────────────┼───────────────┐
                         ↓               ↓               ↓
@@ -119,7 +119,7 @@ Minion → Kafka Sink → Trapd/Syslogd
                    (→ PostgreSQL)  (→ translate     (subscribe to
                                     → re-publish)   relevant events)
                                         ↓
-                              opennms-ipc-events (Kafka)
+                              deltav-ipc-events (Kafka)
                                         ↓
                               Provisiond, Discovery, etc.
 ```
@@ -156,8 +156,8 @@ Minion → Kafka Sink → Trapd/Syslogd
 
 | Topic | Purpose |
 |-------|---------|
-| `opennms-fault-events` | Alarm-bearing events (traps, syslog, translated events with alarm-data) |
-| `opennms-ipc-events` | Daemon-to-daemon internal events (newSuspect, nodeScanCompleted, reloadDaemonConfig) |
+| `deltav-fault-events` | Alarm-bearing events (traps, syslog, translated events with alarm-data) |
+| `deltav-ipc-events` | Daemon-to-daemon internal events (newSuspect, nodeScanCompleted, reloadDaemonConfig) |
 | `OpenNMS.Sink.Trap` | Minion → Trapd raw trap forwarding |
 | `OpenNMS.Sink.Syslog` | Minion → Syslogd raw syslog forwarding |
 | `OpenNMS.Sink.Telemetry-*` | Minion → flow-enricher per-protocol flow forwarding (Netflow5/9, IPFIX, sFlow) |

--- a/core/daemon-boot-alarmd/src/main/resources/application.yml
+++ b/core/daemon-boot-alarmd/src/main/resources/application.yml
@@ -38,7 +38,7 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-core}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
 

--- a/core/daemon-boot-bsmd/src/main/resources/application.yml
+++ b/core/daemon-boot-bsmd/src/main/resources/application.yml
@@ -38,7 +38,7 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-core}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
 

--- a/core/daemon-boot-collectd/src/main/resources/application.yml
+++ b/core/daemon-boot-collectd/src/main/resources/application.yml
@@ -56,8 +56,8 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
-    ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:deltav-ipc-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-collectd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
   rpc:

--- a/core/daemon-boot-discovery/src/main/resources/application.yml
+++ b/core/daemon-boot-discovery/src/main/resources/application.yml
@@ -28,7 +28,7 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-discovery}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
   rpc:

--- a/core/daemon-boot-enlinkd/src/main/resources/application.yml
+++ b/core/daemon-boot-enlinkd/src/main/resources/application.yml
@@ -22,8 +22,8 @@ opennms:
     id: ${OPENNMS_INSTANCE_ID:OpenNMS}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
-    ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:deltav-ipc-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-enlinkd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
   rpc:

--- a/core/daemon-boot-eventtranslator/src/main/resources/application.yml
+++ b/core/daemon-boot-eventtranslator/src/main/resources/application.yml
@@ -32,7 +32,7 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-core}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
 

--- a/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
@@ -53,8 +53,8 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
-    ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:deltav-ipc-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-perspectivepollerd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
   rpc:

--- a/core/daemon-boot-pollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-pollerd/src/main/resources/application.yml
@@ -51,8 +51,8 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
-    ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:deltav-ipc-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-pollerd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
   rpc:

--- a/core/daemon-boot-provisiond/src/main/resources/application.yml
+++ b/core/daemon-boot-provisiond/src/main/resources/application.yml
@@ -68,7 +68,7 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:25}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-provisiond}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
   rpc:

--- a/core/daemon-boot-syslogd/src/main/resources/application.yml
+++ b/core/daemon-boot-syslogd/src/main/resources/application.yml
@@ -28,7 +28,7 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-syslogd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
     sink:

--- a/core/daemon-boot-telemetryd/src/main/resources/application.yml
+++ b/core/daemon-boot-telemetryd/src/main/resources/application.yml
@@ -23,8 +23,8 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
-    ipc-topic: ${KAFKA_IPC_TOPIC:opennms-ipc-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
+    ipc-topic: ${KAFKA_IPC_TOPIC:deltav-ipc-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-telemetryd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
 

--- a/core/daemon-boot-trapd/src/main/resources/application.yml
+++ b/core/daemon-boot-trapd/src/main/resources/application.yml
@@ -28,7 +28,7 @@ opennms:
     node-id: ${OPENNMS_TSID_NODE_ID:0}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
-    event-topic: ${KAFKA_EVENT_TOPIC:opennms-fault-events}
+    event-topic: ${KAFKA_EVENT_TOPIC:deltav-fault-events}
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-trapd}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
     sink:

--- a/core/daemon-common/src/main/java/org/deltav/core/daemon/common/KafkaEventTransportConfiguration.java
+++ b/core/daemon-common/src/main/java/org/deltav/core/daemon/common/KafkaEventTransportConfiguration.java
@@ -52,10 +52,10 @@ public class KafkaEventTransportConfiguration {
     @Value("${opennms.kafka.bootstrap-servers:kafka:9092}")
     private String bootstrapServers;
 
-    @Value("${opennms.kafka.event-topic:opennms-fault-events}")
+    @Value("${opennms.kafka.event-topic:deltav-fault-events}")
     private String eventTopic;
 
-    @Value("${opennms.kafka.ipc-topic:opennms-ipc-events}")
+    @Value("${opennms.kafka.ipc-topic:deltav-ipc-events}")
     private String ipcTopic;
 
     @Value("${opennms.kafka.consumer-group:opennms-core}")

--- a/core/event-forwarder-kafka/src/test/java/org/deltav/core/event/forwarder/kafka/KafkaEventForwarderTest.java
+++ b/core/event-forwarder-kafka/src/test/java/org/deltav/core/event/forwarder/kafka/KafkaEventForwarderTest.java
@@ -44,8 +44,8 @@ import org.opennms.netmgt.xml.event.Value;
 
 public class KafkaEventForwarderTest {
 
-    private static final String FAULT_TOPIC = "opennms-fault-events";
-    private static final String IPC_TOPIC = "opennms-ipc-events";
+    private static final String FAULT_TOPIC = "deltav-fault-events";
+    private static final String IPC_TOPIC = "deltav-ipc-events";
 
     private EventProcessor eventExpander;
     private EventProcessor tsidAssigner;

--- a/core/event-forwarder-kafka/src/test/java/org/deltav/core/event/forwarder/kafka/KafkaEventSubscriptionServiceTest.java
+++ b/core/event-forwarder-kafka/src/test/java/org/deltav/core/event/forwarder/kafka/KafkaEventSubscriptionServiceTest.java
@@ -51,7 +51,7 @@ import org.opennms.netmgt.xml.event.Event;
  */
 public class KafkaEventSubscriptionServiceTest {
 
-    private static final String TOPIC = "opennms-fault-events";
+    private static final String TOPIC = "deltav-fault-events";
     private static final Duration POLL_TIMEOUT = Duration.ofMillis(100);
 
     @SuppressWarnings("unchecked")

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -7,7 +7,7 @@ Delta-V decomposes the monolithic OpenNMS into independently scalable services c
 ```
                     ┌──────────────────────────────────────────────────┐
                     │                   Kafka (KRaft)                  │
-                    │    opennms-fault-events / opennms-ipc-events     │
+                    │    deltav-fault-events / deltav-ipc-events     │
                     └──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬─────┘
                        │  │  │  │  │  │  │  │  │  │  │  │  │  │
   ┌─────────┐     ┌────┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴────┐
@@ -201,7 +201,7 @@ Delta-V replaces the monolithic OpenNMS runtime with a composable service mesh:
 - **Minion** handles distributed data collection (SNMP, ICMP) via Kafka IPC
 - All daemons use **Hibernate 7 / Jakarta Persistence** with the `opennms-model-jakarta` entity model
 
-All services communicate via two Kafka topics: `opennms-fault-events` (alarm-bearing events) and `opennms-ipc-events` (daemon-to-daemon coordination). Each service generates globally unique event IDs using TSID (Time-Sorted IDs) with a unique node-id per JVM.
+All services communicate via two Kafka topics: `deltav-fault-events` (alarm-bearing events) and `deltav-ipc-events` (daemon-to-daemon coordination). Each service generates globally unique event IDs using TSID (Time-Sorted IDs) with a unique node-id per JVM.
 
 ### Event Flow
 

--- a/opennms-container/delta-v/bsmd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/bsmd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Bsmd (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-bsmd
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events

--- a/opennms-container/delta-v/collectd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/collectd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Collectd (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-collectd
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events

--- a/opennms-container/delta-v/discovery-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/discovery-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Discovery (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-discovery
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events

--- a/opennms-container/delta-v/enlinkd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/enlinkd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Enlinkd (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-enlinkd
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events

--- a/opennms-container/delta-v/pollerd-daemon-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/pollerd-daemon-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Pollerd (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-pollerd
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events

--- a/opennms-container/delta-v/provisiond-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/provisiond-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Provisiond (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-provisiond
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events

--- a/opennms-container/delta-v/syslogd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/syslogd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Syslogd (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-syslogd
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events

--- a/opennms-container/delta-v/test-e2e.sh
+++ b/opennms-container/delta-v/test-e2e.sh
@@ -163,13 +163,13 @@ log "Starting Kafka event consumers..."
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-fault-events \
+    --topic deltav-fault-events \
     > "$FAULT_LOG" 2>/dev/null &
 FAULT_CONSUMER_PID=$!
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-ipc-events \
+    --topic deltav-ipc-events \
     > "$IPC_LOG" 2>/dev/null &
 IPC_CONSUMER_PID=$!
 

--- a/opennms-container/delta-v/test-minion-e2e.sh
+++ b/opennms-container/delta-v/test-minion-e2e.sh
@@ -184,13 +184,13 @@ SINK_CONSUMER_PID=$!
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-fault-events \
+    --topic deltav-fault-events \
     > "$FAULT_LOG" 2>/dev/null &
 FAULT_CONSUMER_PID=$!
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-ipc-events \
+    --topic deltav-ipc-events \
     > "$IPC_LOG" 2>/dev/null &
 IPC_CONSUMER_PID=$!
 

--- a/opennms-container/delta-v/test-minion-rpc-e2e.sh
+++ b/opennms-container/delta-v/test-minion-rpc-e2e.sh
@@ -135,7 +135,7 @@ FAULT_LOG="$TEST_TMPDIR/fault-events.log"
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-fault-events \
+    --topic deltav-fault-events \
     > "$FAULT_LOG" 2>/dev/null &
 FAULT_CONSUMER_PID=$!
 sleep 3

--- a/opennms-container/delta-v/test-passive-e2e.sh
+++ b/opennms-container/delta-v/test-passive-e2e.sh
@@ -358,13 +358,13 @@ log "Starting Kafka event consumers..."
 KAFKA_CONTAINER=$(docker compose ps -q kafka)
 docker exec "$KAFKA_CONTAINER" /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-fault-events \
+    --topic deltav-fault-events \
     > "$FAULT_LOG" 2>/dev/null &
 FAULT_CONSUMER_PID=$!
 
 docker exec "$KAFKA_CONTAINER" /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-ipc-events \
+    --topic deltav-ipc-events \
     > "$IPC_LOG" 2>/dev/null &
 IPC_CONSUMER_PID=$!
 

--- a/opennms-container/delta-v/test-perspective-e2e.sh
+++ b/opennms-container/delta-v/test-perspective-e2e.sh
@@ -183,7 +183,7 @@ FAULT_LOG="$TEST_TMPDIR/fault-events.log"
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-fault-events \
+    --topic deltav-fault-events \
     > "$FAULT_LOG" 2>/dev/null &
 FAULT_CONSUMER_PID=$!
 sleep 3

--- a/opennms-container/delta-v/test-syslog-e2e.sh
+++ b/opennms-container/delta-v/test-syslog-e2e.sh
@@ -261,13 +261,13 @@ SINK_CONSUMER_PID=$!
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-fault-events \
+    --topic deltav-fault-events \
     > "$FAULT_LOG" 2>/dev/null &
 FAULT_CONSUMER_PID=$!
 
 docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
-    --topic opennms-ipc-events \
+    --topic deltav-ipc-events \
     > "$IPC_LOG" 2>/dev/null &
 IPC_CONSUMER_PID=$!
 

--- a/opennms-container/delta-v/trapd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
+++ b/opennms-container/delta-v/trapd-overlay/etc/org.opennms.core.event.forwarder.kafka.cfg
@@ -1,6 +1,0 @@
-# Kafka Event Forwarder configuration for standalone Trapd (daemon container)
-bootstrap.servers=kafka:9092
-topic.name=opennms-fault-events
-consumer.group.id=opennms-trapd
-poll.timeout.ms=100
-ipc.topic.name=opennms-ipc-events


### PR DESCRIPTION
PR A of the v1.2.0 GA topic rename. Renames the two event Kafka topics:

- `opennms-fault-events` → `deltav-fault-events`
- `opennms-ipc-events` → `deltav-ipc-events`

Pure delta-v config/test/doc — no horizon dependency, no logic change. **Breaking change** (no mixed-version interoperability — see design doc); GA upgrade requires a full-stack restart.

## Changes
- `KafkaEventTransportConfiguration.java` — both `@Value` defaults
- 12 `core/daemon-boot-*/src/main/resources/application.yml` — `${KAFKA_EVENT_TOPIC:...}` / `${KAFKA_IPC_TOPIC:...}` default values (env-var names unchanged)
- Deleted 8 vestigial Karaf `org.opennms.core.event.forwarder.kafka.cfg` overlay files (no Spring Boot code path reads them — see audit)
- Unit-test constants in `event-forwarder-kafka`
- 6 E2E scripts + `README.md` / `GEMINI.md` / container `README.md`

Audit: `docs/plans/2026-05-16-topic-rename-audit.md` (PR #281).
Design: `docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md`.

## Validation (docker-compose, Mac dev env, `--profile full`)
- `test-e2e.sh` ✅ — trap → `deltav-fault-events` → alarm
- `test-minion-e2e.sh` ✅
- `test-syslog-e2e.sh` ✅
- `test-passive-e2e.sh` — 16/18; the 2 failures are `No AWS outage` / `AWS outage not closed`, **confirmed pre-existing on `develop`** (develop scored 15/18 on the same run). The Pollerd passive-status→outage path is broken independently of this rename; tracked separately. Every event-topic-dependent assertion passes.

Daemon logs confirm consumers subscribed to `deltav-fault-events` / `deltav-ipc-events`.