### PR TITLE
docs(v1.3.0): "Alarms on Kafka" release design + Track 1 plan

### DIFF
--- a/docs/superpowers/plans/2026-05-17-v1.3.0-track1-alarm-kafka-publisher.md
+++ b/docs/superpowers/plans/2026-05-17-v1.3.0-track1-alarm-kafka-publisher.md
@@ -108,7 +108,7 @@ git commit -m "feat(alarms): add deltav-alarm-state protobuf schema"
 
 - [ ] **Step 1: Write the module pom**
 
-Create `core/alarms-kafka-publisher/pom.xml`. Copy the version literal from the root `pom.xml` `<version>` (currently `4.0.3`) into the `<parent><version>` below if it differs:
+Create `core/alarms-kafka-publisher/pom.xml`. The `delta-v-parent` version is `1.2.0` (the root `pom.xml`'s own `<version>`; note its *first* `<version>` element is `spring-boot-starter-parent` `4.0.3`, which is unrelated). If `delta-v-parent` has been bumped, use the current value:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -120,7 +120,7 @@ Create `core/alarms-kafka-publisher/pom.xml`. Copy the version literal from the 
   <parent>
     <groupId>org.deltav</groupId>
     <artifactId>delta-v-parent</artifactId>
-    <version>4.0.3</version>
+    <version>1.2.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/docs/superpowers/plans/2026-05-17-v1.3.0-track1-alarm-kafka-publisher.md
+++ b/docs/superpowers/plans/2026-05-17-v1.3.0-track1-alarm-kafka-publisher.md
@@ -1,0 +1,1115 @@
+# v1.3.0 Track 1 — Alarm Kafka Publisher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `alarmd` publish every alarm lifecycle change (create / update / delete) to a new Kafka topic `deltav-alarms-state-change` as protobuf, while continuing to write PostgreSQL (Phase 1 dual-write).
+
+**Architecture:** A new in-process module `core/alarms-kafka-publisher/` provides a `KafkaAlarmPublisher` that implements horizon's `AlarmLifecycleListener`. It is registered with alarmd's existing `AlarmLifecycleListenerManager`. Because delta-v's `CountingAlarmEntityNotifier` currently only counts Micrometer meters and does **not** fan lifecycle callbacks out to listeners, this plan also revives the `AlarmEntityNotifier → AlarmEntityListener → AlarmLifecycleListener` chain so the publisher receives real-time callbacks. The protobuf schema is added to the existing `core/deltav-kafka-contracts/` module.
+
+**Tech Stack:** Java 21, Spring Boot 4.0.x, Apache Kafka client, Protocol Buffers 3.25.5 (`protobuf-maven-plugin` 0.6.1), JUnit 4 + Mockito, Maven via `./mvnw`.
+
+**Key decision — Kafka key:** The topic is keyed by **`reduction_key` alone** (String), not `{location}@{reduction_key}`. Reason: `AlarmLifecycleListener.handleDeletedAlarm(int alarmId, String reductionKey)` supplies no location, so a composite key could not produce a correct tombstone on delete. `reduction_key` is globally unique per alarm. (This corrects the Track-1 line in the release design doc, which proposed the composite key as "decide at implementation time".)
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto` | Wire schema for the alarm state record (public contract) |
+| `core/alarms-kafka-publisher/pom.xml` | New module — publisher library, bundled into alarmd's fat jar |
+| `.../alarms/publisher/AlarmStateMapper.java` | Pure function `OnmsAlarm` → `AlarmStateProtos.AlarmState` |
+| `.../alarms/publisher/KafkaAlarmPublisher.java` | `AlarmLifecycleListener` impl — publishes proto / tombstone to Kafka |
+| `.../alarms/publisher/AlarmPublisherProperties.java` | `@ConfigurationProperties` for `deltav.alarmd.kafka-publisher.*` |
+| `.../alarms/publisher/AlarmPublisherConfiguration.java` | `@Configuration` — builds the producer + publisher, registers it with the manager |
+| `core/daemon-boot-alarmd/.../CountingAlarmEntityNotifier.java` (modify) | Add `AlarmEntityListener` fan-out alongside the existing meter counting |
+| `core/daemon-boot-alarmd/.../AlarmdApplication.java` (modify) | Add the publisher package to `scanBasePackages` |
+| `core/daemon-boot-alarmd/pom.xml` (modify) | Depend on the new publisher module |
+| `core/daemon-boot-alarmd/src/main/resources/application.yml` (modify) | Add `deltav.alarmd.kafka-publisher.*` config |
+| `pom.xml` (modify) | Register `core/alarms-kafka-publisher` in `<modules>` |
+
+No Docker/CI change in this track — the publisher is a library inside the existing `alarmd` image.
+
+---
+
+## Task 1: Add the protobuf schema
+
+**Files:**
+- Create: `core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto`
+
+- [ ] **Step 1: Write the proto file**
+
+Create `core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto`:
+
+```protobuf
+// Copyright (C) 2026 BeaconStrategists, Inc. Licensed under AGPL v3.
+syntax = "proto3";
+
+package deltav.alarms;
+
+option java_package = "org.deltav.alarms.proto";
+option java_outer_classname = "AlarmStateProtos";
+
+// Thin alarm-state record published to the deltav-alarms-state-change topic.
+// High-cardinality node metadata is intentionally excluded — consumers join
+// the deltav-node-context GlobalKTable for enrichment. Public wire contract:
+// fields are append-only, never renumbered, never repurposed.
+message AlarmState {
+  uint64 alarm_id          = 1;
+  string reduction_key     = 2;
+  Severity severity        = 3;
+  string uei               = 4;
+  uint64 node_id           = 5;   // 0 when the alarm has no node
+  string location          = 6;   // monitoring location; "Default" when unknown
+  uint64 first_event_time  = 7;   // epoch millis
+  uint64 last_event_time   = 8;   // epoch millis
+  uint64 ack_time          = 9;   // epoch millis; 0 when unacknowledged
+  string ack_user          = 10;
+  uint32 count             = 11;
+  string description       = 12;
+  string log_message       = 13;
+
+  enum Severity {
+    INDETERMINATE = 0;
+    CLEARED       = 1;
+    NORMAL        = 2;
+    WARNING       = 3;
+    MINOR         = 4;
+    MAJOR         = 5;
+    CRITICAL      = 6;
+  }
+}
+```
+
+- [ ] **Step 2: Compile the contracts module to verify the proto generates**
+
+Run: `./mvnw -pl core/deltav-kafka-contracts -am install -DskipTests`
+Expected: BUILD SUCCESS, and `core/deltav-kafka-contracts/target/generated-sources/protobuf/java/org/deltav/alarms/proto/AlarmStateProtos.java` exists.
+
+- [ ] **Step 3: Verify the generated class**
+
+Run: `ls core/deltav-kafka-contracts/target/generated-sources/protobuf/java/org/deltav/alarms/proto/`
+Expected: `AlarmStateProtos.java` listed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto
+git commit -m "feat(alarms): add deltav-alarm-state protobuf schema"
+```
+
+---
+
+## Task 2: Create the alarms-kafka-publisher module skeleton
+
+**Files:**
+- Create: `core/alarms-kafka-publisher/pom.xml`
+- Modify: `pom.xml` (root `<modules>` list)
+
+- [ ] **Step 1: Write the module pom**
+
+Create `core/alarms-kafka-publisher/pom.xml`. Copy the version literal from the root `pom.xml` `<version>` (currently `4.0.3`) into the `<parent><version>` below if it differs:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.deltav</groupId>
+    <artifactId>delta-v-parent</artifactId>
+    <version>4.0.3</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.deltav.core</groupId>
+  <artifactId>org.opennms.core.alarms-kafka-publisher</artifactId>
+  <name>OpenNMS :: Core :: Alarms Kafka Publisher</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.deltav.core</groupId>
+      <artifactId>org.opennms.core.deltav-kafka-contracts</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <!-- supplies @ConditionalOnProperty used by AlarmPublisherConfiguration -->
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <!-- Horizon APIs (provided — supplied by the alarmd fat jar at runtime) -->
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-alarm-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-alarmd</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>org.opennms.core.model-jakarta</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Test -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+```
+
+> **Note for the implementer:** verify each `<artifactId>` above resolves — open `core/daemon-boot-alarmd/pom.xml` and confirm the exact artifactId horizon uses for the alarm API / model jar (it imports `org.opennms.netmgt.alarmd.api.AlarmLifecycleListener`, `org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager`, `org.opennms.netmgt.model.OnmsAlarm`, `org.opennms.netmgt.dao.api.AlarmEntityNotifier`). Match alarmd's declared artifactIds exactly; do not invent names. If `opennms-alarm-api` is not the artifact that carries `AlarmLifecycleListener`, use whichever alarmd already depends on. Versions come from the imported horizon BOM — omit `<version>` on `org.opennms:*` deps.
+
+- [ ] **Step 2: Register the module in the root pom**
+
+In `pom.xml`, find the `<modules>` block and add this line next to the other `core/event-forwarder-kafka` / `core/deltav-kafka-contracts` entries (the "Shared infrastructure" group):
+
+```xml
+    <module>core/alarms-kafka-publisher</module>
+```
+
+- [ ] **Step 3: Verify the module is recognized by the reactor**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher -am validate`
+Expected: BUILD SUCCESS, reactor lists `OpenNMS :: Core :: Alarms Kafka Publisher`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/alarms-kafka-publisher/pom.xml pom.xml
+git commit -m "feat(alarms): scaffold alarms-kafka-publisher module"
+```
+
+---
+
+## Task 3: AlarmStateMapper — OnmsAlarm to protobuf
+
+**Files:**
+- Create: `core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmStateMapper.java`
+- Test: `core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `AlarmStateMapperTest.java`:
+
+```java
+package org.deltav.alarms.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.deltav.alarms.proto.AlarmStateProtos.AlarmState;
+import org.junit.Test;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+public class AlarmStateMapperTest {
+
+    @Test
+    public void mapsCoreFields() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(42);
+        alarm.setReductionKey("uei.opennms.org/nodes/nodeDown::1");
+        alarm.setUei("uei.opennms.org/nodes/nodeDown");
+        alarm.setSeverity(OnmsSeverity.MAJOR);
+        alarm.setCounter(3);
+        alarm.setFirstEventTime(new Date(1_000L));
+        alarm.setLastEventTime(new Date(2_000L));
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getAlarmId()).isEqualTo(42L);
+        assertThat(proto.getReductionKey()).isEqualTo("uei.opennms.org/nodes/nodeDown::1");
+        assertThat(proto.getUei()).isEqualTo("uei.opennms.org/nodes/nodeDown");
+        assertThat(proto.getSeverity()).isEqualTo(AlarmState.Severity.MAJOR);
+        assertThat(proto.getCount()).isEqualTo(3);
+        assertThat(proto.getFirstEventTime()).isEqualTo(1_000L);
+        assertThat(proto.getLastEventTime()).isEqualTo(2_000L);
+    }
+
+    @Test
+    public void nullNodeYieldsZeroIdAndDefaultLocation() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+        alarm.setSeverity(OnmsSeverity.NORMAL);
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getNodeId()).isEqualTo(0L);
+        assertThat(proto.getLocation()).isEqualTo("Default");
+    }
+
+    @Test
+    public void nullSeverityMapsToIndeterminate() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getSeverity()).isEqualTo(AlarmState.Severity.INDETERMINATE);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher -am test -Dtest=AlarmStateMapperTest`
+Expected: FAIL — compilation error, `AlarmStateMapper` does not exist.
+
+- [ ] **Step 3: Write the mapper**
+
+Create `AlarmStateMapper.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import java.util.Date;
+
+import org.deltav.alarms.proto.AlarmStateProtos.AlarmState;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+/**
+ * Pure function: converts an {@link OnmsAlarm} entity into the thin
+ * {@link AlarmState} wire record. No I/O, no Spring — trivially unit-testable.
+ */
+public class AlarmStateMapper {
+
+    private static final String DEFAULT_LOCATION = "Default";
+
+    public AlarmState toProto(OnmsAlarm alarm) {
+        AlarmState.Builder b = AlarmState.newBuilder()
+                .setAlarmId(alarm.getId() != null ? alarm.getId() : 0L)
+                .setSeverity(mapSeverity(alarm.getSeverity()))
+                .setCount(alarm.getCounter() != null ? alarm.getCounter() : 0)
+                .setFirstEventTime(epochMillis(alarm.getFirstEventTime()))
+                .setLastEventTime(epochMillis(alarm.getLastEventTime()))
+                .setAckTime(epochMillis(alarm.getAlarmAckTime()));
+        setIfNotNull(alarm.getReductionKey(), b::setReductionKey);
+        setIfNotNull(alarm.getUei(), b::setUei);
+        setIfNotNull(alarm.getAlarmAckUser(), b::setAckUser);
+        setIfNotNull(alarm.getDescription(), b::setDescription);
+        setIfNotNull(alarm.getLogMsg(), b::setLogMessage);
+        b.setNodeId(alarm.getNodeId() != null ? alarm.getNodeId() : 0L);
+        b.setLocation(resolveLocation(alarm));
+        return b.build();
+    }
+
+    private static String resolveLocation(OnmsAlarm alarm) {
+        if (alarm.getNode() != null && alarm.getNode().getLocation() != null
+                && alarm.getNode().getLocation().getLocationName() != null) {
+            return alarm.getNode().getLocation().getLocationName();
+        }
+        return DEFAULT_LOCATION;
+    }
+
+    private static AlarmState.Severity mapSeverity(OnmsSeverity severity) {
+        if (severity == null) {
+            return AlarmState.Severity.INDETERMINATE;
+        }
+        switch (severity) {
+            case CLEARED:  return AlarmState.Severity.CLEARED;
+            case NORMAL:   return AlarmState.Severity.NORMAL;
+            case WARNING:  return AlarmState.Severity.WARNING;
+            case MINOR:    return AlarmState.Severity.MINOR;
+            case MAJOR:    return AlarmState.Severity.MAJOR;
+            case CRITICAL: return AlarmState.Severity.CRITICAL;
+            case INDETERMINATE:
+            default:       return AlarmState.Severity.INDETERMINATE;
+        }
+    }
+
+    private static long epochMillis(Date date) {
+        return date != null ? date.getTime() : 0L;
+    }
+
+    private static void setIfNotNull(String value, java.util.function.Consumer<String> setter) {
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+}
+```
+
+> **Implementer note:** if `OnmsSeverity` does not have exactly the constants `CLEARED/NORMAL/WARNING/MINOR/MAJOR/CRITICAL/INDETERMINATE`, open `OnmsSeverity.java` in the horizon model jar and match the actual enum names. Do not guess.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher -am test -Dtest=AlarmStateMapperTest`
+Expected: PASS — 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alarms-kafka-publisher/src/main/java core/alarms-kafka-publisher/src/test/java
+git commit -m "feat(alarms): add AlarmStateMapper (OnmsAlarm to protobuf)"
+```
+
+---
+
+## Task 4: KafkaAlarmPublisher — the AlarmLifecycleListener
+
+**Files:**
+- Create: `core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/KafkaAlarmPublisher.java`
+- Test: `core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/KafkaAlarmPublisherTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `KafkaAlarmPublisherTest.java`. It uses Kafka's `MockProducer` so no broker is needed:
+
+```java
+package org.deltav.alarms.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.deltav.alarms.proto.AlarmStateProtos.AlarmState;
+import org.junit.Test;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+public class KafkaAlarmPublisherTest {
+
+    private static final String TOPIC = "deltav-alarms-state-change";
+
+    private OnmsAlarm sampleAlarm() {
+        OnmsAlarm a = new OnmsAlarm();
+        a.setId(7);
+        a.setReductionKey("uei.opennms.org/nodes/nodeDown::7");
+        a.setUei("uei.opennms.org/nodes/nodeDown");
+        a.setSeverity(OnmsSeverity.MAJOR);
+        return a;
+    }
+
+    @Test
+    public void publishesProtoOnNewOrUpdatedAlarm() throws Exception {
+        MockProducer<String, byte[]> producer =
+                new MockProducer<>(true, new StringSerializer(), new ByteArraySerializer());
+        KafkaAlarmPublisher publisher = new KafkaAlarmPublisher(producer, TOPIC, new AlarmStateMapper());
+
+        publisher.handleNewOrUpdatedAlarm(sampleAlarm());
+
+        List<ProducerRecord<String, byte[]>> history = producer.history();
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).topic()).isEqualTo(TOPIC);
+        assertThat(history.get(0).key()).isEqualTo("uei.opennms.org/nodes/nodeDown::7");
+        AlarmState decoded = AlarmState.parseFrom(history.get(0).value());
+        assertThat(decoded.getAlarmId()).isEqualTo(7L);
+        assertThat(decoded.getSeverity()).isEqualTo(AlarmState.Severity.MAJOR);
+    }
+
+    @Test
+    public void publishesTombstoneOnDeletedAlarm() {
+        MockProducer<String, byte[]> producer =
+                new MockProducer<>(true, new StringSerializer(), new ByteArraySerializer());
+        KafkaAlarmPublisher publisher = new KafkaAlarmPublisher(producer, TOPIC, new AlarmStateMapper());
+
+        publisher.handleDeletedAlarm(7, "uei.opennms.org/nodes/nodeDown::7");
+
+        List<ProducerRecord<String, byte[]>> history = producer.history();
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).key()).isEqualTo("uei.opennms.org/nodes/nodeDown::7");
+        assertThat(history.get(0).value()).isNull(); // tombstone for log compaction
+    }
+
+    @Test
+    public void snapshotCallbacksDoNotPublish() {
+        MockProducer<String, byte[]> producer =
+                new MockProducer<>(true, new StringSerializer(), new ByteArraySerializer());
+        KafkaAlarmPublisher publisher = new KafkaAlarmPublisher(producer, TOPIC, new AlarmStateMapper());
+
+        publisher.preHandleAlarmSnapshot();
+        publisher.handleAlarmSnapshot(java.util.Collections.emptyList());
+        publisher.postHandleAlarmSnapshot();
+
+        assertThat(producer.history()).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher -am test -Dtest=KafkaAlarmPublisherTest`
+Expected: FAIL — `KafkaAlarmPublisher` does not exist.
+
+- [ ] **Step 3: Write the publisher**
+
+Create `KafkaAlarmPublisher.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.deltav.alarms.proto.AlarmStateProtos.AlarmState;
+import org.opennms.netmgt.alarmd.api.AlarmLifecycleListener;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Publishes alarm lifecycle changes to the {@code deltav-alarms-state-change}
+ * Kafka topic as {@link AlarmState} protobuf.
+ *
+ * <p>This is Phase 1 of the "Alarms on Kafka" migration: alarmd still writes
+ * PostgreSQL directly; Kafka publication is an additional output. Records are
+ * keyed by {@code reduction_key}; a deleted alarm produces a null-valued
+ * tombstone so a compacted topic drops it.</p>
+ *
+ * <p>The periodic snapshot callbacks are intentionally no-ops — the publisher
+ * is an incremental event stream, not a state sync.</p>
+ */
+public class KafkaAlarmPublisher implements AlarmLifecycleListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaAlarmPublisher.class);
+
+    private final Producer<String, byte[]> producer;
+    private final String topic;
+    private final AlarmStateMapper mapper;
+
+    public KafkaAlarmPublisher(Producer<String, byte[]> producer, String topic, AlarmStateMapper mapper) {
+        this.producer = Objects.requireNonNull(producer, "producer");
+        this.topic = Objects.requireNonNull(topic, "topic");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+    }
+
+    @Override
+    public void handleNewOrUpdatedAlarm(OnmsAlarm alarm) {
+        if (alarm == null || alarm.getReductionKey() == null) {
+            LOG.warn("Skipping alarm with null reduction key: {}", alarm);
+            return;
+        }
+        try {
+            AlarmState proto = mapper.toProto(alarm);
+            producer.send(new ProducerRecord<>(topic, alarm.getReductionKey(), proto.toByteArray()));
+            LOG.debug("Published alarm {} (rk={}) to {}", proto.getAlarmId(), alarm.getReductionKey(), topic);
+        } catch (Exception e) {
+            LOG.error("Failed to publish alarm rk={} to {}", alarm.getReductionKey(), topic, e);
+        }
+    }
+
+    @Override
+    public void handleDeletedAlarm(int alarmId, String reductionKey) {
+        if (reductionKey == null) {
+            LOG.warn("Skipping deleted alarm {} with null reduction key", alarmId);
+            return;
+        }
+        try {
+            producer.send(new ProducerRecord<>(topic, reductionKey, null)); // tombstone
+            LOG.debug("Published tombstone for alarm {} (rk={}) to {}", alarmId, reductionKey, topic);
+        } catch (Exception e) {
+            LOG.error("Failed to publish tombstone rk={} to {}", reductionKey, topic, e);
+        }
+    }
+
+    @Override
+    public void preHandleAlarmSnapshot() {
+        // no-op — incremental publisher, not a state sync
+    }
+
+    @Override
+    public void handleAlarmSnapshot(List<OnmsAlarm> alarms) {
+        // no-op — incremental publisher, not a state sync
+    }
+
+    @Override
+    public void postHandleAlarmSnapshot() {
+        // no-op — incremental publisher, not a state sync
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher -am test -Dtest=KafkaAlarmPublisherTest`
+Expected: PASS — 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/KafkaAlarmPublisher.java \
+        core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/KafkaAlarmPublisherTest.java
+git commit -m "feat(alarms): add KafkaAlarmPublisher (AlarmLifecycleListener to Kafka)"
+```
+
+---
+
+## Task 5: Spring configuration — properties, producer, listener registration
+
+**Files:**
+- Create: `core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherProperties.java`
+- Create: `core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java`
+
+- [ ] **Step 1: Write the properties class**
+
+Create `AlarmPublisherProperties.java` (AGPL header as in Task 3, omitted here for brevity — include it):
+
+```java
+package org.deltav.alarms.publisher;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Binds {@code deltav.alarmd.kafka-publisher.*}. Daemon-scoped per the
+ * project's no-shared-config rule.
+ */
+@ConfigurationProperties(prefix = "deltav.alarmd.kafka-publisher")
+public class AlarmPublisherProperties {
+
+    /** Whether the publisher is active. Default true. */
+    private boolean enabled = true;
+
+    /** Kafka bootstrap servers. */
+    private String bootstrapServers = "kafka:9092";
+
+    /** Target topic. */
+    private String topic = "deltav-alarms-state-change";
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public String getBootstrapServers() { return bootstrapServers; }
+    public void setBootstrapServers(String bootstrapServers) { this.bootstrapServers = bootstrapServers; }
+
+    public String getTopic() { return topic; }
+    public void setTopic(String topic) { this.topic = topic; }
+}
+```
+
+- [ ] **Step 2: Write the configuration class**
+
+Create `AlarmPublisherConfiguration.java` (include the AGPL header):
+
+```java
+package org.deltav.alarms.publisher;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the {@link KafkaAlarmPublisher} into alarmd and registers it with the
+ * existing {@link AlarmLifecycleListenerManager} so it receives lifecycle
+ * callbacks. Component-scanned by {@code AlarmdApplication}.
+ */
+@Configuration
+@EnableConfigurationProperties(AlarmPublisherProperties.class)
+@ConditionalOnProperty(prefix = "deltav.alarmd.kafka-publisher", name = "enabled",
+        havingValue = "true", matchIfMissing = true)
+public class AlarmPublisherConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmPublisherConfiguration.class);
+
+    @Bean
+    public Producer<String, byte[]> alarmKafkaProducer(AlarmPublisherProperties props) {
+        Properties p = new Properties();
+        p.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, props.getBootstrapServers());
+        p.setProperty(ProducerConfig.ACKS_CONFIG, "all");
+        return new KafkaProducer<>(p, new StringSerializer(), new ByteArraySerializer());
+    }
+
+    @Bean
+    public KafkaAlarmPublisher kafkaAlarmPublisher(Producer<String, byte[]> alarmKafkaProducer,
+                                                   AlarmPublisherProperties props,
+                                                   AlarmLifecycleListenerManager manager) {
+        KafkaAlarmPublisher publisher =
+                new KafkaAlarmPublisher(alarmKafkaProducer, props.getTopic(), new AlarmStateMapper());
+        manager.onListenerRegistered(publisher, Collections.emptyMap());
+        LOG.info("Registered KafkaAlarmPublisher; publishing alarm lifecycle to topic {}", props.getTopic());
+        return publisher;
+    }
+}
+```
+
+> **Why register inside the `@Bean` body:** `AlarmLifecycleListenerManager` keeps its listeners in a plain `Set` populated via `onListenerRegistered(...)` (horizon's OSGi hook). There is no Spring auto-discovery of `AlarmLifecycleListener` beans, so the registration must be explicit.
+
+- [ ] **Step 3: Compile the module**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher -am install -DskipTests`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Run the full module test suite**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher test`
+Expected: PASS — Task 3 + Task 4 tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherProperties.java \
+        core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java
+git commit -m "feat(alarms): wire KafkaAlarmPublisher Spring config + listener registration"
+```
+
+---
+
+## Task 6: Revive the AlarmEntityNotifier → AlarmEntityListener fan-out
+
+**Context:** alarmd's `CountingAlarmEntityNotifier` implements `AlarmEntityNotifier` but only increments Micrometer counters — it does **not** forward callbacks to any `AlarmEntityListener`. `AlarmLifecycleListenerManager` (an `AlarmEntityListener`) therefore never receives real-time `onAlarmCreated/Updated/Deleted`, so the publisher would only ever see the 2-minute snapshot. This task makes the notifier fan out, restoring the chain `AlarmPersisterImpl → AlarmEntityNotifier → AlarmEntityListener(s) → AlarmLifecycleListenerManager → AlarmLifecycleListener(s)`.
+
+**Files:**
+- Modify: `core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifier.java`
+- Modify: `core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java:171-174`
+- Test: `core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifierTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CountingAlarmEntityNotifierTest.java`:
+
+```java
+package org.deltav.netmgt.alarmd.boot;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Date;
+import java.util.List;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opennms.netmgt.dao.api.AlarmEntityListener;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+public class CountingAlarmEntityNotifierTest {
+
+    @Test
+    public void forwardsCreateToRegisteredListeners() {
+        AlarmEntityListener listener = Mockito.mock(AlarmEntityListener.class);
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of(listener));
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setSeverity(OnmsSeverity.MAJOR);
+
+        notifier.didCreateAlarm(alarm);
+
+        verify(listener).onAlarmCreated(alarm);
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    public void forwardsDeleteToRegisteredListeners() {
+        AlarmEntityListener listener = Mockito.mock(AlarmEntityListener.class);
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of(listener));
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setSeverity(OnmsSeverity.NORMAL);
+
+        notifier.didDeleteAlarm(alarm);
+
+        verify(listener).onAlarmDeleted(alarm);
+    }
+
+    @Test
+    public void forwardsSeverityUpdateToRegisteredListeners() {
+        AlarmEntityListener listener = Mockito.mock(AlarmEntityListener.class);
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of(listener));
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setSeverity(OnmsSeverity.CRITICAL);
+
+        notifier.didUpdateAlarmSeverity(alarm, OnmsSeverity.MINOR);
+
+        verify(listener).onAlarmSeverityUpdated(alarm, OnmsSeverity.MINOR);
+    }
+
+    @Test
+    public void emptyListenerListIsHarmless() {
+        CountingAlarmEntityNotifier notifier =
+                new CountingAlarmEntityNotifier(new SimpleMeterRegistry(), List.of());
+        notifier.didCreateAlarm(new OnmsAlarm()); // must not throw
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -pl core/daemon-boot-alarmd test -Dtest=CountingAlarmEntityNotifierTest`
+Expected: FAIL — constructor `CountingAlarmEntityNotifier(MeterRegistry, List)` does not exist.
+
+- [ ] **Step 3: Modify CountingAlarmEntityNotifier to fan out**
+
+In `CountingAlarmEntityNotifier.java`: add the import `import java.util.List;` and `import org.opennms.netmgt.dao.api.AlarmEntityListener;`, add a field and replace the constructor:
+
+```java
+    private final MeterRegistry registry;
+    private final List<AlarmEntityListener> listeners;
+
+    public CountingAlarmEntityNotifier(MeterRegistry registry, List<AlarmEntityListener> listeners) {
+        this.registry = registry;
+        this.listeners = listeners;
+    }
+```
+
+Then in every `did*` method, **after** the counter line, add the matching fan-out call. The mapping is one-to-one:
+
+```java
+    @Override
+    public void didCreateAlarm(OnmsAlarm alarm) {
+        registry.counter(ALARMS_CREATED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmCreated(alarm));
+    }
+
+    @Override
+    public void didUpdateAlarmWithReducedEvent(OnmsAlarm alarm) {
+        registry.counter(ALARMS_REDUCED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmUpdatedWithReducedEvent(alarm));
+    }
+
+    @Override
+    public void didAcknowledgeAlarm(OnmsAlarm alarm, String user, Date when) {
+        registry.counter(ALARMS_ACKNOWLEDGED).increment();
+        forEach(l -> l.onAlarmAcknowledged(alarm, user, when));
+    }
+
+    @Override
+    public void didUnacknowledgeAlarm(OnmsAlarm alarm, String user, Date when) {
+        registry.counter(ALARMS_UNACKNOWLEDGED).increment();
+        forEach(l -> l.onAlarmUnacknowledged(alarm, user, when));
+    }
+
+    @Override
+    public void didUpdateAlarmSeverity(OnmsAlarm alarm, OnmsSeverity previous) {
+        registry.counter(ALARMS_SEVERITY_UPDATED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmSeverityUpdated(alarm, previous));
+    }
+
+    @Override
+    public void didArchiveAlarm(OnmsAlarm alarm, String previousReductionKey) {
+        registry.counter(ALARMS_ARCHIVED).increment();
+        forEach(l -> l.onAlarmArchived(alarm, previousReductionKey));
+    }
+
+    @Override
+    public void didDeleteAlarm(OnmsAlarm alarm) {
+        registry.counter(ALARMS_DELETED, TAG_SEVERITY, severity(alarm)).increment();
+        forEach(l -> l.onAlarmDeleted(alarm));
+    }
+
+    @Override
+    public void didUpdateStickyMemo(OnmsAlarm a, String b, String au, Date d) {
+        forEach(l -> l.onStickyMemoUpdated(a, b, au, d));
+    }
+
+    @Override
+    public void didUpdateReductionKeyMemo(OnmsAlarm a, String b, String au, Date d) {
+        forEach(l -> l.onReductionKeyMemoUpdated(a, b, au, d));
+    }
+
+    @Override
+    public void didDeleteStickyMemo(OnmsAlarm a, OnmsMemo m) {
+        forEach(l -> l.onStickyMemoDeleted(a, m));
+    }
+
+    @Override
+    public void didDeleteReductionKeyMemo(OnmsAlarm a, OnmsReductionKeyMemo m) {
+        forEach(l -> l.onReductionKeyMemoDeleted(a, m));
+    }
+
+    @Override
+    public void didUpdateLastAutomationTime(OnmsAlarm a, Date d) {
+        forEach(l -> l.onLastAutomationTimeUpdated(a, d));
+    }
+
+    @Override
+    public void didUpdateRelatedAlarms(OnmsAlarm a, Set<OnmsAlarm> s) {
+        forEach(l -> l.onRelatedAlarmsUpdated(a, s));
+    }
+
+    @Override
+    public void didChangeTicketStateForAlarm(OnmsAlarm a, TroubleTicketState s) {
+        forEach(l -> l.onTicketStateChanged(a, s));
+    }
+
+    private void forEach(java.util.function.Consumer<AlarmEntityListener> callback) {
+        for (AlarmEntityListener listener : listeners) {
+            try {
+                callback.accept(listener);
+            } catch (Exception e) {
+                LOG.error("Error invoking alarm entity listener {}; skipping.", listener, e);
+            }
+        }
+    }
+```
+
+Add a logger field at the top of the class: `private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(CountingAlarmEntityNotifier.class);` and update the class Javadoc — it now both counts *and* fans lifecycle callbacks out to registered `AlarmEntityListener`s.
+
+> **Implementer note:** verify the exact `AlarmEntityListener` method signatures against the horizon interface (`opennms-dao-api`, `org.opennms.netmgt.dao.api.AlarmEntityListener`). The list above matches `AlarmEntityNotifierImpl` in horizon `opennms-dao` — cross-check parameter order before relying on it.
+
+- [ ] **Step 4: Update the bean definition**
+
+In `AlarmdConfiguration.java`, replace the `alarmEntityNotifier` bean (lines 171-174). Spring injects every `AlarmEntityListener` bean — `alarmLifecycleListenerManager` is one:
+
+```java
+    @Bean
+    public AlarmEntityNotifier alarmEntityNotifier(MeterRegistry meterRegistry,
+            java.util.List<org.opennms.netmgt.dao.api.AlarmEntityListener> entityListeners) {
+        return new CountingAlarmEntityNotifier(meterRegistry, entityListeners);
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `./mvnw -pl core/daemon-boot-alarmd test -Dtest=CountingAlarmEntityNotifierTest`
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 6: Build the whole alarmd module to confirm no regression**
+
+Run: `./mvnw -pl core/daemon-boot-alarmd test`
+Expected: PASS — all existing alarmd tests still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifier.java \
+        core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdConfiguration.java \
+        core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/CountingAlarmEntityNotifierTest.java
+git commit -m "feat(alarms): fan AlarmEntityNotifier callbacks out to entity listeners"
+```
+
+---
+
+## Task 7: Wire the publisher into the alarmd daemon
+
+**Files:**
+- Modify: `core/daemon-boot-alarmd/pom.xml`
+- Modify: `core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdApplication.java:22-26`
+- Modify: `core/daemon-boot-alarmd/src/main/resources/application.yml`
+
+- [ ] **Step 1: Add the module dependency to alarmd's pom**
+
+In `core/daemon-boot-alarmd/pom.xml`, add to `<dependencies>`:
+
+```xml
+    <dependency>
+      <groupId>org.deltav.core</groupId>
+      <artifactId>org.opennms.core.alarms-kafka-publisher</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+```
+
+- [ ] **Step 2: Add the publisher package to component scanning**
+
+In `AlarmdApplication.java`, extend `scanBasePackages` (lines 22-26):
+
+```java
+@SpringBootApplication(scanBasePackages = {
+    "org.deltav.core.daemon.common",
+    "org.deltav.netmgt.alarmd.boot",
+    "org.deltav.alarms.publisher",
+    "org.opennms.netmgt.model.jakarta.dao"
+})
+public class AlarmdApplication {
+```
+
+- [ ] **Step 3: Add Kafka publisher config to application.yml**
+
+In `core/daemon-boot-alarmd/src/main/resources/application.yml`, add a top-level `deltav:` block (alongside the existing `opennms:` block):
+
+```yaml
+deltav:
+  alarmd:
+    kafka-publisher:
+      enabled: ${DELTAV_ALARMD_KAFKA_PUBLISHER_ENABLED:true}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+      topic: ${DELTAV_ALARMS_STATE_TOPIC:deltav-alarms-state-change}
+```
+
+> Reuses the existing `KAFKA_BOOTSTRAP_SERVERS` env var that other delta-v daemons already honor.
+
+- [ ] **Step 4: Build the alarmd boot jar**
+
+Run: `./mvnw -pl core/alarms-kafka-publisher,core/daemon-boot-alarmd -am clean install -DskipTests`
+Expected: BUILD SUCCESS. `clean` is required — adding a dependency to a module that feeds a Spring Boot repackaged fat jar needs a clean rebuild or the stale fat jar is reused.
+
+- [ ] **Step 5: Verify the publisher classes are in the fat jar**
+
+Run: `unzip -l core/daemon-boot-alarmd/target/*-boot.jar | grep -E "KafkaAlarmPublisher|AlarmStateProtos"`
+Expected: both `KafkaAlarmPublisher.class` and `AlarmStateProtos.class` listed under `BOOT-INF/classes` or `BOOT-INF/lib`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/daemon-boot-alarmd/pom.xml \
+        core/daemon-boot-alarmd/src/main/java/org/deltav/netmgt/alarmd/boot/AlarmdApplication.java \
+        core/daemon-boot-alarmd/src/main/resources/application.yml
+git commit -m "feat(alarms): wire alarm Kafka publisher into the alarmd daemon"
+```
+
+---
+
+## Task 8: Integration smoke — verify alarms reach the topic
+
+This task validates the whole chain on the local docker-compose stack. Per the project's CLAUDE.md and the lesson from the reverted Drools PRs (#257/#258), an alarmd-affecting change is **not** done until it has booted in a real container.
+
+**Files:** none — this is a manual/scripted verification task.
+
+- [ ] **Step 1: Rebuild the alarmd image**
+
+Run: `cd opennms-container/delta-v && ./build.sh deltav`
+Expected: images rebuilt; `deltav/alarmd` tagged with the current `project.version`.
+
+> If `build.sh deltav` fails silently with exit 255 when run as a backgrounded harness command, run it detached from a foreground shell and watch the log — see memory `feedback_build_sh_background_quirk`.
+
+- [ ] **Step 2: Bring up the stack**
+
+Run: `docker compose -f opennms-container/delta-v/docker-compose.yml up -d`
+Expected: all services healthy. Re-run `up -d` once if provisiond's cold-start healthcheck trips (known issue).
+
+- [ ] **Step 3: Confirm alarmd booted with the publisher registered**
+
+Run: `docker compose -f opennms-container/delta-v/docker-compose.yml logs alarmd | grep -i "Registered KafkaAlarmPublisher"`
+Expected: one line — `Registered KafkaAlarmPublisher; publishing alarm lifecycle to topic deltav-alarms-state-change`.
+
+- [ ] **Step 4: Confirm the topic exists**
+
+Run: `docker compose -f opennms-container/delta-v/docker-compose.yml exec kafka kafka-topics.sh --bootstrap-server localhost:9092 --list | grep deltav-alarms-state-change`
+Expected: `deltav-alarms-state-change` listed. (If auto-topic-creation is disabled in the compose Kafka, create it: `kafka-topics.sh --bootstrap-server localhost:9092 --create --topic deltav-alarms-state-change --partitions 3 --config cleanup.policy=compact`.)
+
+- [ ] **Step 5: Fire an alarm and observe the record**
+
+In one terminal, tail the topic:
+
+```bash
+docker compose -f opennms-container/delta-v/docker-compose.yml exec kafka \
+  kafka-console-consumer.sh --bootstrap-server localhost:9092 \
+  --topic deltav-alarms-state-change --from-beginning --property print.key=true
+```
+
+In another, send a `nodeDown`-class trap through the Minion (use the same trap-injection step the existing `test-minion-rpc-e2e.sh` / `test-e2e.sh` smoke scripts use — locate it with `grep -rl "trap" opennms-container/delta-v/*e2e*` and reuse that exact command).
+
+Expected: within a few seconds the consumer prints a record whose key is the alarm's reduction key and whose value is binary protobuf (non-empty).
+
+- [ ] **Step 6: Decode one record to confirm the schema**
+
+Run (replace the offset/partition as needed):
+
+```bash
+docker compose -f opennms-container/delta-v/docker-compose.yml exec kafka \
+  kafka-console-consumer.sh --bootstrap-server localhost:9092 \
+  --topic deltav-alarms-state-change --from-beginning --max-messages 1 | \
+  protoc --decode=deltav.alarms.AlarmState \
+  --proto_path=core/deltav-kafka-contracts/src/main/proto deltav-alarm-state.proto
+```
+
+Expected: a human-readable dump showing `alarm_id`, `reduction_key`, `severity`, `uei` populated.
+
+- [ ] **Step 7: Confirm PG dual-write still works**
+
+Run: `docker compose -f opennms-container/delta-v/docker-compose.yml exec postgres psql -U opennms -c "SELECT alarmid, reductionkey, severity FROM alarms ORDER BY alarmid DESC LIMIT 5;"`
+Expected: the same alarm present in the `alarms` table — Phase 1 dual-write intact.
+
+- [ ] **Step 8: Record the smoke result and commit**
+
+Append a short result note to this plan file under a new `## Track 1 smoke result` heading (date, the log line from Step 3, the decoded record from Step 6), then:
+
+```bash
+git add docs/superpowers/plans/2026-05-17-v1.3.0-track1-alarm-kafka-publisher.md
+git commit -m "docs(alarms): record Track 1 integration smoke result"
+```
+
+---
+
+## Done criteria
+
+- `deltav-alarms-state-change` topic carries a protobuf record on every alarm create/update and a tombstone on every delete.
+- alarmd still writes the PostgreSQL `alarms` table (Phase 1 dual-write).
+- The `AlarmEntityNotifier → AlarmEntityListener → AlarmLifecycleListener` chain delivers real-time callbacks (no longer snapshot-only).
+- All new unit tests pass; all pre-existing alarmd tests still pass.
+- The full chain is verified on the local docker-compose stack with a real alarm.
+
+## Follow-ups (not this track)
+
+- Track 2 — Prometheus alerts forwarder consumes this topic.
+- Track 3 — alarm-state materializer; alarmd's direct PG writes are removed (Phase 2).
+- The release design doc's Track 1 line says key `{location}@{reduction_key}`; this plan uses `reduction_key` alone (delete callback carries no location). Correct the design doc to match.

--- a/docs/superpowers/specs/2026-05-17-v1.3.0-alarms-on-kafka-design.md
+++ b/docs/superpowers/specs/2026-05-17-v1.3.0-alarms-on-kafka-design.md
@@ -127,7 +127,10 @@ is picked up.
   tracking from horizon's `OpennmsKafkaProducer` (the alarm-publishing slice of
   ~650 LOC) — reference, not wholesale port.
 - **Topic:** `deltav-alarms-state-change` — compacted, keyed
-  `{location}@{reduction_key}`, tombstones on delete.
+  `reduction_key`, tombstones on delete. (The key is `reduction_key` alone,
+  not a `{location}@{reduction_key}` composite: the `AlarmLifecycleListener`
+  delete callback supplies no location, so a composite key could not produce
+  a correct tombstone. `reduction_key` is globally unique per alarm.)
 - alarmd **keeps PG writes** for the duration of this track — Phase 1
   dual-write. Kafka is an additional output, not yet the source of truth.
 - **Config:** `deltav.alarmd.kafka-publisher.*`.

--- a/docs/superpowers/specs/2026-05-17-v1.3.0-alarms-on-kafka-design.md
+++ b/docs/superpowers/specs/2026-05-17-v1.3.0-alarms-on-kafka-design.md
@@ -1,0 +1,274 @@
+# Delta-V v1.3.0 — "Alarms on Kafka" — Release Design
+
+> **Status:** Design / release plan. Approved 2026-05-17 in a brainstorming
+> session. No implementation started.
+>
+> **Supersedes for scope:** the v1.3-relevant slice of
+> `docs/plans/2026-05-14-alarmd-northbounder-kafka-consumers.md` (a multi-release
+> roadmap). This document cuts the v1.3-sized slice (build-order items 1, 2, 8, 9)
+> and commits it to four tracks.
+
+## Release theme
+
+**"Alarms on Kafka."** Invert alarm storage so Kafka is the source of truth,
+ship the first standalone alarm consumer (Prometheus alerting), and retire the
+in-process `Northbounder` anti-pattern. This is the alarm-pipeline analog of
+what the event-pipeline rework did for events (`project_eventd_eliminated`):
+state flows through Kafka, PostgreSQL becomes a materialized projection rather
+than a write-contention point.
+
+After v1.3:
+
+- `alarmd` publishes alarm lifecycle to a Kafka topic and **does not write
+  PostgreSQL directly**.
+- A materializer consumer maintains the PG `alarms` table as a read-only view.
+- The Prometheus alerts forwarder is the first standalone Kafka consumer of the
+  alarm stream, and defines the reusable consumer template.
+- The horizon `Northbounder` interface, its six manager classes, and the
+  `opennms-alarms/api` + `opennms-alarms/*-northbounder/` modules are removed
+  from the delta-v reactor.
+
+## Target architecture
+
+```
+   alarmd (lifecycle logic: create/update/ack/clear, reduction-key dedup)
+      |
+      | AlarmLifecycleListener -> protobuf
+      v
+   +----------------------------------+
+   | Kafka: deltav-alarms-state-change |  <- SOURCE OF TRUTH
+   | compacted, keyed {location}@{rk}  |     public contract, single topic,
+   | tombstones on delete              |     consumer-side filtering
+   +----------------------------------+
+      |                          |
+      v                          v
+   alarms-materializer      prometheus-alerts-forwarder
+   (Kafka->PG upsert,       (GlobalKTable join w/ deltav-node-context,
+    idempotent,             labels = low-cardinality / annotations = high,
+    OWNS retention/GC)      POST /api/v2/alerts -> vmalert)
+      |
+      v
+   PostgreSQL alarms table  <- now a READ-ONLY materialized VIEW
+   (UI / REST / SQL queries unchanged)
+```
+
+### Architecture decisions
+
+Carried from the May 14 plan and its PR #269 review, plus decisions made in the
+2026-05-17 brainstorming session:
+
+- **Single topic, consumer-side filtering** — `deltav-alarms-state-change`.
+  alarmd never knows downstream destinations at produce time. Per-destination
+  topics would reintroduce exactly the coupling this release retires.
+- **Public wire contract from day one** — proto versioning and deprecation
+  policy apply. Third-party consumers will appear quickly; the format cannot be
+  broken casually after the first GA.
+- **Thin alarm proto** — `node_id` + `location` only. High-cardinality node
+  metadata (node_label, categories, asset record, parent_node_id) is *not* in
+  the alarm record; consumers join the `deltav-node-context` GlobalKTable for
+  enrichment. Same pattern the Phase 2 prometheus-writer uses for time series.
+- **vmalert as the alert backend.** Delta-v's time-series store is already
+  VictoriaMetrics, so `vmalert` is the natural pairing. The forwarder code is
+  identical for Alertmanager or vmalert — both ingest the Alertmanager
+  `/api/v2/alerts` wire format — so this is an operational choice, not an
+  architectural one.
+- **Kafka SOT migration depth = Phase 1 + Phase 2.** Kafka becomes the source
+  of truth; PG is kept as a materialized view for SQL/UI query expressiveness.
+  Phase 3 (retire the PG table entirely) is explicitly deferred.
+- **Alarm cleanup/GC folds into the materializer.** The long-open alarmd
+  state-management question (`project_alarmd_state_management_strategy_open`)
+  is resolved as a side effect — see "Alarm retention" below.
+- **Standard delta-v conventions for all new code:** `org.deltav.*` packages
+  with delta-v copyright (`feedback_deltav_package_namespace`), Boot 4.0.x,
+  YAML-native config under `deltav.<service>.*`
+  (`feedback_no_shared_config_across_daemons`), `/actuator/prometheus` exposed
+  for the K8s operator (`project_v1_2_app_observability`).
+
+### Alarm retention — resolving the long-open state-management question
+
+The alarmd state-management strategy has been open since the Drools revert
+(PR #259). The user's constraint was explicit: **no hard-coded cleanup
+algorithm inside alarmd.** With Kafka as the source of truth this dissolves:
+
+- alarmd never deletes anything — it only emits lifecycle events.
+- Retention becomes the **materializer's** job. The materializer is a separate
+  service, so cleanup logic there does not violate the "not inside alarmd"
+  constraint.
+- The cleanup windows (horizon's `cleanUp` 5 min, `fullCleanUp` 1 day, `GC`
+  3 days, `fullGC` 8 days equivalents) are expressed as **declarative YAML
+  rules** under `deltav.alarms-materializer.retention.rules` — data, not code.
+- The materializer emits tombstones to the compacted topic for alarms past
+  their window; PG deletes follow from normal materialization.
+
+This combines the design space's Option A (external service) with Option D
+(declarative config) from `project_alarmd_state_management_strategy_open`. The
+"is declarative config still a hard-coded algorithm?" worry from that memo
+evaporates because the logic is no longer in alarmd at all.
+
+## The four tracks
+
+Each track is one design-doc + implementation-plan + PR-series cycle, mirroring
+how v1.2.0 ran. Each track has its own detailed design document written when it
+is picked up.
+
+### Track 1 — Alarm Kafka publisher + proto schema
+
+*Foundation. Must land first — the topic must exist before any consumer.*
+
+- **New module:** `core/alarms-kafka-publisher/`, package
+  `org.deltav.alarms.publisher`.
+- **New proto:** `deltav-alarm-state.proto` — thin schema trimmed from horizon's
+  `OpennmsModelProtos.Alarm`: `alarm_id`, `reduction_key`, `severity`, `uei`,
+  `node_id`, `location`, first/last/ack timestamps, ack state, clear/tombstone
+  marker. Trim-vs-keep is decided per-field in the Track 1 design review,
+  because the proto is a public contract once it ships.
+- **Hook:** implements horizon's `AlarmLifecycleListener`, registered as a
+  Spring bean in alarmd. Lifts batching, error handling, and callback-state
+  tracking from horizon's `OpennmsKafkaProducer` (the alarm-publishing slice of
+  ~650 LOC) — reference, not wholesale port.
+- **Topic:** `deltav-alarms-state-change` — compacted, keyed
+  `{location}@{reduction_key}`, tombstones on delete.
+- alarmd **keeps PG writes** for the duration of this track — Phase 1
+  dual-write. Kafka is an additional output, not yet the source of truth.
+- **Config:** `deltav.alarmd.kafka-publisher.*`.
+- **Test:** fire a trap via Minion -> PG alarm row created -> assert the
+  protobuf record appears on the topic.
+
+### Track 2 — Prometheus alerts forwarder
+
+*The headline consumer. Defines the reusable consumer template.*
+
+- **New service + image:** `deltav/prometheus-alerts-forwarder`, package
+  `org.deltav.alarms.alertsforwarder`.
+- Boot 4 + Kafka Streams. Consumes `deltav-alarms-state-change`, joins the
+  `deltav-node-context` GlobalKTable for high-cardinality enrichment.
+- **Cardinality split:**
+  - `labels` (low cardinality, drives Alertmanager routing) =
+    `severity`, `uei`, `location`, `node_id`.
+  - `annotations` (high cardinality OK, display only) = `node_label`,
+    `node_categories`, asset record fields, alarm description / operator
+    instruction, custom alarm parameters.
+- Builds an Alertmanager `/api/v2/alerts` payload, POSTs to **vmalert**.
+  `endsAt` set to "now" on clear so the backend handles fan-in / replay.
+- Destination I/O happens **off** the Kafka consumer thread.
+- Establishes the **reusable consumer template** — directory layout,
+  `deltav.<consumer>.*` config shape, observability surface, test harness —
+  that future Email / HTTP / Syslog forwarders copy.
+- **Domain metrics:** `deltav_*_alarms_received`, `_alarms_forwarded`,
+  `_forward_latency`, `_downstream_errors`.
+- **Test:** fire alarms -> watch alerts appear in vmalert with correctly
+  enriched annotations; confirm survival of a broker outage.
+
+### Track 3 — Alarm state materializer (Phase 2: Kafka becomes source of truth)
+
+- **New service + image:** `core/alarms-materializer/` — a separate artifact,
+  consistent with delta-v's one-daemon-per-concern thesis.
+- Boot 4 + Kafka Streams. Consumes `deltav-alarms-state-change`, **idempotently
+  upserts** the PG `alarms` view. Lift `AlarmEqualityChecker` from horizon for
+  re-delivery idempotency; `KafkaAlarmDataSync` is the architecture reference.
+- **Owns retention/GC** — declarative `deltav.alarms-materializer.retention.rules`
+  YAML windows; emits tombstones; PG deletes follow. See "Alarm retention" above.
+- **alarmd's direct PG writes are removed in this track** — alarmd publishes
+  only to Kafka. This is the Phase 1 -> Phase 2 inversion.
+- Ship behind a **feature flag** so a misbehaving materializer can roll back to
+  Phase 1 dual-write.
+- A **failure-mode tabletop** is required before the beta3 cutover: what happens
+  if alarmd publishes to Kafka but the materializer has a bug and PG falls
+  behind, and can the rebuilt view be trusted after a topic replay.
+- **Test:** the implementation-agnostic `test-alarm-cleanup-e2e.sh` pattern
+  saved from the Drools session — asserts the alarm row is deleted after the
+  configured window expires. It tests the outcome, not the mechanism.
+
+### Track 4 — Northbounder API retirement
+
+*Lands last.*
+
+- Delete `org.opennms.netmgt.alarmd.northbounder.*` registration and dispatch
+  code from delta-v's alarmd.
+- Drop the six in-process manager beans — Syslog, BSF, SNMPTrap, Drools, Email,
+  JMS — that today register via `Alarmd.registerNorthbounder()`.
+- Drop `opennms-alarms/api` and all `opennms-alarms/*-northbounder/` modules
+  from the delta-v reactor. Horizon upstream retains them.
+- The 12 single-arg `Assert.notNull` sites in the manager classes die with the
+  managers — no horizon PR is spent on them.
+- Update memory `project_future_features` — northbounder retirement DONE.
+- **Pre-work verification:** confirm whether `opennms-alarms/api` is a delta-v
+  reactor module or a horizon pre-built jar. That determines whether a
+  `pbrane/delta-v-horizon` companion PR is needed or delta-v can simply drop the
+  dependency.
+
+## Sequencing
+
+```
+  Track 1 (publisher + topic) --+--> Track 2 (Prometheus forwarder) --+
+                                |                                     +--> Track 4 (API retirement)
+                                +--> Track 3 (materializer, Kafka SOT)-+
+```
+
+- **Track 1 is the gate** — the topic must exist before any consumer is built.
+- **Tracks 2 and 3 proceed in parallel** after Track 1 — both are pure
+  consumers of the topic with no shared state.
+- **Track 4 lands last** — the plan's own rule: delete the `Northbounder` API
+  only after the Prometheus consumer is validated *and* Phase 2 (the
+  materializer) is stable in smoke. Once the interface is gone, the unbuilt
+  destinations (Email, HTTP, Syslog, SNMP-trap, JMS, BSF) are future feature
+  requests, not migration debt.
+
+## RC cadence
+
+Same shape as v1.2.0 (`alpha -> beta -> rc -> GA`):
+
+| Milestone      | Content                                                       |
+|----------------|---------------------------------------------------------------|
+| `v1.3.0-beta1` | Track 1 — publisher + proto on the wire, dual-write           |
+| `v1.3.0-beta2` | Track 2 — Prometheus forwarder; smoke fires alarms -> vmalert |
+| `v1.3.0-beta3` | Track 3 — materializer; alarmd PG writes removed, Kafka = SOT |
+| `v1.3.0-rc1`   | Track 4 — API retirement + full integration smoke             |
+| `v1.3.0-rc{N}` | Smoke-fix iterations on the UTM VM                            |
+| `v1.3.0`       | GA — version-string promotion of the last green rc           |
+
+## Risks and open items
+
+| Risk | Mitigation |
+|---|---|
+| **Proto is a public contract from day one** — a wrong schema is forever. | Lock the proto in the Track 1 design review; decide trim-vs-keep per field before beta1. |
+| **Phase 1 -> Phase 2 transition data loss** — a materializer bug yields a stale or corrupt PG view. | Feature-flagged rollback to dual-write; failure-mode tabletop before the beta3 cutover; the topic is replayable. |
+| **`opennms-alarms/api` reactor-vs-jar ambiguity** — Track 4 may need a `delta-v-horizon` companion PR. | Verify in Track 4 pre-work whether the API module is a delta-v reactor module or a horizon jar. |
+| **`deltav-node-context` GlobalKTable may lack fields** the alerts consumer needs (asset record, parent_node_id). | Audit the protobuf in Track 2 pre-work; coordinate with the prometheus-writer / time-series-pipeline owners who own that schema. |
+| **alarmd-startup regressions are invisible to CI** — the exact failure mode that caused the Drools revert (PRs #257/#258). | Mandatory: every alarmd-affecting PR carries a local docker-compose "boot alarmd" confirmation in its body before merge. Maven build + CI green is not sufficient. |
+
+## Out of scope (deferred to v1.4+)
+
+- **Email / HTTP / Syslog / SNMP-trap / JMS / BSF forwarders** — ship per
+  operator demand, not on speculation. The consumer template from Track 2 makes
+  each one a small build.
+- **Phase 3** — retiring the PG `alarms` table entirely in favour of a Kafka
+  Streams interactive-query store or a Redis projection. Decide only after
+  operating Phase 2 long enough to know whether PG is hurting.
+- **ALEC-on-Kafka** — v1.3 delivers the *integration point* (topic + proto +
+  documented contract); building ALEC as a Kafka consumer is a separate
+  decision with its own stakeholders.
+- **The cloud-native cleanup backlog** — daemon config externalization,
+  cloud-native provisiond requisitions, retire the Default Minion location,
+  Minion image slimming, module restructure, artifactId namespace cleanup.
+  These remain v1.4+ candidates (see the "Looking ahead" section of
+  `docs/plans/2026-04-23-v1.2.0-release-plan.md`).
+
+## References
+
+- `docs/plans/2026-05-14-alarmd-northbounder-kafka-consumers.md` — the parent
+  multi-release roadmap this release plan slices.
+- `docs/plans/2026-04-23-v1.2.0-release-plan.md` — prior release plan; "Looking
+  ahead to v1.3.0" section and the RC-cadence precedent.
+- Memory: `project_alarmd_northbounder_extraction`,
+  `project_alarmd_state_management_strategy_open`,
+  `project_alarmd_alarm_lifecycle_gap`,
+  `project_external_alarm_integrations_as_kafka_consumers`,
+  `project_eventd_eliminated`, `project_kafka_timeseries_pipeline`,
+  `project_v1_2_app_observability`.
+- Horizon source pointers (for Track 1/3 implementation reference):
+  `features/kafka/producer/.../OpennmsKafkaProducer.java`,
+  `.../model/OpennmsModelProtos.java`,
+  `.../datasync/KafkaAlarmDataSync.java`,
+  `.../AlarmEqualityChecker.java`,
+  `opennms-alarms/api/.../AlarmLifecycleListener.java`.


### PR DESCRIPTION
## Summary

Planning artifacts for the **v1.3.0 "Alarms on Kafka"** release. Docs only —
no code. The Track 1 implementation is PR #292.

- `docs/superpowers/specs/2026-05-17-v1.3.0-alarms-on-kafka-design.md` —
  release design: invert alarm storage so Kafka is the source of truth, ship
  the Prometheus alerts forwarder, retire the in-process Northbounder API.
  Four tracks, sequencing, RC cadence, risks.
- `docs/superpowers/plans/2026-05-17-v1.3.0-track1-alarm-kafka-publisher.md` —
  8-task TDD implementation plan for Track 1 (the alarm Kafka publisher).

## The four tracks

1. Alarm Kafka publisher + proto — Phase 1 dual-write *(implemented: PR #292)*
2. Prometheus alerts forwarder — standalone consumer → vmalert
3. Alarm state materializer — Phase 2: Kafka becomes source of truth; owns retention/GC
4. Northbounder API retirement

## Test Plan

- [x] Markdown only; no build impact
- [x] Track 1 plan validated by executing it — see PR #292 (13 unit tests green)