### PR TITLE
feat(alarms): v1.3.0 Track 1 — alarm Kafka publisher (Phase 1 dual-write)

### DIFF
--- a/core/alarms-kafka-publisher/pom.xml
+++ b/core/alarms-kafka-publisher/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>1.2.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>org.opennms.core.alarms-kafka-publisher</artifactId>
+    <name>OpenNMS :: Core :: Alarms Kafka Publisher</name>
+    <description>AlarmLifecycleListener implementation that publishes alarm lifecycle events
+        to Kafka. Bundled into the alarmd Spring Boot fat jar.</description>
+
+    <dependencies>
+        <!-- Delta-V Kafka contracts (protobuf schemas) -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.deltav-kafka-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Kafka client (standard, not ServiceMix OSGi bundle) -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <!-- Spring context (for @Component, ApplicationContext support) -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+        <!-- Spring Boot (for @SpringBootApplication context) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+
+        <!-- Spring Boot autoconfigure (supplies @ConditionalOnProperty) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Horizon APIs — provided: supplied by the alarmd fat jar at runtime -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-alarm-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-alarmd</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core</groupId>
+            <artifactId>org.opennms.core.model-jakarta</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/alarms-kafka-publisher/pom.xml
+++ b/core/alarms-kafka-publisher/pom.xml
@@ -75,8 +75,13 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the {@link KafkaAlarmPublisher} into alarmd and registers it with the
+ * existing {@link AlarmLifecycleListenerManager} so it receives lifecycle
+ * callbacks. Component-scanned by {@code AlarmdApplication}.
+ */
+@Configuration
+@EnableConfigurationProperties(AlarmPublisherProperties.class)
+@ConditionalOnProperty(prefix = "deltav.alarmd.kafka-publisher", name = "enabled",
+        havingValue = "true", matchIfMissing = true)
+public class AlarmPublisherConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmPublisherConfiguration.class);
+
+    @Bean(destroyMethod = "close")
+    public Producer<String, byte[]> alarmKafkaProducer(AlarmPublisherProperties props) {
+        Properties p = new Properties();
+        p.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, props.getBootstrapServers());
+        p.setProperty(ProducerConfig.ACKS_CONFIG, "all");
+        p.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "alarmd-publisher");
+        return new KafkaProducer<>(p, new StringSerializer(), new ByteArraySerializer());
+    }
+
+    @Bean
+    public KafkaAlarmPublisher kafkaAlarmPublisher(Producer<String, byte[]> alarmKafkaProducer,
+                                                   AlarmPublisherProperties props,
+                                                   AlarmLifecycleListenerManager manager) {
+        KafkaAlarmPublisher publisher =
+                new KafkaAlarmPublisher(alarmKafkaProducer, props.getTopic(), new AlarmStateMapper());
+        manager.onListenerRegistered(publisher, Collections.emptyMap());
+        LOG.info("Registered KafkaAlarmPublisher; publishing alarm lifecycle to topic {}", props.getTopic());
+        return publisher;
+    }
+}

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherProperties.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Binds {@code deltav.alarmd.kafka-publisher.*}. Daemon-scoped per the
+ * project's no-shared-config rule.
+ */
+@ConfigurationProperties(prefix = "deltav.alarmd.kafka-publisher")
+public class AlarmPublisherProperties {
+
+    /** Whether the publisher is active. Default true. */
+    private boolean enabled = true;
+
+    /** Kafka bootstrap servers. */
+    private String bootstrapServers = "kafka:9092";
+
+    /** Target topic. */
+    private String topic = "deltav-alarms-state-change";
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public String getBootstrapServers() { return bootstrapServers; }
+    public void setBootstrapServers(String bootstrapServers) { this.bootstrapServers = bootstrapServers; }
+
+    public String getTopic() { return topic; }
+    public void setTopic(String topic) { this.topic = topic; }
+}

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmStateMapper.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmStateMapper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import java.util.Date;
+import java.util.function.Consumer;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+/**
+ * Pure function: converts an {@link OnmsAlarm} entity into the thin
+ * {@link AlarmState} wire record. No I/O, no Spring — trivially unit-testable.
+ */
+public class AlarmStateMapper {
+
+    private static final String DEFAULT_LOCATION = "Default";
+
+    /**
+     * Converts an {@link OnmsAlarm} to its {@link AlarmState} wire representation.
+     * Always returns a non-null instance: missing numeric fields become {@code 0},
+     * missing string fields become empty string, a missing severity becomes
+     * {@code INDETERMINATE}, and a missing node location becomes {@code "Default"}.
+     * The caller must supply a non-null alarm; the publisher filters nulls upstream.
+     */
+    public AlarmState toProto(OnmsAlarm alarm) {
+        AlarmState.Builder b = AlarmState.newBuilder()
+                .setAlarmId(alarm.getId() != null ? alarm.getId() : 0)
+                .setSeverity(mapSeverity(alarm.getSeverity()))
+                .setCount(alarm.getCounter() != null ? alarm.getCounter() : 0)
+                .setFirstEventTimeMs(epochMillis(alarm.getFirstEventTime()))
+                .setLastEventTimeMs(epochMillis(alarm.getLastEventTime()))
+                .setAckTimeMs(epochMillis(alarm.getAlarmAckTime()));
+        setIfNotNull(alarm.getReductionKey(), b::setReductionKey);
+        setIfNotNull(alarm.getUei(), b::setUei);
+        setIfNotNull(alarm.getAlarmAckUser(), b::setAckUser);
+        setIfNotNull(alarm.getDescription(), b::setDescription);
+        setIfNotNull(alarm.getLogMsg(), b::setLogMessage);
+        b.setNodeId(alarm.getNodeId() != null ? alarm.getNodeId() : 0);
+        b.setLocation(resolveLocation(alarm));
+        return b.build();
+    }
+
+    private static String resolveLocation(OnmsAlarm alarm) {
+        if (alarm.getNode() != null && alarm.getNode().getLocation() != null
+                && alarm.getNode().getLocation().getLocationName() != null) {
+            return alarm.getNode().getLocation().getLocationName();
+        }
+        return DEFAULT_LOCATION;
+    }
+
+    private static AlarmState.Severity mapSeverity(OnmsSeverity severity) {
+        if (severity == null) {
+            return AlarmState.Severity.INDETERMINATE;
+        }
+        switch (severity) {
+            case CLEARED:  return AlarmState.Severity.CLEARED;
+            case NORMAL:   return AlarmState.Severity.NORMAL;
+            case WARNING:  return AlarmState.Severity.WARNING;
+            case MINOR:    return AlarmState.Severity.MINOR;
+            case MAJOR:    return AlarmState.Severity.MAJOR;
+            case CRITICAL: return AlarmState.Severity.CRITICAL;
+            case INDETERMINATE:
+            default:       return AlarmState.Severity.INDETERMINATE;
+        }
+    }
+
+    private static long epochMillis(Date date) {
+        return date != null ? date.getTime() : 0L;
+    }
+
+    private static void setIfNotNull(String value, Consumer<String> setter) {
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+}

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/KafkaAlarmPublisher.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/KafkaAlarmPublisher.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.deltav.alarms.proto.AlarmState;
+import org.opennms.netmgt.alarmd.api.AlarmLifecycleListener;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Publishes alarm lifecycle changes to the {@code deltav-alarms-state-change}
+ * Kafka topic as {@link AlarmState} protobuf.
+ *
+ * <p>Phase 1 of the "Alarms on Kafka" migration: alarmd still writes
+ * PostgreSQL directly; Kafka publication is an additional output. Records are
+ * keyed by {@code reduction_key}; a deleted alarm produces a null-valued
+ * tombstone so a compacted topic drops it.</p>
+ *
+ * <p>The periodic snapshot callbacks are intentionally no-ops — the publisher
+ * is an incremental event stream, not a state sync.</p>
+ */
+public class KafkaAlarmPublisher implements AlarmLifecycleListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaAlarmPublisher.class);
+
+    private final Producer<String, byte[]> producer;
+    private final String topic;
+    private final AlarmStateMapper mapper;
+
+    public KafkaAlarmPublisher(Producer<String, byte[]> producer, String topic, AlarmStateMapper mapper) {
+        this.producer = Objects.requireNonNull(producer, "producer");
+        this.topic = Objects.requireNonNull(topic, "topic");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+    }
+
+    @Override
+    public void handleNewOrUpdatedAlarm(OnmsAlarm alarm) {
+        if (alarm == null || alarm.getReductionKey() == null) {
+            LOG.warn("Skipping alarm with null reduction key: {}", alarm);
+            return;
+        }
+        try {
+            AlarmState proto = mapper.toProto(alarm);
+            producer.send(new ProducerRecord<>(topic, alarm.getReductionKey(), proto.toByteArray()));
+            LOG.debug("Published alarm {} (rk={}) to {}", proto.getAlarmId(), alarm.getReductionKey(), topic);
+        } catch (Exception e) {
+            LOG.error("Failed to publish alarm rk={} to {}", alarm.getReductionKey(), topic, e);
+        }
+    }
+
+    @Override
+    public void handleDeletedAlarm(int alarmId, String reductionKey) {
+        if (reductionKey == null) {
+            LOG.warn("Skipping deleted alarm {} with null reduction key", alarmId);
+            return;
+        }
+        try {
+            producer.send(new ProducerRecord<>(topic, reductionKey, null)); // tombstone
+            LOG.debug("Published tombstone for alarm {} (rk={}) to {}", alarmId, reductionKey, topic);
+        } catch (Exception e) {
+            LOG.error("Failed to publish tombstone rk={} to {}", reductionKey, topic, e);
+        }
+    }
+
+    @Override
+    public void preHandleAlarmSnapshot() {
+        // no-op — incremental publisher, not a state sync
+    }
+
+    @Override
+    public void handleAlarmSnapshot(List<OnmsAlarm> alarms) {
+        // no-op — incremental publisher, not a state sync
+    }
+
+    @Override
+    public void postHandleAlarmSnapshot() {
+        // no-op — incremental publisher, not a state sync
+    }
+}

