### PR TITLE
feat(v1.3.0): Track 2a — node-context interface enrichment + durable node identity

### DIFF
--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java
@@ -63,7 +63,8 @@ public class AlarmPublisherConfiguration {
     @Bean
     public ApplicationRunner alarmsTopicInitializerRunner(AlarmPublisherProperties properties) {
         return args -> AlarmsTopicInitializer.ensureCompacted(
-                properties.getBootstrapServers(), properties.getTopic());
+                properties.getBootstrapServers(), properties.getTopic(),
+                properties.getPartitions(), properties.getReplicationFactor());
     }
 
     @Bean

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -52,6 +53,17 @@ public class AlarmPublisherConfiguration {
         p.setProperty(ProducerConfig.ACKS_CONFIG, "all");
         p.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "alarmd-publisher");
         return new KafkaProducer<>(p, new StringSerializer(), new ByteArraySerializer());
+    }
+
+    /**
+     * Runs once at startup: ensures deltav-alarms-state-change is compacted.
+     * An ApplicationRunner (not @PostConstruct) so it runs after the context
+     * is fully refreshed and Kafka connectivity is the only dependency.
+     */
+    @Bean
+    public ApplicationRunner alarmsTopicInitializerRunner(AlarmPublisherProperties properties) {
+        return args -> AlarmsTopicInitializer.ensureCompacted(
+                properties.getBootstrapServers(), properties.getTopic());
     }
 
     @Bean

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherProperties.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherProperties.java
@@ -34,6 +34,12 @@ public class AlarmPublisherProperties {
     /** Target topic. */
     private String topic = "deltav-alarms-state-change";
 
+    /** Number of partitions for the alarms topic. Default 8. */
+    private int partitions = 8;
+
+    /** Replication factor for the alarms topic. Default 1. */
+    private short replicationFactor = 1;
+
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
 
@@ -42,4 +48,10 @@ public class AlarmPublisherProperties {
 
     public String getTopic() { return topic; }
     public void setTopic(String topic) { this.topic = topic; }
+
+    public int getPartitions() { return partitions; }
+    public void setPartitions(int v) { this.partitions = v; }
+
+    public short getReplicationFactor() { return replicationFactor; }
+    public void setReplicationFactor(short v) { this.replicationFactor = v; }
 }

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmStateMapper.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmStateMapper.java
@@ -53,6 +53,13 @@ public class AlarmStateMapper {
         setIfNotNull(alarm.getLogMsg(), b::setLogMessage);
         b.setNodeId(alarm.getNodeId() != null ? alarm.getNodeId() : 0);
         b.setLocation(resolveLocation(alarm));
+        if (alarm.getIpAddr() != null) {
+            b.setIpAddress(alarm.getIpAddr().getHostAddress());
+        }
+        if (alarm.getServiceType() != null && alarm.getServiceType().getName() != null) {
+            b.setServiceName(alarm.getServiceType().getName());
+        }
+        b.setIfIndex(alarm.getIfIndex() != null ? alarm.getIfIndex() : 0);
         return b.build();
     }
 

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmsTopicInitializer.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmsTopicInitializer.java
@@ -68,12 +68,13 @@ public final class AlarmsTopicInitializer {
      * Creates the topic compacted, or — if it already exists — alters its
      * config to compaction. Best-effort: any failure is logged and swallowed.
      */
-    public static void ensureCompacted(String bootstrapServers, String topic) {
+    public static void ensureCompacted(String bootstrapServers, String topic,
+                                       int partitions, short replicationFactor) {
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         try (Admin admin = Admin.create(props)) {
             try {
-                admin.createTopics(List.of(compactedTopic(topic, 8, (short) 1)))
+                admin.createTopics(List.of(compactedTopic(topic, partitions, replicationFactor)))
                         .all().get();
                 LOG.info("Created compacted topic {}", topic);
             } catch (ExecutionException e) {

--- a/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmsTopicInitializer.java
+++ b/core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmsTopicInitializer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Ensures the {@code deltav-alarms-state-change} topic exists with
+ * {@code cleanup.policy=compact}. Track 2b's resolve-on-tombstone logic depends
+ * on compaction: the latest record per reduction key must survive forever, and
+ * a null-valued tombstone must eventually garbage-collect a deleted alarm.
+ *
+ * <p>Fresh broker: {@code createTopics} creates the topic compacted. Existing
+ * broker (the topic was auto-created with {@code cleanup.policy=delete}):
+ * {@code createTopics} fails with {@link TopicExistsException} and we fall
+ * through to {@code incrementalAlterConfigs}, switching the live topic to
+ * compaction without data loss.</p>
+ *
+ * <p>Invoked once at startup by {@link AlarmPublisherConfiguration}. Failures
+ * are logged, not fatal — a misconfigured topic degrades Track 2b behaviour
+ * but must not stop alarmd from booting.</p>
+ */
+public final class AlarmsTopicInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmsTopicInitializer.class);
+
+    private AlarmsTopicInitializer() {
+    }
+
+    /** Builds the desired compacted-topic spec. Package-visible for unit testing. */
+    static NewTopic compactedTopic(String name, int partitions, short replicationFactor) {
+        return new NewTopic(name, partitions, replicationFactor)
+                .configs(Map.of(
+                        "cleanup.policy", "compact",
+                        "retention.ms", "-1",
+                        "min.compaction.lag.ms", "60000",
+                        "delete.retention.ms", "86400000"));
+    }
+
+    /**
+     * Creates the topic compacted, or — if it already exists — alters its
+     * config to compaction. Best-effort: any failure is logged and swallowed.
+     */
+    public static void ensureCompacted(String bootstrapServers, String topic) {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        try (Admin admin = Admin.create(props)) {
+            try {
+                admin.createTopics(List.of(compactedTopic(topic, 8, (short) 1)))
+                        .all().get();
+                LOG.info("Created compacted topic {}", topic);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof TopicExistsException) {
+                    alterToCompact(admin, topic);
+                } else {
+                    LOG.warn("Could not create topic {} — Track 2b compaction not guaranteed", topic, e);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted ensuring compacted topic {}", topic, e);
+        } catch (Exception e) {
+            LOG.warn("Could not ensure compacted topic {} — Track 2b compaction not guaranteed", topic, e);
+        }
+    }
+
+    private static void alterToCompact(Admin admin, String topic) {
+        ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+        Map<ConfigResource, java.util.Collection<AlterConfigOp>> ops = Map.of(
+                resource, List.of(
+                        new AlterConfigOp(new ConfigEntry("cleanup.policy", "compact"), AlterConfigOp.OpType.SET),
+                        new AlterConfigOp(new ConfigEntry("retention.ms", "-1"), AlterConfigOp.OpType.SET),
+                        new AlterConfigOp(new ConfigEntry("min.compaction.lag.ms", "60000"), AlterConfigOp.OpType.SET),
+                        new AlterConfigOp(new ConfigEntry("delete.retention.ms", "86400000"), AlterConfigOp.OpType.SET)));
+        try {
+            admin.incrementalAlterConfigs(ops).all().get();
+            LOG.info("Altered existing topic {} to cleanup.policy=compact", topic);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted altering topic {} to compact", topic, e);
+        } catch (Exception e) {
+            LOG.warn("Could not alter topic {} to compact — Track 2b compaction not guaranteed", topic, e);
+        }
+    }
+}

--- a/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java
+++ b/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java
@@ -24,6 +24,7 @@ import org.deltav.alarms.proto.AlarmState;
 import org.junit.jupiter.api.Test;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsServiceType;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 
@@ -103,5 +104,34 @@ public class AlarmStateMapperTest {
 
         assertThat(proto.getAckUser()).isEqualTo("admin");
         assertThat(proto.getAckTimeMs()).isEqualTo(5000L);
+    }
+
+    @Test
+    void interfaceAndServiceIdentityMapped() throws Exception {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+        alarm.setIpAddr(java.net.InetAddress.getByName("192.0.2.10"));
+        alarm.setServiceType(new OnmsServiceType("ICMP"));
+        alarm.setIfIndex(7);
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getIpAddress()).isEqualTo("192.0.2.10");
+        assertThat(proto.getServiceName()).isEqualTo("ICMP");
+        assertThat(proto.getIfIndex()).isEqualTo(7);
+    }
+
+    @Test
+    void interfaceAndServiceIdentityDefaultWhenAbsent() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setReductionKey("rk");
+
+        AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+        assertThat(proto.getIpAddress()).isEmpty();
+        assertThat(proto.getServiceName()).isEmpty();
+        assertThat(proto.getIfIndex()).isZero();
     }
 }

--- a/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmsTopicInitializerTest.java
+++ b/core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmsTopicInitializerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmsTopicInitializerTest {
+
+    @Test
+    void buildsCompactedTopicSpec() {
+        NewTopic topic = AlarmsTopicInitializer.compactedTopic("deltav-alarms-state-change", 8, (short) 1);
+
+        assertThat(topic.name()).isEqualTo("deltav-alarms-state-change");
+        assertThat(topic.numPartitions()).isEqualTo(8);
+        assertThat(topic.replicationFactor()).isEqualTo((short) 1);
+        Map<String, String> cfg = topic.configs();
+        assertThat(cfg).containsEntry("cleanup.policy", "compact");
+        assertThat(cfg).containsEntry("retention.ms", "-1");
+        assertThat(cfg).containsEntry("min.compaction.lag.ms", "60000");
+        assertThat(cfg).containsEntry("delete.retention.ms", "86400000");
+    }
+}

--- a/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/AlarmdApplicationIT.java
+++ b/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/AlarmdApplicationIT.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import java.util.Date;
 
 import org.junit.jupiter.api.Test;
-import org.opennms.netmgt.dao.api.AlarmEntityNotifier;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -39,9 +38,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionOperations;
-import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -84,31 +80,6 @@ class AlarmdApplicationIT {
         @Primary
         public EventSubscriptionService eventSubscriptionService() {
             return mock(EventSubscriptionService.class);
-        }
-
-        @Bean
-        public AlarmEntityNotifier alarmEntityNotifier() {
-            return mock(AlarmEntityNotifier.class);
-        }
-
-        @Bean
-        public org.opennms.netmgt.eventd.EventUtil eventUtil() {
-            return mock(org.opennms.netmgt.eventd.EventUtil.class);
-        }
-
-        @Bean
-        public TransactionOperations transactionOperations(PlatformTransactionManager txManager) {
-            return new TransactionTemplate(txManager);
-        }
-
-        @Bean
-        public org.opennms.netmgt.dao.api.SessionUtils sessionUtils() {
-            return mock(org.opennms.netmgt.dao.api.SessionUtils.class);
-        }
-
-        @Bean(name = "eventProxy")
-        public org.opennms.netmgt.events.api.EventProxy eventProxy() {
-            return mock(org.opennms.netmgt.events.api.EventProxy.class);
         }
 
     }

--- a/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/AlarmdApplicationIT.java
+++ b/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/AlarmdApplicationIT.java
@@ -68,6 +68,7 @@ class AlarmdApplicationIT {
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
         registry.add("opennms.kafka.bootstrap-servers", () -> "localhost:9092");
+        registry.add("deltav.alarmd.kafka-publisher.enabled", () -> "false");
     }
 
     /**

--- a/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslator.java
+++ b/core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslator.java
@@ -19,11 +19,13 @@ package org.deltav.netmgt.provision.nodecontext;
 import org.deltav.timeseries.proto.InterfaceContext;
 import org.deltav.timeseries.proto.NodeContext;
 import org.deltav.timeseries.proto.ServiceContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMetaData;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
 
 /**
  * Pure function. Translates a fully-loaded {@link OnmsNode} (with its
@@ -92,6 +94,26 @@ public class NodeToProtobufTranslator {
                         b.putServiceMetadata(svcKey, sc.build());
                     }
                 }
+            }
+        }
+
+        if (node.getSnmpInterfaces() != null) {
+            for (OnmsSnmpInterface snmp : node.getSnmpInterfaces()) {
+                if (snmp.getIfIndex() == null) {
+                    // ifIndex is the map key — an interface without one cannot
+                    // be addressed; skip it.
+                    continue;
+                }
+                int ifIndex = snmp.getIfIndex();
+                SnmpInterfaceContext.Builder sic = SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(ifIndex)
+                        .setIfName(nullSafe(snmp.getIfName()))
+                        .setIfDescr(nullSafe(snmp.getIfDescr()))
+                        .setIfAlias(nullSafe(snmp.getIfAlias()))
+                        .setIfSpeed(snmp.getIfSpeed() != null ? snmp.getIfSpeed() : 0L)
+                        .setIfType(snmp.getIfType() != null ? snmp.getIfType() : 0)
+                        .setPhysicalAddress(nullSafe(snmp.getPhysAddr()));
+                b.putSnmpInterfaceMetadata(ifIndex, sic.build());
             }
         }
 

--- a/core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslatorTest.java
+++ b/core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslatorTest.java
@@ -69,6 +69,7 @@ class NodeToProtobufTranslatorTest {
         assertThat(ctx.getMetadataCount()).isZero();
         assertThat(ctx.getInterfaceMetadataCount()).isZero();
         assertThat(ctx.getServiceMetadataCount()).isZero();
+        assertThat(ctx.getSnmpInterfaceMetadataCount()).isZero();
     }
 
     @Test
@@ -284,6 +285,7 @@ class NodeToProtobufTranslatorTest {
 
         NodeContext ctx = translator.translate(node, 0L);
 
+        assertThat(ctx.getSnmpInterfaceMetadataCount()).isEqualTo(1);
         assertThat(ctx.getSnmpInterfaceMetadataMap()).containsKey(3);
         SnmpInterfaceContext sic = ctx.getSnmpInterfaceMetadataMap().get(3);
         assertThat(sic.getIfIndex()).isEqualTo(3);

--- a/core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslatorTest.java
+++ b/core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslatorTest.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.util.List;
 
 import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
 import org.junit.jupiter.api.Test;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsIpInterface;
@@ -29,6 +30,7 @@ import org.opennms.netmgt.model.OnmsMetaData;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 
 class NodeToProtobufTranslatorTest {
@@ -263,6 +265,49 @@ class NodeToProtobufTranslatorTest {
         assertThat(ctx.toByteArray()).isNotEmpty();
         assertThat(ctx.getInterfaceMetadataCount()).isEqualTo(100);
         assertThat(ctx.getMetadataCount()).isEqualTo(50);
+    }
+
+    @Test
+    void translate_snmpInterface_keyedByIfIndex() {
+        OnmsNode node = new OnmsNode();
+        node.setId(1);
+        node.setLocation(location("Default"));
+
+        // The 2-arg OnmsSnmpInterface constructor adds itself to node.getSnmpInterfaces().
+        OnmsSnmpInterface snmp = new OnmsSnmpInterface(node, 3);
+        snmp.setIfName("Gi0/3");
+        snmp.setIfDescr("GigabitEthernet0/3");
+        snmp.setIfAlias("uplink-to-core");
+        snmp.setIfSpeed(1_000_000_000L);
+        snmp.setIfType(6);
+        snmp.setPhysAddr("00:11:22:33:44:55");
+
+        NodeContext ctx = translator.translate(node, 0L);
+
+        assertThat(ctx.getSnmpInterfaceMetadataMap()).containsKey(3);
+        SnmpInterfaceContext sic = ctx.getSnmpInterfaceMetadataMap().get(3);
+        assertThat(sic.getIfIndex()).isEqualTo(3);
+        assertThat(sic.getIfName()).isEqualTo("Gi0/3");
+        assertThat(sic.getIfDescr()).isEqualTo("GigabitEthernet0/3");
+        assertThat(sic.getIfAlias()).isEqualTo("uplink-to-core");
+        assertThat(sic.getIfSpeed()).isEqualTo(1_000_000_000L);
+        assertThat(sic.getIfType()).isEqualTo(6);
+        assertThat(sic.getPhysicalAddress()).isEqualTo("00:11:22:33:44:55");
+    }
+
+    @Test
+    void translate_snmpInterface_withNullIfIndex_isSkipped() {
+        OnmsNode node = new OnmsNode();
+        node.setId(1);
+        node.setLocation(location("Default"));
+        OnmsSnmpInterface snmp = new OnmsSnmpInterface();
+        snmp.setNode(node);
+        snmp.setIfName("no-index");          // ifIndex left null
+        node.getSnmpInterfaces().add(snmp);
+
+        NodeContext ctx = translator.translate(node, 0L);
+
+        assertThat(ctx.getSnmpInterfaceMetadataMap()).isEmpty();
     }
 
     // --- helpers ---

--- a/core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto
@@ -82,6 +82,20 @@ message AlarmState {
   // Alarm log message.
   string log_message = 13;
 
+  // IP address the alarm is scoped to (OnmsAlarm.getIpAddr()); empty when the
+  // alarm has no interface scope. Lets a consumer join the alarm to
+  // NodeContext.interface_metadata / service_metadata without a DB lookup.
+  string ip_address = 14;
+
+  // Monitored-service name (e.g. "ICMP", "HTTP"); from
+  // OnmsAlarm.getServiceType().getName(). Empty when the alarm is not
+  // service-scoped.
+  string service_name = 15;
+
+  // SNMP ifIndex (OnmsAlarm.getIfIndex()); 0 when the alarm is not
+  // interface-scoped. Joins to NodeContext.snmp_interface_metadata.
+  int32 if_index = 16;
+
   enum Severity {
     INDETERMINATE = 0;
     CLEARED       = 1;

--- a/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// API version: 1 (FROZEN at Phase 2 GA — delta-v#174)
+// API version: 1 (FROZEN at v1.3.0 GA — Track 2a added snmp_interface_metadata field 12)
 //
 // Public contract for the deltav-node-context Kafka topic.
 //

--- a/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+++ b/core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
@@ -98,6 +98,13 @@ message NodeContext {
   // compaction to eventually garbage-collect the key. Consumers should
   // treat a tombstoned node as "not present."
   bool deleted = 11;
+
+  // SNMP (physical) interface table, keyed by ifIndex. Sourced from
+  // OnmsNode.getSnmpInterfaces(). Distinct from interface_metadata (field 8),
+  // which is keyed by IP address — SNMP interfaces are physical ports keyed by
+  // the integer ifIndex, IP interfaces are L3 addresses. Empty map is valid
+  // and means "no SNMP interfaces discovered for this node."
+  map<int32, SnmpInterfaceContext> snmp_interface_metadata = 12;
 }
 
 // Interface-scoped metadata. Carried as a nested message so the map value
@@ -113,4 +120,31 @@ message InterfaceContext {
 message ServiceContext {
   map<string, string> metadata = 1;
   // Future: service-level display name, criticality hint, etc.
+}
+
+// SNMP (physical) interface — keyed by ifIndex in
+// NodeContext.snmp_interface_metadata. Carries the physical-interface
+// attributes consumers need to label SNMP-interface metrics and alarms
+// (ifName/ifDescr/ifAlias/ifSpeed/ifType). Sourced from OnmsSnmpInterface.
+message SnmpInterfaceContext {
+  // SNMP ifIndex. Matches the map key and OnmsSnmpInterface.getIfIndex().
+  int32 if_index = 1;
+
+  // ifName (e.g. "Gi0/3"). From OnmsSnmpInterface.getIfName().
+  string if_name = 2;
+
+  // ifDescr (e.g. "GigabitEthernet0/3"). From OnmsSnmpInterface.getIfDescr().
+  string if_descr = 3;
+
+  // ifAlias — operator-assigned interface description. From getIfAlias().
+  string if_alias = 4;
+
+  // ifSpeed in bits/sec. From OnmsSnmpInterface.getIfSpeed(); 0 when unknown.
+  int64 if_speed = 5;
+
+  // IANA ifType. From OnmsSnmpInterface.getIfType(); 0 when unknown.
+  int32 if_type = 6;
+
+  // Physical (MAC) address. From OnmsSnmpInterface.getPhysAddr().
+  string physical_address = 7;
 }

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
@@ -4,6 +4,8 @@ package org.deltav.prometheus.writer.nodecontext;
 import org.deltav.timeseries.proto.NodeContext;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -61,8 +63,8 @@ public class NodeContextCache {
      * emitter to sweep all nodes. O(n) copy — called once per emit interval,
      * not on the hot path.
      */
-    public java.util.Collection<NodeContext> snapshot() {
-        return java.util.List.copyOf(map.values());
+    public Collection<NodeContext> snapshot() {
+        return List.copyOf(map.values());
     }
 
     /**

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java
@@ -57,6 +57,15 @@ public class NodeContextCache {
     }
 
     /**
+     * An immutable snapshot of every cached entry. Used by the info-metric
+     * emitter to sweep all nodes. O(n) copy — called once per emit interval,
+     * not on the hot path.
+     */
+    public java.util.Collection<NodeContext> snapshot() {
+        return java.util.List.copyOf(map.values());
+    }
+
+    /**
      * Finds a NodeContext by node_id alone, ignoring location. Used as a
      * fallback when the primary {location}@{node_id} key lookup misses —
      * specifically for the Phase 0 limitation where Delta-V Collectd

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitter.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitter.java
@@ -45,6 +45,10 @@ public class NodeInfoMetricEmitter {
 
     /** Emits an info-metric for every node and SNMP interface in the cache. */
     public void sweep() {
+        if (!cache.isReady()) {
+            LOG.debug("NodeContextCache not yet ready; skipping info-metric sweep");
+            return;
+        }
         long now = System.currentTimeMillis();
         int nodes = 0;
         int interfaces = 0;

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitter.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitter.java
@@ -1,0 +1,90 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodeinfo;
+
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.translate.InstanceLabelResolver;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Sweeps the {@link NodeContextCache} on a schedule and emits Prometheus
+ * info-metrics — gauges with constant value {@code 1.0} — that carry node and
+ * SNMP-interface attributes as labels. Dashboards join data metrics to these
+ * with PromQL {@code group_left} (spec §2.1).
+ *
+ * <p>{@code deltav_node_info}: one sample per node, carrying the durable
+ * {@code node} identity plus node_label / foreign_source / foreign_id /
+ * categories. {@code deltav_snmp_interface_info}: one sample per SNMP
+ * interface, carrying ifName / ifDescr / ifAlias / ifSpeed / ifType.</p>
+ *
+ * <p>Re-emitted every {@code emit-interval} so Prometheus/VM does not stale
+ * the series. The sink is a {@link Consumer} of {@link PromSample} so the
+ * class is unit-testable without a remote-write endpoint.</p>
+ */
+public class NodeInfoMetricEmitter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NodeInfoMetricEmitter.class);
+
+    private final NodeContextCache cache;
+    private final Consumer<PromSample> sink;
+
+    public NodeInfoMetricEmitter(NodeContextCache cache, Consumer<PromSample> sink) {
+        this.cache = cache;
+        this.sink = sink;
+    }
+
+    /** Emits an info-metric for every node and SNMP interface in the cache. */
+    public void sweep() {
+        long now = System.currentTimeMillis();
+        int nodes = 0;
+        int interfaces = 0;
+        for (NodeContext nc : cache.snapshot()) {
+            String node = InstanceLabelResolver.nodeIdentity(nc.getNodeId(), Optional.of(nc));
+            sink.accept(new PromSample("deltav_node_info", nodeLabels(node, nc), 1.0, now));
+            nodes++;
+            for (SnmpInterfaceContext sic : nc.getSnmpInterfaceMetadataMap().values()) {
+                sink.accept(new PromSample(
+                        "deltav_snmp_interface_info", interfaceLabels(node, sic), 1.0, now));
+                interfaces++;
+            }
+        }
+        LOG.debug("Emitted info-metrics: {} nodes, {} SNMP interfaces", nodes, interfaces);
+    }
+
+    private static Map<String, String> nodeLabels(String node, NodeContext nc) {
+        Map<String, String> l = new LinkedHashMap<>();
+        l.put("node", node);
+        l.put("node_id", Integer.toString(nc.getNodeId()));
+        l.put("node_label", nc.getNodeLabel());
+        l.put("foreign_source", nc.getForeignSource());
+        l.put("foreign_id", nc.getForeignId());
+        List<String> cats = new ArrayList<>(nc.getCategoriesList());
+        cats.sort(String::compareTo);
+        l.put("categories", String.join(",", cats));
+        l.put("location", nc.getLocation());
+        return l;
+    }
+
+    private static Map<String, String> interfaceLabels(String node, SnmpInterfaceContext sic) {
+        Map<String, String> l = new LinkedHashMap<>();
+        l.put("node", node);
+        l.put("if_index", Integer.toString(sic.getIfIndex()));
+        l.put("if_name", sic.getIfName());
+        l.put("if_descr", sic.getIfDescr());
+        l.put("if_alias", sic.getIfAlias());
+        l.put("if_speed", Long.toString(sic.getIfSpeed()));
+        l.put("if_type", Integer.toString(sic.getIfType()));
+        l.put("physical_address", sic.getPhysicalAddress());
+        return l;
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterConfiguration.java
@@ -21,7 +21,7 @@ public class NodeInfoMetricEmitterConfiguration {
         return new NodeInfoMetricEmitter(cache, writer::add);
     }
 
-    /** Drives the emitter sweep. Default 60s; override with deltav.node-info.emit-interval-ms. */
+    /** Drives the emitter sweep. Default 60s; override with prometheus-writer.node-info.emit-interval-ms. */
     @Component
     static class NodeInfoEmitterSchedule {
         private final NodeInfoMetricEmitter emitter;
@@ -30,7 +30,7 @@ public class NodeInfoMetricEmitterConfiguration {
             this.emitter = emitter;
         }
 
-        @Scheduled(fixedDelayString = "${deltav.node-info.emit-interval-ms:60000}")
+        @Scheduled(fixedDelayString = "${prometheus-writer.node-info.emit-interval-ms:60000}")
         void tick() {
             emitter.sweep();
         }

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterConfiguration.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterConfiguration.java
@@ -1,0 +1,38 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodeinfo;
+
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.rw.BatchingRwWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wires {@link NodeInfoMetricEmitter} to the live {@link BatchingRwWriter}
+ * remote-write path and drives it on a fixed schedule. {@code @EnableScheduling}
+ * is already on {@code PrometheusWriterApplication}.
+ */
+@Configuration
+public class NodeInfoMetricEmitterConfiguration {
+
+    @Bean
+    public NodeInfoMetricEmitter nodeInfoMetricEmitter(NodeContextCache cache, BatchingRwWriter writer) {
+        return new NodeInfoMetricEmitter(cache, writer::add);
+    }
+
+    /** Drives the emitter sweep. Default 60s; override with deltav.node-info.emit-interval-ms. */
+    @Component
+    static class NodeInfoEmitterSchedule {
+        private final NodeInfoMetricEmitter emitter;
+
+        NodeInfoEmitterSchedule(NodeInfoMetricEmitter emitter) {
+            this.emitter = emitter;
+        }
+
+        @Scheduled(fixedDelayString = "${deltav.node-info.emit-interval-ms:60000}")
+        void tick() {
+            emitter.sweep();
+        }
+    }
+}

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/InstanceLabelResolver.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/InstanceLabelResolver.java
@@ -13,7 +13,9 @@ import java.util.Optional;
  * {@link InstanceSource} policy. Always returns a non-empty string — falls back
  * to {@code "node:{node_id}"} whenever the chosen source produces an empty
  * value, so {@code {instance=""}} never appears on the wire (Grafana templating
- * unhappiness).
+ * unhappiness). Also exposes the static {@link #nodeIdentity(int, java.util.Optional)}
+ * helper — the durable {@code foreignSource:foreignId} node identity used by
+ * {@link LabelBuilder} when populating the {@code node} label.
  */
 @Component
 public class InstanceLabelResolver {

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/InstanceLabelResolver.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/InstanceLabelResolver.java
@@ -30,13 +30,25 @@ public class InstanceLabelResolver {
                 String label = nc.map(NodeContext::getNodeLabel).orElse("");
                 yield label.isEmpty() ? fallback(batch) : label;
             }
-            case FOREIGN_ID -> {
-                String fs = nc.map(NodeContext::getForeignSource).orElse("");
-                String fi = nc.map(NodeContext::getForeignId).orElse("");
-                yield (fs.isEmpty() || fi.isEmpty()) ? fallback(batch) : fs + ":" + fi;
-            }
+            case FOREIGN_ID -> nodeIdentity(batch.getNodeId(), nc);
             case NODE_ID -> fallback(batch);
         };
+    }
+
+    /**
+     * The durable node identity (spec §4): {@code foreignSource:foreignId} when
+     * the node was provisioned, otherwise {@code delta-v:{node_id}} for
+     * discovery/newSuspect nodes that have no requisition. The {@code delta-v:}
+     * prefix keeps the identity uniformly {@code <source>:<id>}-shaped and
+     * honestly namespaces it as a delta-v-internal id rather than a CMDB key.
+     */
+    public static String nodeIdentity(int nodeId, Optional<NodeContext> nc) {
+        String fs = nc.map(NodeContext::getForeignSource).orElse("");
+        String fi = nc.map(NodeContext::getForeignId).orElse("");
+        if (!fs.isEmpty() && !fi.isEmpty()) {
+            return fs + ":" + fi;
+        }
+        return "delta-v:" + nodeId;
     }
 
     private static String fallback(TimeseriesBatch batch) {

--- a/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/LabelBuilder.java
+++ b/core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/LabelBuilder.java
@@ -34,6 +34,7 @@ public class LabelBuilder {
                                      Optional<NodeContext> nc, List<String> metadataAllowlist) {
         Map<String, String> labels = new LinkedHashMap<>();
         labels.put("node_id", Integer.toString(batch.getNodeId()));
+        labels.put("node", InstanceLabelResolver.nodeIdentity(batch.getNodeId(), nc));
         labels.put("instance", instanceResolver.resolve(batch, nc));
         labels.put("location", nullToEmpty(batch.getLocation()));
         labels.put("node_label", nc.map(NodeContext::getNodeLabel).orElse(""));

--- a/core/prometheus-writer/src/main/resources/application.yml
+++ b/core/prometheus-writer/src/main/resources/application.yml
@@ -53,7 +53,7 @@ prometheus-writer:
     # NODE_LABEL  — use the human-readable node label (default; matches Grafana
     #               convention but is mutable — series rename when a node is renamed).
     # FOREIGN_ID  — use "{foreign_source}:{foreign_id}" — stable across renames
-    #               but less recognizable in dashboards. Falls back to "node:{node_id}"
+    #               but less recognizable in dashboards. Falls back to "delta-v:{node_id}"
     #               when foreign_source or foreign_id is empty.
     # NODE_ID     — use "node:{node_id}" — pure stable integer key; ugliest but never
     #               mutates.

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/PrometheusWriterApplicationScanIT.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/PrometheusWriterApplicationScanIT.java
@@ -8,6 +8,7 @@ import org.deltav.prometheus.writer.dlq.DlqPublisher;
 import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
 import org.deltav.prometheus.writer.nodecontext.NodeContextCacheHealthIndicator;
 import org.deltav.prometheus.writer.nodecontext.NodeContextKafkaBootstrap;
+import org.deltav.prometheus.writer.nodeinfo.NodeInfoMetricEmitter;
 import org.deltav.prometheus.writer.rw.BatchingRwWriter;
 import org.deltav.prometheus.writer.rw.ConsumerPauseListener;
 import org.deltav.prometheus.writer.rw.RemoteWriteHttpClient;
@@ -72,6 +73,7 @@ class PrometheusWriterApplicationScanIT {
         assertThat(ctx.getBean(NodeContextCache.class)).isNotNull();
         assertThat(ctx.getBean(NodeContextKafkaBootstrap.class)).isNotNull();
         assertThat(ctx.getBean(NodeContextCacheHealthIndicator.class)).isNotNull();
+        assertThat(ctx.getBean(NodeInfoMetricEmitter.class)).isNotNull();
         // Translation
         assertThat(ctx.getBean(NameSanitizer.class)).isNotNull();
         assertThat(ctx.getBean(LabelBuilder.class)).isNotNull();

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java
@@ -65,6 +65,19 @@ class NodeInfoMetricEmitterTest {
     }
 
     @Test
+    void emitsNothingWhenCacheNotReady() {
+        NodeContextCache cache = new NodeContextCache();
+        // populated but markReady() NOT called — the production "bootstrap replay
+        // still draining" window — the guard must short-circuit.
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).setLocation("Default").build());
+
+        List<PromSample> emitted = new ArrayList<>();
+        new NodeInfoMetricEmitter(cache, emitted::add).sweep();
+
+        assertThat(emitted).isEmpty();
+    }
+
+    @Test
     void emitsOneSnmpInterfaceInfoPerInterface() {
         NodeContextCache cache = new NodeContextCache();
         NodeContext nc = NodeContext.newBuilder()

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java
@@ -1,0 +1,64 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodeinfo;
+
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeInfoMetricEmitterTest {
+
+    @Test
+    void emitsNodeInfoAndSnmpInterfaceInfoSamples() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder()
+                .setNodeId(1042).setLocation("Default")
+                .setNodeLabel("web01.corp").setForeignSource("Servers").setForeignId("web-01")
+                .addCategories("Production")
+                .putSnmpInterfaceMetadata(3, SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(3).setIfName("Gi0/3").setIfDescr("GigabitEthernet0/3")
+                        .setIfAlias("uplink").setIfSpeed(1_000_000_000L).setIfType(6)
+                        .setPhysicalAddress("00:11:22:33:44:55").build())
+                .build();
+        cache.put("Default@1042", nc);
+
+        List<PromSample> emitted = new ArrayList<>();
+        NodeInfoMetricEmitter emitter = new NodeInfoMetricEmitter(cache, emitted::add);
+
+        emitter.sweep();
+
+        PromSample nodeInfo = emitted.stream()
+                .filter(s -> s.name().equals("deltav_node_info")).findFirst().orElseThrow();
+        assertThat(nodeInfo.value()).isEqualTo(1.0);
+        assertThat(nodeInfo.labels()).containsEntry("node", "Servers:web-01");
+        assertThat(nodeInfo.labels()).containsEntry("node_id", "1042");
+        assertThat(nodeInfo.labels()).containsEntry("node_label", "web01.corp");
+        assertThat(nodeInfo.labels()).containsEntry("foreign_source", "Servers");
+        assertThat(nodeInfo.labels()).containsEntry("categories", "Production");
+
+        PromSample ifInfo = emitted.stream()
+                .filter(s -> s.name().equals("deltav_snmp_interface_info")).findFirst().orElseThrow();
+        assertThat(ifInfo.value()).isEqualTo(1.0);
+        assertThat(ifInfo.labels()).containsEntry("node", "Servers:web-01");
+        assertThat(ifInfo.labels()).containsEntry("if_index", "3");
+        assertThat(ifInfo.labels()).containsEntry("if_name", "Gi0/3");
+        assertThat(ifInfo.labels()).containsEntry("if_descr", "GigabitEthernet0/3");
+        assertThat(ifInfo.labels()).containsEntry("if_alias", "uplink");
+        assertThat(ifInfo.labels()).containsEntry("if_speed", "1000000000");
+        assertThat(ifInfo.labels()).containsEntry("if_type", "6");
+    }
+
+    @Test
+    void emitsNothingForEmptyCache() {
+        NodeContextCache cache = new NodeContextCache();
+        List<PromSample> emitted = new ArrayList<>();
+        new NodeInfoMetricEmitter(cache, emitted::add).sweep();
+        assertThat(emitted).isEmpty();
+    }
+}

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java
@@ -27,6 +27,7 @@ class NodeInfoMetricEmitterTest {
                         .setPhysicalAddress("00:11:22:33:44:55").build())
                 .build();
         cache.put("Default@1042", nc);
+        cache.markReady();
 
         List<PromSample> emitted = new ArrayList<>();
         NodeInfoMetricEmitter emitter = new NodeInfoMetricEmitter(cache, emitted::add);
@@ -52,6 +53,7 @@ class NodeInfoMetricEmitterTest {
         assertThat(ifInfo.labels()).containsEntry("if_alias", "uplink");
         assertThat(ifInfo.labels()).containsEntry("if_speed", "1000000000");
         assertThat(ifInfo.labels()).containsEntry("if_type", "6");
+        assertThat(ifInfo.labels()).containsEntry("physical_address", "00:11:22:33:44:55");
     }
 
     @Test
@@ -60,5 +62,42 @@ class NodeInfoMetricEmitterTest {
         List<PromSample> emitted = new ArrayList<>();
         new NodeInfoMetricEmitter(cache, emitted::add).sweep();
         assertThat(emitted).isEmpty();
+    }
+
+    @Test
+    void emitsOneSnmpInterfaceInfoPerInterface() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder()
+                .setNodeId(2001).setLocation("Core")
+                .setNodeLabel("sw01.corp").setForeignSource("Switches").setForeignId("sw-01")
+                .putSnmpInterfaceMetadata(3, SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(3).setIfName("Gi0/3").setIfDescr("GigabitEthernet0/3")
+                        .setIfAlias("uplink-a").setIfSpeed(1_000_000_000L).setIfType(6)
+                        .setPhysicalAddress("AA:BB:CC:DD:EE:03").build())
+                .putSnmpInterfaceMetadata(4, SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(4).setIfName("Gi0/4").setIfDescr("GigabitEthernet0/4")
+                        .setIfAlias("uplink-b").setIfSpeed(1_000_000_000L).setIfType(6)
+                        .setPhysicalAddress("AA:BB:CC:DD:EE:04").build())
+                .build();
+        cache.put("Core@2001", nc);
+        cache.markReady();
+
+        List<PromSample> emitted = new ArrayList<>();
+        new NodeInfoMetricEmitter(cache, emitted::add).sweep();
+
+        long nodeInfoCount = emitted.stream()
+                .filter(s -> s.name().equals("deltav_node_info")).count();
+        long ifInfoCount = emitted.stream()
+                .filter(s -> s.name().equals("deltav_snmp_interface_info")).count();
+
+        assertThat(nodeInfoCount).isEqualTo(1);
+        assertThat(ifInfoCount).isEqualTo(2);
+
+        List<String> ifNames = emitted.stream()
+                .filter(s -> s.name().equals("deltav_snmp_interface_info"))
+                .map(s -> s.labels().get("if_name"))
+                .sorted()
+                .toList();
+        assertThat(ifNames).containsExactly("Gi0/3", "Gi0/4");
     }
 }

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/InstanceLabelResolverTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/InstanceLabelResolverTest.java
@@ -67,21 +67,21 @@ class InstanceLabelResolverTest {
     void foreignIdSource_emptyForeignSource_fallsBackToNodeId() {
         InstanceLabelResolver r = resolver(InstanceSource.FOREIGN_ID);
         assertThat(r.resolve(batch(42), Optional.of(nc("router-1", "", "server-01"))))
-                .isEqualTo("node:42");
+                .isEqualTo("delta-v:42");
     }
 
     @Test
     void foreignIdSource_emptyForeignId_fallsBackToNodeId() {
         InstanceLabelResolver r = resolver(InstanceSource.FOREIGN_ID);
         assertThat(r.resolve(batch(42), Optional.of(nc("router-1", "provision-prod", ""))))
-                .isEqualTo("node:42");
+                .isEqualTo("delta-v:42");
     }
 
     @Test
     void foreignIdSource_absentNodeContext_fallsBackToNodeId() {
         InstanceLabelResolver r = resolver(InstanceSource.FOREIGN_ID);
         assertThat(r.resolve(batch(42), Optional.empty()))
-                .isEqualTo("node:42");
+                .isEqualTo("delta-v:42");
     }
 
     @Test
@@ -90,5 +90,36 @@ class InstanceLabelResolverTest {
         assertThat(r.resolve(batch(42), Optional.of(nc("router-1", "fs", "fi"))))
                 .isEqualTo("node:42");
         assertThat(r.resolve(batch(7), Optional.empty())).isEqualTo("node:7");
+    }
+
+    // --- nodeIdentity static helper ---
+
+    @Test
+    void nodeIdentity_usesForeignSourceColonForeignId() {
+        NodeContext n = NodeContext.newBuilder()
+                .setNodeId(1042).setForeignSource("Servers").setForeignId("web-01").build();
+        assertThat(InstanceLabelResolver.nodeIdentity(1042, Optional.of(n)))
+                .isEqualTo("Servers:web-01");
+    }
+
+    @Test
+    void nodeIdentity_fallsBackToDeltaVPrefixWhenNoForeignSource() {
+        NodeContext n = NodeContext.newBuilder().setNodeId(1042).build();
+        assertThat(InstanceLabelResolver.nodeIdentity(1042, Optional.of(n)))
+                .isEqualTo("delta-v:1042");
+    }
+
+    @Test
+    void nodeIdentity_fallsBackWhenNodeContextAbsent() {
+        assertThat(InstanceLabelResolver.nodeIdentity(77, Optional.empty()))
+                .isEqualTo("delta-v:77");
+    }
+
+    @Test
+    void nodeIdentity_fallsBackWhenForeignIdEmpty() {
+        NodeContext n = NodeContext.newBuilder()
+                .setNodeId(5).setForeignSource("Servers").build();   // foreignId empty
+        assertThat(InstanceLabelResolver.nodeIdentity(5, Optional.of(n)))
+                .isEqualTo("delta-v:5");
     }
 }

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java
@@ -205,10 +205,11 @@ class LabelBuilderTest {
         Map<String, String> labels = labelBuilder.build(b, r, Optional.empty(), List.of());
 
         assertThat(labels).containsEntry("foreign_id", "");
+        assertThat(labels).containsEntry("node", "delta-v:7");
     }
 
     @Test
-    void node_label_is_durable_composite_identity() {
+    void node_identity_is_durable_composite() {
         TimeseriesBatch b = batch(1042, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
         Resource r = resource("node", "");
         NodeContext n = nc("web01.corp", "Servers", "web-01", List.of(), Map.of());
@@ -219,7 +220,7 @@ class LabelBuilderTest {
     }
 
     @Test
-    void node_label_falls_back_to_delta_v_prefix_for_discovery_node() {
+    void node_identity_falls_back_to_delta_v_prefix_for_discovery_node() {
         TimeseriesBatch b = batch(1042, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
         Resource r = resource("node", "");
         NodeContext n = nc("scanned-host", "", "", List.of(), Map.of());

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java
@@ -73,9 +73,9 @@ class LabelBuilderTest {
         Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
 
         assertThat(labels.keySet()).containsExactlyInAnyOrder(
-                "node_id", "instance", "location", "node_label", "foreign_source", "foreign_id",
+                "node_id", "node", "instance", "location", "node_label", "foreign_source", "foreign_id",
                 "categories", "resource_type", "resource_instance", "collection_package", "producer");
-        assertThat(labels).hasSize(11);
+        assertThat(labels).hasSize(12);
         assertThat(labels.get("node_id")).isEqualTo("42");
         assertThat(labels.get("instance")).isEqualTo("router-1");
         assertThat(labels.get("location")).isEqualTo("Default");
@@ -205,5 +205,27 @@ class LabelBuilderTest {
         Map<String, String> labels = labelBuilder.build(b, r, Optional.empty(), List.of());
 
         assertThat(labels).containsEntry("foreign_id", "");
+    }
+
+    @Test
+    void node_label_is_durable_composite_identity() {
+        TimeseriesBatch b = batch(1042, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("web01.corp", "Servers", "web-01", List.of(), Map.of());
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+        assertThat(labels).containsEntry("node", "Servers:web-01");
+    }
+
+    @Test
+    void node_label_falls_back_to_delta_v_prefix_for_discovery_node() {
+        TimeseriesBatch b = batch(1042, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+        Resource r = resource("node", "");
+        NodeContext n = nc("scanned-host", "", "", List.of(), Map.of());
+
+        Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+        assertThat(labels).containsEntry("node", "delta-v:1042");
     }
 }

--- a/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslatorTest.java
+++ b/core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/TimeseriesToPromTranslatorTest.java
@@ -175,8 +175,8 @@ class TimeseriesToPromTranslatorTest {
         assertThat(samples).hasSize(1);
         Map<String, String> labels = samples.get(0).labels();
         assertThat(labels.keySet()).containsExactlyInAnyOrder(
-                "node_id", "instance", "location", "node_label", "foreign_source", "foreign_id",
+                "node_id", "node", "instance", "location", "node_label", "foreign_source", "foreign_id",
                 "categories", "resource_type", "resource_instance", "collection_package", "producer");
-        assertThat(labels).hasSize(11);
+        assertThat(labels).hasSize(12);
     }
 }


### PR DESCRIPTION
## Summary

Track 2a of v1.3.0 "Alarms on Kafka" — the shared contract/producer/consumer infrastructure that Track 2b's alerts-forwarder will depend on.

- **Contracts** (additive only, frozen-v1 rules) — `deltav-node-context.proto` gains `SnmpInterfaceContext` + `snmp_interface_metadata` map (tag 12); `deltav-alarm-state.proto` gains `ip_address`/`service_name`/`if_index` (tags 14/15/16).
- **provisiond** — `NodeToProtobufTranslator` now populates `snmp_interface_metadata` from `OnmsNode.getSnmpInterfaces()`.
- **alarmd** — `AlarmStateMapper` populates the new alarm identity fields; new `AlarmsTopicInitializer` declares `deltav-alarms-state-change` as `cleanup.policy=compact` via `AdminClient` (create-or-incrementalAlterConfigs) so existing dev brokers self-heal.
- **prometheus-writer** — `InstanceLabelResolver.nodeIdentity(...)` produces the durable `foreignSource:foreignId` composite (`delta-v:{node_id}` fallback for discovery nodes); `LabelBuilder` emits a `node` label on every series; latent `FOREIGN_ID` policy bug (joined on `foreign_id` alone — non-unique across requisitions) fixed; new `NodeInfoMetricEmitter` sweeps the `NodeContextCache` every 60s and emits `deltav_node_info` + `deltav_snmp_interface_info` info-metrics for PromQL `group_left` joins (guarded on cache readiness).

Spec: \`docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md\` §3 + §4.
Plan: \`docs/superpowers/plans/2026-05-19-v1.3.0-track2a-node-context-interface-enrichment.md\`.

(The spec + Track 2a/2b plan docs are on a companion branch \`docs/v1.3.0-track2-alerts-forwarder-design\` — separate PR to follow.)

## Test Plan

- [x] All per-module unit tests green (JUnit 5 Jupiter).
- [x] Cross-module \`./mvnw clean install\` for contracts + provisiond + alarms-kafka-publisher + alarmd + prometheus-writer + \`-am\` dependents — BUILD SUCCESS, all failsafe ITs included.
- [x] Docker-compose end-to-end smoke (spec §3.4 acceptance test): VictoriaMetrics shows 30 \`deltav_node_info\` series + 642 \`deltav_snmp_interface_info\` series; every \`node\` label is the \`foreignSource:foreignId\` composite; the two info-metrics join cleanly on \`node\`. \`deltav-alarms-state-change\` confirmed \`cleanup.policy=compact\` (alarmd log: "Altered existing topic deltav-alarms-state-change to cleanup.policy=compact").

## Notes for reviewers

- Two proto changes are strictly additive — no field renumbered, no semantic change to existing fields.
- The \`AlarmdApplicationIT\` test-config diff removes five mock beans that were duplicates of beans \`AlarmdConfiguration\` already provides (predating Track 1). Spring Boot 4's \`allow-bean-definition-overriding=false\` had been silently breaking the IT on \`develop\` since pre-Track-1; the cross-module \`clean install\` here surfaced it. The IT's three \`@Test\` methods are untouched.
- Two small operational notes from the smoke worth folding into the plan: VictoriaMetrics is published on host port \`18428\` (not 8428), and \`docker compose up -d\` does not redeploy retagged images onto already-running containers without \`--force-recreate\`.

## Sequencing

Track 2a gates Track 2b (the alerts-forwarder module, separate plan).