### PR TITLE
docs(plans): reconcile v1.2.0 release plan to GA-shipped state

### DIFF
--- a/docs/plans/2026-04-23-v1.2.0-release-plan.md
+++ b/docs/plans/2026-04-23-v1.2.0-release-plan.md
@@ -1,10 +1,10 @@
 # Delta-V v1.2.0 Release Plan
 
-> **Status:** In progress. v1.2.0-alpha1/2/3 cut 2026-04-23; v1.2.0-beta1
-> cut 2026-04-24; v1.2.0-beta2 cut 2026-04-25. Tracks 1
-> (self-contained images), 3 (app observability — Scope A bridge + Scope B
-> domain metrics across all 13 daemons), and 4 (Pollerd time-series
-> publishing) complete. Track 2 (Minion gRPC) remains for rc1/rc2.
+> **Status:** GA shipped 2026-05-17. v1.2.0 released as tag `v1.2.0` with 26
+> images published at `1.2.0`. All four tracks complete. Cadence: alpha1-3
+> (2026-04-23), beta1 (04-24), beta2 (04-25), rc1-rc3.1 (Minion gRPC
+> migration), rc4/rc4.1 (Kafka topic de-legacy rename), GA (2026-05-17).
+> See "Release history" below.
 
 ## Release theme — "Delta-V runs well on Kubernetes"
 
@@ -239,17 +239,47 @@ PRs [#220](https://github.com/pbrane/delta-v/pull/220),
    Smoke confirmed Pollerd's data-plane pipeline end-to-end against
    ghcr beta2 images. PRs #220, #221, #222.
 
-### Remaining
+### Shipped (continued)
 
-No firm dates. Order based on dependencies, risk, and bundle-ability:
+6. **`v1.2.0-rc1` … `v1.2.0-rc3.1`** — Track 2, Minion gRPC migration.
+   Minion ↔ minion-gateway IPC moved from Kafka request/response to gRPC
+   (streaming sink channels, bidi-streaming RPC, server-streaming Twin)
+   behind an Envoy / Spring Cloud Gateway ingress. The Kafka IPC rollback
+   path was removed (PR #260), making the gateway the sole Minion ingress.
+   Cut across rc1–rc3.1 — see git history for per-RC PRs.
+7. **`v1.2.0-rc4`** (2026-05-16) — Kafka topic de-legacy rename, the only
+   GA-blocking work remaining after the four tracks completed. `OpenNMS.*`
+   → `DeltaV.*` (RPC, Twin), `opennms-*` → `deltav-*` (fault/IPC events).
+   Topic-rename audit (PR #281), event topics (PR #282), RPC/Twin topics
+   (PR #283), rc4 cut (PR #285). Design + plan: PR #279.
+8. **`v1.2.0-rc4.1`** (2026-05-17) — rc4 smoke regression fix. The
+   `OPENNMS_INSTANCE_ID` env var did not reach the `org.opennms.instance.id`
+   system property under Spring Boot 4 — the `EnvironmentPostProcessor` runs
+   too late for a value read in a static initializer — so daemons still
+   emitted `OpenNMS.*` topics. Fixed by passing `-Dorg.opennms.instance.id`
+   as a JVM arg in `entrypoint.sh` (PR #286); rc4.1 cut (PR #287).
+9. **`v1.2.0`** (2026-05-17) — **GA**. Version-string promotion of rc4.1
+   (PR #289); tag `v1.2.0`; 26 images published at `1.2.0`. Also merged
+   pre-GA: snmp-agent static-IP pin (PR #288). GA smoke green — topic
+   rename validated on the wire (all `DeltaV.*`/`deltav-*`, gateway and
+   daemon RPC consumers at lag 0), 0 false outages, response-time metrics
+   and flows flowing.
 
-6. **`v1.2.0-rc1`** — Minion gRPC migration midpoint: protobuf service
-   definitions published, parallel Kafka+gRPC paths running, ActiveMQ
-   and ServiceMix bundles purged from minion-boot.
-7. **`v1.2.0-rc2`** — Minion gRPC migration complete: Kafka IPC path
-   removed, sink topics renamed, "Default" location retired, full
-   E2E validation.
-8. **`v1.2.0`** — GA.
+### Deferred to v1.3
+
+Three items the original Track 2 bundled were re-scoped out of v1.2.0 GA as
+non-blocking cleanup rather than gRPC-migration blockers:
+
+- **Minion ActiveMQ + ServiceMix bundle purge** — image-slimming cleanup.
+- **Sink topic rename `OpenNMS.Sink.*` → `DeltaV.Sink.*`** — sink topics
+  already ship as `DeltaV.Sink.*` from the gRPC migration; the residual
+  inconsistency (the terse `n.*` Sink scheme) is a v1.3 cosmetic item.
+- **Retire the "Default" Minion location** — horizon-era semantic, deferred
+  with the test-harness retargeting it requires.
+
+A known issue also ships with GA: the Pollerd/Perspective dashboards each
+carry three "No Data" panels (the `deltav_*` Micrometer counters are not yet
+scraped into VictoriaMetrics) — a follow-up closes the actuator-to-VM gap.
 
 ### Divergence note
 


### PR DESCRIPTION
## Summary

v1.2.0 shipped GA on 2026-05-17. Reconciles `docs/plans/2026-04-23-v1.2.0-release-plan.md` to the as-shipped state (Task 8 of the GA finalization plan).

## Changes

- **Status header** — "in progress" → "GA shipped", with the real release cadence.
- **"Remaining" → "Shipped (continued)"** — the old section listed rc1/rc2/GA as future cuts. Replaced with what actually shipped: rc1–rc3.1 (Minion gRPC migration), rc4 (Kafka topic de-legacy rename — PRs #281/#282/#283/#285), rc4.1 (instance-id JVM-arg fix — PRs #286/#287), v1.2.0 GA (PR #289, tag `v1.2.0`, 26 images).
- **New "Deferred to v1.3" section** — the three Track 2 cleanup items re-scoped out of GA (ActiveMQ/ServiceMix purge, `OpenNMS.Sink.*` → terse-scheme rename, retire "Default" location), plus the known dashboard "No Data" panel gap.

Docs-only.