--- a/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java
+++ b/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.deltav.alarms.publisher;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java
+++ b/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java
@@ -1,0 +1,91 @@
+package org.deltav.alarms.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+
+public class AlarmStateMapperTest {
+
+    @Test
+    void mapsCoreFields() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(42);
+        alarm.setReductionKey("uei.opennms.org/nodes/nodeDown::1");
+        alarm.setUei("uei.opennms.org/nodes/nodeDown");
+        alarm.setSeverity(OnmsSeverity.MAJOR);
+        alarm.setCounter(3);
+        alarm.setFirstEventTime(new Date(1_000L));
+        alarm.setLastEventTime(new Date(2_000L));
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getAlarmId()).isEqualTo(42);
+        assertThat(proto.getReductionKey()).isEqualTo("uei.opennms.org/nodes/nodeDown::1");
+        assertThat(proto.getUei()).isEqualTo("uei.opennms.org/nodes/nodeDown");
+        assertThat(proto.getSeverity()).isEqualTo(AlarmState.Severity.MAJOR);
+        assertThat(proto.getCount()).isEqualTo(3);
+        assertThat(proto.getFirstEventTimeMs()).isEqualTo(1_000L);
+        assertThat(proto.getLastEventTimeMs()).isEqualTo(2_000L);
+    }
+
+    @Test
+    void nullNodeYieldsZeroIdAndDefaultLocation() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+        alarm.setSeverity(OnmsSeverity.NORMAL);
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getNodeId()).isEqualTo(0);
+        assertThat(proto.getLocation()).isEqualTo("Default");
+    }
+
+    @Test
+    void nullSeverityMapsToIndeterminate() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getSeverity()).isEqualTo(AlarmState.Severity.INDETERMINATE);
+    }
+
+    @Test
+    void locationResolvedFromNodeMonitoringLocation() {
+        OnmsMonitoringLocation location = new OnmsMonitoringLocation("Durham", "Durham");
+        OnmsNode node = new OnmsNode();
+        node.setLocation(location);
+
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+        alarm.setNode(node);
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getLocation()).isEqualTo("Durham");
+    }
+
+    @Test
+    void acknowledgementFieldsAreMapped() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+        alarm.setAlarmAckUser("admin");
+        alarm.setAlarmAckTime(new Date(5000L));
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getAckUser()).isEqualTo("admin");
+        assertThat(proto.getAckTimeMs()).isEqualTo(5000L);
+    }
+}

