### PR TITLE
fix(compose): pin snmp-agent to static IP 172.18.0.2

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -114,6 +114,14 @@ services:
     image: ${IMAGE_PREFIX:-deltav}/mock-snmp-agent:${VERSION}
     container_name: delta-v-snmp-agent
     hostname: snmp-agent
+    # Pinned IP so the rpc-canary requisition can target a stable address.
+    # The requisition (provisiond-overlay/etc/imports-seed/rpc-canary.xml)
+    # hard-codes 172.18.0.2; before the ip_range was added this service
+    # happened to receive .0.2 from the dynamic allocator, but ip_range now
+    # confines dynamic allocation to 172.18.1.0/24, so it must be pinned.
+    networks:
+      default:
+        ipv4_address: 172.18.0.2
     healthcheck:
       test: ["CMD-SHELL", "true"]
       interval: 10s
@@ -1018,10 +1026,10 @@ networks:
   # Docker default (172.18.0.0/16) so existing services aren't disturbed.
   #
   # ip_range confines DYNAMIC allocation to 172.18.1.0/24, keeping it clear
-  # of the static ipv4_address pins in 172.18.0.x (flow test nodes .20-.22,
-  # l8opensim .30). Without this, in a large-profile bring-up the dynamic
-  # allocator marches up from .2 and can hand a static-pinned IP to another
-  # container before the pinned service starts, failing it with
+  # of the static ipv4_address pins in 172.18.0.x (snmp-agent .2, flow test
+  # nodes .20-.22, l8opensim .30). Without this, in a large-profile bring-up
+  # the dynamic allocator marches up from .2 and can hand a static-pinned IP
+  # to another container before the pinned service starts, failing it with
   # "failed to set up container networking: Address already in use".
   default:
     name: delta-v_default


### PR DESCRIPTION
## Problem

The `rpc-canary` requisition (`provisiond-overlay/etc/imports-seed/rpc-canary.xml`) hard-codes interface IP `172.18.0.2` for the `snmp-agent-canary` node. The `snmp-agent` service carried no static `ipv4_address` — it relied on Docker's dynamic allocator handing it `.0.2` by marching up from the subnet base.

PR #273 added `ip_range: 172.18.1.0/24` to keep dynamic allocation clear of the `172.18.0.x` static pins. That side-effect moved `snmp-agent` into `172.18.1.x` (observed at `172.18.1.0`). The canary node now polls a dead address — **both ICMP and SNMP open permanent outages on every bring-up**.

Surfaced during the v1.2.0-rc4.1 smoke wire-check: 2 open outages, both on `snmp-agent-canary`. Confirmed orthogonal to the topic rename — the RPC path itself is healthy (the outages are genuine "down" poll results delivered over `DeltaV.*` topics).

## Fix

Pin `snmp-agent` to `ipv4_address: 172.18.0.2` — inside the reserved `172.18.0.x` static zone, matching the requisition. No requisition change required. IPAM comment updated to list the new pin.

## Validation

`docker compose --profile full --profile metrics config -q` parses clean.