### PR TITLE
docs(v1.3.0): Track 2 design spec + Track 2a/2b implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-05-19-v1.3.0-track2a-node-context-interface-enrichment.md
+++ b/docs/superpowers/plans/2026-05-19-v1.3.0-track2a-node-context-interface-enrichment.md
@@ -1,0 +1,1057 @@
+# v1.3.0 Track 2a — Node-Context Interface Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the `deltav-node-context` and `deltav-alarm-state` Kafka contracts (and their producers) to carry SNMP physical-interface attributes and alarm interface/service identity, so downstream consumers can join metrics and alarms to durable node identity.
+
+**Architecture:** Two additive protobuf changes in `core/deltav-kafka-contracts` (forward-compatible, frozen-v1 rules — new tag numbers only). provisiond's `NodeToProtobufTranslator` is extended to populate an ifIndex-keyed SNMP-interface map; alarmd's `AlarmStateMapper` is extended to populate IP/service/ifIndex identity. A startup initializer makes `deltav-alarms-state-change` a compacted topic. prometheus-writer adopts the new fields — fixing a latent identity bug and emitting info-metrics — which validates the contract end-to-end.
+
+**Tech Stack:** Java 21, Spring Boot 4, protobuf 3.25.5 (`protobuf-maven-plugin` 0.6.1), Apache Kafka client 4.1.1, JUnit 5 Jupiter, AssertJ, Mockito.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md` §3, §4.
+
+---
+
+## Conventions for every task
+
+- Build the whole reactor with `./mvnw` (delta-v ships its own wrapper — `compile.pl` does not exist here).
+- New code uses the `org.deltav` package namespace and the `BeaconStrategists, Inc.` copyright header (see existing files in each module for the exact header text).
+- Tests are JUnit 5 Jupiter ONLY. JUnit 4 tests silently skip (0 run) under delta-v's surefire.
+- When a change adds a dependency or a generated class to a module other modules consume, downstream modules must `./mvnw clean install` — a plain `install` re-uses the stale repackaged jar.
+- Commit after every task with a Conventional Commit message.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto` | + `SnmpInterfaceContext` message, + `snmp_interface_metadata` map | 1 |
+| `core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto` | + `ip_address`, `service_name`, `if_index` fields | 2 |
+| `core/daemon-boot-provisiond/.../nodecontext/NodeToProtobufTranslator.java` | populate `snmp_interface_metadata` from `OnmsNode.getSnmpInterfaces()` | 3 |
+| `core/alarms-kafka-publisher/.../publisher/AlarmStateMapper.java` | populate `ip_address`/`service_name`/`if_index` from `OnmsAlarm` | 4 |
+| `core/alarms-kafka-publisher/.../publisher/AlarmsTopicInitializer.java` (new) | declare `deltav-alarms-state-change` compacted via `AdminClient` | 5 |
+| `core/prometheus-writer/.../translate/InstanceLabelResolver.java` | fix `FOREIGN_ID` policy to a `foreignSource:foreignId` composite | 6 |
+| `core/prometheus-writer/.../translate/LabelBuilder.java` | emit the durable composite `node` label + `delta-v:` fallback | 6 |
+| `core/prometheus-writer/.../nodeinfo/NodeInfoMetricEmitter.java` (new) | scheduled emit of `deltav_node_info` + `deltav_snmp_interface_info` | 7 |
+
+---
+
+## Task 1: Extend `deltav-node-context.proto` with the SNMP-interface table
+
+**Files:**
+- Modify: `core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto`
+
+The proto is frozen at API v1 — only additive changes (new tag numbers) are allowed. The current `NodeContext` message uses tag numbers 1–11 (highest is `bool deleted = 11`). The new map gets tag **12**. `SnmpInterfaceContext` is a brand-new message; its internal tags start at 1.
+
+- [ ] **Step 1: Add the `snmp_interface_metadata` field to `NodeContext`**
+
+In `deltav-node-context.proto`, inside `message NodeContext { ... }`, immediately after the `bool deleted = 11;` field (and its comment block), add:
+
+```proto
+  // SNMP (physical) interface table, keyed by ifIndex. Sourced from
+  // OnmsNode.getSnmpInterfaces(). Distinct from interface_metadata (field 8),
+  // which is keyed by IP address — SNMP interfaces are physical ports keyed by
+  // the integer ifIndex, IP interfaces are L3 addresses. Empty map is valid
+  // and means "no SNMP interfaces discovered for this node."
+  map<int32, SnmpInterfaceContext> snmp_interface_metadata = 12;
+```
+
+- [ ] **Step 2: Add the `SnmpInterfaceContext` message**
+
+At the end of the file, after `message ServiceContext { ... }`, add:
+
+```proto
+// SNMP (physical) interface — keyed by ifIndex in
+// NodeContext.snmp_interface_metadata. Carries the physical-interface
+// attributes consumers need to label SNMP-interface metrics and alarms
+// (ifName/ifDescr/ifAlias/ifSpeed/ifType). Sourced from OnmsSnmpInterface.
+message SnmpInterfaceContext {
+  // SNMP ifIndex. Matches the map key and OnmsSnmpInterface.getIfIndex().
+  int32 if_index = 1;
+
+  // ifName (e.g. "Gi0/3"). From OnmsSnmpInterface.getIfName().
+  string if_name = 2;
+
+  // ifDescr (e.g. "GigabitEthernet0/3"). From OnmsSnmpInterface.getIfDescr().
+  string if_descr = 3;
+
+  // ifAlias — operator-assigned interface description. From getIfAlias().
+  string if_alias = 4;
+
+  // ifSpeed in bits/sec. From OnmsSnmpInterface.getIfSpeed(); 0 when unknown.
+  int64 if_speed = 5;
+
+  // IANA ifType. From OnmsSnmpInterface.getIfType(); 0 when unknown.
+  int32 if_type = 6;
+
+  // Physical (MAC) address. From OnmsSnmpInterface.getPhysAddr().
+  string physical_address = 7;
+}
+```
+
+- [ ] **Step 3: Regenerate and verify the generated API**
+
+Run: `./mvnw -q -pl :org.opennms.core.deltav-kafka-contracts clean install`
+Expected: `BUILD SUCCESS`.
+
+Run: `grep -c 'getSnmpInterfaceMetadataMap\|class SnmpInterfaceContext' core/deltav-kafka-contracts/target/generated-sources/protobuf/java/org/deltav/timeseries/proto/NodeContext.java core/deltav-kafka-contracts/target/generated-sources/protobuf/java/org/deltav/timeseries/proto/SnmpInterfaceContext.java`
+Expected: both files exist and the grep finds matches (the protoc plugin generated `NodeContext.getSnmpInterfaceMetadataMap()` and the new `SnmpInterfaceContext` class — `java_multiple_files = true` puts each message in its own file).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/deltav-kafka-contracts/src/main/proto/deltav-node-context.proto
+git commit -m "feat(contracts): add SnmpInterfaceContext to deltav-node-context proto"
+```
+
+---
+
+## Task 2: Extend `deltav-alarm-state.proto` with interface/service identity
+
+**Files:**
+- Modify: `core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto`
+
+`AlarmState` currently uses tag numbers 1–13 (highest is `string log_message = 13;`). The `enum Severity` is declared inside the message after field 13. New fields get tags **14, 15, 16** and are inserted after field 13 but before the `enum Severity` block.
+
+- [ ] **Step 1: Add the three identity fields**
+
+In `deltav-alarm-state.proto`, inside `message AlarmState { ... }`, immediately after `string log_message = 13;` and immediately before the `enum Severity {` line, add:
+
+```proto
+  // IP address the alarm is scoped to (OnmsAlarm.getIpAddr()); empty when the
+  // alarm has no interface scope. Lets a consumer join the alarm to
+  // NodeContext.interface_metadata / service_metadata without a DB lookup.
+  string ip_address = 14;
+
+  // Monitored-service name (e.g. "ICMP", "HTTP"); from
+  // OnmsAlarm.getServiceType().getName(). Empty when the alarm is not
+  // service-scoped.
+  string service_name = 15;
+
+  // SNMP ifIndex (OnmsAlarm.getIfIndex()); 0 when the alarm is not
+  // interface-scoped. Joins to NodeContext.snmp_interface_metadata.
+  int32 if_index = 16;
+```
+
+- [ ] **Step 2: Regenerate and verify**
+
+Run: `./mvnw -q -pl :org.opennms.core.deltav-kafka-contracts clean install`
+Expected: `BUILD SUCCESS`.
+
+Run: `grep -c 'getIpAddress\|getServiceName\|getIfIndex' core/deltav-kafka-contracts/target/generated-sources/protobuf/java/org/deltav/alarms/proto/AlarmState.java`
+Expected: a count ≥ 3 (the three new getters were generated).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/deltav-kafka-contracts/src/main/proto/deltav-alarm-state.proto
+git commit -m "feat(contracts): add ip_address/service_name/if_index to deltav-alarm-state proto"
+```
+
+---
+
+## Task 3: Populate `snmp_interface_metadata` in provisiond's translator
+
+**Files:**
+- Modify: `core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslator.java`
+- Test: `core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslatorTest.java`
+
+`NodeToProtobufTranslator.translate(OnmsNode, long)` currently iterates IP interfaces and services. It must also iterate `node.getSnmpInterfaces()` (returns `Set<OnmsSnmpInterface>`) and populate the new map. `OnmsSnmpInterface` getters: `getIfIndex()` → `Integer`, `getIfName()`/`getIfDescr()`/`getIfAlias()`/`getPhysAddr()` → `String`, `getIfSpeed()` → `Long`, `getIfType()` → `Integer`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test method to `NodeToProtobufTranslatorTest.java` (the class already imports `OnmsNode`, AssertJ, JUnit 5, and has a `translator` field and a `location(String)` helper — match the existing style):
+
+```java
+@Test
+void translate_snmpInterface_keyedByIfIndex() {
+    OnmsNode node = new OnmsNode();
+    node.setId(1);
+    node.setLocation(location("Default"));
+
+    // The 2-arg OnmsSnmpInterface constructor adds itself to node.getSnmpInterfaces().
+    OnmsSnmpInterface snmp = new OnmsSnmpInterface(node, 3);
+    snmp.setIfName("Gi0/3");
+    snmp.setIfDescr("GigabitEthernet0/3");
+    snmp.setIfAlias("uplink-to-core");
+    snmp.setIfSpeed(1_000_000_000L);
+    snmp.setIfType(6);
+    snmp.setPhysAddr("00:11:22:33:44:55");
+
+    NodeContext ctx = translator.translate(node, 0L);
+
+    assertThat(ctx.getSnmpInterfaceMetadataMap()).containsKey(3);
+    SnmpInterfaceContext sic = ctx.getSnmpInterfaceMetadataMap().get(3);
+    assertThat(sic.getIfIndex()).isEqualTo(3);
+    assertThat(sic.getIfName()).isEqualTo("Gi0/3");
+    assertThat(sic.getIfDescr()).isEqualTo("GigabitEthernet0/3");
+    assertThat(sic.getIfAlias()).isEqualTo("uplink-to-core");
+    assertThat(sic.getIfSpeed()).isEqualTo(1_000_000_000L);
+    assertThat(sic.getIfType()).isEqualTo(6);
+    assertThat(sic.getPhysicalAddress()).isEqualTo("00:11:22:33:44:55");
+}
+
+@Test
+void translate_snmpInterface_withNullIfIndex_isSkipped() {
+    OnmsNode node = new OnmsNode();
+    node.setId(1);
+    node.setLocation(location("Default"));
+    OnmsSnmpInterface snmp = new OnmsSnmpInterface();
+    snmp.setNode(node);
+    snmp.setIfName("no-index");          // ifIndex left null
+    node.getSnmpInterfaces().add(snmp);
+
+    NodeContext ctx = translator.translate(node, 0L);
+
+    assertThat(ctx.getSnmpInterfaceMetadataMap()).isEmpty();
+}
+```
+
+Add the imports `org.opennms.netmgt.model.OnmsSnmpInterface` and `org.deltav.timeseries.proto.SnmpInterfaceContext` to the test file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :daemon-boot-provisiond -Dtest=NodeToProtobufTranslatorTest test`
+Expected: FAIL — compilation error (`getSnmpInterfaceMetadataMap` not yet produced by the translator path) or assertion failure (`expected to contain key 3` — the map is empty because the translator does not populate it).
+
+- [ ] **Step 3: Implement the translation**
+
+In `NodeToProtobufTranslator.java`, add this import near the other `org.opennms.netmgt.model.*` imports:
+
+```java
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+```
+
+In `translate(OnmsNode node, long updatedAtMs)`, immediately before the closing `return b.build();`, add:
+
+```java
+        if (node.getSnmpInterfaces() != null) {
+            for (OnmsSnmpInterface snmp : node.getSnmpInterfaces()) {
+                if (snmp.getIfIndex() == null) {
+                    // ifIndex is the map key — an interface without one cannot
+                    // be addressed; skip it.
+                    continue;
+                }
+                int ifIndex = snmp.getIfIndex();
+                SnmpInterfaceContext.Builder sic = SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(ifIndex)
+                        .setIfName(nullSafe(snmp.getIfName()))
+                        .setIfDescr(nullSafe(snmp.getIfDescr()))
+                        .setIfAlias(nullSafe(snmp.getIfAlias()))
+                        .setIfSpeed(snmp.getIfSpeed() != null ? snmp.getIfSpeed() : 0L)
+                        .setIfType(snmp.getIfType() != null ? snmp.getIfType() : 0)
+                        .setPhysicalAddress(nullSafe(snmp.getPhysAddr()));
+                b.putSnmpInterfaceMetadata(ifIndex, sic.build());
+            }
+        }
+```
+
+(`nullSafe` is the existing private helper in this class.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :daemon-boot-provisiond -Dtest=NodeToProtobufTranslatorTest test`
+Expected: PASS — all `NodeToProtobufTranslatorTest` methods green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/daemon-boot-provisiond/src/main/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslator.java \
+        core/daemon-boot-provisiond/src/test/java/org/deltav/netmgt/provision/nodecontext/NodeToProtobufTranslatorTest.java
+git commit -m "feat(provisiond): publish SNMP interface table in node-context records"
+```
+
+---
+
+## Task 4: Populate alarm interface/service identity in `AlarmStateMapper`
+
+**Files:**
+- Modify: `core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmStateMapper.java`
+- Test: `core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java`
+
+`AlarmStateMapper.toProto(OnmsAlarm)` maps an `OnmsAlarm` to the `AlarmState` proto. `OnmsAlarm` getters: `getIpAddr()` → `java.net.InetAddress`, `getServiceType()` → `OnmsServiceType` (has `getName()` → `String`), `getIfIndex()` → `Integer`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AlarmStateMapperTest.java` (match the existing JUnit 5 + AssertJ style; the class builds `OnmsAlarm` directly):
+
+```java
+@Test
+void interfaceAndServiceIdentityMapped() throws Exception {
+    OnmsAlarm alarm = new OnmsAlarm();
+    alarm.setId(1);
+    alarm.setReductionKey("rk");
+    alarm.setIpAddr(java.net.InetAddress.getByName("192.0.2.10"));
+    alarm.setServiceType(new OnmsServiceType("ICMP"));
+    alarm.setIfIndex(7);
+
+    AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+    assertThat(proto.getIpAddress()).isEqualTo("192.0.2.10");
+    assertThat(proto.getServiceName()).isEqualTo("ICMP");
+    assertThat(proto.getIfIndex()).isEqualTo(7);
+}
+
+@Test
+void interfaceAndServiceIdentityDefaultWhenAbsent() {
+    OnmsAlarm alarm = new OnmsAlarm();
+    alarm.setId(1);
+    alarm.setReductionKey("rk");
+
+    AlarmState proto = new AlarmStateMapper().toProto(alarm);
+
+    assertThat(proto.getIpAddress()).isEmpty();
+    assertThat(proto.getServiceName()).isEmpty();
+    assertThat(proto.getIfIndex()).isZero();
+}
+```
+
+Add the import `org.opennms.netmgt.model.OnmsServiceType` to the test file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alarms-kafka-publisher -Dtest=AlarmStateMapperTest test`
+Expected: FAIL — `getIpAddress()` returns empty / `getIfIndex()` returns 0 because the mapper does not set them yet (the first test fails its assertions; the second would pass but proves nothing until the mapper compiles against the new fields).
+
+- [ ] **Step 3: Implement the mapping**
+
+In `AlarmStateMapper.java`, in `toProto(OnmsAlarm alarm)`, immediately before `return b.build();`, add:
+
+```java
+        if (alarm.getIpAddr() != null) {
+            b.setIpAddress(alarm.getIpAddr().getHostAddress());
+        }
+        if (alarm.getServiceType() != null && alarm.getServiceType().getName() != null) {
+            b.setServiceName(alarm.getServiceType().getName());
+        }
+        b.setIfIndex(alarm.getIfIndex() != null ? alarm.getIfIndex() : 0);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alarms-kafka-publisher -Dtest=AlarmStateMapperTest test`
+Expected: PASS — all `AlarmStateMapperTest` methods green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmStateMapper.java \
+        core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmStateMapperTest.java
+git commit -m "feat(alarmd): publish ip_address/service_name/if_index in alarm-state records"
+```
+
+---
+
+## Task 5: Declare `deltav-alarms-state-change` as a compacted topic
+
+**Files:**
+- Create: `core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmsTopicInitializer.java`
+- Modify: `core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java`
+- Test: `core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmsTopicInitializerTest.java`
+
+`deltav-alarms-state-change` is currently broker-auto-created with `cleanup.policy=delete` and a 1-hour retention. Track 2b's resolve-on-tombstone design requires `cleanup.policy=compact`. The `alarms-kafka-publisher` module uses the raw `kafka-clients` library (no Spring Kafka `KafkaAdmin`), so we cannot use the `NewTopic` bean pattern that `NodeContextProducerConfiguration` uses. Instead, an initializer uses `AdminClient` directly: it tries `createTopics` (works on a fresh broker), and on `TopicExistsException` it issues `incrementalAlterConfigs` to switch an already-existing topic to compaction.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `AlarmsTopicInitializerTest.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmsTopicInitializerTest {
+
+    @Test
+    void buildsCompactedTopicSpec() {
+        NewTopic topic = AlarmsTopicInitializer.compactedTopic("deltav-alarms-state-change", 8, (short) 1);
+
+        assertThat(topic.name()).isEqualTo("deltav-alarms-state-change");
+        assertThat(topic.numPartitions()).isEqualTo(8);
+        assertThat(topic.replicationFactor()).isEqualTo((short) 1);
+        Map<String, String> cfg = topic.configs();
+        assertThat(cfg).containsEntry("cleanup.policy", "compact");
+        assertThat(cfg).containsEntry("retention.ms", "-1");
+        assertThat(cfg).containsEntry("min.compaction.lag.ms", "60000");
+        assertThat(cfg).containsEntry("delete.retention.ms", "86400000");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alarms-kafka-publisher -Dtest=AlarmsTopicInitializerTest test`
+Expected: FAIL — compilation error: `AlarmsTopicInitializer` does not exist.
+
+- [ ] **Step 3: Create `AlarmsTopicInitializer`**
+
+Create `AlarmsTopicInitializer.java`:
+
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.alarms.publisher;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Ensures the {@code deltav-alarms-state-change} topic exists with
+ * {@code cleanup.policy=compact}. Track 2b's resolve-on-tombstone logic depends
+ * on compaction: the latest record per reduction key must survive forever, and
+ * a null-valued tombstone must eventually garbage-collect a deleted alarm.
+ *
+ * <p>Fresh broker: {@code createTopics} creates the topic compacted. Existing
+ * broker (the topic was auto-created with {@code cleanup.policy=delete}):
+ * {@code createTopics} fails with {@link TopicExistsException} and we fall
+ * through to {@code incrementalAlterConfigs}, switching the live topic to
+ * compaction without data loss.</p>
+ *
+ * <p>Invoked once at startup by {@link AlarmPublisherConfiguration}. Failures
+ * are logged, not fatal — a misconfigured topic degrades Track 2b behaviour
+ * but must not stop alarmd from booting.</p>
+ */
+public final class AlarmsTopicInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmsTopicInitializer.class);
+
+    private AlarmsTopicInitializer() {
+    }
+
+    /** Builds the desired compacted-topic spec. Package-visible for unit testing. */
+    static NewTopic compactedTopic(String name, int partitions, short replicationFactor) {
+        return new NewTopic(name, partitions, replicationFactor)
+                .configs(Map.of(
+                        "cleanup.policy", "compact",
+                        "retention.ms", "-1",
+                        "min.compaction.lag.ms", "60000",
+                        "delete.retention.ms", "86400000"));
+    }
+
+    /**
+     * Creates the topic compacted, or — if it already exists — alters its
+     * config to compaction. Best-effort: any failure is logged and swallowed.
+     */
+    public static void ensureCompacted(String bootstrapServers, String topic) {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        try (Admin admin = Admin.create(props)) {
+            try {
+                admin.createTopics(List.of(compactedTopic(topic, 8, (short) 1)))
+                        .all().get();
+                LOG.info("Created compacted topic {}", topic);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof TopicExistsException) {
+                    alterToCompact(admin, topic);
+                } else {
+                    LOG.warn("Could not create topic {} — Track 2b compaction not guaranteed", topic, e);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted ensuring compacted topic {}", topic, e);
+        } catch (Exception e) {
+            LOG.warn("Could not ensure compacted topic {} — Track 2b compaction not guaranteed", topic, e);
+        }
+    }
+
+    private static void alterToCompact(Admin admin, String topic) {
+        ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+        Map<ConfigResource, java.util.Collection<AlterConfigOp>> ops = Map.of(
+                resource, List.of(
+                        new AlterConfigOp(new ConfigEntry("cleanup.policy", "compact"), AlterConfigOp.OpType.SET),
+                        new AlterConfigOp(new ConfigEntry("retention.ms", "-1"), AlterConfigOp.OpType.SET),
+                        new AlterConfigOp(new ConfigEntry("min.compaction.lag.ms", "60000"), AlterConfigOp.OpType.SET),
+                        new AlterConfigOp(new ConfigEntry("delete.retention.ms", "86400000"), AlterConfigOp.OpType.SET)));
+        try {
+            admin.incrementalAlterConfigs(ops).all().get();
+            LOG.info("Altered existing topic {} to cleanup.policy=compact", topic);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted altering topic {} to compact", topic, e);
+        } catch (Exception e) {
+            LOG.warn("Could not alter topic {} to compact — Track 2b compaction not guaranteed", topic, e);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alarms-kafka-publisher -Dtest=AlarmsTopicInitializerTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the initializer into `AlarmPublisherConfiguration`**
+
+In `AlarmPublisherConfiguration.java`, add — inside the existing `@Configuration` class, as a new method — an `ApplicationRunner` bean that runs the initializer once at startup. Add the imports `org.springframework.boot.ApplicationRunner` and reuse the injected `AlarmPublisherProperties`:
+
+```java
+    /**
+     * Runs once at startup: ensures deltav-alarms-state-change is compacted.
+     * An ApplicationRunner (not @PostConstruct) so it runs after the context
+     * is fully refreshed and Kafka connectivity is the only dependency.
+     */
+    @Bean
+    public ApplicationRunner alarmsTopicInitializerRunner(AlarmPublisherProperties properties) {
+        return args -> AlarmsTopicInitializer.ensureCompacted(
+                properties.getBootstrapServers(), properties.getTopic());
+    }
+```
+
+- [ ] **Step 6: Build the module**
+
+Run: `./mvnw -q -pl :alarms-kafka-publisher clean install`
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmsTopicInitializer.java \
+        core/alarms-kafka-publisher/src/main/java/org/deltav/alarms/publisher/AlarmPublisherConfiguration.java \
+        core/alarms-kafka-publisher/src/test/java/org/deltav/alarms/publisher/AlarmsTopicInitializerTest.java
+git commit -m "feat(alarmd): declare deltav-alarms-state-change as a compacted topic"
+```
+
+---
+
+## Task 6: Durable composite `node` identity label in prometheus-writer
+
+**Files:**
+- Modify: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/InstanceLabelResolver.java`
+- Modify: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/LabelBuilder.java`
+- Test: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/InstanceLabelResolverTest.java` (create if absent)
+- Test: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java`
+
+Spec §4: the durable node identity is the `foreignSource:foreignId` composite. `LabelBuilder` must emit a new `node` label = that composite; discovery nodes (no requisition) fall back to `delta-v:{node_id}`. `InstanceLabelResolver`'s `FOREIGN_ID` policy has a latent bug — it joins on `foreign_id` alone, which is unique only within a `foreign_source`. The composite is computed once in a shared static helper so the resolver and the builder cannot diverge.
+
+- [ ] **Step 1: Write the failing test — the composite helper**
+
+Create `InstanceLabelResolverTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.translate;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InstanceLabelResolverTest {
+
+    @Test
+    void nodeIdentity_usesForeignSourceColonForeignId() {
+        NodeContext nc = NodeContext.newBuilder()
+                .setNodeId(1042).setForeignSource("Servers").setForeignId("web-01").build();
+        assertThat(InstanceLabelResolver.nodeIdentity(1042, Optional.of(nc)))
+                .isEqualTo("Servers:web-01");
+    }
+
+    @Test
+    void nodeIdentity_fallsBackToDeltaVPrefixWhenNoForeignSource() {
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1042).build();
+        assertThat(InstanceLabelResolver.nodeIdentity(1042, Optional.of(nc)))
+                .isEqualTo("delta-v:1042");
+    }
+
+    @Test
+    void nodeIdentity_fallsBackWhenNodeContextAbsent() {
+        assertThat(InstanceLabelResolver.nodeIdentity(77, Optional.empty()))
+                .isEqualTo("delta-v:77");
+    }
+
+    @Test
+    void nodeIdentity_fallsBackWhenForeignIdEmpty() {
+        NodeContext nc = NodeContext.newBuilder()
+                .setNodeId(5).setForeignSource("Servers").build();   // foreignId empty
+        assertThat(InstanceLabelResolver.nodeIdentity(5, Optional.of(nc)))
+                .isEqualTo("delta-v:5");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :prometheus-writer -Dtest=InstanceLabelResolverTest test`
+Expected: FAIL — compilation error: `InstanceLabelResolver.nodeIdentity` does not exist.
+
+- [ ] **Step 3: Add the `nodeIdentity` helper and fix the `FOREIGN_ID` policy**
+
+In `InstanceLabelResolver.java`, add this `public static` method to the class:
+
+```java
+    /**
+     * The durable node identity (spec §4): {@code foregnSource:foreignId} when
+     * the node was provisioned, otherwise {@code delta-v:{node_id}} for
+     * discovery/newSuspect nodes that have no requisition. The {@code delta-v:}
+     * prefix keeps the identity uniformly {@code <source>:<id>}-shaped and
+     * honestly namespaces it as a delta-v-internal id rather than a CMDB key.
+     */
+    public static String nodeIdentity(int nodeId, Optional<NodeContext> nc) {
+        String fs = nc.map(NodeContext::getForeignSource).orElse("");
+        String fi = nc.map(NodeContext::getForeignId).orElse("");
+        if (!fs.isEmpty() && !fi.isEmpty()) {
+            return fs + ":" + fi;
+        }
+        return "delta-v:" + nodeId;
+    }
+```
+
+Then replace the `FOREIGN_ID` arm of the `resolve` switch. Change:
+
+```java
+            case FOREIGN_ID -> {
+                String fs = nc.map(NodeContext::getForeignSource).orElse("");
+                String fi = nc.map(NodeContext::getForeignId).orElse("");
+                yield (fs.isEmpty() || fi.isEmpty()) ? fallback(batch) : fs + ":" + fi;
+            }
+```
+
+to:
+
+```java
+            case FOREIGN_ID -> nodeIdentity(batch.getNodeId(), nc);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :prometheus-writer -Dtest=InstanceLabelResolverTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test — the `node` label in `LabelBuilder`**
+
+Add to `LabelBuilderTest.java`:
+
+```java
+@Test
+void node_label_is_durable_composite_identity() {
+    TimeseriesBatch b = batch(1042, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+    Resource r = resource("node", "");
+    NodeContext n = nc("web01.corp", "Servers", "web-01", List.of(), Map.of());
+
+    Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+    assertThat(labels).containsEntry("node", "Servers:web-01");
+}
+
+@Test
+void node_label_falls_back_to_delta_v_prefix_for_discovery_node() {
+    TimeseriesBatch b = batch(1042, "Default", "pkg", ProducerType.PRODUCER_COLLECTD);
+    Resource r = resource("node", "");
+    NodeContext n = nc("scanned-host", "", "", List.of(), Map.of());
+
+    Map<String, String> labels = labelBuilder.build(b, r, Optional.of(n), List.of());
+
+    assertThat(labels).containsEntry("node", "delta-v:1042");
+}
+```
+
+Note the existing `default_labels_always_emitted` test asserts an exact label-key set and `hasSize(11)`. Update it: add `"node"` to the `containsExactlyInAnyOrder(...)` list and change `hasSize(11)` to `hasSize(12)`.
+
+- [ ] **Step 6: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :prometheus-writer -Dtest=LabelBuilderTest test`
+Expected: FAIL — `node_label_is_durable_composite_identity` fails (`node` key absent), and `default_labels_always_emitted` fails the size assertion.
+
+- [ ] **Step 7: Emit the `node` label**
+
+In `LabelBuilder.java`, in `build(...)`, immediately after the `labels.put("node_id", ...)` line, add:
+
+```java
+        labels.put("node", InstanceLabelResolver.nodeIdentity(batch.getNodeId(), nc));
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :prometheus-writer -Dtest=LabelBuilderTest,InstanceLabelResolverTest test`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/InstanceLabelResolver.java \
+        core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/translate/LabelBuilder.java \
+        core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/InstanceLabelResolverTest.java \
+        core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/translate/LabelBuilderTest.java
+git commit -m "feat(prometheus-writer): emit durable composite node identity label"
+```
+
+---
+
+## Task 7: Emit `deltav_node_info` and `deltav_snmp_interface_info` info-metrics
+
+**Files:**
+- Create: `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitter.java`
+- Test: `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java`
+
+Spec §3.4: the Track 2a acceptance test is prometheus-writer emitting a `deltav_snmp_interface_info` gauge — the info-metric half of the `group_left` join. This new component sweeps the `NodeContextCache` on a schedule and emits, per node, one `deltav_node_info` sample and one `deltav_snmp_interface_info` sample per SNMP interface, each with value `1.0`. It reuses the existing `BatchingRwWriter.add(PromSample)` remote-write path. Periodic re-emission (default 60s) refreshes the series so Prometheus/VM does not mark them stale.
+
+`PromSample` is the existing record in `org.deltav.prometheus.writer.translate` — `PromSample(String name, Map<String,String> labels, double value, long timestampMs)` (constructor positional order confirmed by `WriteRequestBuilder`, which reads `s.name()`, `s.labels()`, `s.value()`, `s.timestampMs()`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `NodeInfoMetricEmitterTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodeinfo;
+
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeInfoMetricEmitterTest {
+
+    @Test
+    void emitsNodeInfoAndSnmpInterfaceInfoSamples() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder()
+                .setNodeId(1042).setLocation("Default")
+                .setNodeLabel("web01.corp").setForeignSource("Servers").setForeignId("web-01")
+                .addCategories("Production")
+                .putSnmpInterfaceMetadata(3, SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(3).setIfName("Gi0/3").setIfDescr("GigabitEthernet0/3")
+                        .setIfAlias("uplink").setIfSpeed(1_000_000_000L).setIfType(6)
+                        .setPhysicalAddress("00:11:22:33:44:55").build())
+                .build();
+        cache.put("Default@1042", nc);
+
+        List<PromSample> emitted = new ArrayList<>();
+        NodeInfoMetricEmitter emitter = new NodeInfoMetricEmitter(cache, emitted::add);
+
+        emitter.sweep();
+
+        PromSample nodeInfo = emitted.stream()
+                .filter(s -> s.name().equals("deltav_node_info")).findFirst().orElseThrow();
+        assertThat(nodeInfo.value()).isEqualTo(1.0);
+        assertThat(nodeInfo.labels()).containsEntry("node", "Servers:web-01");
+        assertThat(nodeInfo.labels()).containsEntry("node_id", "1042");
+        assertThat(nodeInfo.labels()).containsEntry("node_label", "web01.corp");
+        assertThat(nodeInfo.labels()).containsEntry("foreign_source", "Servers");
+        assertThat(nodeInfo.labels()).containsEntry("categories", "Production");
+
+        PromSample ifInfo = emitted.stream()
+                .filter(s -> s.name().equals("deltav_snmp_interface_info")).findFirst().orElseThrow();
+        assertThat(ifInfo.value()).isEqualTo(1.0);
+        assertThat(ifInfo.labels()).containsEntry("node", "Servers:web-01");
+        assertThat(ifInfo.labels()).containsEntry("if_index", "3");
+        assertThat(ifInfo.labels()).containsEntry("if_name", "Gi0/3");
+        assertThat(ifInfo.labels()).containsEntry("if_descr", "GigabitEthernet0/3");
+        assertThat(ifInfo.labels()).containsEntry("if_alias", "uplink");
+        assertThat(ifInfo.labels()).containsEntry("if_speed", "1000000000");
+        assertThat(ifInfo.labels()).containsEntry("if_type", "6");
+    }
+
+    @Test
+    void emitsNothingForEmptyCache() {
+        NodeContextCache cache = new NodeContextCache();
+        List<PromSample> emitted = new ArrayList<>();
+        new NodeInfoMetricEmitter(cache, emitted::add).sweep();
+        assertThat(emitted).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :prometheus-writer -Dtest=NodeInfoMetricEmitterTest test`
+Expected: FAIL — compilation error: `NodeInfoMetricEmitter` does not exist.
+
+- [ ] **Step 3: Add a cache-snapshot accessor to `NodeContextCache`**
+
+`NodeContextCache` exposes `get`/`findByNodeId` but not a full snapshot. Add to `NodeContextCache.java`:
+
+```java
+    /**
+     * An immutable snapshot of every cached entry. Used by the info-metric
+     * emitter to sweep all nodes. O(n) copy — called once per emit interval,
+     * not on the hot path.
+     */
+    public java.util.Collection<NodeContext> snapshot() {
+        return java.util.List.copyOf(map.values());
+    }
+```
+
+- [ ] **Step 4: Create `NodeInfoMetricEmitter`**
+
+Create `NodeInfoMetricEmitter.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodeinfo;
+
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.translate.InstanceLabelResolver;
+import org.deltav.prometheus.writer.translate.PromSample;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Sweeps the {@link NodeContextCache} on a schedule and emits Prometheus
+ * info-metrics — gauges with constant value {@code 1.0} — that carry node and
+ * SNMP-interface attributes as labels. Dashboards join data metrics to these
+ * with PromQL {@code group_left} (spec §2.1).
+ *
+ * <p>{@code deltav_node_info}: one sample per node, carrying the durable
+ * {@code node} identity plus node_label / foreign_source / foreign_id /
+ * categories. {@code deltav_snmp_interface_info}: one sample per SNMP
+ * interface, carrying ifName / ifDescr / ifAlias / ifSpeed / ifType.</p>
+ *
+ * <p>Re-emitted every {@code emit-interval} so Prometheus/VM does not stale
+ * the series. The sink is a {@link Consumer} of {@link PromSample} so the
+ * class is unit-testable without a remote-write endpoint.</p>
+ */
+public class NodeInfoMetricEmitter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NodeInfoMetricEmitter.class);
+
+    private final NodeContextCache cache;
+    private final Consumer<PromSample> sink;
+
+    public NodeInfoMetricEmitter(NodeContextCache cache, Consumer<PromSample> sink) {
+        this.cache = cache;
+        this.sink = sink;
+    }
+
+    /** Emits an info-metric for every node and SNMP interface in the cache. */
+    public void sweep() {
+        long now = System.currentTimeMillis();
+        int nodes = 0;
+        int interfaces = 0;
+        for (NodeContext nc : cache.snapshot()) {
+            String node = InstanceLabelResolver.nodeIdentity(nc.getNodeId(), Optional.of(nc));
+            sink.accept(new PromSample("deltav_node_info", nodeLabels(node, nc), 1.0, now));
+            nodes++;
+            for (SnmpInterfaceContext sic : nc.getSnmpInterfaceMetadataMap().values()) {
+                sink.accept(new PromSample(
+                        "deltav_snmp_interface_info", interfaceLabels(node, sic), 1.0, now));
+                interfaces++;
+            }
+        }
+        LOG.debug("Emitted info-metrics: {} nodes, {} SNMP interfaces", nodes, interfaces);
+    }
+
+    private static Map<String, String> nodeLabels(String node, NodeContext nc) {
+        Map<String, String> l = new LinkedHashMap<>();
+        l.put("node", node);
+        l.put("node_id", Integer.toString(nc.getNodeId()));
+        l.put("node_label", nc.getNodeLabel());
+        l.put("foreign_source", nc.getForeignSource());
+        l.put("foreign_id", nc.getForeignId());
+        List<String> cats = new ArrayList<>(nc.getCategoriesList());
+        cats.sort(String::compareTo);
+        l.put("categories", String.join(",", cats));
+        l.put("location", nc.getLocation());
+        return l;
+    }
+
+    private static Map<String, String> interfaceLabels(String node, SnmpInterfaceContext sic) {
+        Map<String, String> l = new LinkedHashMap<>();
+        l.put("node", node);
+        l.put("if_index", Integer.toString(sic.getIfIndex()));
+        l.put("if_name", sic.getIfName());
+        l.put("if_descr", sic.getIfDescr());
+        l.put("if_alias", sic.getIfAlias());
+        l.put("if_speed", Long.toString(sic.getIfSpeed()));
+        l.put("if_type", Integer.toString(sic.getIfType()));
+        l.put("physical_address", sic.getPhysicalAddress());
+        return l;
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :prometheus-writer -Dtest=NodeInfoMetricEmitterTest test`
+Expected: PASS.
+
+- [ ] **Step 6: Register the emitter as a scheduled Spring bean**
+
+Create `NodeInfoMetricEmitterConfiguration.java` in the same `nodeinfo` package:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.prometheus.writer.nodeinfo;
+
+import org.deltav.prometheus.writer.nodecontext.NodeContextCache;
+import org.deltav.prometheus.writer.rw.BatchingRwWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wires {@link NodeInfoMetricEmitter} to the live {@link BatchingRwWriter}
+ * remote-write path and drives it on a fixed schedule. {@code @EnableScheduling}
+ * is already on {@code PrometheusWriterApplication}.
+ */
+@Configuration
+public class NodeInfoMetricEmitterConfiguration {
+
+    @Bean
+    public NodeInfoMetricEmitter nodeInfoMetricEmitter(NodeContextCache cache, BatchingRwWriter writer) {
+        return new NodeInfoMetricEmitter(cache, writer::add);
+    }
+
+    /** Drives the emitter sweep. Default 60s; override with deltav.node-info.emit-interval-ms. */
+    @Component
+    static class NodeInfoEmitterSchedule {
+        private final NodeInfoMetricEmitter emitter;
+
+        NodeInfoEmitterSchedule(NodeInfoMetricEmitter emitter) {
+            this.emitter = emitter;
+        }
+
+        @Scheduled(fixedDelayString = "${deltav.node-info.emit-interval-ms:60000}")
+        void tick() {
+            emitter.sweep();
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Build the module**
+
+Run: `./mvnw -q -pl :prometheus-writer clean install`
+Expected: `BUILD SUCCESS` — full module test suite green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodeinfo/ \
+        core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/NodeContextCache.java \
+        core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodeinfo/NodeInfoMetricEmitterTest.java
+git commit -m "feat(prometheus-writer): emit deltav_node_info and deltav_snmp_interface_info metrics"
+```
+
+---
+
+## Task 8: Full reactor build and integration verification
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Build every module touched plus dependents**
+
+Run: `./mvnw -q -pl :org.opennms.core.deltav-kafka-contracts,:daemon-boot-provisiond,:alarms-kafka-publisher,:daemon-boot-alarmd,:prometheus-writer -am clean install`
+Expected: `BUILD SUCCESS` for all modules. (`-am` also builds upstream dependencies; `daemon-boot-alarmd` is included because it bundles `alarms-kafka-publisher` into its fat jar — see memory `feedback_spring_boot_repackage_needs_clean`.)
+
+- [ ] **Step 2: Rebuild the provisiond, alarmd, and prometheus-writer images**
+
+Run: `cd opennms-container/delta-v && ./build.sh daemon provisiond && ./build.sh daemon alarmd`
+Expected: both single-daemon image builds report success.
+
+(prometheus-writer is not a `DAEMON_NAMES` entry — it builds via its module Dockerfile. Build it with: `docker build -t deltav/prometheus-writer:latest -f core/prometheus-writer/Dockerfile core/prometheus-writer` after `./mvnw -pl :prometheus-writer install`.)
+
+- [ ] **Step 3: Smoke the contract end-to-end with docker-compose**
+
+Bring the stack up (`docker compose -f opennms-container/delta-v/docker-compose.yml up -d`), wait for provisiond and prometheus-writer to report healthy, then:
+
+```bash
+# 1. provisiond publishes the SNMP-interface table — inspect a node-context record:
+docker exec delta-v-kafka-1 /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 --topic deltav-node-context \
+  --from-beginning --max-messages 1 --property print.key=true | head
+
+# 2. prometheus-writer emits the info-metrics — query VictoriaMetrics:
+curl -s 'http://localhost:8428/api/v1/query?query=deltav_snmp_interface_info' | head
+curl -s 'http://localhost:8428/api/v1/query?query=deltav_node_info' | head
+```
+
+Expected: `deltav_node_info` and `deltav_snmp_interface_info` series are present in VictoriaMetrics, each carrying a `node` label of the form `foreignSource:foreignId` (or `delta-v:{id}` for discovery nodes). This is the spec §3.4 acceptance test — the contract is proven end-to-end before Track 2b begins.
+
+- [ ] **Step 4: Verify the alarms topic is compacted**
+
+```bash
+docker exec delta-v-kafka-1 /opt/kafka/bin/kafka-configs.sh \
+  --bootstrap-server localhost:9092 --entity-type topics \
+  --entity-name deltav-alarms-state-change --describe
+```
+
+Expected: the output includes `cleanup.policy=compact`.
+
+- [ ] **Step 5: Commit any compose/config fixes surfaced by the smoke**
+
+If steps 3–4 required a compose or config change, commit it:
+
+```bash
+git add -A
+git commit -m "fix(track2a): <describe the smoke fix>"
+```
+
+If no fixes were needed, skip this step.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §3.1 proto changes → Tasks 1–2. §3.2 provisiond producer → Task 3. §3.3 compacted topic → Task 5. §3.4 prometheus-writer validation → Tasks 6–7, verified in Task 8. §4.3 composite `node` label → Task 6. §4.4 `delta-v:` fallback → Task 6 (`nodeIdentity` helper). §4.5 `InstanceLabelResolver` bug → Task 6 Step 3.
+- **Type consistency:** `InstanceLabelResolver.nodeIdentity(int, Optional<NodeContext>)` is defined in Task 6 and reused by `NodeInfoMetricEmitter` in Task 7 with the same signature. `PromSample(name, labels, value, timestampMs)` positional constructor is used consistently in Task 7.
+- **Out of scope, intentionally:** the `alerts-forwarder` module is Track 2b.

--- a/docs/superpowers/plans/2026-05-19-v1.3.0-track2a-node-context-interface-enrichment.md
+++ b/docs/superpowers/plans/2026-05-19-v1.3.0-track2a-node-context-interface-enrichment.md
@@ -1014,6 +1014,8 @@ Expected: both single-daemon image builds report success.
 
 Bring the stack up (`docker compose -f opennms-container/delta-v/docker-compose.yml up -d`), wait for provisiond and prometheus-writer to report healthy, then:
 
+> **Note:** if the stack was already running and you just rebuilt the images, `docker compose up -d` does **not** redeploy retagged-image containers — it has no diff to detect. Re-run with `--force-recreate --no-deps provisiond alarmd prometheus-writer` (or `docker compose ... up -d --force-recreate`) to pick up the new images.
+
 ```bash
 # 1. provisiond publishes the SNMP-interface table — inspect a node-context record:
 docker exec delta-v-kafka-1 /opt/kafka/bin/kafka-console-consumer.sh \
@@ -1021,8 +1023,9 @@ docker exec delta-v-kafka-1 /opt/kafka/bin/kafka-console-consumer.sh \
   --from-beginning --max-messages 1 --property print.key=true | head
 
 # 2. prometheus-writer emits the info-metrics — query VictoriaMetrics:
-curl -s 'http://localhost:8428/api/v1/query?query=deltav_snmp_interface_info' | head
-curl -s 'http://localhost:8428/api/v1/query?query=deltav_node_info' | head
+# VictoriaMetrics is published on host port 18428 in the dev compose stack (NOT 8428).
+curl -s 'http://localhost:18428/api/v1/query?query=deltav_snmp_interface_info' | head
+curl -s 'http://localhost:18428/api/v1/query?query=deltav_node_info' | head
 ```
 
 Expected: `deltav_node_info` and `deltav_snmp_interface_info` series are present in VictoriaMetrics, each carrying a `node` label of the form `foreignSource:foreignId` (or `delta-v:{id}` for discovery nodes). This is the spec §3.4 acceptance test — the contract is proven end-to-end before Track 2b begins.

--- a/docs/superpowers/plans/2026-05-19-v1.3.0-track2b-alerts-forwarder.md
+++ b/docs/superpowers/plans/2026-05-19-v1.3.0-track2b-alerts-forwarder.md
@@ -1,0 +1,2266 @@
+# v1.3.0 Track 2b — Prometheus Alerts Forwarder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `core/alerts-forwarder` — a standalone Spring Boot 4 daemon that consumes the compacted `deltav-alarms-state-change` Kafka topic, enriches each alarm against a node-context `GlobalKTable`, and forwards firing/resolved alerts to Alertmanager and/or VictoriaMetrics through a pluggable `AlarmSink` seam.
+
+**Architecture:** Two dedicated Kafka bootstrap-replay consumers — one for `deltav-node-context` (cloned from `prometheus-writer`), one for `deltav-alarms-state-change`. The alarms consumer is gated on node-context readiness, replays the compacted topic to rebuild an in-memory active-alarm registry, then live-tails. Each record runs through a pipeline: filter → enrich → registry → sink(s). Lifecycle: a non-tombstone record above the severity filter is *firing*; a tombstone, a `CLEARED` severity, or a drop below the filter is *resolved*, forwarded from the registry's stored identity for label stability.
+
+**Tech Stack:** Java 21, Spring Boot 4, Apache Kafka client 4.1.1 (raw `kafka-clients`), protobuf 3.25.5, snappy-java, JUnit 5 Jupiter, AssertJ, Mockito, OkHttp MockWebServer, Testcontainers.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md` §5, §6.
+
+**Depends on:** Track 2a (merged) — the `deltav-alarm-state` proto identity fields and the compacted `deltav-alarms-state-change` topic.
+
+---
+
+## Architecture note — refinement vs spec §5
+
+The spec §5.1/§5.5 describe the alarm consumer as a Spring Cloud Stream binding with a "binding gate reused verbatim from prometheus-writer." During planning this proved incorrect for one requirement the spec *also* states (§5.6): *"a restart rebuilds correct current state from the compacted topic."* A Spring Cloud Stream consumer-group binding resumes from committed offsets — it does **not** replay a compacted topic — so `ActiveAlertRegistry` would be empty after a restart and the forwarder could not resolve alarms that fired before it. This plan therefore uses the **bootstrap-replay consumer pattern** (the same `NodeContextKafkaBootstrap` pattern prometheus-writer uses for node-context) for the alarms topic as well. Consequences, all deliberate:
+
+- The module does **not** depend on `spring-cloud-stream`. The alarm consumer is a raw `KafkaConsumer` on a random group id, seeking to the beginning every start. Replaying a *compacted* topic is bounded (one record per active/recently-deleted key), so a full replay per restart is cheap and removes all offset-commit bookkeeping.
+- The §5.5 startup gate becomes: the alarm consumer thread waits for `NodeContextCacheReadyEvent` before starting (same intent, simpler mechanism — no SCS `ListenerContainerCustomizer`).
+- The §5.6 circuit breaker is replaced by natural consumer back-pressure: on sustained sink failure the consumer thread blocks retrying the current record and stops polling. A raw consumer back-pressures by not polling; the breaker existed in prometheus-writer only to *pause an SCS binding*, which no longer exists here.
+
+These refinements keep every behavioural guarantee in §5 and resolve the §5.5↔§5.6 inconsistency. The spec should be amended to match.
+
+---
+
+## Conventions for every task
+
+- Build with `./mvnw` (delta-v's wrapper). New code: `org.deltav` packages, `BeaconStrategists, Inc.` copyright header — the one-line form `/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */` is accepted (used throughout `prometheus-writer`).
+- Tests are JUnit 5 Jupiter ONLY.
+- Commit after every task with a Conventional Commit message.
+- The new module's base package is `org.deltav.alerts.forwarder`.
+
+---
+
+## File Structure
+
+| File (under `core/alerts-forwarder/`) | Responsibility | Task |
+|---|---|---|
+| `pom.xml`, `Dockerfile`, `src/main/resources/application.yml` | module build + container + config | 1 |
+| `.../alerts/forwarder/AlertsForwarderApplication.java` | Spring Boot entry point | 1 |
+| `.../config/AlertsForwarderProperties.java` | `deltav.alerts-forwarder.*` binding | 1 |
+| `.../metrics/AlertsForwarderMetrics.java` | Micrometer metric-name constants | 1 |
+| `.../nodecontext/NodeContext{Cache,KafkaBootstrap,CacheHealthIndicator,CacheReadyEvent}.java` | node-context GlobalKTable (cloned) | 2 |
+| `.../filter/AlarmFilter.java` | severity + UEI denylist gate | 3 |
+| `.../enrich/{NodeIdentity,EnrichedAlarm,AlarmEnricher}.java` | join alarm to node context | 4 |
+| `.../lifecycle/ActiveAlertRegistry.java` | reduction_key → forwarded identity | 5 |
+| `.../sink/{ForwardedAlarm,AlarmSink}.java` | the seam | 6 |
+| `.../sink/AlertmanagerAlarmSink.java` | POST `/api/v2/alerts` | 7 |
+| `.../sink/VictoriaMetricsAlarmSink.java` | remote-write `deltav_alarm_state` | 8 |
+| `.../pipeline/AlarmForwardingPipeline.java` | filter→enrich→registry→sink + lifecycle | 9 |
+| `.../consume/AlarmStateKafkaConsumer.java`, `.../dlq/DlqPublisher.java` | bootstrap-replay alarm consumer + DLQ | 10 |
+| `opennms-container/delta-v/build.sh`, `.github/workflows/delta-v-build-images.yml`, `docker-compose.yml` | image + compose wiring | 11 |
+| `src/test/.../AlertsForwarderIntegrationIT.java` | Testcontainers end-to-end | 12 |
+
+---
+
+## Task 1: Scaffold the `core/alerts-forwarder` module
+
+**Files:**
+- Create: `core/alerts-forwarder/pom.xml`
+- Modify: `pom.xml` (root reactor — add the module)
+- Create: `core/alerts-forwarder/Dockerfile`
+- Create: `core/alerts-forwarder/src/main/resources/application.yml`
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/AlertsForwarderApplication.java`
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderProperties.java`
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/metrics/AlertsForwarderMetrics.java`
+
+- [ ] **Step 1: Create the module pom**
+
+`core/alerts-forwarder/pom.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>1.2.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>alerts-forwarder</artifactId>
+    <name>Delta-V :: Core :: Prometheus Alerts Forwarder</name>
+    <description>Consumes deltav-alarms-state-change, enriches each alarm against a
+        local materialization of deltav-node-context, and forwards firing/resolved
+        alerts to Alertmanager and/or VictoriaMetrics through a pluggable AlarmSink.</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Raw Kafka client — bootstrap-replay consumers (no Spring Cloud Stream). -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <!-- Protobuf contracts: AlarmState + NodeContext + prometheus.prompb. -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.deltav-kafka-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <!-- Snappy: VictoriaMetrics remote-write compression. -->
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- commons-io >= 2.16: Testcontainers transitive commons-compress needs it. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- surefire 3.5.4 needs this explicitly for Boot 4 modules. -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>alerts-forwarder</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>org.deltav.alerts.forwarder.AlertsForwarderApplication</mainClass>
+                    <executable>true</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+- [ ] **Step 2: Register the module in the root reactor**
+
+In the root `pom.xml`, in the `<modules>` section, add `<module>core/alerts-forwarder</module>` immediately after the existing `<module>core/prometheus-writer</module>` entry.
+
+- [ ] **Step 3: Create the Dockerfile**
+
+`core/alerts-forwarder/Dockerfile` (cloned from `core/prometheus-writer/Dockerfile`, jar name changed):
+
+```dockerfile
+# Copyright (C) 2026 BeaconStrategists, Inc.
+# Licensed under the GNU Affero General Public License v3.
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache curl && \
+    addgroup -g 10001 deltav && \
+    adduser -u 10001 -G deltav -D deltav
+
+COPY --chown=deltav:deltav target/alerts-forwarder.jar /app/alerts-forwarder.jar
+
+USER deltav
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/alerts-forwarder.jar"]
+```
+
+- [ ] **Step 4: Create `application.yml`**
+
+`core/alerts-forwarder/src/main/resources/application.yml`:
+
+```yaml
+# Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later
+spring:
+  application:
+    name: alerts-forwarder
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+
+deltav:
+  alerts-forwarder:
+    alarms-topic: ${DELTAV_ALARMS_STATE_TOPIC:deltav-alarms-state-change}
+    node-context-topic: deltav-node-context
+    filter:
+      # Minimum severity to forward. One of: WARNING, MINOR, MAJOR, CRITICAL.
+      min-severity: ${DELTAV_ALERTS_MIN_SEVERITY:WARNING}
+      # UEIs never forwarded, even above min-severity.
+      uei-denylist: []
+    alertmanager:
+      enabled: ${DELTAV_ALERTS_ALERTMANAGER_ENABLED:true}
+      url: ${DELTAV_ALERTS_ALERTMANAGER_URL:http://alertmanager:9093/api/v2/alerts}
+      # Firing alerts get endsAt = now + this; Alertmanager auto-resolves if no refresh.
+      resolve-timeout-ms: 300000
+    victoriametrics:
+      enabled: ${DELTAV_ALERTS_VM_ENABLED:false}
+      url: ${DELTAV_ALERTS_VM_URL:http://victoriametrics:8428/api/v1/write}
+    dlq:
+      topic: deltav-alerts-forwarder-dlq
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+      group:
+        readiness:
+          include: readinessState, nodeContextCache
+```
+
+- [ ] **Step 5: Create the main application class**
+
+`core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/AlertsForwarderApplication.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder;
+
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+/**
+ * Entry point for the Delta-V alerts-forwarder daemon. Consumes
+ * {@code deltav-alarms-state-change}, enriches against a local materialization
+ * of {@code deltav-node-context}, and forwards firing/resolved alerts through
+ * the {@link org.deltav.alerts.forwarder.sink.AlarmSink} seam.
+ *
+ * <p>v1.3.0 "Alarms on Kafka" Track 2b. See
+ * {@code docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md}.
+ */
+@SpringBootApplication(scanBasePackages = "org.deltav.alerts.forwarder")
+@EnableConfigurationProperties(AlertsForwarderProperties.class)
+public class AlertsForwarderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AlertsForwarderApplication.class, args);
+    }
+}
+```
+
+- [ ] **Step 6: Create the properties class**
+
+`core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderProperties.java` — a plain class with defaults (the `AlarmPublisherProperties` style from Track 1):
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Binds {@code deltav.alerts-forwarder.*}. */
+@ConfigurationProperties(prefix = "deltav.alerts-forwarder")
+public class AlertsForwarderProperties {
+
+    private String alarmsTopic = "deltav-alarms-state-change";
+    private String nodeContextTopic = "deltav-node-context";
+    private final Filter filter = new Filter();
+    private final Alertmanager alertmanager = new Alertmanager();
+    private final VictoriaMetrics victoriametrics = new VictoriaMetrics();
+    private final Dlq dlq = new Dlq();
+
+    public String getAlarmsTopic() { return alarmsTopic; }
+    public void setAlarmsTopic(String v) { this.alarmsTopic = v; }
+    public String getNodeContextTopic() { return nodeContextTopic; }
+    public void setNodeContextTopic(String v) { this.nodeContextTopic = v; }
+    public Filter getFilter() { return filter; }
+    public Alertmanager getAlertmanager() { return alertmanager; }
+    public VictoriaMetrics getVictoriametrics() { return victoriametrics; }
+    public Dlq getDlq() { return dlq; }
+
+    public static class Filter {
+        private String minSeverity = "WARNING";
+        private List<String> ueiDenylist = new ArrayList<>();
+        public String getMinSeverity() { return minSeverity; }
+        public void setMinSeverity(String v) { this.minSeverity = v; }
+        public List<String> getUeiDenylist() { return ueiDenylist; }
+        public void setUeiDenylist(List<String> v) { this.ueiDenylist = v; }
+    }
+
+    public static class Alertmanager {
+        private boolean enabled = true;
+        private String url = "http://alertmanager:9093/api/v2/alerts";
+        private long resolveTimeoutMs = 300000;
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean v) { this.enabled = v; }
+        public String getUrl() { return url; }
+        public void setUrl(String v) { this.url = v; }
+        public long getResolveTimeoutMs() { return resolveTimeoutMs; }
+        public void setResolveTimeoutMs(long v) { this.resolveTimeoutMs = v; }
+    }
+
+    public static class VictoriaMetrics {
+        private boolean enabled = false;
+        private String url = "http://victoriametrics:8428/api/v1/write";
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean v) { this.enabled = v; }
+        public String getUrl() { return url; }
+        public void setUrl(String v) { this.url = v; }
+    }
+
+    public static class Dlq {
+        private String topic = "deltav-alerts-forwarder-dlq";
+        public String getTopic() { return topic; }
+        public void setTopic(String v) { this.topic = v; }
+    }
+}
+```
+
+- [ ] **Step 7: Create the metrics constants class**
+
+`core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/metrics/AlertsForwarderMetrics.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.metrics;
+
+/** Centralized Micrometer metric names for the alerts-forwarder. */
+public final class AlertsForwarderMetrics {
+    private AlertsForwarderMetrics() {}
+
+    public static final String ALARMS_CONSUMED = "deltav_alerts_forwarder_alarms_consumed_total";
+    public static final String FORWARDED = "deltav_alerts_forwarder_forwarded_total";       // tag: outcome
+    public static final String FILTERED = "deltav_alerts_forwarder_filtered_total";         // tag: reason
+    public static final String ENRICHMENT = "deltav_alerts_forwarder_enrichment_total";     // tag: result
+    public static final String SINK_ERRORS = "deltav_alerts_forwarder_sink_errors_total";   // tag: sink
+    public static final String DLQ_RECORDS = "deltav_alerts_forwarder_dlq_total";
+    public static final String NC_CACHE_SIZE = "deltav_alerts_forwarder_node_context_cache_size";
+    public static final String NC_CACHE_READY = "deltav_alerts_forwarder_node_context_cache_ready";
+    public static final String NC_BOOTSTRAP_DURATION = "deltav_alerts_forwarder_node_context_bootstrap_seconds";
+    public static final String ACTIVE_ALERTS = "deltav_alerts_forwarder_active_alerts";
+}
+```
+
+- [ ] **Step 8: Verify the module compiles**
+
+Run: `./mvnw -q -pl :alerts-forwarder -am clean install`
+Expected: `BUILD SUCCESS` (no sources beyond the scaffold yet — the app boots with no consumers; that is fine).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/alerts-forwarder pom.xml
+git commit -m "feat(alerts-forwarder): scaffold module — pom, app, properties, metrics"
+```
+
+---
+
+## Task 2: Clone the node-context GlobalKTable package
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCache.java`
+- Create: `.../nodecontext/NodeContextKafkaBootstrap.java`
+- Create: `.../nodecontext/NodeContextCacheHealthIndicator.java`
+- Create: `.../nodecontext/NodeContextCacheReadyEvent.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCacheTest.java`
+
+These four files are cloned from `core/prometheus-writer/src/main/java/org/deltav/prometheus/writer/nodecontext/` — that implementation is correct and already in production. Clone, do not redesign.
+
+- [ ] **Step 1: Clone `NodeContextCache.java`**
+
+Copy `core/prometheus-writer/.../nodecontext/NodeContextCache.java` verbatim into the new path, then apply exactly these edits:
+- Change the package line to `package org.deltav.alerts.forwarder.nodecontext;`.
+- No other changes — keep `get`, `put`, `remove`, `applyUpdate`, `size`, `isReady`, `markReady`, `findByNodeId` as-is.
+
+- [ ] **Step 2: Clone `NodeContextCacheReadyEvent.java`**
+
+Copy `core/prometheus-writer/.../nodecontext/NodeContextCacheReadyEvent.java` verbatim, change the package to `org.deltav.alerts.forwarder.nodecontext`. No other changes.
+
+- [ ] **Step 3: Clone `NodeContextCacheHealthIndicator.java`**
+
+Copy `core/prometheus-writer/.../nodecontext/NodeContextCacheHealthIndicator.java` verbatim, change the package to `org.deltav.alerts.forwarder.nodecontext`. No other changes (the `@Component("nodeContextCacheHealthIndicator")` name matches the `readiness` health group in `application.yml`).
+
+- [ ] **Step 4: Clone `NodeContextKafkaBootstrap.java`**
+
+Copy `core/prometheus-writer/.../nodecontext/NodeContextKafkaBootstrap.java` verbatim, then apply exactly these edits:
+- Change the package to `org.deltav.alerts.forwarder.nodecontext;`.
+- Replace the import `org.deltav.prometheus.writer.metrics.PrometheusWriterMetrics` with `org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics`.
+- Replace every `PrometheusWriterMetrics.NC_CACHE_READY` with `AlertsForwarderMetrics.NC_CACHE_READY`, `PrometheusWriterMetrics.NC_CACHE_SIZE` with `AlertsForwarderMetrics.NC_CACHE_SIZE`, and `PrometheusWriterMetrics.NC_BOOTSTRAP_DURATION` with `AlertsForwarderMetrics.NC_BOOTSTRAP_DURATION`.
+- Change the consumer group-id prefix string from `"prometheus-writer-node-context-"` to `"alerts-forwarder-node-context-"`.
+- Keep everything else verbatim — the `ApplicationReadyEvent` trigger, the HWM-replay loop, the `NodeContextCacheReadyEvent` publication.
+
+- [ ] **Step 5: Clone the cache test**
+
+Copy `core/prometheus-writer/src/test/java/org/deltav/prometheus/writer/nodecontext/NodeContextCacheTest.java` verbatim, change the package to `org.deltav.alerts.forwarder.nodecontext`. No other changes.
+
+- [ ] **Step 6: Run the test**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=NodeContextCacheTest test`
+Expected: PASS — all cache tests green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/nodecontext
+git commit -m "feat(alerts-forwarder): clone node-context GlobalKTable from prometheus-writer"
+```
+
+---
+
+## Task 3: `AlarmFilter` — severity and UEI gate
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/filter/AlarmFilter.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/filter/AlarmFilterTest.java`
+
+`AlarmState.Severity` enum numbers: `INDETERMINATE=0, CLEARED=1, NORMAL=2, WARNING=3, MINOR=4, MAJOR=5, CRITICAL=6`. "Severity ≥ min" is an enum-number comparison. `CLEARED` (1) is naturally below any valid `min-severity`, so a cleared alarm fails the filter — which the pipeline (Task 9) maps to a resolve.
+
+- [ ] **Step 1: Write the failing test**
+
+`AlarmFilterTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.filter;
+
+import java.util.List;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmFilterTest {
+
+    private AlarmState alarm(AlarmState.Severity severity, String uei) {
+        return AlarmState.newBuilder()
+                .setReductionKey("rk").setSeverity(severity).setUei(uei).build();
+    }
+
+    @Test
+    void acceptsAtOrAboveMinSeverity() {
+        AlarmFilter filter = new AlarmFilter("WARNING", List.of());
+        assertThat(filter.accept(alarm(AlarmState.Severity.WARNING, "uei/x"))).isTrue();
+        assertThat(filter.accept(alarm(AlarmState.Severity.CRITICAL, "uei/x"))).isTrue();
+    }
+
+    @Test
+    void rejectsBelowMinSeverity() {
+        AlarmFilter filter = new AlarmFilter("MAJOR", List.of());
+        assertThat(filter.accept(alarm(AlarmState.Severity.WARNING, "uei/x"))).isFalse();
+        assertThat(filter.accept(alarm(AlarmState.Severity.CLEARED, "uei/x"))).isFalse();
+    }
+
+    @Test
+    void rejectsDenylistedUei() {
+        AlarmFilter filter = new AlarmFilter("WARNING", List.of("uei/noisy"));
+        assertThat(filter.accept(alarm(AlarmState.Severity.CRITICAL, "uei/noisy"))).isFalse();
+        assertThat(filter.accept(alarm(AlarmState.Severity.CRITICAL, "uei/ok"))).isTrue();
+    }
+
+    @Test
+    void invalidMinSeverityFallsBackToWarning() {
+        AlarmFilter filter = new AlarmFilter("NONSENSE", List.of());
+        assertThat(filter.accept(alarm(AlarmState.Severity.WARNING, "uei/x"))).isTrue();
+        assertThat(filter.accept(alarm(AlarmState.Severity.NORMAL, "uei/x"))).isFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlarmFilterTest test`
+Expected: FAIL — compilation error: `AlarmFilter` does not exist.
+
+- [ ] **Step 3: Implement `AlarmFilter`**
+
+`AlarmFilter.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.filter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Decides whether an alarm is forwarded. An alarm passes when its severity is
+ * at or above the configured minimum AND its UEI is not denylisted. A cleared
+ * alarm (severity {@code CLEARED}, enum number 1) is always below a valid
+ * minimum, so it fails the filter — the pipeline maps a filter failure on a
+ * currently-active alarm to a resolve.
+ */
+public class AlarmFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmFilter.class);
+
+    private final int minSeverityNumber;
+    private final Set<String> ueiDenylist;
+
+    public AlarmFilter(String minSeverity, List<String> ueiDenylist) {
+        this.minSeverityNumber = parseMinSeverity(minSeverity);
+        this.ueiDenylist = new HashSet<>(ueiDenylist);
+    }
+
+    public boolean accept(AlarmState alarm) {
+        if (alarm.getSeverity().getNumber() < minSeverityNumber) {
+            return false;
+        }
+        return !ueiDenylist.contains(alarm.getUei());
+    }
+
+    private static int parseMinSeverity(String configured) {
+        try {
+            return AlarmState.Severity.valueOf(configured.trim().toUpperCase()).getNumber();
+        } catch (RuntimeException e) {
+            LOG.warn("Invalid deltav.alerts-forwarder.filter.min-severity '{}' — defaulting to WARNING",
+                    configured);
+            return AlarmState.Severity.WARNING.getNumber();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlarmFilterTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/filter \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/filter
+git commit -m "feat(alerts-forwarder): add severity/UEI alarm filter"
+```
+
+---
+
+## Task 4: `AlarmEnricher` — join alarm to node context
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich/NodeIdentity.java`
+- Create: `.../enrich/EnrichedAlarm.java`
+- Create: `.../enrich/AlarmEnricher.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/enrich/AlarmEnricherTest.java`
+
+`AlarmEnricher` looks the alarm's node up in the `NodeContextCache` (key `{location}@{node_id}`, with a node-id-only fallback) and produces an `EnrichedAlarm`: a low-cardinality **label** map (identity + dimensions) and a free-text **annotation** map. `NodeIdentity` is the durable-identity helper — the alerts-forwarder cannot depend on `prometheus-writer`, so it carries its own copy (identical logic to Track 2a's `InstanceLabelResolver.nodeIdentity`).
+
+- [ ] **Step 1: Create `NodeIdentity`**
+
+`NodeIdentity.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import java.util.Optional;
+
+import org.deltav.timeseries.proto.NodeContext;
+
+/**
+ * Durable node identity (spec §4): {@code foreignSource:foreignId} for a
+ * provisioned node, else {@code delta-v:{node_id}} for a discovery node with
+ * no requisition. Identical to prometheus-writer's
+ * {@code InstanceLabelResolver.nodeIdentity} — duplicated because the two
+ * modules must not depend on each other.
+ */
+public final class NodeIdentity {
+    private NodeIdentity() {}
+
+    public static String of(int nodeId, Optional<NodeContext> nc) {
+        String fs = nc.map(NodeContext::getForeignSource).orElse("");
+        String fi = nc.map(NodeContext::getForeignId).orElse("");
+        if (!fs.isEmpty() && !fi.isEmpty()) {
+            return fs + ":" + fi;
+        }
+        return "delta-v:" + nodeId;
+    }
+}
+```
+
+- [ ] **Step 2: Create `EnrichedAlarm`**
+
+`EnrichedAlarm.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import java.util.Map;
+
+/**
+ * An alarm joined to node context. {@code labels} are low-cardinality
+ * dimensions safe for a TSDB series (identity, severity, uei, interface
+ * attributes); {@code annotations} are unbounded free text (description,
+ * log message) — Alertmanager-only, never a label. {@code enrichmentComplete}
+ * is false when the node was not found in the cache (partial enrichment).
+ */
+public record EnrichedAlarm(
+        Map<String, String> labels,
+        Map<String, String> annotations,
+        boolean enrichmentComplete) {
+}
+```
+
+- [ ] **Step 3: Write the failing test**
+
+`AlarmEnricherTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmEnricherTest {
+
+    @Test
+    void enrichesWithNodeIdentityAndDimensions() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1042", NodeContext.newBuilder()
+                .setNodeId(1042).setLocation("Default").setNodeLabel("web01.corp")
+                .setForeignSource("Servers").setForeignId("web-01")
+                .addCategories("Production").build());
+        AlarmEnricher enricher = new AlarmEnricher(cache);
+
+        AlarmState alarm = AlarmState.newBuilder()
+                .setReductionKey("rk").setAlarmId(7).setNodeId(1042).setLocation("Default")
+                .setSeverity(AlarmState.Severity.MAJOR).setUei("uei/nodeDown")
+                .setDescription("Node is down").setLogMessage("down since 10:00").build();
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+
+        assertThat(e.enrichmentComplete()).isTrue();
+        assertThat(e.labels()).containsEntry("node", "Servers:web-01");
+        assertThat(e.labels()).containsEntry("severity", "MAJOR");
+        assertThat(e.labels()).containsEntry("uei", "uei/nodeDown");
+        assertThat(e.labels()).containsEntry("foreign_source", "Servers");
+        assertThat(e.labels()).containsEntry("categories", "Production");
+        assertThat(e.labels()).containsEntry("alarm_id", "7");
+        assertThat(e.annotations()).containsEntry("description", "Node is down");
+        assertThat(e.annotations()).containsEntry("log_message", "down since 10:00");
+    }
+
+    @Test
+    void addsSnmpInterfaceLabelsWhenIfIndexPresent() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1042", NodeContext.newBuilder()
+                .setNodeId(1042).setLocation("Default")
+                .setForeignSource("Servers").setForeignId("web-01")
+                .putSnmpInterfaceMetadata(3, SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(3).setIfName("Gi0/3").setIfDescr("GigabitEthernet0/3")
+                        .setIfAlias("uplink").setIfSpeed(1_000_000_000L).setIfType(6).build())
+                .build());
+        AlarmEnricher enricher = new AlarmEnricher(cache);
+
+        AlarmState alarm = AlarmState.newBuilder()
+                .setReductionKey("rk").setNodeId(1042).setLocation("Default")
+                .setSeverity(AlarmState.Severity.MINOR).setUei("uei/ifDown").setIfIndex(3).build();
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+
+        assertThat(e.labels()).containsEntry("if_name", "Gi0/3");
+        assertThat(e.labels()).containsEntry("if_alias", "uplink");
+        assertThat(e.labels()).containsEntry("if_speed", "1000000000");
+    }
+
+    @Test
+    void partialEnrichmentWhenNodeMissing() {
+        AlarmEnricher enricher = new AlarmEnricher(new NodeContextCache());
+        AlarmState alarm = AlarmState.newBuilder()
+                .setReductionKey("rk").setNodeId(999).setLocation("Default")
+                .setSeverity(AlarmState.Severity.MAJOR).setUei("uei/x").build();
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+
+        assertThat(e.enrichmentComplete()).isFalse();
+        assertThat(e.labels()).containsEntry("node", "delta-v:999");
+        assertThat(e.labels()).containsEntry("enrichment", "partial");
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlarmEnricherTest test`
+Expected: FAIL — compilation error: `AlarmEnricher` does not exist.
+
+- [ ] **Step 5: Implement `AlarmEnricher`**
+
+`AlarmEnricher.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * Joins an {@link AlarmState} to its {@link NodeContext} and produces an
+ * {@link EnrichedAlarm}. Lookup key is {@code {location}@{node_id}}; on a miss
+ * (Collectd/alarmd location skew, or a node not yet materialized) it falls back
+ * to a node-id-only scan, and failing that produces a partial enrichment.
+ */
+@Component
+public class AlarmEnricher {
+
+    private final NodeContextCache cache;
+
+    public AlarmEnricher(NodeContextCache cache) {
+        this.cache = cache;
+    }
+
+    public EnrichedAlarm enrich(AlarmState alarm) {
+        Optional<NodeContext> nc = lookup(alarm);
+
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("node", NodeIdentity.of(alarm.getNodeId(), nc));
+        labels.put("node_id", Integer.toString(alarm.getNodeId()));
+        labels.put("severity", alarm.getSeverity().name());
+        labels.put("uei", alarm.getUei());
+        labels.put("location", alarm.getLocation());
+        labels.put("alarm_id", Integer.toString(alarm.getAlarmId()));
+        labels.put("node_label", nc.map(NodeContext::getNodeLabel).orElse(""));
+        labels.put("foreign_source", nc.map(NodeContext::getForeignSource).orElse(""));
+        labels.put("foreign_id", nc.map(NodeContext::getForeignId).orElse(""));
+        labels.put("categories", categories(nc));
+
+        if (!alarm.getServiceName().isEmpty()) {
+            labels.put("service_name", alarm.getServiceName());
+        }
+        if (!alarm.getIpAddress().isEmpty()) {
+            labels.put("ip_address", alarm.getIpAddress());
+        }
+        if (alarm.getIfIndex() > 0) {
+            labels.put("if_index", Integer.toString(alarm.getIfIndex()));
+            nc.map(n -> n.getSnmpInterfaceMetadataMap().get(alarm.getIfIndex()))
+              .ifPresent(sic -> addInterfaceLabels(labels, sic));
+        }
+
+        boolean complete = nc.isPresent();
+        if (!complete) {
+            labels.put("enrichment", "partial");
+        }
+
+        Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("description", alarm.getDescription());
+        annotations.put("log_message", alarm.getLogMessage());
+        if (!alarm.getAckUser().isEmpty()) {
+            annotations.put("ack_user", alarm.getAckUser());
+        }
+
+        return new EnrichedAlarm(labels, annotations, complete);
+    }
+
+    private Optional<NodeContext> lookup(AlarmState alarm) {
+        Optional<NodeContext> nc = cache.get(alarm.getLocation() + "@" + alarm.getNodeId());
+        if (nc.isEmpty() && alarm.getNodeId() > 0) {
+            nc = cache.findByNodeId(alarm.getNodeId());
+        }
+        return nc;
+    }
+
+    private static void addInterfaceLabels(Map<String, String> labels, SnmpInterfaceContext sic) {
+        labels.put("if_name", sic.getIfName());
+        labels.put("if_descr", sic.getIfDescr());
+        labels.put("if_alias", sic.getIfAlias());
+        labels.put("if_speed", Long.toString(sic.getIfSpeed()));
+        labels.put("if_type", Integer.toString(sic.getIfType()));
+    }
+
+    private static String categories(Optional<NodeContext> nc) {
+        List<String> cats = new ArrayList<>(nc.map(NodeContext::getCategoriesList).orElse(List.of()));
+        cats.sort(String::compareTo);
+        return String.join(",", cats);
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlarmEnricherTest test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/enrich
+git commit -m "feat(alerts-forwarder): add alarm enricher joining node context"
+```
+
+---
+
+## Task 5: `ActiveAlertRegistry` — stable forwarded identity
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistry.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistryTest.java`
+
+The registry holds, per reduction key, the last forwarded *firing* `ForwardedAlarm`. A resolve reuses that stored value so the resolved alert carries the exact label set the firing alert did — which is what keeps Alertmanager's dedup fingerprint matched. `ForwardedAlarm` is defined in Task 6; this task references it, so Task 6 must be implemented before this task compiles. **Implement Task 6 first, then return here** — or implement both before running tests. (The plan orders Task 5 before 6 for narrative flow; the executor should create `ForwardedAlarm`/`AlarmSink` from Task 6 Step 1–2 before compiling Task 5.)
+
+- [ ] **Step 1: Write the failing test** (after Task 6's `ForwardedAlarm` exists)
+
+`ActiveAlertRegistryTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.lifecycle;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActiveAlertRegistryTest {
+
+    private ForwardedAlarm firing(String rk) {
+        return new ForwardedAlarm(rk, ForwardedAlarm.State.FIRING,
+                Map.of("node", "Servers:web-01"), Map.of("description", "down"), 1000L);
+    }
+
+    @Test
+    void markFiringThenIsActive() {
+        ActiveAlertRegistry registry = new ActiveAlertRegistry();
+        assertThat(registry.isActive("rk")).isFalse();
+        registry.markFiring(firing("rk"));
+        assertThat(registry.isActive("rk")).isTrue();
+        assertThat(registry.size()).isEqualTo(1);
+    }
+
+    @Test
+    void removeReturnsStoredIdentityAndEvicts() {
+        ActiveAlertRegistry registry = new ActiveAlertRegistry();
+        ForwardedAlarm stored = firing("rk");
+        registry.markFiring(stored);
+
+        Optional<ForwardedAlarm> removed = registry.remove("rk");
+
+        assertThat(removed).contains(stored);
+        assertThat(registry.isActive("rk")).isFalse();
+    }
+
+    @Test
+    void removeUnknownKeyReturnsEmpty() {
+        assertThat(new ActiveAlertRegistry().remove("nope")).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=ActiveAlertRegistryTest test`
+Expected: FAIL — compilation error: `ActiveAlertRegistry` does not exist.
+
+- [ ] **Step 3: Implement `ActiveAlertRegistry`**
+
+`ActiveAlertRegistry.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.lifecycle;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.springframework.stereotype.Component;
+
+/**
+ * In-memory record of currently-firing alerts, keyed by reduction key. Stores
+ * the last forwarded firing {@link ForwardedAlarm} so a later resolve reuses
+ * the exact same label set — Alertmanager's dedup fingerprint then matches and
+ * the firing alert resolves instead of leaking. Rebuilt on every restart by
+ * {@code AlarmStateKafkaConsumer} replaying the compacted alarms topic.
+ */
+@Component
+public class ActiveAlertRegistry {
+
+    private final ConcurrentHashMap<String, ForwardedAlarm> active = new ConcurrentHashMap<>();
+
+    public void markFiring(ForwardedAlarm alarm) {
+        active.put(alarm.reductionKey(), alarm);
+    }
+
+    public boolean isActive(String reductionKey) {
+        return active.containsKey(reductionKey);
+    }
+
+    /** Removes and returns the stored firing identity, or empty if not active. */
+    public Optional<ForwardedAlarm> remove(String reductionKey) {
+        return Optional.ofNullable(active.remove(reductionKey));
+    }
+
+    public int size() {
+        return active.size();
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=ActiveAlertRegistryTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/lifecycle \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/lifecycle
+git commit -m "feat(alerts-forwarder): add active-alert registry for stable resolve identity"
+```
+
+---
+
+## Task 6: The `AlarmSink` seam
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/ForwardedAlarm.java`
+- Create: `.../sink/AlarmSink.java`
+
+This is the seam: a transport-agnostic representation of an alarm to forward, and the one-method interface every sink implements. Implement this before Task 5 compiles (Task 5 references `ForwardedAlarm`).
+
+- [ ] **Step 1: Create `ForwardedAlarm`**
+
+`ForwardedAlarm.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+
+/**
+ * A transport-agnostic alarm to forward. {@code labels} are low-cardinality
+ * dimensions; {@code annotations} are free text. {@code state} drives the
+ * lifecycle: FIRING asserts the alert, RESOLVED clears it. {@code startsAtMs}
+ * is the alarm's first-event time. A resolve carries the firing alert's stored
+ * label set verbatim (see {@code ActiveAlertRegistry}).
+ */
+public record ForwardedAlarm(
+        String reductionKey,
+        State state,
+        Map<String, String> labels,
+        Map<String, String> annotations,
+        long startsAtMs) {
+
+    public enum State { FIRING, RESOLVED }
+}
+```
+
+- [ ] **Step 2: Create `AlarmSink`**
+
+`AlarmSink.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+/**
+ * Output port. An implementation forwards a {@link ForwardedAlarm} to one
+ * alerting/metrics backend. Implementations are activated by
+ * {@code @ConditionalOnProperty} so an operator chooses which ship.
+ *
+ * <p>Contract: {@link #forward} throws on a transport failure so the caller
+ * (the pipeline) can retry and back-pressure the Kafka consumer. It must NOT
+ * swallow failures — a silently-dropped alert is worse than a stalled consumer.
+ */
+public interface AlarmSink {
+
+    /** Forwards one alarm. Throws on transport failure. */
+    void forward(ForwardedAlarm alarm) throws Exception;
+
+    /** Short stable name for metrics tags and logs (e.g. "alertmanager"). */
+    String name();
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `./mvnw -q -pl :alerts-forwarder test-compile`
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/ForwardedAlarm.java \
+        core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlarmSink.java
+git commit -m "feat(alerts-forwarder): add AlarmSink seam (ForwardedAlarm + interface)"
+```
+
+---
+
+## Task 7: `AlertmanagerAlarmSink`
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSink.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSinkTest.java`
+
+POSTs a one-element JSON array to Alertmanager's `/api/v2/alerts`. Each alert object has `labels`, `annotations`, `startsAt`, `endsAt` (ISO-8601 UTC). FIRING: `endsAt = now + resolveTimeoutMs` (Alertmanager auto-resolves if not refreshed). RESOLVED: `endsAt = now` (Alertmanager marks it resolved immediately).
+
+- [ ] **Step 1: Write the failing test**
+
+`AlertmanagerAlarmSinkTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlertmanagerAlarmSinkTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    private AlertmanagerAlarmSink sink() {
+        AlertsForwarderProperties props = new AlertsForwarderProperties();
+        props.getAlertmanager().setUrl(server.url("/api/v2/alerts").toString());
+        props.getAlertmanager().setResolveTimeoutMs(300000);
+        return new AlertmanagerAlarmSink(props);
+    }
+
+    @Test
+    void postsFiringAlertAsJsonArray() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.FIRING,
+                Map.of("node", "Servers:web-01", "severity", "MAJOR"),
+                Map.of("description", "Node is down"), 1_700_000_000_000L);
+
+        sink().forward(alarm);
+
+        RecordedRequest req = server.takeRequest();
+        assertThat(req.getMethod()).isEqualTo("POST");
+        assertThat(req.getPath()).isEqualTo("/api/v2/alerts");
+        String body = req.getBody().readUtf8();
+        assertThat(body).startsWith("[").endsWith("]");
+        assertThat(body).contains("\"node\":\"Servers:web-01\"");
+        assertThat(body).contains("\"description\":\"Node is down\"");
+        assertThat(body).contains("\"startsAt\"").contains("\"endsAt\"");
+    }
+
+    @Test
+    void throwsOnNon2xx() {
+        server.enqueue(new MockResponse().setResponseCode(503));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.FIRING,
+                Map.of("node", "n"), Map.of(), 1L);
+
+        org.junit.jupiter.api.Assertions.assertThrows(Exception.class,
+                () -> sink().forward(alarm));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlertmanagerAlarmSinkTest test`
+Expected: FAIL — compilation error: `AlertmanagerAlarmSink` does not exist.
+
+- [ ] **Step 3: Implement `AlertmanagerAlarmSink`**
+
+`AlertmanagerAlarmSink.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Forwards alarms to Alertmanager's {@code POST /api/v2/alerts}. The request
+ * body is a one-element JSON array; a FIRING alert gets {@code endsAt = now +
+ * resolveTimeout} so Alertmanager auto-resolves if the forwarder stops
+ * refreshing it; a RESOLVED alert gets {@code endsAt = now}.
+ *
+ * <p>Activated by {@code deltav.alerts-forwarder.alertmanager.enabled} (default
+ * true).</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "deltav.alerts-forwarder.alertmanager",
+        name = "enabled", havingValue = "true", matchIfMissing = true)
+public class AlertmanagerAlarmSink implements AlarmSink {
+
+    private final RestClient client;
+    private final String url;
+    private final long resolveTimeoutMs;
+
+    public AlertmanagerAlarmSink(AlertsForwarderProperties props) {
+        this.url = props.getAlertmanager().getUrl();
+        this.resolveTimeoutMs = props.getAlertmanager().getResolveTimeoutMs();
+        this.client = RestClient.builder().build();
+    }
+
+    @Override
+    public void forward(ForwardedAlarm alarm) throws Exception {
+        Instant now = Instant.now();
+        Instant endsAt = alarm.state() == ForwardedAlarm.State.RESOLVED
+                ? now
+                : now.plus(Duration.ofMillis(resolveTimeoutMs));
+
+        Map<String, Object> alert = Map.of(
+                "labels", alarm.labels(),
+                "annotations", alarm.annotations(),
+                "startsAt", Instant.ofEpochMilli(alarm.startsAtMs()).toString(),
+                "endsAt", endsAt.toString());
+
+        client.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(List.of(alert))
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Override
+    public String name() {
+        return "alertmanager";
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlertmanagerAlarmSinkTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSink.java \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSinkTest.java
+git commit -m "feat(alerts-forwarder): add Alertmanager sink implementation"
+```
+
+---
+
+## Task 8: `VictoriaMetricsAlarmSink`
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSink.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSinkTest.java`
+
+Remote-writes a single `deltav_alarm_state` gauge series to VictoriaMetrics: value `1.0` for FIRING, `0.0` for RESOLVED. The series labels are the `ForwardedAlarm` labels plus `__name__`. Uses the `prometheus.prompb` protobuf classes from `deltav-kafka-contracts` and Snappy compression — the same wire format prometheus-writer uses, written inline (one series per call, no batching needed).
+
+- [ ] **Step 1: Write the failing test**
+
+`VictoriaMetricsAlarmSinkTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.WriteRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VictoriaMetricsAlarmSinkTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    private VictoriaMetricsAlarmSink sink() {
+        AlertsForwarderProperties props = new AlertsForwarderProperties();
+        props.getVictoriametrics().setUrl(server.url("/api/v1/write").toString());
+        return new VictoriaMetricsAlarmSink(props);
+    }
+
+    @Test
+    void remoteWritesFiringAsGaugeValueOne() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.FIRING,
+                Map.of("node", "Servers:web-01", "severity", "MAJOR"), Map.of(), 1000L);
+
+        sink().forward(alarm);
+
+        RecordedRequest req = server.takeRequest();
+        assertThat(req.getHeader("Content-Encoding")).isEqualTo("snappy");
+        WriteRequest wr = WriteRequest.parseFrom(Snappy.uncompress(req.getBody().readByteArray()));
+        assertThat(wr.getTimeseriesCount()).isEqualTo(1);
+        assertThat(wr.getTimeseries(0).getLabelsList())
+                .anyMatch(l -> l.getName().equals("__name__") && l.getValue().equals("deltav_alarm_state"));
+        assertThat(wr.getTimeseries(0).getSamples(0).getValue()).isEqualTo(1.0);
+    }
+
+    @Test
+    void remoteWritesResolvedAsGaugeValueZero() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.RESOLVED,
+                Map.of("node", "n"), Map.of(), 1000L);
+
+        sink().forward(alarm);
+
+        WriteRequest wr = WriteRequest.parseFrom(Snappy.uncompress(server.takeRequest().getBody().readByteArray()));
+        assertThat(wr.getTimeseries(0).getSamples(0).getValue()).isEqualTo(0.0);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=VictoriaMetricsAlarmSinkTest test`
+Expected: FAIL — compilation error: `VictoriaMetricsAlarmSink` does not exist.
+
+- [ ] **Step 3: Implement `VictoriaMetricsAlarmSink`**
+
+`VictoriaMetricsAlarmSink.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.Label;
+import prometheus.prompb.Sample;
+import prometheus.prompb.TimeSeries;
+import prometheus.prompb.WriteRequest;
+
+/**
+ * Forwards alarms to VictoriaMetrics as a {@code deltav_alarm_state} gauge via
+ * Prometheus remote-write: value {@code 1.0} while firing, {@code 0.0} on
+ * resolve. The series labels are the {@link ForwardedAlarm} labels (the same
+ * low-cardinality set the Alertmanager sink uses).
+ *
+ * <p>Activated by {@code deltav.alerts-forwarder.victoriametrics.enabled}
+ * (default false — Alertmanager is the default backend).</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "deltav.alerts-forwarder.victoriametrics",
+        name = "enabled", havingValue = "true")
+public class VictoriaMetricsAlarmSink implements AlarmSink {
+
+    private static final String METRIC_NAME = "deltav_alarm_state";
+
+    private final RestClient client;
+    private final String url;
+
+    public VictoriaMetricsAlarmSink(AlertsForwarderProperties props) {
+        this.url = props.getVictoriametrics().getUrl();
+        this.client = RestClient.builder().build();
+    }
+
+    @Override
+    public void forward(ForwardedAlarm alarm) throws Exception {
+        double value = alarm.state() == ForwardedAlarm.State.FIRING ? 1.0 : 0.0;
+
+        // Sorted labels — stable series identity; __name__ first by sort order.
+        Map<String, String> labels = new TreeMap<>(alarm.labels());
+        labels.put("__name__", METRIC_NAME);
+
+        TimeSeries.Builder ts = TimeSeries.newBuilder();
+        labels.forEach((k, v) -> ts.addLabels(Label.newBuilder().setName(k).setValue(v).build()));
+        ts.addSamples(Sample.newBuilder()
+                .setValue(value)
+                .setTimestamp(System.currentTimeMillis())
+                .build());
+
+        WriteRequest request = WriteRequest.newBuilder().addTimeseries(ts).build();
+        byte[] compressed = Snappy.compress(request.toByteArray());
+
+        client.post()
+                .uri(url)
+                .contentType(MediaType.parseMediaType("application/x-protobuf"))
+                .header("Content-Encoding", "snappy")
+                .header("X-Prometheus-Remote-Write-Version", "0.1.0")
+                .body(compressed)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Override
+    public String name() {
+        return "victoriametrics";
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=VictoriaMetricsAlarmSinkTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSink.java \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSinkTest.java
+git commit -m "feat(alerts-forwarder): add VictoriaMetrics sink implementation"
+```
+
+---
+
+## Task 9: `AlarmForwardingPipeline` — lifecycle orchestration
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipeline.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipelineTest.java`
+
+The pipeline turns one consumed record into sink calls. `onRecord(reductionKey, alarm)` — a `null` alarm is a Kafka tombstone. Logic (spec §5.3):
+- **tombstone** → resolve (if active).
+- **non-tombstone, fails filter** → resolve if currently active (dropped below threshold / `CLEARED`), else ignore.
+- **non-tombstone, passes filter** → enrich, build a FIRING `ForwardedAlarm`, register it, forward to every sink.
+A resolve reuses the registry's stored firing identity. Sink failures propagate (the consumer back-pressures).
+
+- [ ] **Step 1: Write the failing test**
+
+`AlarmForwardingPipelineTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.enrich.AlarmEnricher;
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.alerts.forwarder.sink.AlarmSink;
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmForwardingPipelineTest {
+
+    private final List<ForwardedAlarm> sent = new ArrayList<>();
+
+    private final AlarmSink recordingSink = new AlarmSink() {
+        public void forward(ForwardedAlarm a) { sent.add(a); }
+        public String name() { return "recording"; }
+    };
+
+    private AlarmForwardingPipeline pipeline(String minSeverity) {
+        return new AlarmForwardingPipeline(
+                new AlarmFilter(minSeverity, List.of()),
+                new AlarmEnricher(new NodeContextCache()),
+                new ActiveAlertRegistry(),
+                List.of(recordingSink),
+                new SimpleMeterRegistry());
+    }
+
+    private AlarmState alarm(String rk, AlarmState.Severity sev) {
+        return AlarmState.newBuilder()
+                .setReductionKey(rk).setSeverity(sev).setUei("uei/x").setNodeId(1).build();
+    }
+
+    @Test
+    void firingAlarmAboveThresholdIsForwarded() {
+        pipeline("WARNING").onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        assertThat(sent).hasSize(1);
+        assertThat(sent.get(0).state()).isEqualTo(ForwardedAlarm.State.FIRING);
+    }
+
+    @Test
+    void alarmBelowThresholdIsNotForwarded() {
+        pipeline("MAJOR").onRecord("rk", alarm("rk", AlarmState.Severity.WARNING));
+        assertThat(sent).isEmpty();
+    }
+
+    @Test
+    void tombstoneResolvesActiveAlarm() {
+        AlarmForwardingPipeline p = pipeline("WARNING");
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        p.onRecord("rk", null);
+        assertThat(sent).hasSize(2);
+        assertThat(sent.get(1).state()).isEqualTo(ForwardedAlarm.State.RESOLVED);
+    }
+
+    @Test
+    void clearedSeverityResolvesActiveAlarm() {
+        AlarmForwardingPipeline p = pipeline("WARNING");
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.CLEARED));
+        assertThat(sent).hasSize(2);
+        assertThat(sent.get(1).state()).isEqualTo(ForwardedAlarm.State.RESOLVED);
+    }
+
+    @Test
+    void resolveReusesStoredFiringLabels() {
+        AlarmForwardingPipeline p = pipeline("WARNING");
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        p.onRecord("rk", null);
+        assertThat(sent.get(1).labels()).isEqualTo(sent.get(0).labels());
+    }
+
+    @Test
+    void tombstoneForUnknownKeyForwardsNothing() {
+        pipeline("WARNING").onRecord("never-seen", null);
+        assertThat(sent).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlarmForwardingPipelineTest test`
+Expected: FAIL — compilation error: `AlarmForwardingPipeline` does not exist.
+
+- [ ] **Step 3: Implement `AlarmForwardingPipeline`**
+
+`AlarmForwardingPipeline.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.pipeline;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.enrich.AlarmEnricher;
+import org.deltav.alerts.forwarder.enrich.EnrichedAlarm;
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.deltav.alerts.forwarder.sink.AlarmSink;
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Turns one consumed alarm record into sink calls. Lifecycle (spec §5.3): a
+ * tombstone or a sub-threshold record on an active alarm resolves it; a record
+ * above the filter fires it. Resolves reuse the {@link ActiveAlertRegistry}'s
+ * stored firing identity so label sets stay stable.
+ *
+ * <p>Sink failures propagate out of {@link #onRecord} so the Kafka consumer
+ * can retry and back-pressure rather than drop the alarm.</p>
+ */
+@Component
+public class AlarmForwardingPipeline {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmForwardingPipeline.class);
+
+    private final AlarmFilter filter;
+    private final AlarmEnricher enricher;
+    private final ActiveAlertRegistry registry;
+    private final List<AlarmSink> sinks;
+    private final Counter consumed;
+    private final MeterRegistry metrics;
+
+    public AlarmForwardingPipeline(AlarmFilter filter, AlarmEnricher enricher,
+                                   ActiveAlertRegistry registry, List<AlarmSink> sinks,
+                                   MeterRegistry metrics) {
+        this.filter = filter;
+        this.enricher = enricher;
+        this.registry = registry;
+        this.sinks = sinks;
+        this.metrics = metrics;
+        this.consumed = metrics.counter(AlertsForwarderMetrics.ALARMS_CONSUMED);
+    }
+
+    /** Processes one record. A {@code null} alarm is a Kafka tombstone (delete). */
+    public void onRecord(String reductionKey, AlarmState alarm) {
+        consumed.increment();
+
+        if (alarm == null) {
+            resolve(reductionKey);
+            return;
+        }
+        if (!filter.accept(alarm)) {
+            // Sub-threshold or CLEARED: resolve if we are currently firing it.
+            if (registry.isActive(reductionKey)) {
+                resolve(reductionKey);
+            } else {
+                metrics.counter(AlertsForwarderMetrics.FILTERED, "reason", "severity").increment();
+            }
+            return;
+        }
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+        metrics.counter(AlertsForwarderMetrics.ENRICHMENT,
+                "result", e.enrichmentComplete() ? "hit" : "partial").increment();
+
+        ForwardedAlarm fa = new ForwardedAlarm(reductionKey, ForwardedAlarm.State.FIRING,
+                e.labels(), e.annotations(), alarm.getFirstEventTimeMs());
+        registry.markFiring(fa);
+        forward(fa);
+        metrics.counter(AlertsForwarderMetrics.FORWARDED, "outcome", "firing").increment();
+    }
+
+    private void resolve(String reductionKey) {
+        Optional<ForwardedAlarm> firing = registry.remove(reductionKey);
+        if (firing.isEmpty()) {
+            return;   // not active — nothing to resolve
+        }
+        ForwardedAlarm prev = firing.get();
+        ForwardedAlarm resolved = new ForwardedAlarm(reductionKey, ForwardedAlarm.State.RESOLVED,
+                prev.labels(), prev.annotations(), prev.startsAtMs());
+        forward(resolved);
+        metrics.counter(AlertsForwarderMetrics.FORWARDED, "outcome", "resolved").increment();
+    }
+
+    private void forward(ForwardedAlarm alarm) {
+        for (AlarmSink sink : sinks) {
+            try {
+                sink.forward(alarm);
+            } catch (Exception e) {
+                metrics.counter(AlertsForwarderMetrics.SINK_ERRORS, "sink", sink.name()).increment();
+                // Propagate so the consumer retries and back-pressures.
+                throw new SinkForwardException(sink.name(), e);
+            }
+        }
+    }
+
+    /** Thrown when a sink fails; the consumer retries the record. */
+    public static class SinkForwardException extends RuntimeException {
+        public SinkForwardException(String sink, Throwable cause) {
+            super("sink '" + sink + "' failed to forward alarm", cause);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlarmForwardingPipelineTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/pipeline \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/pipeline
+git commit -m "feat(alerts-forwarder): add forwarding pipeline with firing/resolved lifecycle"
+```
+
+---
+
+## Task 10: `AlarmStateKafkaConsumer` + `DlqPublisher`
+
+**Files:**
+- Create: `core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/dlq/DlqPublisher.java`
+- Create: `.../consume/AlarmStateKafkaConsumer.java`
+- Test: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/dlq/DlqPublisherTest.java`
+
+`AlarmStateKafkaConsumer` is the bootstrap-replay consumer for `deltav-alarms-state-change` — structurally the `NodeContextKafkaBootstrap` pattern. It starts on `NodeContextCacheReadyEvent` (the §5.5 startup gate), seeks to the beginning, and feeds every record to `AlarmForwardingPipeline.onRecord`. The compacted topic means the replay rebuilds the `ActiveAlertRegistry` to current state. A record whose value fails `AlarmState.parseFrom` goes to `DlqPublisher`. On a sink failure (`SinkForwardException`) the consumer sleeps and retries the same record — natural back-pressure.
+
+- [ ] **Step 1: Write the failing test — `DlqPublisher`**
+
+`DlqPublisherTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.dlq;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DlqPublisherTest {
+
+    @Test
+    void publishesPoisonRecordToDlqTopicWithReasonHeader() {
+        // Kafka client 4.1.1: MockProducer takes (autoComplete, partitioner, keySer, valueSer).
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(
+                true, null, new ByteArraySerializer(), new ByteArraySerializer());
+        SimpleMeterRegistry metrics = new SimpleMeterRegistry();
+        DlqPublisher dlq = new DlqPublisher(producer, "deltav-alerts-forwarder-dlq", metrics);
+
+        dlq.publish("rk".getBytes(), "bad-bytes".getBytes(), "parse-error");
+
+        assertThat(producer.history()).hasSize(1);
+        ProducerRecord<byte[], byte[]> rec = producer.history().get(0);
+        assertThat(rec.topic()).isEqualTo("deltav-alerts-forwarder-dlq");
+        assertThat(new String(rec.headers().lastHeader("x-dlq-reason").value()))
+                .isEqualTo("parse-error");
+        assertThat(metrics.counter(AlertsForwarderMetrics.DLQ_RECORDS).count()).isEqualTo(1.0);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=DlqPublisherTest test`
+Expected: FAIL — compilation error: `DlqPublisher` does not exist.
+
+- [ ] **Step 3: Implement `DlqPublisher`**
+
+`DlqPublisher.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.dlq;
+
+import java.nio.charset.StandardCharsets;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Publishes records that cannot be parsed as {@link org.deltav.alarms.proto.AlarmState}
+ * to the dead-letter topic, preserving the original key and bytes plus a reason
+ * header. A poison record never wedges the consumer — it is DLQ'd and skipped.
+ */
+public class DlqPublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DlqPublisher.class);
+
+    private final Producer<byte[], byte[]> producer;
+    private final String topic;
+    private final MeterRegistry metrics;
+
+    public DlqPublisher(Producer<byte[], byte[]> producer, String topic, MeterRegistry metrics) {
+        this.producer = producer;
+        this.topic = topic;
+        this.metrics = metrics;
+    }
+
+    public void publish(byte[] key, byte[] sourcePayload, String reason) {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, key, sourcePayload);
+        record.headers().add("x-dlq-reason", reason.getBytes(StandardCharsets.UTF_8));
+        record.headers().add("x-dlq-timestamp-ms",
+                Long.toString(System.currentTimeMillis()).getBytes(StandardCharsets.UTF_8));
+        producer.send(record, (md, ex) -> {
+            if (ex != null) {
+                LOG.error("Failed to publish DLQ record reason={}", reason, ex);
+            }
+        });
+        metrics.counter(AlertsForwarderMetrics.DLQ_RECORDS).increment();
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=DlqPublisherTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Implement `AlarmStateKafkaConsumer`**
+
+`AlarmStateKafkaConsumer.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.consume;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.deltav.alerts.forwarder.dlq.DlqPublisher;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCacheReadyEvent;
+import org.deltav.alerts.forwarder.pipeline.AlarmForwardingPipeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Dedicated bootstrap-replay consumer for {@code deltav-alarms-state-change}.
+ * Starts only after {@link NodeContextCacheReadyEvent} (the §5.5 startup gate),
+ * seeks to the beginning, and feeds every record to {@link AlarmForwardingPipeline}.
+ * Because the topic is compacted, the replay rebuilds {@link ActiveAlertRegistry}
+ * to the exact current set, then the loop live-tails.
+ *
+ * <p>A value that fails {@code AlarmState.parseFrom} is DLQ'd and skipped. A
+ * sink failure ({@code SinkForwardException}) makes the thread sleep and retry
+ * the same record — back-pressure, no alarm dropped.</p>
+ */
+@Component
+public class AlarmStateKafkaConsumer implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmStateKafkaConsumer.class);
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration RETRY_BACKOFF = Duration.ofSeconds(5);
+
+    private final AlertsForwarderProperties props;
+    private final AlarmForwardingPipeline pipeline;
+    private final DlqPublisher dlq;
+    private final String bootstrapServers;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread thread;
+
+    public AlarmStateKafkaConsumer(AlertsForwarderProperties props,
+                                   AlarmForwardingPipeline pipeline,
+                                   ActiveAlertRegistry registry,
+                                   MeterRegistry meterRegistry,
+                                   @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        this.props = props;
+        this.pipeline = pipeline;
+        this.dlq = new DlqPublisher(buildProducer(bootstrapServers), props.getDlq().getTopic(), meterRegistry);
+        this.bootstrapServers = bootstrapServers;
+        Gauge.builder(AlertsForwarderMetrics.ACTIVE_ALERTS, registry, ActiveAlertRegistry::size)
+                .register(meterRegistry);
+    }
+
+    /** §5.5 startup gate: do not consume alarms until node context is materialized. */
+    @EventListener
+    public void onNodeContextReady(NodeContextCacheReadyEvent event) {
+        if (running.compareAndSet(false, true)) {
+            LOG.info("NodeContextCache ready (size={}) — starting alarm consumer", event.getCacheSize());
+            thread = new Thread(this, "alarm-state-consumer");
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+
+    @PreDestroy
+    public void stop() {
+        running.set(false);
+        if (thread != null) {
+            try {
+                thread.join(5000);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        try (KafkaConsumer<byte[], byte[]> consumer = buildConsumer()) {
+            consumer.subscribe(List.of(props.getAlarmsTopic()));
+            // Compacted topic: replay from the beginning every start to rebuild
+            // the active-alert registry. seekToBeginning on first assignment.
+            boolean seeked = false;
+            while (running.get()) {
+                ConsumerRecords<byte[], byte[]> records = consumer.poll(POLL_TIMEOUT);
+                if (!seeked && !consumer.assignment().isEmpty()) {
+                    consumer.seekToBeginning(consumer.assignment());
+                    seeked = true;
+                    continue;
+                }
+                for (ConsumerRecord<byte[], byte[]> record : records) {
+                    handleWithRetry(record);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("AlarmStateKafkaConsumer fatal error", e);
+        }
+    }
+
+    private void handleWithRetry(ConsumerRecord<byte[], byte[]> record) {
+        while (running.get()) {
+            try {
+                handle(record);
+                return;
+            } catch (AlarmForwardingPipeline.SinkForwardException e) {
+                LOG.warn("Sink failure — retrying record in {}s", RETRY_BACKOFF.toSeconds(), e);
+                sleep(RETRY_BACKOFF);
+            }
+        }
+    }
+
+    private void handle(ConsumerRecord<byte[], byte[]> record) {
+        String reductionKey = record.key() == null ? "" : new String(record.key());
+        if (record.value() == null) {
+            pipeline.onRecord(reductionKey, null);   // Kafka tombstone — alarm deleted.
+            return;
+        }
+        AlarmState alarm;
+        try {
+            alarm = AlarmState.parseFrom(record.value());
+        } catch (Exception e) {
+            LOG.warn("Unparseable AlarmState key={} offset={} — DLQ", reductionKey, record.offset(), e);
+            dlq.publish(record.key(), record.value(), "parse-error");
+            return;
+        }
+        pipeline.onRecord(reductionKey, alarm);
+    }
+
+    private static void sleep(Duration d) {
+        try {
+            Thread.sleep(d.toMillis());
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private KafkaConsumer<byte[], byte[]> buildConsumer() {
+        Properties p = new Properties();
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        p.put(ConsumerConfig.GROUP_ID_CONFIG, "alerts-forwarder-alarms-" + UUID.randomUUID());
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        p.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        return new KafkaConsumer<>(p);
+    }
+
+    private static KafkaProducer<byte[], byte[]> buildProducer(String bootstrapServers) {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        p.put(ProducerConfig.CLIENT_ID_CONFIG, "alerts-forwarder-dlq");
+        return new KafkaProducer<>(p);
+    }
+}
+```
+
+- [ ] **Step 6: Build the whole module**
+
+Run: `./mvnw -q -pl :alerts-forwarder clean install`
+Expected: `BUILD SUCCESS` — every unit test green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/consume \
+        core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/dlq \
+        core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/dlq
+git commit -m "feat(alerts-forwarder): add bootstrap-replay alarm consumer and DLQ"
+```
+
+---
+
+## Task 11: Build, CI, and compose wiring
+
+**Files:**
+- Modify: `opennms-container/delta-v/build.sh`
+- Modify: `.github/workflows/delta-v-build-images.yml`
+- Modify: `opennms-container/delta-v/docker-compose.yml`
+- Modify: `opennms-container/delta-v/Dockerfile.daemon-per` — verify it can build `alerts-forwarder` (see Step 1 note)
+
+`alerts-forwarder` is a Spring Boot fat-jar daemon like the existing `DAEMON_NAMES` entries, so it joins the per-daemon build path.
+
+- [ ] **Step 1: Add to `build.sh`**
+
+In `opennms-container/delta-v/build.sh`, change the `DAEMON_NAMES` line (currently line 28):
+
+```bash
+DAEMON_NAMES="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd"
+```
+
+to append `alerts-forwarder`:
+
+```bash
+DAEMON_NAMES="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd alerts-forwarder"
+```
+
+Verify the staging step that writes `staging/<name>/.main_class` picks up the new module — it derives the main class from each module's `spring-boot-maven-plugin` `<mainClass>`, which Task 1 set to `org.deltav.alerts.forwarder.AlertsForwarderApplication`. If the staging script enumerates modules from a hard-coded list rather than `DAEMON_NAMES`, add `alerts-forwarder` there too.
+
+- [ ] **Step 2: Add to the GitHub Actions workflow**
+
+In `.github/workflows/delta-v-build-images.yml`, change the `DAEMONS` line in the "Build and push per-daemon images" step (currently line 173) to append `alerts-forwarder`:
+
+```bash
+DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd alerts-forwarder"
+```
+
+And in the image-summary `DAEMONS` list near the end of the workflow (currently line 415), append `alerts-forwarder` so the summary lists it.
+
+- [ ] **Step 3: Add the `alertmanager` service to docker-compose**
+
+In `opennms-container/delta-v/docker-compose.yml`, add an `alertmanager` service (model the indentation and `networks`/`restart` keys on the existing `victoriametrics` service):
+
+```yaml
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: delta-v-alertmanager-1
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "9093:9093"
+    networks:
+      - deltav
+    restart: unless-stopped
+```
+
+Create `opennms-container/delta-v/alertmanager/alertmanager.yml` — a minimal config (a null receiver is enough for the dev stack; alerts are visible in the Alertmanager UI):
+
+```yaml
+route:
+  receiver: deltav-null
+  group_by: ['node']
+receivers:
+  - name: deltav-null
+```
+
+- [ ] **Step 4: Add the `alerts-forwarder` service to docker-compose**
+
+Add an `alerts-forwarder` service (model on the existing `prometheus-writer` service):
+
+```yaml
+  alerts-forwarder:
+    image: deltav/alerts-forwarder:${VERSION:-latest}
+    container_name: delta-v-alerts-forwarder-1
+    depends_on:
+      - kafka
+      - alertmanager
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      DELTAV_ALERTS_ALERTMANAGER_URL: http://alertmanager:9093/api/v2/alerts
+      DELTAV_ALERTS_ALERTMANAGER_ENABLED: "true"
+      DELTAV_ALERTS_VM_ENABLED: "false"
+    networks:
+      - deltav
+    restart: unless-stopped
+```
+
+- [ ] **Step 5: Add the Grafana Alertmanager datasource**
+
+Locate the Grafana datasource provisioning file under `opennms-container/delta-v/` (the existing VictoriaMetrics datasource lives there — search for `victoriametrics` under `opennms-container/delta-v/grafana/`). Add an Alertmanager datasource entry alongside it:
+
+```yaml
+  - name: Alertmanager
+    type: alertmanager
+    access: proxy
+    url: http://alertmanager:9093
+    jsonData:
+      implementation: prometheus
+```
+
+- [ ] **Step 6: Build the image**
+
+Run: `cd opennms-container/delta-v && ./build.sh daemon alerts-forwarder`
+Expected: the single-daemon build reports success and `docker images` lists `deltav/alerts-forwarder`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add opennms-container/delta-v/build.sh \
+        .github/workflows/delta-v-build-images.yml \
+        opennms-container/delta-v/docker-compose.yml \
+        opennms-container/delta-v/alertmanager \
+        opennms-container/delta-v/grafana
+git commit -m "feat(alerts-forwarder): wire image build, CI, and docker-compose"
+```
+
+---
+
+## Task 12: Integration test and end-to-end smoke
+
+**Files:**
+- Create: `core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/AlertsForwarderIntegrationIT.java`
+
+A Testcontainers Kafka integration test: publish synthetic `AlarmState` records to `deltav-alarms-state-change`, run the consumer pipeline, and assert the sink saw the right calls.
+
+- [ ] **Step 1: Write the integration test**
+
+`AlertsForwarderIntegrationIT.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.enrich.AlarmEnricher;
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.alerts.forwarder.pipeline.AlarmForwardingPipeline;
+import org.deltav.alerts.forwarder.sink.AlarmSink;
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Testcontainers
+class AlertsForwarderIntegrationIT {
+
+    @Container
+    static KafkaContainer kafka = new KafkaContainer("apache/kafka:3.8.0");
+
+    @Test
+    @Timeout(60)
+    void firingThenTombstoneProducesFiringThenResolved() throws Exception {
+        String topic = "deltav-alarms-state-change";
+        CopyOnWriteArrayList<ForwardedAlarm> sent = new CopyOnWriteArrayList<>();
+        AlarmSink sink = new AlarmSink() {
+            public void forward(ForwardedAlarm a) { sent.add(a); }
+            public String name() { return "test"; }
+        };
+
+        AlarmForwardingPipeline pipeline = new AlarmForwardingPipeline(
+                new AlarmFilter("WARNING", List.of()),
+                new AlarmEnricher(new NodeContextCache()),
+                new ActiveAlertRegistry(),
+                List.of(sink),
+                new SimpleMeterRegistry());
+
+        // Publish a firing alarm, then a tombstone, both keyed by reduction key.
+        try (KafkaProducer<byte[], byte[]> producer = producer()) {
+            AlarmState alarm = AlarmState.newBuilder()
+                    .setReductionKey("rk-1").setSeverity(AlarmState.Severity.MAJOR)
+                    .setUei("uei/nodeDown").setNodeId(1).build();
+            producer.send(new ProducerRecord<>(topic, "rk-1".getBytes(), alarm.toByteArray())).get();
+            producer.send(new ProducerRecord<>(topic, "rk-1".getBytes(), null)).get();
+        }
+
+        // Drain the topic through the pipeline, mirroring AlarmStateKafkaConsumer.handle.
+        try (var consumer = consumer()) {
+            consumer.subscribe(List.of(topic));
+            await().atMost(Duration.ofSeconds(30)).until(() -> {
+                var records = consumer.poll(Duration.ofSeconds(2));
+                records.forEach(r -> pipeline.onRecord(
+                        new String(r.key()),
+                        r.value() == null ? null : parse(r.value())));
+                return sent.size() >= 2;
+            });
+        }
+
+        assertThat(sent).hasSize(2);
+        assertThat(sent.get(0).state()).isEqualTo(ForwardedAlarm.State.FIRING);
+        assertThat(sent.get(1).state()).isEqualTo(ForwardedAlarm.State.RESOLVED);
+        assertThat(sent.get(1).labels()).isEqualTo(sent.get(0).labels());
+    }
+
+    private static AlarmState parse(byte[] bytes) {
+        try {
+            return AlarmState.parseFrom(bytes);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static KafkaProducer<byte[], byte[]> producer() {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        return new KafkaProducer<>(p);
+    }
+
+    private static org.apache.kafka.clients.consumer.KafkaConsumer<byte[], byte[]> consumer() {
+        Properties p = new Properties();
+        p.put("bootstrap.servers", kafka.getBootstrapServers());
+        p.put("group.id", "it-" + System.nanoTime());
+        p.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        p.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        p.put("auto.offset.reset", "earliest");
+        return new org.apache.kafka.clients.consumer.KafkaConsumer<>(p);
+    }
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `./mvnw -q -pl :alerts-forwarder -Dtest=AlertsForwarderIntegrationIT test`
+Expected: PASS — the firing record and the tombstone produce a FIRING then a RESOLVED forward with identical labels.
+
+- [ ] **Step 3: Full reactor build**
+
+Run: `./mvnw -q -pl :alerts-forwarder -am clean install`
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/AlertsForwarderIntegrationIT.java
+git commit -m "test(alerts-forwarder): add Testcontainers end-to-end integration test"
+```
+
+- [ ] **Step 5: End-to-end docker-compose smoke**
+
+Bring the stack up (`docker compose -f opennms-container/delta-v/docker-compose.yml up -d`), wait for `alerts-forwarder` to report healthy, then trigger a real alarm (e.g. stop a monitored node so alarmd raises a `nodeDown` alarm). Verify:
+
+```bash
+# alerts-forwarder logged the startup gate and consumer start:
+docker logs delta-v-alerts-forwarder-1 2>&1 | grep -E "NodeContextCache ready|alarm consumer"
+
+# the alert reached Alertmanager:
+curl -s http://localhost:9093/api/v2/alerts | head
+```
+
+Expected: `alerts-forwarder` logs "NodeContextCache ready ... starting alarm consumer"; the Alertmanager API lists the forwarded alert with a `node` label of the form `foreignSource:foreignId`. Clear the alarm and confirm the alert resolves in Alertmanager.
+
+- [ ] **Step 6: Commit any smoke fixes**
+
+If the smoke required compose/config changes, commit them:
+
+```bash
+git add -A
+git commit -m "fix(alerts-forwarder): <describe the smoke fix>"
+```
+
+If no fixes were needed, skip this step.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §5.1 module/components → Tasks 1–10. §5.2 `AlarmSink` seam → Tasks 6–8. §5.3 lifecycle mapping → Task 9. §5.4 filtering → Task 3. §5.5 startup gate → Task 10 (`@EventListener(NodeContextCacheReadyEvent)`), see Architecture note for the mechanism refinement. §5.6 error handling → Task 9 (sink failure propagation) + Task 10 (DLQ for poison records, back-pressure retry). §5.7 observability → `AlertsForwarderMetrics` (Task 1) wired in Tasks 9–10. §5.8 compose/build → Task 11. §6 testing → unit tests per task + Task 12 integration test.
+- **Type consistency:** `ForwardedAlarm(reductionKey, state, labels, annotations, startsAtMs)` is defined in Task 6 and constructed identically in Tasks 9; `ForwardedAlarm.State.{FIRING,RESOLVED}` used consistently. `AlarmSink.forward(ForwardedAlarm) throws Exception` / `name()` — implemented by both sinks (Tasks 7–8) and the pipeline's recording test sink. `EnrichedAlarm(labels, annotations, enrichmentComplete)` defined in Task 4, consumed in Task 9. `AlarmForwardingPipeline.onRecord(String, AlarmState)` and `SinkForwardException` defined in Task 9, used in Task 10.
+- **Ordering caveat:** Task 5 references `ForwardedAlarm` from Task 6 — the executor should create Task 6's two files before compiling Task 5 (called out in Task 5's preamble).
+- **Deviation from spec:** see the Architecture note — the alarm consumer is a bootstrap-replay `KafkaConsumer`, not a Spring Cloud Stream binding, because only a replay rebuilds `ActiveAlertRegistry` after a restart (which §5.6 itself requires).

--- a/docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md
+++ b/docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md
@@ -1,0 +1,398 @@
+# v1.3.0 Track 2 — Node-Context Interface Enrichment + Prometheus Alerts Forwarder
+
+**Status:** Design — approved in brainstorming 2026-05-19
+**Release:** v1.3.0 "Alarms on Kafka"
+**Parent design:** [`2026-05-17-v1.3.0-alarms-on-kafka-design.md`](./2026-05-17-v1.3.0-alarms-on-kafka-design.md)
+**Depends on:** Track 1 (alarm Kafka publisher) — merged to `develop`
+
+---
+
+## 1. Purpose and scope
+
+Track 1 made alarm lifecycle observable on Kafka: alarmd publishes every
+alarm state change to the compacted topic `deltav-alarms-state-change`, keyed
+by reduction key. Track 2 consumes that stream and forwards it to the
+alerting/metrics ecosystem so operators see alarms as actionable alerts.
+
+During design it became clear the forwarder needs node enrichment that the
+existing `deltav-node-context` contract does not yet carry — specifically the
+SNMP (physical) interface table (`ifName`, `ifDescr`, `ifAlias`, `ifSpeed`,
+`ifType`). That enrichment has its **own producer** (provisiond) and an
+**existing second consumer** (`prometheus-writer`), so it is genuinely shared
+infrastructure rather than forwarder-specific. Track 2 is therefore split:
+
+- **Track 2a — node-context interface enrichment.** Extend the
+  `deltav-node-context` and `deltav-alarm-state` contracts and the provisiond
+  producer to carry SNMP-interface and interface/service identity. Shippable
+  and independently validated by `prometheus-writer` adopting the new fields.
+- **Track 2b — Prometheus alerts forwarder.** A new standalone daemon that
+  consumes `deltav-alarms-state-change`, enriches each alarm from a
+  node-context `GlobalKTable`, and forwards via a pluggable `AlarmSink` seam.
+
+**Sequencing:** 2a gates 2b. Both are designed here; each gets its own
+implementation plan. 2a is validated end-to-end before 2b code begins.
+
+### Out of scope
+
+- Phase 2 of the alarm migration (Kafka as source of truth, materializer) —
+  that is Track 3.
+- Northbounder API retirement — Track 4.
+- Re-keying any Kafka topic. The transient-identity problem (Section 4.4) is
+  solved entirely in label policy, not in keys or schema.
+
+---
+
+## 2. Background — the two planes
+
+Alarms flow to two consumers with different constraints:
+
+| | **Metrics plane** | **Alerts plane** |
+|---|---|---|
+| Backend | VictoriaMetrics (Prometheus TSDB) | Alertmanager |
+| Carries | labels only — cardinality-constrained | labels **and** annotations |
+| Identity | label set, must be durable across time | dedup fingerprint |
+| Free text | no (cardinality blow-up) | yes (annotations) |
+
+The constraint that matters is **cardinality, not stringiness**. A
+three-tier model governs what becomes a label:
+
+1. **Low-cardinality dimensions** — severity, UEI, location, category,
+   `foreign_source`. Safe as labels on every series.
+2. **Bounded, node-correlated metadata** — node label, asset fields,
+   interface attributes, OpenNMS `context:key` metadata. Moderate
+   cardinality; carried via the **info-metric / `group_left` pattern**
+   (Section 2.1) so it is joinable without multiplying series.
+3. **Unbounded free text** — alarm description, log message, operator
+   instructions. Never a label. Goes to Alertmanager annotations only.
+
+### 2.1 The info-metric / `group_left` pattern
+
+Moderate-cardinality attributes are not stamped onto every metric series.
+Instead a consumer emits a dedicated **info metric** — a gauge with constant
+value `1` — once per entity, carrying the attributes as labels:
+
+```
+deltav_node_info{node="Servers:web-01", node_label="web01.corp", category="Production", ...} 1
+deltav_snmp_interface_info{node="Servers:web-01", if_index="3", if_name="Gi0/3", if_speed="1000000000", ...} 1
+```
+
+A dashboard query joins the data metric to the info metric in PromQL:
+
+```promql
+deltav_response_time{service="ICMP"}
+  * on(node) group_left(node_label, category)
+  deltav_node_info
+```
+
+This keeps the data series narrow (only stable join keys as labels) while
+making rich context available on demand. Both `AlarmSink` implementations
+and `prometheus-writer` use this pattern.
+
+The OpenNMS `context:key` metadata model maps directly onto info-metric
+labels: each `context:key` pair becomes one label on `deltav_node_info`.
+The **Metadata DSL is not needed** by Track 2 — the DSL is an upstream
+interpolation engine; the forwarder does plain map lookups against the
+node-context `GlobalKTable`.
+
+---
+
+## 3. Track 2a — node-context interface enrichment
+
+### 3.1 Proto changes (`core/deltav-kafka-contracts`)
+
+`deltav-node-context.proto` is frozen at API v1. Only **additive** changes
+(new fields with fresh tag numbers) are permitted — no renumbering, no
+semantic change to existing fields.
+
+A new ifIndex-keyed message, distinct from the existing IP-keyed
+`InterfaceContext`:
+
+```proto
+// SNMP (physical) interface — keyed by ifIndex, sourced from OnmsSnmpInterface.
+message SnmpInterfaceContext {
+  int32  if_index         = 1;
+  string if_name          = 2;   // ifName
+  string if_descr         = 3;   // ifDescr
+  string if_alias         = 4;   // ifAlias
+  int64  if_speed         = 5;   // ifSpeed (bits/sec)
+  int32  if_type          = 6;   // ifType (IANA ifType)
+  string physical_address = 7;   // MAC
+}
+```
+
+Added to `NodeContext` at the next free tag number:
+
+```proto
+map<int32, SnmpInterfaceContext> snmp_interface_metadata = <next>;
+```
+
+The existing `InterfaceContext` (IP-keyed) and `ServiceContext`
+(`{ip}/{service}`-keyed) maps are untouched — they serve the
+polling-latency join.
+
+`deltav-alarm-state.proto` (Track 1) gains three optional fields so an
+SNMP-interface or service alarm can be identified without a separate
+lookup. `OnmsAlarm` already carries all three:
+
+```proto
+string ip_address   = <next>;   // OnmsAlarm.ipAddr
+string service_name = <next>;   // OnmsAlarm.serviceType.name
+int32  if_index     = <next>;   // OnmsAlarm.ifIndex
+```
+
+These are additive to a frozen-v1-style contract — same forward-compatible
+rule as `deltav-node-context`.
+
+### 3.2 Producer — provisiond
+
+`NodeToProtobufTranslator` iterates `OnmsNode.getSnmpInterfaces()` and
+populates `snmp_interface_metadata`. The existing change feed
+(`NodeContextChangeFeedListener`) already fires on node updates, and SNMP
+interface discovery mutates the node, so the existing trigger covers it —
+no new feed wiring. `NodeContextDebouncer` coalesces the per-interface
+update burst during a discovery scan.
+
+### 3.3 Compacted-topic declaration (Track 1 follow-up)
+
+`deltav-alarms-state-change` is currently broker-auto-created: 4 partitions,
+`retention.ms=3600000`, **not compacted**. Track 2b's resolve-on-tombstone
+design (Section 4.3) depends on `cleanup.policy=compact`. Track 2a adds a
+`NewTopic` admin bean declaring it compacted — the same mechanism
+`deltav-node-context` already uses.
+
+### 3.4 Consumer validation — prometheus-writer
+
+`prometheus-writer`'s `NodeContextCache` deserializes the same protobuf, so
+the new map is available the moment provisiond republishes. Track 2a's
+acceptance test: `prometheus-writer` emits a `deltav_snmp_interface_info`
+gauge (value `1`) carrying `node`/`if_index`/`if_name`/`if_descr`/
+`if_alias`/`if_speed`/`if_type` as labels — the info-metric half of the
+`group_left` join. This proves the contract end-to-end **before** Track 2b
+exists.
+
+---
+
+## 4. Node identity
+
+### 4.1 The problem
+
+OpenNMS's value when integrating with CMDB/inventory systems comes from the
+`foreignSource` + `foreignId` tuple — a stable identity meaningful in the
+operator's external systems. The PostgreSQL sequence `node_id` is transient:
+if inventory is repopulated, every node gets a new `node_id`.
+
+A **join key** may be transient as long as both sides share one inventory
+generation (they do — alarm record and node-context record come from the
+same PostgreSQL snapshot). A **series identity** must be durable: Prometheus/
+VM treats a changed identity label as a new series, orphaning all history.
+
+### 4.2 What already exists
+
+- `deltav-node-context.proto` already carries `foreign_source` (tag 4),
+  `foreign_id` (tag 5), and `node_label` (tag 3). The durable identity is
+  already on the wire.
+- `prometheus-writer`'s `LabelBuilder` already emits `foreign_source` and
+  `foreign_id` labels on every series, and has an `InstanceLabelResolver`
+  with a configurable policy.
+- The `deltav-node-context` Kafka key is `{location}@{node_id}`; the
+  metric→node join uses `node_id`. This is a transport/join key and stays
+  unchanged — no topic re-keying.
+
+### 4.3 The decision
+
+**Canonical identity = `foreignSource:foreignId`**, emitted as a single
+composite label plus the two raw dimensions:
+
+| Label | Source | Purpose |
+|---|---|---|
+| `node` | `foreignSource:foreignId` composite | durable identity; `group_left` join key; `instance` |
+| `foreign_source` | `OnmsNode.foreignSource` | filterable dimension ("all nodes in requisition X") |
+| `foreign_id` | `OnmsNode.foreignId` | filterable dimension |
+| `node_id` | PostgreSQL sequence | retained, **documented as transient**; in-process join only |
+| `node_label` | `OnmsNode.label` | display; mutable, not an identity |
+
+Example series:
+
+```
+deltav_response_time{node="Servers:web-01", foreign_source="Servers",
+  foreign_id="web-01", node_id="1042", node_label="web01.corp"} ...
+```
+
+### 4.4 Discovery nodes (no requisition)
+
+Nodes created by discovery/newSuspect have no `foreignSource`/`foreignId`.
+Their fallback identity is **`node="delta-v:{node_id}"`** — uniformly shaped
+as `<source>:<id>`, with the `delta-v:` prefix honestly namespacing it as a
+delta-v-internal id rather than a CMDB identity.
+
+Caveat recorded deliberately: a discovery node's `node_id` is itself
+regenerated on repopulation, so `delta-v:1042` is stable only while that
+node row lives. There is no durable identity to recover because the node was
+never provisioned — the `delta-v:` prefix makes that honest rather than
+papering over it. The raw `foreign_source`/`foreign_id` labels stay **empty**
+for these nodes; we do not fabricate a fake requisition.
+
+### 4.5 Latent bug to fix in Track 2a
+
+`prometheus-writer`'s `InstanceLabelResolver` has a `FOREIGN_ID` policy that
+uses `foreign_id` **alone**. `foreign_id` is unique only *within* a
+`foreign_source` — two requisitions can each contain a node `id="switch-1"`.
+Track 2a corrects this to a `FOREIGN_SOURCE:FOREIGN_ID` composite (the same
+`node` label defined in 4.3), so selecting that policy cannot silently
+collide nodes.
+
+---
+
+## 5. Track 2b — Prometheus alerts forwarder
+
+### 5.1 Module and components
+
+A new standalone Spring Boot 4 daemon, `core/alerts-forwarder`, with its own
+image — structurally cloned from `prometheus-writer`.
+
+| Component | Responsibility |
+|---|---|
+| `AlarmStateConsumer` | Kafka consumer of `deltav-alarms-state-change` |
+| `NodeContextCache` + bootstrap | node-context `GlobalKTable`; reused prometheus-writer template; sees the 2a SNMP-interface map |
+| `AlarmEnricher` | joins alarm record against `NodeContextCache` — node labels, categories, asset/metadata, and interface/service context via `if_index` or `ip_address`+`service_name` |
+| `AlarmFilter` | severity gate (default ≥ `WARNING`) + optional UEI denylist |
+| `AlarmSink` (seam) | output port; `AlertmanagerAlarmSink` and `VictoriaMetricsAlarmSink` behind one interface, activated by `@ConditionalOnProperty` |
+| `ActiveAlertRegistry` | `reduction_key → forwarded identity (label set + fingerprint)`; the only mutable state |
+
+### 5.2 The `AlarmSink` seam
+
+`AlarmSink` is an output-port interface. The implementation choice is
+deliberately low-stakes — it is configuration, not a rewrite:
+
+| | `AlertmanagerAlarmSink` | `VictoriaMetricsAlarmSink` |
+|---|---|---|
+| Endpoint | `POST /api/v2/alerts` | remote-write `POST /api/v1/write` |
+| Wire format | JSON | protobuf + snappy |
+| Carries free text | yes — annotations | no — labels only |
+| Lifecycle | `startsAt`/`endsAt` | gauge value `1`/`0` + staleness |
+
+Both implementations support node labels, categories, asset fields, and
+OpenNMS `context:key` metadata via the info-metric / `group_left` pattern
+(Section 2.1). The operator picks which bean(s) activate.
+
+### 5.3 Lifecycle mapping
+
+`deltav-alarms-state-change` is compacted and keyed by `reduction_key`. The
+consumer sees one of two things per key:
+
+- **Non-tombstone record** — alarm exists. If severity passes the filter:
+  forward as **firing**. `AlertmanagerAlarmSink` POSTs with `startsAt` from
+  `first_event_time_ms` and a rolling `endsAt` (now + resolve-timeout);
+  `VictoriaMetricsAlarmSink` remote-writes `deltav_alarm_state{...} = 1`.
+  `ActiveAlertRegistry` records the forwarded label set so re-publishes
+  (count bump, ack) keep a stable fingerprint.
+- **Tombstone (null value)**, *or* a record whose severity drops below the
+  filter, *or* `CLEARED` — forward as **resolved**. Alertmanager: re-POST
+  the registry's *stored* label set with `endsAt = now`. VictoriaMetrics:
+  write `deltav_alarm_state = 0`. Then evict from the registry.
+
+The registry resolving from the *stored* identity (not a recomputed one) is
+what keeps Alertmanager dedup keys matched across a firing→resolved
+transition.
+
+### 5.4 Filtering
+
+Daemon-scoped configuration (per the no-shared-config rule — property names
+are `deltav.<daemon>.<feature>.<knob>`):
+
+```yaml
+deltav.alerts-forwarder.filter.min-severity: WARNING   # WARNING|MINOR|MAJOR|CRITICAL
+deltav.alerts-forwarder.filter.uei-denylist: []        # optional UEI exclusions
+```
+
+`AlarmFilter` applies severity first, then the denylist. A record that *was*
+forwarded and now drops below `min-severity` is treated as a **resolve**
+(Section 5.3), not a silent drop — otherwise Alertmanager keeps a stale
+firing alert.
+
+### 5.5 Enrichment startup gate
+
+`AlarmStateConsumer` does not subscribe until `NodeContextCacheReadyEvent`
+fires — reused verbatim from `prometheus-writer`'s binding gate. Without it,
+the first burst of alarms after a cold start forwards un-enriched (no `node`
+label, no categories), creating a cohort of malformed alerts. The gate
+trades a few seconds of startup latency for correctness.
+
+### 5.6 Error handling — three failure classes
+
+| Failure | Response |
+|---|---|
+| Unparseable Kafka record | `DlqPublisher` (prometheus-writer template); offset commits; consumer moves on — a poison record never wedges the consumer |
+| Enrichment miss (node not yet cached) | forward anyway with `node="delta-v:{node_id}"` and `enrichment="partial"` label; **not** DLQ'd — transient, self-heals on next node-context update |
+| Sink HTTP failure | circuit breaker + bounded retry (prometheus-writer `rw/` template); Kafka offset commits **only after** a successful sink write or DLQ — on a sustained sink outage the consumer pauses rather than dropping alarms; a restart rebuilds correct state from the compacted topic |
+
+### 5.7 Observability
+
+`deltav_*` Micrometer metrics, scraped by VM:
+
+- `deltav_alerts_forwarder_alarms_consumed_total`
+- `deltav_alerts_forwarder_forwarded_total{outcome=firing|resolved}`
+- `deltav_alerts_forwarder_filtered_total{reason=severity|uei}`
+- `deltav_alerts_forwarder_enrichment_total{result=hit|partial}`
+- `deltav_alerts_forwarder_sink_errors_total{sink=...}`
+- `NodeContextCache` size gauge; sink circuit-breaker state gauge
+
+### 5.8 Compose and build wiring
+
+- Add an `alertmanager` service to `docker-compose.yml` and a Grafana
+  Alertmanager datasource.
+- The `alerts-forwarder` image is added to **both** `build.sh` **and**
+  `.github/workflows/delta-v-build-images.yml` — they drift silently, so
+  both get the entry in the same change.
+
+---
+
+## 6. Testing strategy
+
+JUnit 5 Jupiter only (delta-v surefire runs only the Jupiter engine; JUnit 4
+tests silently skip).
+
+**Track 2a**
+- Unit: `NodeToProtobufTranslator` populates `snmp_interface_metadata` from
+  `OnmsNode.getSnmpInterfaces()`.
+- Integration: provisiond republishes node-context with the new map;
+  `prometheus-writer` emits `deltav_snmp_interface_info` with the expected
+  labels (the acceptance test of Section 3.4).
+
+**Track 2b**
+- Unit: `AlarmEnricher` join logic; `AlarmFilter` severity + denylist;
+  `ActiveAlertRegistry` lifecycle mapping; each `AlarmSink` against a
+  `MockWebServer`.
+- Integration: Testcontainers Kafka — publish synthetic `AlarmState`
+  records, assert the right sink calls; one test for startup-gate ordering;
+  one for resolve-on-tombstone.
+
+---
+
+## 7. Deliverables
+
+**Track 2a**
+- `deltav-node-context.proto`: `SnmpInterfaceContext` + `snmp_interface_metadata`.
+- `deltav-alarm-state.proto`: `ip_address`, `service_name`, `if_index`.
+- provisiond `NodeToProtobufTranslator`: populate the SNMP-interface map.
+- `deltav-alarms-state-change` `NewTopic` admin bean (`cleanup.policy=compact`).
+- `prometheus-writer`: emit `deltav_snmp_interface_info`; fix
+  `InstanceLabelResolver` `FOREIGN_ID` → `FOREIGN_SOURCE:FOREIGN_ID`; emit
+  the composite `node` label and `delta-v:{node_id}` fallback.
+
+**Track 2b**
+- `core/alerts-forwarder` module + image.
+- `AlarmStateConsumer`, `AlarmEnricher`, `AlarmFilter`, `ActiveAlertRegistry`.
+- `AlarmSink` seam + `AlertmanagerAlarmSink` + `VictoriaMetricsAlarmSink`.
+- Reused `NodeContextCache`/bootstrap, `DlqPublisher`, `rw/` HTTP client.
+- `docker-compose.yml`: `alertmanager` service + Grafana datasource.
+- `build.sh` + `delta-v-build-images.yml`: `alerts-forwarder` image entry.
+
+---
+
+## 8. Open follow-ups (not blocking Track 2)
+
+- Existing `prometheus-writer` series may carry a `node_label`-derived
+  `instance`; switching the canonical identity to the composite `node` label
+  is a one-time series discontinuity in the dev stack — acceptable, and
+  cheaper to do now than after more history accumulates.

--- a/docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md
+++ b/docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md
@@ -250,9 +250,19 @@ collide nodes.
 A new standalone Spring Boot 4 daemon, `core/alerts-forwarder`, with its own
 image — structurally cloned from `prometheus-writer`.
 
+**Consumer mechanism.** Both Kafka consumers use the *bootstrap-replay* pattern
+(`prometheus-writer`'s `NodeContextKafkaBootstrap`): a raw `KafkaConsumer` on a
+random group id that seeks to the beginning and replays the compacted topic
+every start. This is required, not stylistic — a Spring Cloud Stream
+consumer-group binding resumes from committed offsets and would leave
+`ActiveAlertRegistry` empty after a restart, so the forwarder could not resolve
+alarms that fired before it. Replaying a *compacted* topic is bounded (one
+record per active key), so a full replay per restart is cheap and removes all
+offset-commit bookkeeping. The module does not depend on `spring-cloud-stream`.
+
 | Component | Responsibility |
 |---|---|
-| `AlarmStateConsumer` | Kafka consumer of `deltav-alarms-state-change` |
+| `AlarmStateKafkaConsumer` | bootstrap-replay `KafkaConsumer` of `deltav-alarms-state-change` — replays the compacted topic from the beginning every start to rebuild `ActiveAlertRegistry`, then live-tails |
 | `NodeContextCache` + bootstrap | node-context `GlobalKTable`; reused prometheus-writer template; sees the 2a SNMP-interface map |
 | `AlarmEnricher` | joins alarm record against `NodeContextCache` — node labels, categories, asset/metadata, and interface/service context via `if_index` or `ip_address`+`service_name` |
 | `AlarmFilter` | severity gate (default ≥ `WARNING`) + optional UEI denylist |
@@ -312,19 +322,20 @@ firing alert.
 
 ### 5.5 Enrichment startup gate
 
-`AlarmStateConsumer` does not subscribe until `NodeContextCacheReadyEvent`
-fires — reused verbatim from `prometheus-writer`'s binding gate. Without it,
-the first burst of alarms after a cold start forwards un-enriched (no `node`
-label, no categories), creating a cohort of malformed alerts. The gate
-trades a few seconds of startup latency for correctness.
+`AlarmStateKafkaConsumer` does not start its consume loop until
+`NodeContextCacheReadyEvent` fires — its thread is launched from an
+`@EventListener` for that event. Without the gate, the first burst of alarms
+after a cold start forwards un-enriched (no `node` label, no categories),
+creating a cohort of malformed alerts. The gate trades a few seconds of
+startup latency for correctness.
 
 ### 5.6 Error handling — three failure classes
 
 | Failure | Response |
 |---|---|
-| Unparseable Kafka record | `DlqPublisher` (prometheus-writer template); offset commits; consumer moves on — a poison record never wedges the consumer |
+| Unparseable Kafka record | `DlqPublisher` produces the raw bytes to `deltav-alerts-forwarder-dlq` with a reason header; consumer moves on — a poison record never wedges the consumer |
 | Enrichment miss (node not yet cached) | forward anyway with `node="delta-v:{node_id}"` and `enrichment="partial"` label; **not** DLQ'd — transient, self-heals on next node-context update |
-| Sink HTTP failure | circuit breaker + bounded retry (prometheus-writer `rw/` template); Kafka offset commits **only after** a successful sink write or DLQ — on a sustained sink outage the consumer pauses rather than dropping alarms; a restart rebuilds correct state from the compacted topic |
+| Sink failure | bounded retry; on sustained failure the consumer thread blocks retrying the current record and stops polling — natural back-pressure (a raw consumer back-pressures by not polling, so no SCS binding to pause and no circuit breaker needed). No alarm is dropped, and a restart replays the compacted topic from the beginning to rebuild correct state |
 
 ### 5.7 Observability
 


### PR DESCRIPTION
## Summary

Design and planning docs for v1.3.0 "Alarms on Kafka" Track 2 — the companion docs PR for the Track 2a implementation (PR #295).

- **Design spec** — \`docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md\` covers the shared node-context interface enrichment (Track 2a) and the new \`core/alerts-forwarder\` daemon (Track 2b): the \`AlarmSink\` seam (Alertmanager + VictoriaMetrics implementations behind \`@ConditionalOnProperty\`), the firing/resolved lifecycle via a stable \`ActiveAlertRegistry\`, the durable \`foreignSource:foreignId\` node identity (with the \`delta-v:{node_id}\` discovery fallback), and the info-metric / PromQL \`group_left\` enrichment pattern.
- **Track 2a plan** — \`docs/superpowers/plans/2026-05-19-v1.3.0-track2a-node-context-interface-enrichment.md\`. 8 tasks: proto extensions, provisiond/alarmd producer changes, compacted-topic initializer, prometheus-writer durable \`node\` label + info-metric emitter, end-to-end smoke. **Now executed and in review at #295.**
- **Track 2b plan** — \`docs/superpowers/plans/2026-05-19-v1.3.0-track2b-alerts-forwarder.md\`. 12 tasks scaffolding the new \`core/alerts-forwarder\` daemon (bootstrap-replay consumer pattern, filter/enricher/registry/sink pipeline, two sink implementations, Testcontainers integration test, build + compose wiring).

## Notable architectural decisions

- **Two tracks, sequenced.** Track 2a is contracts + shared infra (validated by prometheus-writer adopting the new fields end-to-end); Track 2b is the new alerts-forwarder daemon. Splitting them keeps the contract change shippable and independently validated before any new consumer depends on it.
- **Durable node identity.** Series in the TSDB and alerts in Alertmanager carry a \`node\` label = \`foreignSource:foreignId\` (or \`delta-v:{node_id}\` for non-provisioned discovery nodes). Survives inventory repopulation; the transient PostgreSQL \`node_id\` is retained as a join-only label but documented as transient.
- **Bootstrap-replay consumer (Track 2b §5).** The alarms consumer is a raw \`KafkaConsumer\` on a random group id that replays the compacted \`deltav-alarms-state-change\` topic from the beginning every restart — required so \`ActiveAlertRegistry\` correctly resolves alarms that fired before a restart. A Spring Cloud Stream binding would resume from committed offsets and miss them. Spec §5 was amended during planning to make this explicit; documented in the plan's "Architecture note."

## Companion implementation PR

PR #295 — \`feat/v1.3.0-track2a-node-context-interface-enrichment\` (Track 2a executed and smoke-passed).

## Test Plan

- [x] Spec self-review — placeholder/consistency/scope/ambiguity pass.
- [x] Plan self-review — spec coverage check, type/signature consistency across tasks, no placeholders.
- Docs-only PR — no CI build to verify.