### PR TITLE
feat: rename RPC and Twin Kafka topics to DeltaV.* prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ Minion → Kafka Sink → Trapd/Syslogd
 | `deltav-flows` | flow-enricher → ClickHouse enriched flow records (ClickHouse Kafka engine table consumes this topic) |
 | `deltav-timeseries` | Collectd + Provisiond → prometheus-writer (metric samples + node-context stream for label enrichment) |
 | `deltav-prometheus-writer-dlq` | prometheus-writer dead-letter queue for samples that failed VictoriaMetrics remote-write |
-| `OpenNMS.twin.response` | Pollerd → Minion Twin API state sync (passive status, SNMPv3 users) |
-| `OpenNMS.twin.request` | Minion → Pollerd Twin API subscription requests |
+| `DeltaV.twin.response` | Pollerd → Minion Twin API state sync (passive status, SNMPv3 users) |
+| `DeltaV.twin.request` | Minion → Pollerd Twin API subscription requests |
 
 ## Quick Start
 

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>spring-kafka</artifactId>
         </dependency>
         <!-- Horizon's RpcMessageProto wire format on the daemon-facing Kafka
-             topics (OpenNMS.<location>.rpc-request, OpenNMS.rpc-response). The
+             topics (DeltaV.<location>.rpc-request, DeltaV.rpc-response). The
              gateway translates between this and the rc2 RpcRequest/RpcResponse
              proto used on the gateway-Minion gRPC stream — see
              RpcChannelDispatcher and RpcResponsePublisher. -->
@@ -96,7 +96,7 @@
             </exclusions>
         </dependency>
         <!-- horizon's TwinResponseProto / TwinRequestProto wire format on the
-             daemon-facing Kafka topic OpenNMS.twin.response.<location>. The
+             daemon-facing Kafka topic DeltaV.twin.response.<location>. The
              gateway's TwinChannelDispatcher (Task 8) translates between this
              and the rc2 TwinUpdate proto used on the gateway-Minion gRPC
              stream — same pattern as the rpc.kafka dep added in PR1. -->

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
  * {@link RpcResponseHandler} (forward Minion responses to internal Kafka).
  *
  * <p>Inbound RPCs from ServiceDaemons arrive on
- * {@code OpenNMS.<location>.rpc-request} (the topic name is parameterized
+ * {@code DeltaV.<location>.rpc-request} (the topic name is parameterized
  * but matches horizon's KafkaRpcClient producer convention). The dispatcher
  * picks a stream from the location's pool, records the in-flight entry,
  * and forwards.
@@ -66,15 +66,15 @@ public class RpcChannelDispatcher implements RpcStreamCloseHandler, RpcResponseH
     }
 
     /**
-     * Topic name encodes the Minion location: {@code OpenNMS.<location>.rpc-request}.
+     * Topic name encodes the Minion location: {@code DeltaV.<location>.rpc-request}.
      * Horizon's RpcMessageProto does NOT carry a location field — that information
      * lives only in the Kafka topic name on horizon's side. The translator below
      * extracts location from the topic name and populates rc2's RpcRequest accordingly.
      */
-    private static final Pattern RPC_REQUEST_TOPIC = Pattern.compile("OpenNMS\\.(.*)\\.rpc-request");
+    private static final Pattern RPC_REQUEST_TOPIC = Pattern.compile("DeltaV\\.(.*)\\.rpc-request");
 
     @KafkaListener(
-        topicPattern = "OpenNMS\\..*\\.rpc-request",
+        topicPattern = "DeltaV\\..*\\.rpc-request",
         groupId = "minion-gateway-rpc",
         containerFactory = "rpcRequestContainerFactory"
     )

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponsePublisher.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcResponsePublisher.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * Publishes RPC responses to {@code OpenNMS.rpc-response} in horizon's
+ * Publishes RPC responses to {@code DeltaV.rpc-response} in horizon's
  * RpcMessageProto wire format. Translates from rc2's RpcResponse (used on
  * the gateway-Minion gRPC stream) so horizon's KafkaRpcClient on the daemon
  * side can correlate by rpc_id and unmarshal rpc_content as before.