--- a/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/KafkaAlarmPublisherTest.java
+++ b/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/KafkaAlarmPublisherTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.deltav.alarms.proto.AlarmState;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+class KafkaAlarmPublisherTest {
+
+    private static final String TOPIC = "deltav-alarms-state-change";
+
+    /**
+     * Kafka 4.1.1 removed the 3-arg MockProducer(boolean, Serializer, Serializer) constructor.
+     * The nearest equivalent is the 4-arg (boolean, Partitioner, Serializer, Serializer);
+     * passing null for Partitioner uses the default round-robin behaviour.
+     */
+    private static MockProducer<String, byte[]> newMockProducer() {
+        return new MockProducer<>(true, null, new StringSerializer(), new ByteArraySerializer());
+    }
+
+    private static OnmsAlarm sampleAlarm() {
+        OnmsAlarm a = new OnmsAlarm();
+        a.setId(7);
+        a.setReductionKey("uei.opennms.org/nodes/nodeDown::7");
+        a.setUei("uei.opennms.org/nodes/nodeDown");
+        a.setSeverity(OnmsSeverity.MAJOR);
+        return a;
+    }
+
+    @Test
+    void publishesProtoOnNewOrUpdatedAlarm() throws Exception {
+        MockProducer<String, byte[]> producer = newMockProducer();
+        KafkaAlarmPublisher publisher = new KafkaAlarmPublisher(producer, TOPIC, new AlarmStateMapper());
+
+        publisher.handleNewOrUpdatedAlarm(sampleAlarm());
+
+        List<ProducerRecord<String, byte[]>> history = producer.history();
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).topic()).isEqualTo(TOPIC);
+        assertThat(history.get(0).key()).isEqualTo("uei.opennms.org/nodes/nodeDown::7");
+        AlarmState decoded = AlarmState.parseFrom(history.get(0).value());
+        assertThat(decoded.getAlarmId()).isEqualTo(7);
+        assertThat(decoded.getSeverity()).isEqualTo(AlarmState.Severity.MAJOR);
+    }
+
+    @Test
+    void publishesTombstoneOnDeletedAlarm() {
+        MockProducer<String, byte[]> producer = newMockProducer();
+        KafkaAlarmPublisher publisher = new KafkaAlarmPublisher(producer, TOPIC, new AlarmStateMapper());
+
+        publisher.handleDeletedAlarm(7, "uei.opennms.org/nodes/nodeDown::7");
+
+        List<ProducerRecord<String, byte[]>> history = producer.history();
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).key()).isEqualTo("uei.opennms.org/nodes/nodeDown::7");
+        assertThat(history.get(0).value()).isNull(); // tombstone for log compaction
+    }
+
+    @Test
+    void snapshotCallbacksDoNotPublish() {
+        MockProducer<String, byte[]> producer = newMockProducer();
+        KafkaAlarmPublisher publisher = new KafkaAlarmPublisher(producer, TOPIC, new AlarmStateMapper());
+
+        publisher.preHandleAlarmSnapshot();
+        publisher.handleAlarmSnapshot(Collections.emptyList());
+        publisher.postHandleAlarmSnapshot();
+
+        assertThat(producer.history()).isEmpty();
+    }
+}

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -35,6 +35,13 @@
             <artifactId>org.opennms.core.model-api</artifactId>
         </dependency>
 
