### PR TITLE
chore(v1.2.0): promote version to 1.2.0 GA

### DIFF
--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/horizon-metric-bridge/pom.xml
+++ b/core/horizon-metric-bridge/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-grpc-contracts/pom.xml
+++ b/core/minion-grpc-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/poller-timeseries-common/pom.xml
+++ b/core/poller-timeseries-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.2.0-rc4.1</version>
+        <version>1.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/opennms-container/delta-v/.env.example
+++ b/opennms-container/delta-v/.env.example
@@ -2,5 +2,5 @@
 # `.env` is gitignored so local overrides (e.g., bumping VERSION to a published
 # tag for smoke testing) don't pollute git status. Defaults below match a
 # from-source dev build against host.docker.internal Kafka.
-VERSION=1.2.0-rc4.1
+VERSION=1.2.0
 KAFKA_EXTERNAL_HOST=host.docker.internal

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>1.2.0-rc4.1</version>
+  <version>1.2.0</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>


### PR DESCRIPTION
## Summary

Version-string promotion of **v1.2.0-rc4.1** → **1.2.0 GA**.

rc4.1 passed the topic-rename smoke gate — all RPC/Twin/event Kafka topics renamed to `DeltaV.*` / `deltav-*`, verified on the wire (gateway + daemon consumers at lag 0, response-time metrics continuous, no false outages). The canary-IP fix (#288) and audit correction (#281) are already on `develop`.

## Changes

`mvn versions:set` — no code changes:
- `project.version` across 28 `core/*` module POMs + root `pom.xml`: `1.2.0-rc4.1` → `1.2.0`
- `opennms-container/delta-v/.env.example` `VERSION`: `1.2.0-rc4.1` → `1.2.0`

## Validation

- `./mvnw validate` — reactor resolves clean across all 29 POMs.
- `build.sh` / `delta-v-build-images.yml` parity verified — identical 12-daemon list, both derive `VERSION` from `project.version`. No image added/removed this cycle.

## Release step

Merging this PR and tagging `v1.2.0` triggers the "Delta-V Build & Push Images" workflow, which publishes all 26 images at `1.2.0`.