### PR TITLE
fix: set org.opennms.instance.id as JVM arg so RPC/Twin topic rename takes effect

### DIFF
--- a/opennms-container/delta-v/entrypoint.sh
+++ b/opennms-container/delta-v/entrypoint.sh
@@ -4,14 +4,24 @@
 # Launches the daemon using classpath-based execution.
 #
 # Environment variables:
-#   MAIN_CLASS  — baked into image at build time (from MANIFEST.MF Start-Class)
-#   JAVA_OPTS   — JVM options (set in docker-compose.yml per daemon)
+#   MAIN_CLASS           — baked into image at build time (from MANIFEST.MF Start-Class)
+#   JAVA_OPTS            — JVM options (set in docker-compose.yml per daemon)
+#   OPENNMS_INSTANCE_ID  — Kafka RPC/Twin topic prefix (default: DeltaV)
 #
 if [ -z "$MAIN_CLASS" ]; then
     echo "ERROR: MAIN_CLASS not set" >&2
     exit 1
 fi
 
+# Horizon's SystemInfoUtils.getInstanceId() reads the JVM system property
+# org.opennms.instance.id (default "OpenNMS") in a static initializer, and
+# KafkaTopicProvider derives RPC/Twin topic names (<instanceId>.<location>.rpc-request,
+# <instanceId>.twin.*) from it. It must be passed as a -D flag — the
+# SystemPropertyBridgePostProcessor (Spring EnvironmentPostProcessor) does not
+# run early enough / reliably, so the OPENNMS_INSTANCE_ID env var alone has no
+# effect on topic naming. Default DeltaV so every delta-v daemon agrees with the
+# minion-gateway's DeltaV.* listener patterns.
 exec java $JAVA_OPTS \
+    -Dorg.opennms.instance.id="${OPENNMS_INSTANCE_ID:-DeltaV}" \
     -cp "/opt/libs/priority/*:/opt/libs/external/*:/opt/libs/internal/*:/opt/libs/daemon/*:/opt/app/*" \
     "$MAIN_CLASS"


### PR DESCRIPTION
## Problem (caught by the rc4 smoke)

PR #283 renamed the minion-gateway RPC/Twin Kafka listeners to `DeltaV.*` and set `OPENNMS_INSTANCE_ID=DeltaV` env vars on the daemons (per the topic-rename audit's "verdict A"). But the rc4 smoke showed the **daemons still produced `OpenNMS.<location>.rpc-request` / `OpenNMS.twin.*` / `OpenNMS.rpc-response`** — so the minion-gateway (listening on `DeltaV.*`) never received daemon RPC. pollerd's polls never completed → no response-time → empty `deltav-timeseries` → empty VictoriaMetrics. (The "0 outages" was a false-green: RPC timeouts correctly don't create outages.)

**Root cause:** the daemon-side prefix comes from horizon's `SystemInfoUtils.getInstanceId()`, which reads the **JVM system property** `org.opennms.instance.id` (default `OpenNMS`) in a static initializer. `SystemPropertyBridgePostProcessor` — a Spring `EnvironmentPostProcessor` meant to bridge the `OPENNMS_INSTANCE_ID` env var into that system property — does not run / does not deliver under Spring Boot 4.0. The system property is never set; `getInstanceId()` returns the hardcoded default `OpenNMS`. The env-var approach was always inert — harmless until the rename, because `OpenNMS` was also the real value.

## Fix

`opennms-container/delta-v/entrypoint.sh` now passes `-Dorg.opennms.instance.id="${OPENNMS_INSTANCE_ID:-DeltaV}"` as a JVM argument. A `-D` flag is set before any class loads — mechanism-independent, no post-processor, no Boot-4 discovery dependency — and applied uniformly to **every** daemon (the PR #283 env-var list missed collectd/enlinkd). It follows the existing `-Dorg.opennms.*` flags already in `JAVA_OPTS`. Verdict A's *conclusion* (delta-v-only, no horizon change) holds; only its mechanism was wrong.

## Validation (docker-compose, `--profile full --profile metrics`, real wire inspection)

- ✅ Kafka topics now `DeltaV.Default.rpc-request`, `DeltaV.rpc-response`, `DeltaV.twin.*` — zero `OpenNMS.*`
- ✅ pollerd JVM has `org.opennms.instance.id=DeltaV`; RPC client `group.id=DeltaV-rpc`
- ✅ `minion-gateway-rpc` consumer group consuming `DeltaV.*.rpc-request` (lag 0)
- ✅ pollerd polls via RPC → `deltav-timeseries` flowing → prometheus-writer → VictoriaMetrics
- ✅ `opennms_response_time_response` in VictoriaMetrics, producers `pollerd` + `perspective_pollerd` (52 series)

Fix-forward for the red rc4 smoke; `v1.2.0-rc4.1` will be cut from this once merged.

Note: the inert `SystemPropertyBridgePostProcessor` / `OPENNMS_INSTANCE_ID` env vars are left in place (harmless) — cleaning them up is separate scope.