+        <!-- Alarm Kafka publisher -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.alarms-kafka-publisher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Shared daemon infrastructure -->
         <dependency>
             <groupId>org.deltav.core</groupId>

--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdApplication.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdApplication.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication(scanBasePackages = {
     "org.deltav.core.daemon.common",
     "org.deltav.netmgt.alarmd.boot",
+    "org.deltav.alarms.publisher",
     "org.opennms.netmgt.model.jakarta.dao"
 })
 public class AlarmdApplication {

--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java
@@ -163,14 +163,18 @@ public class AlarmdConfiguration {
 
     /**
      * Counting AlarmEntityNotifier — increments {@code deltav_alarmd_alarms_*}
-     * Micrometer counters on every lifecycle notification. Downstream listener
-     * integration (BSMd, REST callers) is tracked in memory
-     * {@code project_alarmd_alarm_lifecycle_gap}; this bean only surfaces
-     * domain signal, it does not forward events.
+     * Micrometer counters on every lifecycle notification AND fans each callback
+     * out to all registered {@link org.opennms.netmgt.dao.api.AlarmEntityListener}
+     * beans in the application context. This restores the full chain:
+     * {@code AlarmPersisterImpl → AlarmEntityNotifier → AlarmEntityListener(s)
+     * → AlarmLifecycleListenerManager → AlarmLifecycleListener(s)},
+     * enabling real-time delivery to downstream components such as the Kafka
+     * alarm publisher.
      */
     @Bean
-    public AlarmEntityNotifier alarmEntityNotifier(MeterRegistry meterRegistry) {
-        return new CountingAlarmEntityNotifier(meterRegistry);
+    public AlarmEntityNotifier alarmEntityNotifier(MeterRegistry meterRegistry,
+            java.util.List<org.opennms.netmgt.dao.api.AlarmEntityListener> entityListeners) {
+        return new CountingAlarmEntityNotifier(meterRegistry, entityListeners);
     }
 
     @Bean

--- a/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifier.java
+++ b/core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifier.java
@@ -26,53 +26,71 @@ import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.ALARMS_UNACKNOWL
 import static org.deltav.netmgt.alarmd.boot.AlarmdDomainMetrics.TAG_SEVERITY;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
+import org.opennms.netmgt.dao.api.AlarmEntityListener;
 import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.TroubleTicketState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * {@link AlarmEntityNotifier} that counts every lifecycle notification it
- * receives via Micrometer. Replaces the no-op anonymous implementation
- * previously declared inline in {@code AlarmdConfiguration}.
+ * {@link AlarmEntityNotifier} that both increments Micrometer counters on every
+ * lifecycle notification it receives AND fans each callback out to all registered
+ * {@link AlarmEntityListener} beans.
  *
- * <p>Downstream listener integration (BSMd, REST callers) is tracked
- * separately in memory {@code project_alarmd_alarm_lifecycle_gap}. This
- * class exists purely to surface domain signal — it does not forward
- * events anywhere.
+ * <p>This restores the full chain:
+ * {@code AlarmPersisterImpl → AlarmEntityNotifier → AlarmEntityListener(s)
+ * → AlarmLifecycleListenerManager → AlarmLifecycleListener(s)},
+ * enabling real-time delivery to downstream components such as the Kafka
+ * alarm publisher. Without listener fan-out only the 2-minute snapshot timer
+ * in {@code AlarmLifecycleListenerManager} would fire.</p>
+ *
+ * <p>Listener failures are isolated per-listener — a failing listener does not
+ * prevent the remaining listeners from receiving the callback.</p>
  */
 public class CountingAlarmEntityNotifier implements AlarmEntityNotifier {
 
-    private final MeterRegistry registry;
+    private static final Logger LOG = LoggerFactory.getLogger(CountingAlarmEntityNotifier.class);
 
-    public CountingAlarmEntityNotifier(MeterRegistry registry) {
+    private final MeterRegistry registry;
+    private final List<AlarmEntityListener> listeners;
+
+    public CountingAlarmEntityNotifier(MeterRegistry registry, List<AlarmEntityListener> listeners) {
         this.registry = registry;
+        this.listeners = listeners;
     }
 
     @Override
     public void didCreateAlarm(OnmsAlarm alarm) {
         registry.counter(ALARMS_CREATED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmCreated(alarm));
     }
 
     @Override
     public void didUpdateAlarmWithReducedEvent(OnmsAlarm alarm) {
         registry.counter(ALARMS_REDUCED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmUpdatedWithReducedEvent(alarm));
     }
 
     @Override
     public void didAcknowledgeAlarm(OnmsAlarm alarm, String user, Date when) {
         registry.counter(ALARMS_ACKNOWLEDGED).increment();
+        forEach(l -> l.onAlarmAcknowledged(alarm, user, when));
     }
 
     @Override
     public void didUnacknowledgeAlarm(OnmsAlarm alarm, String user, Date when) {
         registry.counter(ALARMS_UNACKNOWLEDGED).increment();
+        forEach(l -> l.onAlarmUnacknowledged(alarm, user, when));
     }
 
     @Override
@@ -80,25 +98,65 @@ public class CountingAlarmEntityNotifier implements AlarmEntityNotifier {
         // Tag by *new* severity (what the alarm is now, which is the operationally
         // interesting dimension — "alarms that just became CRITICAL").
         registry.counter(ALARMS_SEVERITY_UPDATED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmSeverityUpdated(alarm, previous));
     }
 
     @Override
     public void didArchiveAlarm(OnmsAlarm alarm, String previousReductionKey) {
         registry.counter(ALARMS_ARCHIVED).increment();
+        forEach(l -> l.onAlarmArchived(alarm, previousReductionKey));
     }
 
     @Override
     public void didDeleteAlarm(OnmsAlarm alarm) {
         registry.counter(ALARMS_DELETED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmDeleted(alarm));
     }
 
-    @Override public void didUpdateStickyMemo(OnmsAlarm a, String b, String au, Date d) {}
-    @Override public void didUpdateReductionKeyMemo(OnmsAlarm a, String b, String au, Date d) {}
-    @Override public void didDeleteStickyMemo(OnmsAlarm a, OnmsMemo m) {}
-    @Override public void didDeleteReductionKeyMemo(OnmsAlarm a, OnmsReductionKeyMemo m) {}
-    @Override public void didUpdateLastAutomationTime(OnmsAlarm a, Date d) {}
-    @Override public void didUpdateRelatedAlarms(OnmsAlarm a, Set<OnmsAlarm> s) {}
-    @Override public void didChangeTicketStateForAlarm(OnmsAlarm a, TroubleTicketState s) {}
+    @Override
+    public void didUpdateStickyMemo(OnmsAlarm alarm, String previousBody, String previousAuthor, Date previousUpdated) {
+        forEach(l -> l.onStickyMemoUpdated(alarm, previousBody, previousAuthor, previousUpdated));
+    }
+
+    @Override
+    public void didUpdateReductionKeyMemo(OnmsAlarm alarm, String previousBody, String previousAuthor, Date previousUpdated) {
+        forEach(l -> l.onReductionKeyMemoUpdated(alarm, previousBody, previousAuthor, previousUpdated));
+    }
+
+    @Override
+    public void didDeleteStickyMemo(OnmsAlarm alarm, OnmsMemo memo) {
+        forEach(l -> l.onStickyMemoDeleted(alarm, memo));
+    }
+
+    @Override
+    public void didDeleteReductionKeyMemo(OnmsAlarm alarm, OnmsReductionKeyMemo memo) {
+        forEach(l -> l.onReductionKeyMemoDeleted(alarm, memo));
+    }
+
+    @Override
+    public void didUpdateLastAutomationTime(OnmsAlarm alarm, Date previousLastAutomationTime) {
+        forEach(l -> l.onLastAutomationTimeUpdated(alarm, previousLastAutomationTime));
+    }
+
+    @Override
+    public void didUpdateRelatedAlarms(OnmsAlarm alarm, Set<OnmsAlarm> previousRelatedAlarms) {
+        forEach(l -> l.onRelatedAlarmsUpdated(alarm, previousRelatedAlarms));
+    }
+
+    @Override
+    public void didChangeTicketStateForAlarm(OnmsAlarm alarm, TroubleTicketState previousState) {
+        forEach(l -> l.onTicketStateChanged(alarm, previousState));
+    }
+
+    private void forEach(Consumer<AlarmEntityListener> callback) {
+        for (AlarmEntityListener listener : listeners) {
+            try {
+                callback.accept(listener);
+            } catch (Exception e) {
+                LOG.error("Error invoking alarm entity listener {}; skipping.", listener, e);
+            }
+        }
+    }
 
     private static String severity(OnmsAlarm alarm) {
         OnmsSeverity s = alarm != null ? alarm.getSeverity() : null;

--- a/core/daemon-boot-alarmd/src/main/resources/application.yml
+++ b/core/daemon-boot-alarmd/src/main/resources/application.yml
@@ -42,6 +42,13 @@ opennms:
     consumer-group: ${KAFKA_CONSUMER_GROUP:opennms-core}
     poll-timeout-ms: ${KAFKA_POLL_TIMEOUT_MS:100}
 
+deltav:
+  alarmd:
+    kafka-publisher:
+      enabled: ${DELTAV_ALARMD_KAFKA_PUBLISHER_ENABLED:true}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+      topic: ${DELTAV_ALARMS_STATE_TOPIC:deltav-alarms-state-change}
+
 logging:
   level:
     org.opennms: INFO

--- a/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifierTest.java
+++ b/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifierTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.netmgt.alarmd.boot;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.List;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opennms.netmgt.dao.api.AlarmEntityListener;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+class CountingAlarmEntityNotifierTest {
+
+    @Test
+    void forwardsCreateToRegisteredListeners() {
+        AlarmEntityListener listener = Mockito.mock(AlarmEntityListener.class);
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of(listener));
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setSeverity(OnmsSeverity.MAJOR);
+
+        notifier.didCreateAlarm(alarm);
+
+        verify(listener).onAlarmCreated(alarm);
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    void forwardsDeleteToRegisteredListeners() {
+        AlarmEntityListener listener = Mockito.mock(AlarmEntityListener.class);
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of(listener));
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setSeverity(OnmsSeverity.NORMAL);
+
+        notifier.didDeleteAlarm(alarm);
+
+        verify(listener).onAlarmDeleted(alarm);
+    }
+
+    @Test
+    void forwardsSeverityUpdateToRegisteredListeners() {
+        AlarmEntityListener listener = Mockito.mock(AlarmEntityListener.class);
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of(listener));
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setSeverity(OnmsSeverity.CRITICAL);
+
+        notifier.didUpdateAlarmSeverity(alarm, OnmsSeverity.MINOR);
+
+        verify(listener).onAlarmSeverityUpdated(alarm, OnmsSeverity.MINOR);
+    }
+
+    @Test
+    void emptyListenerListIsHarmless() {
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of());
+        notifier.didCreateAlarm(new OnmsAlarm()); // must not throw
+    }
+
+    @Test
+    void oneFailingListenerDoesNotBlockOthers() {
+        AlarmEntityListener broken = Mockito.mock(AlarmEntityListener.class);
+        Mockito.doThrow(new RuntimeException("broken listener"))
+               .when(broken).onAlarmCreated(org.mockito.ArgumentMatchers.any());
+        AlarmEntityListener healthy = Mockito.mock(AlarmEntityListener.class);
+
+        CountingAlarmEntityNotifier notifier = new CountingAlarmEntityNotifier(
+                new SimpleMeterRegistry(), List.of(broken, healthy));
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setSeverity(OnmsSeverity.MAJOR);
+
+        notifier.didCreateAlarm(alarm); // must not throw despite the broken listener
+
+        verify(healthy).onAlarmCreated(alarm); // healthy listener still invoked
+    }
+}

--- a/core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 BeaconStrategists, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// API version: 1 (FROZEN at v1.3.0 GA — delta-v "Alarms on Kafka" Track 1)
+//
+// Public contract for the deltav-alarms-state-change Kafka topic.
+//
+// Versioning: this wire format is frozen as of v1.3.0 GA. Only
+// forward-compatible changes are permitted: new fields with new tag
+// numbers, new enum values appended at the end. Renaming or renumbering
+// existing fields, deleting fields, or changing field types are breaking
+// changes that require bumping to // API version: 2 with a one-release
+// deprecation cycle maintaining v1 as read-only.
+//
+// Producer: alarmd (KafkaAlarmPublisher, AlarmLifecycleListener). One record
+// per alarm lifecycle change; tombstone (null value) on alarm deletion.
+
+syntax = "proto3";
+
+package org.deltav.alarms;
+
+option java_package = "org.deltav.alarms.proto";
+option java_multiple_files = true;
+
+// Thin alarm-state record published to the deltav-alarms-state-change topic
+// on every alarm create/update; a null-valued tombstone is published on
+// delete. The topic is compacted, keyed by reduction_key.
+//
+// High-cardinality node metadata (node_label, categories, asset record) is
+// intentionally excluded — consumers join the deltav-node-context topic for
+// enrichment. node_id is int32 to match NodeContext.node_id so consumers can
+// join directly without a key/type transformer.
+message AlarmState {
+  // Numeric alarm ID (OnmsAlarm.id).
+  int32 alarm_id = 1;
+
+  // Reduction key — globally unique per alarm; the Kafka record key.
+  string reduction_key = 2;
+
+  // Current alarm severity.
+  Severity severity = 3;
+
+  // Alarm UEI.
+  string uei = 4;
+
+  // Numeric node ID; 0 when the alarm has no node. Matches NodeContext.node_id.
+  int32 node_id = 5;
+
+  // Monitoring location; "Default" when unknown.
+  string location = 6;
+
+  // First event time, epoch milliseconds.
+  int64 first_event_time_ms = 7;
+
+  // Last event time, epoch milliseconds.
+  int64 last_event_time_ms = 8;
+
+  // Acknowledgement time, epoch milliseconds; 0 when unacknowledged.
+  int64 ack_time_ms = 9;
+
+  // Acknowledging user; empty when unacknowledged.
+  string ack_user = 10;
+
+  // Event count rolled into this alarm.
+  int32 count = 11;
+
+  // Alarm description.
+  string description = 12;
+
+  // Alarm log message.
+  string log_message = 13;
+
+  enum Severity {
+    INDETERMINATE = 0;
+    CLEARED       = 1;
+    NORMAL        = 2;
+    WARNING       = 3;
+    MINOR         = 4;
+    MAJOR         = 5;
+    CRITICAL      = 6;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <module>core/daemon-sink-kafka</module>
     <module>core/dao-jpa-support</module>
     <module>core/deltav-kafka-contracts</module>
+    <module>core/alarms-kafka-publisher</module>
     <module>core/event-forwarder-kafka</module>
     <module>core/horizon-metric-bridge</module>
     <module>core/minion-gateway</module>


### PR DESCRIPTION
## Summary

First track of the v1.3.0 "Alarms on Kafka" release. Makes `alarmd` publish
every alarm lifecycle change to a new Kafka topic as protobuf, while still
writing PostgreSQL (Phase 1 dual-write — PG remains authoritative).

- **New wire contract** — `deltav-alarm-state.proto` (`AlarmState` message) in
  `core/deltav-kafka-contracts`; published to the new compacted topic
  `deltav-alarms-state-change`, keyed by `reduction_key`, tombstone on delete.
- **New module `core/alarms-kafka-publisher`** — `AlarmStateMapper`
  (`OnmsAlarm`→proto), `KafkaAlarmPublisher` (an `AlarmLifecycleListener`),
  and Spring wiring (`deltav.alarmd.kafka-publisher.*` config).
- **Revives a dead callback chain** — `CountingAlarmEntityNotifier` only
  incremented Micrometer counters; it now also fans alarm lifecycle callbacks
  out to registered `AlarmEntityListener`s, so the publisher receives
  real-time `handleNewOrUpdatedAlarm`/`handleDeletedAlarm` instead of only the
  2-minute snapshot.
- alarmd wired to depend on + component-scan the new module.

Design: `docs/superpowers/specs/2026-05-17-v1.3.0-alarms-on-kafka-design.md`
Plan: `docs/superpowers/plans/2026-05-17-v1.3.0-track1-alarm-kafka-publisher.md`

## Test Plan

- [x] 13 unit tests pass — `AlarmStateMapper` (5), `KafkaAlarmPublisher` (3,
  incl. tombstone + listener-isolation), `CountingAlarmEntityNotifier` (5)
- [x] `./mvnw -pl core/alarms-kafka-publisher,core/daemon-boot-alarmd -am clean install` — BUILD SUCCESS; publisher + proto classes verified present in the alarmd fat jar
- [ ] **Integration smoke (docker-compose):** alarmd boots in-container with log line `Registered KafkaAlarmPublisher`
- [ ] Fire an alarm → assert a protobuf record lands on `deltav-alarms-state-change` (key = reduction key)
- [ ] Confirm PG `alarms` dual-write is intact (Phase 1)

Draft pending the integration smoke — per project rule, an alarmd-affecting
change must boot in a real container before merge.