### PR TITLE
fix(compose): raise provisiond healthcheck start_period to 240s

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -638,7 +638,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
-      start_period: 20s
+      # provisiond is the slowest daemon to first-healthy — it runs the
+      # requisition import (Hibernate + node scans) on top of Spring Boot init.
+      # On a cold start, especially while the host is pulling images, it has
+      # been observed taking ~210s. With the default 20s start_period the
+      # container flips to `unhealthy` at start_period + retries*interval
+      # (20 + 12*10 = 140s), and `docker compose up` then aborts the services
+      # that depend_on provisiond (perspective-app-init, perspectivepollerd).
+      # 240s keeps failing checks in `starting` through a slow cold start so
+      # compose keeps waiting instead of bailing.
+      start_period: 240s
     stop_grace_period: 60s
 
   bsmd:


### PR DESCRIPTION
## Problem

Surfaced during the **v1.2.0 GA smoke**. On a cold start where the host is also pulling images, `provisiond` took ~210s to pass its first healthcheck (it runs the requisition import — Hibernate + node scans — on top of Spring Boot init; it is the slowest daemon to first-healthy).

`provisiond`'s healthcheck used `start_period: 20s` with `retries: 12` / `interval: 10s`. Docker flips a container to `unhealthy` at `start_period + retries*interval` = `20 + 120 = 140s`. 210s > 140s, so docker marked provisiond `unhealthy`, `docker compose up` reported `dependency provisiond failed to start`, and the services that `depends_on` provisiond with `condition: service_healthy` (`perspective-app-init`, `perspectivepollerd`) were aborted into `Created`. provisiond itself was fine — it went healthy seconds later.

## Fix

Raise `provisiond`'s healthcheck `start_period` to `240s`. During `start_period`, a failing healthcheck keeps the container in `starting` (compose keeps waiting) and does not count toward `retries` — so a slow cold start no longer aborts the bring-up. Only provisiond is changed; the other daemons reliably go healthy within the existing window.

## Validation

`docker compose --profile full --profile metrics config -q` parses clean.

## Notes

Not a code regression — `provisiond:1.2.0` is identical code to `rc4.1`. v1.2.0 ships with the `docker compose up -d` re-run documented as a known issue; this fix lands for the next release.