### PR TITLE
chore(v1.2.0): bump version to 1.2.0-rc4.1

### DIFF
--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/horizon-metric-bridge/pom.xml
+++ b/core/horizon-metric-bridge/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-grpc-contracts/pom.xml
+++ b/core/minion-grpc-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/poller-timeseries-common/pom.xml
+++ b/core/poller-timeseries-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4</version>
+        <version>1.2.0-rc4.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/opennms-container/delta-v/.env.example
+++ b/opennms-container/delta-v/.env.example
@@ -2,5 +2,5 @@
 # `.env` is gitignored so local overrides (e.g., bumping VERSION to a published
 # tag for smoke testing) don't pollute git status. Defaults below match a
 # from-source dev build against host.docker.internal Kafka.
-VERSION=1.2.0-rc4
+VERSION=1.2.0-rc4.1
 KAFKA_EXTERNAL_HOST=host.docker.internal

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>1.2.0-rc4</version>
+  <version>1.2.0-rc4.1</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>


### PR DESCRIPTION
rc4.1 cut — re-spin of the red rc4 smoke. Version bump `1.2.0-rc4` → `1.2.0-rc4.1` (30 poms via `mvn versions:set`) + `.env.example`.

Picks up the fix already merged to `develop`:
- #286 — `org.opennms.instance.id` set as a JVM arg so the RPC/Twin topic rename actually takes effect on the daemon side (rc4 smoke regression).

The rc4 smoke caught that PR #283's RPC/Twin rename only landed on the gateway side; #286 fixes the daemon side. rc4.1 re-validates the breaking topic rename on the UTM VM before GA.

Reactor `clean install` (skip tests/ITs): BUILD SUCCESS.