@@ -40,7 +40,7 @@ public class RpcResponsePublisher {
     private final String responseTopic;
 
     public RpcResponsePublisher(KafkaProducer<String, byte[]> minionGatewayKafkaProducer,
-                                @Value("${minion-gateway.rpc.response-topic:OpenNMS.rpc-response}") String responseTopic) {
+                                @Value("${minion-gateway.rpc.response-topic:DeltaV.rpc-response}") String responseTopic) {
         this.producer = minionGatewayKafkaProducer;
         this.responseTopic = responseTopic;
     }

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinChannelDispatcher.java
@@ -31,7 +31,7 @@ import java.time.Instant;
 
 /**
  * Dispatcher for the Twin channel. Consumes horizon's
- * {@code OpenNMS.twin.response.<location>} Kafka topic, translates the
+ * {@code DeltaV.twin.response.<location>} Kafka topic, translates the
  * inbound {@link TwinResponseProto} wire format into rc2's {@link TwinUpdate},
  * updates the {@link TwinStateCache}, and broadcasts to all subscribers in
  * {@link MinionTwinSubscriberRegistry} for the matching (consumer_key, location).
@@ -68,7 +68,7 @@ public class TwinChannelDispatcher {
     }
 
     @KafkaListener(
-        topicPattern = "OpenNMS\\.twin\\.response\\..*",
+        topicPattern = "DeltaV\\.twin\\.response\\..*",
         groupId = "minion-gateway-twin",
         containerFactory = "twinResponseContainerFactory"
     )

--- a/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/twin/TwinStateCache.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * (Decision 2 sub-decision 2-i).
  *
  * <p>Populated by {@link TwinChannelDispatcher} consuming horizon's
- * {@code OpenNMS.twin.response.<location>} Kafka topic on gateway startup
+ * {@code DeltaV.twin.response.<location>} Kafka topic on gateway startup
  * (read-to-tail) and on every subsequent state change. Per Decision 2
  * sub-decision 2-iii: state is recovered from Kafka, not from
  * inter-gateway coordination, so multi-instance deployments work without

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -335,7 +335,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-pollerd
       OPENNMS_HOME: /opt/deltav
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "4"
       OPENNMS_RPC_KAFKA_ENABLED: "true"
       OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
@@ -407,7 +407,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
       INTERFACE_NODE_CACHE_REFRESH_MS: "15000"
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "24"
       RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       RPC_KAFKA_FORCE_REMOTE: "true"
@@ -440,7 +440,7 @@ services:
       KAFKA_SINK_CONSUMER_GROUP: opennms-trapd-sink
       OPENNMS_HOME: /opt/deltav
       INTERFACE_NODE_CACHE_REFRESH_MS: "15000"
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "20"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
@@ -470,7 +470,7 @@ services:
       KAFKA_SINK_CONSUMER_GROUP: opennms-syslogd-sink
       OPENNMS_HOME: /opt/deltav
       INTERFACE_NODE_CACHE_REFRESH_MS: "15000"
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "21"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
@@ -498,7 +498,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-eventtranslator
       OPENNMS_HOME: /opt/deltav
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "22"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
@@ -613,7 +613,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: opennms
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "25"
       RPC_KAFKA_ENABLED: "true"
       RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
@@ -652,7 +652,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-bsmd
       OPENNMS_HOME: /opt/deltav
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "17"
     ports:
       - "8180:8080"
@@ -705,7 +705,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-perspectivepollerd
       OPENNMS_HOME: /opt/deltav
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "7"
       OPENNMS_RPC_KAFKA_ENABLED: "true"
       OPENNMS_RPC_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
@@ -739,7 +739,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-alarmd
       OPENNMS_HOME: /opt/deltav
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "23"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
@@ -767,7 +767,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-telemetryd
       OPENNMS_HOME: /opt/deltav
-      OPENNMS_INSTANCE_ID: OpenNMS
+      OPENNMS_INSTANCE_ID: DeltaV
       OPENNMS_TSID_NODE_ID: "18"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]

--- a/opennms-container/delta-v/test-enlinkd-e2e.sh
+++ b/opennms-container/delta-v/test-enlinkd-e2e.sh
@@ -191,7 +191,7 @@ ok "Required services running (postgres, kafka, provisiond, enlinkd, minion-gate
 # v1.2.0-rc2 PR1: RPC channel migrated to gRPC bidi via minion-gateway.
 # Default for opennms.minion.transport.rpc is "grpc" (matchIfMissing=true).
 # Enlinkd's SNMP RPCs to the labbox Minion now flow through the gateway's
-# bidi gRPC stream rather than the OpenNMS.mhuot-labs.rpc-request Kafka
+# bidi gRPC stream rather than the DeltaV.mhuot-labs.rpc-request Kafka
 # topic. Verify the stream is live before running the topology assertions
 # that depend on it.
 log "Checking gRPC RPC transport for location=${FOREIGN_SOURCE} (rc2 PR1)..."

--- a/opennms-container/delta-v/test-minion-rpc-e2e.sh
+++ b/opennms-container/delta-v/test-minion-rpc-e2e.sh
@@ -385,7 +385,7 @@ else
     log ""
     log "Hint: pollerd is either not scheduling polls for this node, or RPC requests"
     log "      to minion-gateway are timing out. Check pollerd logs for"
-    log "      'Topic OpenNMS.Default.rpc-request not present in metadata' (the producer-"
+    log "      'Topic DeltaV.Default.rpc-request not present in metadata' (the producer-"
     log "      side metadata-fetch timeout per project_pollerd_kafka_producer_metadata_timeout)."
     log "      Note: PSM (#125) is fixed; that hint is no longer relevant."
     log ""


### PR DESCRIPTION
PR B of the v1.2.0 GA topic rename. Renames the RPC + Twin Kafka topic prefix from `OpenNMS` to `DeltaV`:

- `OpenNMS.<location>.rpc-request` → `DeltaV.<location>.rpc-request`
- `OpenNMS.rpc-response` → `DeltaV.rpc-response`
- `OpenNMS.twin.response.<location>` / `OpenNMS.twin.request` → `DeltaV.twin.*`

Per the topic-rename audit (PR #281), **verdict A — delta-v-only**: no `delta-v-horizon` companion PR needed. The daemon-side prefix is `SystemInfoUtils.getInstanceId()`, driven by `org.opennms.instance.id` ← Spring `opennms.instance.id` ← env var `OPENNMS_INSTANCE_ID`. **Breaking change** — no mixed-version interoperability; GA upgrade requires a full-stack restart.

## Changes
- `docker-compose.yml` — 10 `OPENNMS_INSTANCE_ID: OpenNMS` → `DeltaV` (env-var name unchanged); this renames every daemon-side RPC request/response + Twin topic
- `minion-gateway` — `RpcChannelDispatcher` `Pattern` + `@KafkaListener` topicPattern, `RpcResponsePublisher` `@Value` default, `TwinChannelDispatcher` `@KafkaListener` topicPattern; javadoc + `pom.xml` description
- `README.md` Kafka-topic table, `test-enlinkd-e2e.sh` / `test-minion-rpc-e2e.sh` references

No event topics or Sink topics touched (those were PR A / already `DeltaV.*`). No logic change. minion-gateway: build SUCCESS, 51 tests pass.

Design: `docs/superpowers/specs/2026-05-16-v1.2.0-ga-finalization-design.md`.

## Validation (docker-compose, Mac dev env, `--profile full`)
- `test-grpc-twin-e2e.sh` ✅ — Twin sync over `DeltaV.twin.*`
- `test-grpc-heartbeat-e2e.sh` ✅ 4/4 — Envoy gRPC stream + `DeltaV.Sink.Heartbeat` + p99 latency gate
- `test-minion-rpc-e2e.sh` 8/9 — **Phase 2 passes**: "ICMP/SNMP service detected via Minion RPC" proves the renamed `DeltaV.<location>.rpc-request` path works end-to-end. The 1 fail is Phase 3 (`No recent poll timestamp within 180s`) — the documented pre-existing Pollerd poll-recording issue (`project_pollerd_kafka_producer_metadata_timeout`), not topic-related (a rename regression would break Phase 2 too).
- `test-enlinkd-e2e.sh` — not run on the Mac dev env: it requires the `mhuot-labs` labbox Minion via SSH tunnel (lab-infra-only). Will be exercised on the rc4 UTM VM smoke.