### PR TITLE
feat(v1.3.0): Track 2b — Prometheus alerts forwarder daemon

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -1,6 +1,6 @@
 # Delta-V Build & Push Images
 #
-# Builds all Delta-V Docker images (26 total) and pushes them to GitHub
+# Builds all Delta-V Docker images (27 total) and pushes them to GitHub
 # Container Registry (GHCR) as multi-arch images (linux/amd64 + linux/arm64).
 #
 # Trigger: Push a tag matching 'v*' (e.g., v1.1.0)
@@ -11,7 +11,7 @@
 #     - ghcr.io/<owner>/jre-deltav:21          Custom JRE (jlink, Alpine)
 #     - ghcr.io/<owner>/daemon-base:<version>  Shared libs for all daemons
 #
-#   Daemons (12 Spring Boot fat JARs):
+#   Daemons (12 Spring Boot fat JARs sharing daemon-base):
 #     - ghcr.io/<owner>/alarmd:<version>
 #     - ghcr.io/<owner>/bsmd:<version>
 #     - ghcr.io/<owner>/collectd:<version>
@@ -26,6 +26,7 @@
 #     - ghcr.io/<owner>/trapd:<version>
 #
 #   Infrastructure:
+#     - ghcr.io/<owner>/alerts-forwarder:<version>         Alarm → Alertmanager forwarder
 #     - ghcr.io/<owner>/minion-boot:<version>              Spring Boot Minion
 #     - ghcr.io/<owner>/minion-gateway:<version>           gRPC ingress translator (Minion → Kafka)
 #     - ghcr.io/<owner>/envoy:<version>                    gRPC ingress in front of minion-gateway
@@ -243,6 +244,18 @@ jobs:
             --push \
             .
 
+      - name: Build and push alerts-forwarder image
+        working-directory: core/alerts-forwarder
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform "${{ env.PLATFORMS }}" \
+            -t "${{ env.IMAGE_PREFIX }}/alerts-forwarder:${VERSION}" \
+            -t "${{ env.IMAGE_PREFIX }}/alerts-forwarder:latest" \
+            --push \
+            .
+
       - name: Build and push minion-gateway image
         # minion-gateway's Dockerfile lives at opennms-container/delta-v/minion-gateway/Dockerfile
         # (not core/minion-gateway/, unlike db-init / flow-enricher / prometheus-writer).
@@ -412,7 +425,7 @@ jobs:
           echo "     ./deploy.sh up lite"
           echo ""
           echo "### Images"
-          DAEMONS="alarmd bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init flow-enricher prometheus-writer clickhouse clickhouse-init grafana provisiond-imports-init perspective-app-init l8opensim-provisioner mock-snmp-agent flow-exporter sflow-exporter jre-deltav daemon-base"
+          DAEMONS="alarmd alerts-forwarder bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init flow-enricher prometheus-writer clickhouse clickhouse-init grafana provisiond-imports-init perspective-app-init l8opensim-provisioner mock-snmp-agent flow-exporter sflow-exporter jre-deltav daemon-base"
           for name in $DAEMONS; do
             echo "  ${{ env.IMAGE_PREFIX }}/$name:${VERSION}"
           done

--- a/core/alerts-forwarder/Dockerfile
+++ b/core/alerts-forwarder/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 BeaconStrategists, Inc.
+# Licensed under the GNU Affero General Public License v3.
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk add --no-cache curl && \
+    addgroup -g 10001 deltav && \
+    adduser -u 10001 -G deltav -D deltav
+
+COPY --chown=deltav:deltav target/alerts-forwarder.jar /app/alerts-forwarder.jar
+
+USER deltav
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/alerts-forwarder.jar"]

--- a/core/alerts-forwarder/pom.xml
+++ b/core/alerts-forwarder/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>1.2.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>alerts-forwarder</artifactId>
+    <name>Delta-V :: Core :: Prometheus Alerts Forwarder</name>
+    <description>Consumes deltav-alarms-state-change, enriches each alarm against a
+        local materialization of deltav-node-context, and forwards firing/resolved
+        alerts to Alertmanager and/or VictoriaMetrics through a pluggable AlarmSink.</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Raw Kafka client — bootstrap-replay consumers (no Spring Cloud Stream). -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <!-- Protobuf contracts: AlarmState + NodeContext + prometheus.prompb. -->
+        <dependency>
+            <groupId>org.deltav.core</groupId>
+            <artifactId>org.opennms.core.deltav-kafka-contracts</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <!-- Snappy: VictoriaMetrics remote-write compression. -->
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- commons-io >= 2.16: Testcontainers transitive commons-compress needs it. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- surefire 3.5.4 needs this explicitly for Boot 4 modules. -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>alerts-forwarder</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>org.deltav.alerts.forwarder.AlertsForwarderApplication</mainClass>
+                    <executable>true</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/AlertsForwarderApplication.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/AlertsForwarderApplication.java
@@ -1,0 +1,25 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder;
+
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+/**
+ * Entry point for the Delta-V alerts-forwarder daemon. Consumes
+ * {@code deltav-alarms-state-change}, enriches against a local materialization
+ * of {@code deltav-node-context}, and forwards firing/resolved alerts through
+ * the {@link org.deltav.alerts.forwarder.sink.AlarmSink} seam.
+ *
+ * <p>v1.3.0 "Alarms on Kafka" Track 2b. See
+ * {@code docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md}.
+ */
+@SpringBootApplication(scanBasePackages = "org.deltav.alerts.forwarder")
+@EnableConfigurationProperties(AlertsForwarderProperties.class)
+public class AlertsForwarderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AlertsForwarderApplication.class, args);
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderBeansConfiguration.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderBeansConfiguration.java
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.config;
+
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Bean factory for collaborators that need constructor args sourced from
+ * {@link AlertsForwarderProperties} — Spring component-scan can't autowire
+ * {@code String} / {@code List<String>} into a {@code @Component}, so we
+ * hand-build them here.
+ *
+ * <p>Suffix is {@code Configuration} so the class's default bean name doesn't
+ * collide with the {@code @Bean} method inside (per project convention —
+ * {@code feedback_configuration_class_bean_name_collision}).</p>
+ */
+@Configuration
+public class AlertsForwarderBeansConfiguration {
+
+    @Bean
+    public AlarmFilter alarmFilter(AlertsForwarderProperties props) {
+        return new AlarmFilter(props.getFilter().getMinSeverity(),
+                props.getFilter().getUeiDenylist());
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderProperties.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderProperties.java
@@ -11,7 +11,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class AlertsForwarderProperties {
 
     private String alarmsTopic = "deltav-alarms-state-change";
-    private String nodeContextTopic = "deltav-node-context";
     private final Filter filter = new Filter();
     private final Alertmanager alertmanager = new Alertmanager();
     private final VictoriaMetrics victoriametrics = new VictoriaMetrics();
@@ -19,8 +18,6 @@ public class AlertsForwarderProperties {
 
     public String getAlarmsTopic() { return alarmsTopic; }
     public void setAlarmsTopic(String v) { this.alarmsTopic = v; }
-    public String getNodeContextTopic() { return nodeContextTopic; }
-    public void setNodeContextTopic(String v) { this.nodeContextTopic = v; }
     public Filter getFilter() { return filter; }
     public Alertmanager getAlertmanager() { return alertmanager; }
     public VictoriaMetrics getVictoriametrics() { return victoriametrics; }

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderProperties.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/config/AlertsForwarderProperties.java
@@ -1,0 +1,64 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Binds {@code deltav.alerts-forwarder.*}. */
+@ConfigurationProperties(prefix = "deltav.alerts-forwarder")
+public class AlertsForwarderProperties {
+
+    private String alarmsTopic = "deltav-alarms-state-change";
+    private String nodeContextTopic = "deltav-node-context";
+    private final Filter filter = new Filter();
+    private final Alertmanager alertmanager = new Alertmanager();
+    private final VictoriaMetrics victoriametrics = new VictoriaMetrics();
+    private final Dlq dlq = new Dlq();
+
+    public String getAlarmsTopic() { return alarmsTopic; }
+    public void setAlarmsTopic(String v) { this.alarmsTopic = v; }
+    public String getNodeContextTopic() { return nodeContextTopic; }
+    public void setNodeContextTopic(String v) { this.nodeContextTopic = v; }
+    public Filter getFilter() { return filter; }
+    public Alertmanager getAlertmanager() { return alertmanager; }
+    public VictoriaMetrics getVictoriametrics() { return victoriametrics; }
+    public Dlq getDlq() { return dlq; }
+
+    public static class Filter {
+        private String minSeverity = "WARNING";
+        private List<String> ueiDenylist = new ArrayList<>();
+        public String getMinSeverity() { return minSeverity; }
+        public void setMinSeverity(String v) { this.minSeverity = v; }
+        public List<String> getUeiDenylist() { return ueiDenylist; }
+        public void setUeiDenylist(List<String> v) { this.ueiDenylist = v; }
+    }
+
+    public static class Alertmanager {
+        private boolean enabled = true;
+        private String url = "http://alertmanager:9093/api/v2/alerts";
+        private long resolveTimeoutMs = 300000;
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean v) { this.enabled = v; }
+        public String getUrl() { return url; }
+        public void setUrl(String v) { this.url = v; }
+        public long getResolveTimeoutMs() { return resolveTimeoutMs; }
+        public void setResolveTimeoutMs(long v) { this.resolveTimeoutMs = v; }
+    }
+
+    public static class VictoriaMetrics {
+        private boolean enabled = false;
+        private String url = "http://victoriametrics:8428/api/v1/write";
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean v) { this.enabled = v; }
+        public String getUrl() { return url; }
+        public void setUrl(String v) { this.url = v; }
+    }
+
+    public static class Dlq {
+        private String topic = "deltav-alerts-forwarder-dlq";
+        public String getTopic() { return topic; }
+        public void setTopic(String v) { this.topic = v; }
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/consume/AlarmStateKafkaConsumer.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/consume/AlarmStateKafkaConsumer.java
@@ -90,6 +90,7 @@ public class AlarmStateKafkaConsumer implements Runnable {
                 Thread.currentThread().interrupt();
             }
         }
+        dlq.close();
     }
 
     @Override

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/consume/AlarmStateKafkaConsumer.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/consume/AlarmStateKafkaConsumer.java
@@ -1,0 +1,174 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.consume;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.deltav.alerts.forwarder.dlq.DlqPublisher;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCacheReadyEvent;
+import org.deltav.alerts.forwarder.pipeline.AlarmForwardingPipeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Dedicated bootstrap-replay consumer for {@code deltav-alarms-state-change}.
+ * Starts only after {@link NodeContextCacheReadyEvent} (the §5.5 startup gate),
+ * seeks to the beginning, and feeds every record to {@link AlarmForwardingPipeline}.
+ * Because the topic is compacted, the replay rebuilds {@link ActiveAlertRegistry}
+ * to the exact current set, then the loop live-tails.
+ *
+ * <p>A value that fails {@code AlarmState.parseFrom} is DLQ'd and skipped. A
+ * sink failure ({@code SinkForwardException}) makes the thread sleep and retry
+ * the same record — back-pressure, no alarm dropped.</p>
+ */
+@Component
+public class AlarmStateKafkaConsumer implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmStateKafkaConsumer.class);
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration RETRY_BACKOFF = Duration.ofSeconds(5);
+
+    private final AlertsForwarderProperties props;
+    private final AlarmForwardingPipeline pipeline;
+    private final DlqPublisher dlq;
+    private final String bootstrapServers;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread thread;
+
+    public AlarmStateKafkaConsumer(AlertsForwarderProperties props,
+                                   AlarmForwardingPipeline pipeline,
+                                   ActiveAlertRegistry registry,
+                                   MeterRegistry meterRegistry,
+                                   @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        this.props = props;
+        this.pipeline = pipeline;
+        this.dlq = new DlqPublisher(buildProducer(bootstrapServers), props.getDlq().getTopic(), meterRegistry);
+        this.bootstrapServers = bootstrapServers;
+        Gauge.builder(AlertsForwarderMetrics.ACTIVE_ALERTS, registry, ActiveAlertRegistry::size)
+                .register(meterRegistry);
+    }
+
+    /** §5.5 startup gate: do not consume alarms until node context is materialized. */
+    @EventListener
+    public void onNodeContextReady(NodeContextCacheReadyEvent event) {
+        if (running.compareAndSet(false, true)) {
+            LOG.info("NodeContextCache ready (size={}) — starting alarm consumer", event.getCacheSize());
+            thread = new Thread(this, "alarm-state-consumer");
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+
+    @PreDestroy
+    public void stop() {
+        running.set(false);
+        if (thread != null) {
+            try {
+                thread.join(5000);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        try (KafkaConsumer<byte[], byte[]> consumer = buildConsumer()) {
+            consumer.subscribe(List.of(props.getAlarmsTopic()));
+            // Compacted topic: replay from the beginning every start to rebuild
+            // the active-alert registry. seekToBeginning on first assignment.
+            boolean seeked = false;
+            while (running.get()) {
+                ConsumerRecords<byte[], byte[]> records = consumer.poll(POLL_TIMEOUT);
+                if (!seeked && !consumer.assignment().isEmpty()) {
+                    consumer.seekToBeginning(consumer.assignment());
+                    seeked = true;
+                    continue;
+                }
+                for (ConsumerRecord<byte[], byte[]> record : records) {
+                    handleWithRetry(record);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("AlarmStateKafkaConsumer fatal error", e);
+        }
+    }
+
+    private void handleWithRetry(ConsumerRecord<byte[], byte[]> record) {
+        while (running.get()) {
+            try {
+                handle(record);
+                return;
+            } catch (AlarmForwardingPipeline.SinkForwardException e) {
+                LOG.warn("Sink failure — retrying record in {}s", RETRY_BACKOFF.toSeconds(), e);
+                sleep(RETRY_BACKOFF);
+            }
+        }
+    }
+
+    private void handle(ConsumerRecord<byte[], byte[]> record) {
+        String reductionKey = record.key() == null ? "" : new String(record.key());
+        if (record.value() == null) {
+            pipeline.onRecord(reductionKey, null);   // Kafka tombstone — alarm deleted.
+            return;
+        }
+        AlarmState alarm;
+        try {
+            alarm = AlarmState.parseFrom(record.value());
+        } catch (Exception e) {
+            LOG.warn("Unparseable AlarmState key={} offset={} — DLQ", reductionKey, record.offset(), e);
+            dlq.publish(record.key(), record.value(), "parse-error");
+            return;
+        }
+        pipeline.onRecord(reductionKey, alarm);
+    }
+
+    private static void sleep(Duration d) {
+        try {
+            Thread.sleep(d.toMillis());
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private KafkaConsumer<byte[], byte[]> buildConsumer() {
+        Properties p = new Properties();
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        p.put(ConsumerConfig.GROUP_ID_CONFIG, "alerts-forwarder-alarms-" + UUID.randomUUID());
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        p.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        return new KafkaConsumer<>(p);
+    }
+
+    private static KafkaProducer<byte[], byte[]> buildProducer(String bootstrapServers) {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        p.put(ProducerConfig.CLIENT_ID_CONFIG, "alerts-forwarder-dlq");
+        return new KafkaProducer<>(p);
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/dlq/DlqPublisher.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/dlq/DlqPublisher.java
@@ -1,0 +1,44 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.dlq;
+
+import java.nio.charset.StandardCharsets;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Publishes records that cannot be parsed as {@link org.deltav.alarms.proto.AlarmState}
+ * to the dead-letter topic, preserving the original key and bytes plus a reason
+ * header. A poison record never wedges the consumer — it is DLQ'd and skipped.
+ */
+public class DlqPublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DlqPublisher.class);
+
+    private final Producer<byte[], byte[]> producer;
+    private final String topic;
+    private final MeterRegistry metrics;
+
+    public DlqPublisher(Producer<byte[], byte[]> producer, String topic, MeterRegistry metrics) {
+        this.producer = producer;
+        this.topic = topic;
+        this.metrics = metrics;
+    }
+
+    public void publish(byte[] key, byte[] sourcePayload, String reason) {
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, key, sourcePayload);
+        record.headers().add("x-dlq-reason", reason.getBytes(StandardCharsets.UTF_8));
+        record.headers().add("x-dlq-timestamp-ms",
+                Long.toString(System.currentTimeMillis()).getBytes(StandardCharsets.UTF_8));
+        producer.send(record, (md, ex) -> {
+            if (ex != null) {
+                LOG.error("Failed to publish DLQ record reason={}", reason, ex);
+            }
+        });
+        metrics.counter(AlertsForwarderMetrics.DLQ_RECORDS).increment();
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/dlq/DlqPublisher.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/dlq/DlqPublisher.java
@@ -2,6 +2,7 @@
 package org.deltav.alerts.forwarder.dlq;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.clients.producer.Producer;
@@ -27,6 +28,10 @@ public class DlqPublisher {
         this.producer = producer;
         this.topic = topic;
         this.metrics = metrics;
+    }
+
+    public void close() {
+        producer.close(Duration.ofSeconds(5));
     }
 
     public void publish(byte[] key, byte[] sourcePayload, String reason) {

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich/AlarmEnricher.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich/AlarmEnricher.java
@@ -1,0 +1,95 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * Joins an {@link AlarmState} to its {@link NodeContext} and produces an
+ * {@link EnrichedAlarm}. Lookup key is {@code {location}@{node_id}}; on a miss
+ * (Collectd/alarmd location skew, or a node not yet materialized) it falls back
+ * to a node-id-only scan, and failing that produces a partial enrichment.
+ */
+@Component
+public class AlarmEnricher {
+
+    private final NodeContextCache cache;
+
+    public AlarmEnricher(NodeContextCache cache) {
+        this.cache = cache;
+    }
+
+    public EnrichedAlarm enrich(AlarmState alarm) {
+        Optional<NodeContext> nc = lookup(alarm);
+
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("node", NodeIdentity.of(alarm.getNodeId(), nc));
+        labels.put("node_id", Integer.toString(alarm.getNodeId()));
+        labels.put("severity", alarm.getSeverity().name());
+        labels.put("uei", alarm.getUei());
+        labels.put("location", alarm.getLocation());
+        labels.put("alarm_id", Integer.toString(alarm.getAlarmId()));
+        labels.put("node_label", nc.map(NodeContext::getNodeLabel).orElse(""));
+        labels.put("foreign_source", nc.map(NodeContext::getForeignSource).orElse(""));
+        labels.put("foreign_id", nc.map(NodeContext::getForeignId).orElse(""));
+        labels.put("categories", categories(nc));
+
+        if (!alarm.getServiceName().isEmpty()) {
+            labels.put("service_name", alarm.getServiceName());
+        }
+        if (!alarm.getIpAddress().isEmpty()) {
+            labels.put("ip_address", alarm.getIpAddress());
+        }
+        if (alarm.getIfIndex() > 0) {
+            labels.put("if_index", Integer.toString(alarm.getIfIndex()));
+            nc.map(n -> n.getSnmpInterfaceMetadataMap().get(alarm.getIfIndex()))
+              .ifPresent(sic -> addInterfaceLabels(labels, sic));
+        }
+
+        boolean complete = nc.isPresent();
+        if (!complete) {
+            labels.put("enrichment", "partial");
+        }
+
+        Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("description", alarm.getDescription());
+        annotations.put("log_message", alarm.getLogMessage());
+        if (!alarm.getAckUser().isEmpty()) {
+            annotations.put("ack_user", alarm.getAckUser());
+        }
+
+        return new EnrichedAlarm(labels, annotations, complete);
+    }
+
+    private Optional<NodeContext> lookup(AlarmState alarm) {
+        Optional<NodeContext> nc = cache.get(alarm.getLocation() + "@" + alarm.getNodeId());
+        if (nc.isEmpty() && alarm.getNodeId() > 0) {
+            nc = cache.findByNodeId(alarm.getNodeId());
+        }
+        return nc;
+    }
+
+    private static void addInterfaceLabels(Map<String, String> labels, SnmpInterfaceContext sic) {
+        labels.put("if_name", sic.getIfName());
+        labels.put("if_descr", sic.getIfDescr());
+        labels.put("if_alias", sic.getIfAlias());
+        labels.put("if_speed", Long.toString(sic.getIfSpeed()));
+        labels.put("if_type", Integer.toString(sic.getIfType()));
+    }
+
+    private static String categories(Optional<NodeContext> nc) {
+        List<String> cats = new ArrayList<>(
+                nc.map(n -> (List<String>) new ArrayList<>(n.getCategoriesList())).orElse(List.of()));
+        cats.sort(String::compareTo);
+        return String.join(",", cats);
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich/EnrichedAlarm.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich/EnrichedAlarm.java
@@ -1,0 +1,17 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import java.util.Map;
+
+/**
+ * An alarm joined to node context. {@code labels} are low-cardinality
+ * dimensions safe for a TSDB series (identity, severity, uei, interface
+ * attributes); {@code annotations} are unbounded free text (description,
+ * log message) — Alertmanager-only, never a label. {@code enrichmentComplete}
+ * is false when the node was not found in the cache (partial enrichment).
+ */
+public record EnrichedAlarm(
+        Map<String, String> labels,
+        Map<String, String> annotations,
+        boolean enrichmentComplete) {
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich/NodeIdentity.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/enrich/NodeIdentity.java
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import java.util.Optional;
+
+import org.deltav.timeseries.proto.NodeContext;
+
+/**
+ * Durable node identity (spec §4): {@code foreignSource:foreignId} for a
+ * provisioned node, else {@code delta-v:{node_id}} for a discovery node with
+ * no requisition. Identical to prometheus-writer's
+ * {@code InstanceLabelResolver.nodeIdentity} — duplicated because the two
+ * modules must not depend on each other.
+ */
+public final class NodeIdentity {
+    private NodeIdentity() {}
+
+    public static String of(int nodeId, Optional<NodeContext> nc) {
+        String fs = nc.map(NodeContext::getForeignSource).orElse("");
+        String fi = nc.map(NodeContext::getForeignId).orElse("");
+        if (!fs.isEmpty() && !fi.isEmpty()) {
+            return fs + ":" + fi;
+        }
+        return "delta-v:" + nodeId;
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/filter/AlarmFilter.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/filter/AlarmFilter.java
@@ -1,0 +1,47 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.filter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Decides whether an alarm is forwarded. An alarm passes when its severity is
+ * at or above the configured minimum AND its UEI is not denylisted. A cleared
+ * alarm (severity {@code CLEARED}, enum number 1) is always below a valid
+ * minimum, so it fails the filter — the pipeline maps a filter failure on a
+ * currently-active alarm to a resolve.
+ */
+public class AlarmFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmFilter.class);
+
+    private final int minSeverityNumber;
+    private final Set<String> ueiDenylist;
+
+    public AlarmFilter(String minSeverity, List<String> ueiDenylist) {
+        this.minSeverityNumber = parseMinSeverity(minSeverity);
+        this.ueiDenylist = new HashSet<>(ueiDenylist);
+    }
+
+    public boolean accept(AlarmState alarm) {
+        if (alarm.getSeverity().getNumber() < minSeverityNumber) {
+            return false;
+        }
+        return !ueiDenylist.contains(alarm.getUei());
+    }
+
+    private static int parseMinSeverity(String configured) {
+        try {
+            return AlarmState.Severity.valueOf(configured.trim().toUpperCase()).getNumber();
+        } catch (RuntimeException e) {
+            LOG.warn("Invalid deltav.alerts-forwarder.filter.min-severity '{}' — defaulting to WARNING",
+                    configured);
+            return AlarmState.Severity.WARNING.getNumber();
+        }
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistry.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistry.java
@@ -1,0 +1,38 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.lifecycle;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.springframework.stereotype.Component;
+
+/**
+ * In-memory record of currently-firing alerts, keyed by reduction key. Stores
+ * the last forwarded firing {@link ForwardedAlarm} so a later resolve reuses
+ * the exact same label set — Alertmanager's dedup fingerprint then matches and
+ * the firing alert resolves instead of leaking. Rebuilt on every restart by
+ * {@code AlarmStateKafkaConsumer} replaying the compacted alarms topic.
+ */
+@Component
+public class ActiveAlertRegistry {
+
+    private final ConcurrentHashMap<String, ForwardedAlarm> active = new ConcurrentHashMap<>();
+
+    public void markFiring(ForwardedAlarm alarm) {
+        active.put(alarm.reductionKey(), alarm);
+    }
+
+    public boolean isActive(String reductionKey) {
+        return active.containsKey(reductionKey);
+    }
+
+    /** Removes and returns the stored firing identity, or empty if not active. */
+    public Optional<ForwardedAlarm> remove(String reductionKey) {
+        return Optional.ofNullable(active.remove(reductionKey));
+    }
+
+    public int size() {
+        return active.size();
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistry.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistry.java
@@ -27,6 +27,11 @@ public class ActiveAlertRegistry {
         return active.containsKey(reductionKey);
     }
 
+    /** Non-destructive lookup of the stored firing identity. */
+    public Optional<ForwardedAlarm> getFiring(String reductionKey) {
+        return Optional.ofNullable(active.get(reductionKey));
+    }
+
     /** Removes and returns the stored firing identity, or empty if not active. */
     public Optional<ForwardedAlarm> remove(String reductionKey) {
         return Optional.ofNullable(active.remove(reductionKey));

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/metrics/AlertsForwarderMetrics.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/metrics/AlertsForwarderMetrics.java
@@ -1,0 +1,18 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.metrics;
+
+/** Centralized Micrometer metric names for the alerts-forwarder. */
+public final class AlertsForwarderMetrics {
+    private AlertsForwarderMetrics() {}
+
+    public static final String ALARMS_CONSUMED = "deltav_alerts_forwarder_alarms_consumed_total";
+    public static final String FORWARDED = "deltav_alerts_forwarder_forwarded_total";       // tag: outcome
+    public static final String FILTERED = "deltav_alerts_forwarder_filtered_total";         // tag: reason
+    public static final String ENRICHMENT = "deltav_alerts_forwarder_enrichment_total";     // tag: result
+    public static final String SINK_ERRORS = "deltav_alerts_forwarder_sink_errors_total";   // tag: sink
+    public static final String DLQ_RECORDS = "deltav_alerts_forwarder_dlq_total";
+    public static final String NC_CACHE_SIZE = "deltav_alerts_forwarder_node_context_cache_size";
+    public static final String NC_CACHE_READY = "deltav_alerts_forwarder_node_context_cache_ready";
+    public static final String NC_BOOTSTRAP_DURATION = "deltav_alerts_forwarder_node_context_bootstrap_seconds";
+    public static final String ACTIVE_ALERTS = "deltav_alerts_forwarder_active_alerts";
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCache.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCache.java
@@ -1,0 +1,88 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.nodecontext;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * In-memory cache of {@link NodeContext} records keyed {@code {location}@{node_id}}.
+ * Hot-path {@link #get(String)} is a plain {@link ConcurrentHashMap#get(Object)} —
+ * no locking, no network hop. State mutation is confined to the Kafka consumer
+ * thread owned by {@link NodeContextKafkaBootstrap}.
+ */
+@Component
+public class NodeContextCache {
+
+    private final ConcurrentHashMap<String, NodeContext> map = new ConcurrentHashMap<>();
+    private final AtomicBoolean ready = new AtomicBoolean(false);
+
+    public Optional<NodeContext> get(String key) {
+        return Optional.ofNullable(map.get(key));
+    }
+
+    public void put(String key, NodeContext value) {
+        map.put(key, value);
+    }
+
+    public void remove(String key) {
+        map.remove(key);
+    }
+
+    /**
+     * Apply a record from the {@code deltav-node-context} topic. If {@code deleted=true},
+     * treats as tombstone and removes the key. Otherwise stores the value.
+     */
+    public void applyUpdate(String key, NodeContext value) {
+        if (value.getDeleted()) {
+            remove(key);
+        } else {
+            put(key, value);
+        }
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public boolean isReady() {
+        return ready.get();
+    }
+
+    public void markReady() {
+        ready.set(true);
+    }
+
+    /**
+     * An immutable snapshot of every cached entry. Used by the info-metric
+     * emitter to sweep all nodes. O(n) copy — called once per emit interval,
+     * not on the hot path.
+     */
+    public Collection<NodeContext> snapshot() {
+        return List.copyOf(map.values());
+    }
+
+    /**
+     * Finds a NodeContext by node_id alone, ignoring location. Used as a
+     * fallback when the primary {location}@{node_id} key lookup misses —
+     * specifically for the Phase 0 limitation where Delta-V Collectd
+     * publishes TimeseriesBatch records with location="" while NodeContext
+     * records carry real locations from provisiond. See memory
+     * project_kafka_timeseries_producer_next_session for context.
+     *
+     * <p>O(n) stream scan over the cache. Acceptable because the cache is
+     * bounded (~10K nodes max) and this fallback should be rare once
+     * Collectd populates location correctly. Returns the first match;
+     * deterministic order is not guaranteed across HashMap implementations.
+     */
+    public Optional<NodeContext> findByNodeId(int nodeId) {
+        return map.values().stream()
+                .filter(nc -> nc.getNodeId() == nodeId)
+                .findFirst();
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCacheHealthIndicator.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCacheHealthIndicator.java
@@ -1,0 +1,23 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.nodecontext;
+
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component("nodeContextCacheHealthIndicator")
+public class NodeContextCacheHealthIndicator implements HealthIndicator {
+    private final NodeContextCache cache;
+
+    public NodeContextCacheHealthIndicator(NodeContextCache cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public Health health() {
+        Health.Builder b = cache.isReady() ? Health.up() : Health.down();
+        return b.withDetail("ready", cache.isReady())
+                .withDetail("size", cache.size())
+                .build();
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCacheReadyEvent.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCacheReadyEvent.java
@@ -1,0 +1,19 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.nodecontext;
+
+import org.springframework.context.ApplicationEvent;
+
+/** Published once when {@link NodeContextKafkaBootstrap} finishes initial bootstrap. */
+public class NodeContextCacheReadyEvent extends ApplicationEvent {
+    private final long bootstrapDurationMs;
+    private final int cacheSize;
+
+    public NodeContextCacheReadyEvent(Object source, long bootstrapDurationMs, int cacheSize) {
+        super(source);
+        this.bootstrapDurationMs = bootstrapDurationMs;
+        this.cacheSize = cacheSize;
+    }
+
+    public long getBootstrapDurationMs() { return bootstrapDurationMs; }
+    public int getCacheSize() { return cacheSize; }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextKafkaBootstrap.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/nodecontext/NodeContextKafkaBootstrap.java
@@ -1,0 +1,195 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.nodecontext;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.deltav.timeseries.proto.NodeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Dedicated Kafka consumer for {@code deltav-node-context}. On startup, records the
+ * end-offset high-water mark (HWM) per partition, seeks to earliest, consumes
+ * records until every partition's offset catches the recorded HWM, and marks
+ * the cache ready. Then transitions to a live-tail loop.
+ */
+@Component
+public class NodeContextKafkaBootstrap implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NodeContextKafkaBootstrap.class);
+    private static final String TOPIC = "deltav-node-context";
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(5);
+
+    private final NodeContextCache cache;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MeterRegistry meterRegistry;
+    private final String bootstrapServers;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread thread;
+    private Timer.Sample bootstrapSample;
+
+    public NodeContextKafkaBootstrap(
+            NodeContextCache cache,
+            ApplicationEventPublisher eventPublisher,
+            MeterRegistry meterRegistry,
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        this.cache = cache;
+        this.eventPublisher = eventPublisher;
+        this.meterRegistry = meterRegistry;
+        this.bootstrapServers = bootstrapServers;
+
+        Gauge.builder(AlertsForwarderMetrics.NC_CACHE_READY, cache, c -> c.isReady() ? 1.0 : 0.0)
+                .register(meterRegistry);
+        Gauge.builder(AlertsForwarderMetrics.NC_CACHE_SIZE, cache, c -> (double) c.size())
+                .register(meterRegistry);
+    }
+
+    @EventListener
+    public void onAppReady(ApplicationReadyEvent event) {
+        start();
+    }
+
+    public void start() {
+        running.set(true);
+        bootstrapSample = Timer.start(meterRegistry);
+        thread = new Thread(this, "node-context-bootstrap");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        running.set(false);
+        if (thread != null) {
+            try {
+                thread.join(5000);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        // Tracks per-partition end-offset captured at the moment the broker assigned the
+        // partition to us. The bootstrap is "complete" when every assigned partition has
+        // been drained up to its captured HWM. Both maps mutate from the consumer thread
+        // (poll loop) and the rebalance listener (called inline during poll), so a
+        // ConcurrentHashMap is defensive-but-cheap.
+        Map<TopicPartition, Long> endOffsets = new ConcurrentHashMap<>();
+        Set<TopicPartition> caughtUp = ConcurrentHashMap.newKeySet();
+        AtomicBoolean bootstrapMarked = new AtomicBoolean(false);
+
+        try (KafkaConsumer<String, byte[]> consumer = buildConsumer()) {
+            consumer.subscribe(List.of(TOPIC), new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> assigned) {
+                    // Record HWM at assignment time so we know when we have replayed the
+                    // compacted topic up to "now". Then seek to the beginning so we
+                    // actually replay everything (compacted topic semantics: we need
+                    // the latest value per key, not just the live tail).
+                    Map<TopicPartition, Long> hwm = consumer.endOffsets(assigned);
+                    endOffsets.putAll(hwm);
+                    consumer.seekToBeginning(assigned);
+                    // Empty partitions (end offset == 0) are instantly caught up.
+                    for (Map.Entry<TopicPartition, Long> e : hwm.entrySet()) {
+                        if (e.getValue() == 0L) {
+                            caughtUp.add(e.getKey());
+                        }
+                    }
+                }
+
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> revoked) {
+                    // No-op. Kafka may reassign us; the next onPartitionsAssigned will
+                    // re-establish HWM and re-seek. AtomicBoolean bootstrapMarked
+                    // prevents duplicate NodeContextCacheReadyEvent publication.
+                }
+            });
+
+            while (running.get()) {
+                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+                for (ConsumerRecord<String, byte[]> r : records) {
+                    applyRecord(r);
+                    TopicPartition tp = new TopicPartition(r.topic(), r.partition());
+                    Long hwm = endOffsets.get(tp);
+                    if (hwm != null && r.offset() + 1 >= hwm) {
+                        caughtUp.add(tp);
+                    }
+                }
+                // Mark cache ready exactly once, after the first full drain across all
+                // currently-assigned partitions. The compareAndSet guards against double-
+                // firing if poll() somehow re-enters this branch before bootstrapMarked
+                // becomes visible (defensive — single consumer thread, but cheap).
+                if (!bootstrapMarked.get()
+                        && !endOffsets.isEmpty()
+                        && caughtUp.containsAll(endOffsets.keySet())
+                        && bootstrapMarked.compareAndSet(false, true)) {
+                    finishBootstrap();
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("NodeContextKafkaBootstrap fatal error", e);
+        }
+    }
+
+    private void applyRecord(ConsumerRecord<String, byte[]> r) {
+        if (r.value() == null) {
+            // Kafka log-compaction tombstone (null value). Treat as delete.
+            cache.remove(r.key());
+            return;
+        }
+        try {
+            NodeContext nc = NodeContext.parseFrom(r.value());
+            cache.applyUpdate(r.key(), nc);
+        } catch (Exception e) {
+            LOG.warn("Malformed NodeContext record key={} offset={} — skipping", r.key(), r.offset(), e);
+        }
+    }
+
+    private void finishBootstrap() {
+        cache.markReady();
+        long durationNs = bootstrapSample.stop(
+                meterRegistry.timer(AlertsForwarderMetrics.NC_BOOTSTRAP_DURATION));
+        long durationMillis = durationNs / 1_000_000L;
+        LOG.info("NodeContextCache bootstrap complete: {} entries in {} ms", cache.size(), durationMillis);
+        eventPublisher.publishEvent(new NodeContextCacheReadyEvent(this, durationMillis, cache.size()));
+    }
+
+    private KafkaConsumer<String, byte[]> buildConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "alerts-forwarder-node-context-" + UUID.randomUUID());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); // we manage offsets via seek
+        return new KafkaConsumer<>(props);
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipeline.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipeline.java
@@ -1,0 +1,112 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.pipeline;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.enrich.AlarmEnricher;
+import org.deltav.alerts.forwarder.enrich.EnrichedAlarm;
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.deltav.alerts.forwarder.sink.AlarmSink;
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Turns one consumed alarm record into sink calls. Lifecycle (spec §5.3): a
+ * tombstone or a sub-threshold record on an active alarm resolves it; a record
+ * above the filter fires it. Resolves reuse the {@link ActiveAlertRegistry}'s
+ * stored firing identity so label sets stay stable.
+ *
+ * <p>Sink failures propagate out of {@link #onRecord} so the Kafka consumer
+ * can retry and back-pressure rather than drop the alarm.</p>
+ */
+@Component
+public class AlarmForwardingPipeline {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmForwardingPipeline.class);
+
+    private final AlarmFilter filter;
+    private final AlarmEnricher enricher;
+    private final ActiveAlertRegistry registry;
+    private final List<AlarmSink> sinks;
+    private final Counter consumed;
+    private final MeterRegistry metrics;
+
+    public AlarmForwardingPipeline(AlarmFilter filter, AlarmEnricher enricher,
+                                   ActiveAlertRegistry registry, List<AlarmSink> sinks,
+                                   MeterRegistry metrics) {
+        this.filter = filter;
+        this.enricher = enricher;
+        this.registry = registry;
+        this.sinks = sinks;
+        this.metrics = metrics;
+        this.consumed = metrics.counter(AlertsForwarderMetrics.ALARMS_CONSUMED);
+    }
+
+    /** Processes one record. A {@code null} alarm is a Kafka tombstone (delete). */
+    public void onRecord(String reductionKey, AlarmState alarm) {
+        consumed.increment();
+
+        if (alarm == null) {
+            resolve(reductionKey);
+            return;
+        }
+        if (!filter.accept(alarm)) {
+            // Sub-threshold or CLEARED: resolve if we are currently firing it.
+            if (registry.isActive(reductionKey)) {
+                resolve(reductionKey);
+            } else {
+                metrics.counter(AlertsForwarderMetrics.FILTERED, "reason", "severity").increment();
+            }
+            return;
+        }
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+        metrics.counter(AlertsForwarderMetrics.ENRICHMENT,
+                "result", e.enrichmentComplete() ? "hit" : "partial").increment();
+
+        ForwardedAlarm fa = new ForwardedAlarm(reductionKey, ForwardedAlarm.State.FIRING,
+                e.labels(), e.annotations(), alarm.getFirstEventTimeMs());
+        registry.markFiring(fa);
+        forward(fa);
+        metrics.counter(AlertsForwarderMetrics.FORWARDED, "outcome", "firing").increment();
+    }
+
+    private void resolve(String reductionKey) {
+        Optional<ForwardedAlarm> firing = registry.remove(reductionKey);
+        if (firing.isEmpty()) {
+            return;   // not active — nothing to resolve
+        }
+        ForwardedAlarm prev = firing.get();
+        ForwardedAlarm resolved = new ForwardedAlarm(reductionKey, ForwardedAlarm.State.RESOLVED,
+                prev.labels(), prev.annotations(), prev.startsAtMs());
+        forward(resolved);
+        metrics.counter(AlertsForwarderMetrics.FORWARDED, "outcome", "resolved").increment();
+    }
+
+    private void forward(ForwardedAlarm alarm) {
+        for (AlarmSink sink : sinks) {
+            try {
+                sink.forward(alarm);
+            } catch (Exception e) {
+                metrics.counter(AlertsForwarderMetrics.SINK_ERRORS, "sink", sink.name()).increment();
+                // Propagate so the consumer retries and back-pressures.
+                throw new SinkForwardException(sink.name(), e);
+            }
+        }
+    }
+
+    /** Thrown when a sink fails; the consumer retries the record. */
+    public static class SinkForwardException extends RuntimeException {
+        public SinkForwardException(String sink, Throwable cause) {
+            super("sink '" + sink + "' failed to forward alarm", cause);
+        }
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipeline.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipeline.java
@@ -80,14 +80,15 @@ public class AlarmForwardingPipeline {
     }
 
     private void resolve(String reductionKey) {
-        Optional<ForwardedAlarm> firing = registry.remove(reductionKey);
+        Optional<ForwardedAlarm> firing = registry.getFiring(reductionKey);
         if (firing.isEmpty()) {
             return;   // not active — nothing to resolve
         }
         ForwardedAlarm prev = firing.get();
         ForwardedAlarm resolved = new ForwardedAlarm(reductionKey, ForwardedAlarm.State.RESOLVED,
                 prev.labels(), prev.annotations(), prev.startsAtMs());
-        forward(resolved);
+        forward(resolved);   // throws → consumer retries; registry still populated
+        registry.remove(reductionKey);
         metrics.counter(AlertsForwarderMetrics.FORWARDED, "outcome", "resolved").increment();
     }
 

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlarmSink.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlarmSink.java
@@ -1,0 +1,20 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+/**
+ * Output port. An implementation forwards a {@link ForwardedAlarm} to one
+ * alerting/metrics backend. Implementations are activated by
+ * {@code @ConditionalOnProperty} so an operator chooses which ship.
+ *
+ * <p>Contract: {@link #forward} throws on a transport failure so the caller
+ * (the pipeline) can retry and back-pressure the Kafka consumer. It must NOT
+ * swallow failures — a silently-dropped alert is worse than a stalled consumer.
+ */
+public interface AlarmSink {
+
+    /** Forwards one alarm. Throws on transport failure. */
+    void forward(ForwardedAlarm alarm) throws Exception;
+
+    /** Short stable name for metrics tags and logs (e.g. "alertmanager"). */
+    String name();
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSink.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSink.java
@@ -1,0 +1,64 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Forwards alarms to Alertmanager's {@code POST /api/v2/alerts}. The request
+ * body is a one-element JSON array; a FIRING alert gets {@code endsAt = now +
+ * resolveTimeout} so Alertmanager auto-resolves if the forwarder stops
+ * refreshing it; a RESOLVED alert gets {@code endsAt = now}.
+ *
+ * <p>Activated by {@code deltav.alerts-forwarder.alertmanager.enabled} (default
+ * true).</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "deltav.alerts-forwarder.alertmanager",
+        name = "enabled", havingValue = "true", matchIfMissing = true)
+public class AlertmanagerAlarmSink implements AlarmSink {
+
+    private final RestClient client;
+    private final String url;
+    private final long resolveTimeoutMs;
+
+    public AlertmanagerAlarmSink(AlertsForwarderProperties props) {
+        this.url = props.getAlertmanager().getUrl();
+        this.resolveTimeoutMs = props.getAlertmanager().getResolveTimeoutMs();
+        this.client = RestClient.builder().build();
+    }
+
+    @Override
+    public void forward(ForwardedAlarm alarm) throws Exception {
+        Instant now = Instant.now();
+        Instant endsAt = alarm.state() == ForwardedAlarm.State.RESOLVED
+                ? now
+                : now.plus(Duration.ofMillis(resolveTimeoutMs));
+
+        Map<String, Object> alert = Map.of(
+                "labels", alarm.labels(),
+                "annotations", alarm.annotations(),
+                "startsAt", Instant.ofEpochMilli(alarm.startsAtMs()).toString(),
+                "endsAt", endsAt.toString());
+
+        client.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(List.of(alert))
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Override
+    public String name() {
+        return "alertmanager";
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSink.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSink.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -33,7 +34,10 @@ public class AlertmanagerAlarmSink implements AlarmSink {
     public AlertmanagerAlarmSink(AlertsForwarderProperties props) {
         this.url = props.getAlertmanager().getUrl();
         this.resolveTimeoutMs = props.getAlertmanager().getResolveTimeoutMs();
-        this.client = RestClient.builder().build();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
+        factory.setReadTimeout((int) Duration.ofSeconds(10).toMillis());
+        this.client = RestClient.builder().requestFactory(factory).build();
     }
 
     @Override

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/ForwardedAlarm.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/ForwardedAlarm.java
@@ -1,0 +1,21 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+
+/**
+ * A transport-agnostic alarm to forward. {@code labels} are low-cardinality
+ * dimensions; {@code annotations} are free text. {@code state} drives the
+ * lifecycle: FIRING asserts the alert, RESOLVED clears it. {@code startsAtMs}
+ * is the alarm's first-event time. A resolve carries the firing alert's stored
+ * label set verbatim (see {@code ActiveAlertRegistry}).
+ */
+public record ForwardedAlarm(
+        String reductionKey,
+        State state,
+        Map<String, String> labels,
+        Map<String, String> annotations,
+        long startsAtMs) {
+
+    public enum State { FIRING, RESOLVED }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSink.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSink.java
@@ -1,0 +1,74 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.Label;
+import prometheus.prompb.Sample;
+import prometheus.prompb.TimeSeries;
+import prometheus.prompb.WriteRequest;
+
+/**
+ * Forwards alarms to VictoriaMetrics as a {@code deltav_alarm_state} gauge via
+ * Prometheus remote-write: value {@code 1.0} while firing, {@code 0.0} on
+ * resolve. The series labels are the {@link ForwardedAlarm} labels (the same
+ * low-cardinality set the Alertmanager sink uses).
+ *
+ * <p>Activated by {@code deltav.alerts-forwarder.victoriametrics.enabled}
+ * (default false — Alertmanager is the default backend).</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "deltav.alerts-forwarder.victoriametrics",
+        name = "enabled", havingValue = "true")
+public class VictoriaMetricsAlarmSink implements AlarmSink {
+
+    private static final String METRIC_NAME = "deltav_alarm_state";
+
+    private final RestClient client;
+    private final String url;
+
+    public VictoriaMetricsAlarmSink(AlertsForwarderProperties props) {
+        this.url = props.getVictoriametrics().getUrl();
+        this.client = RestClient.builder().build();
+    }
+
+    @Override
+    public void forward(ForwardedAlarm alarm) throws Exception {
+        double value = alarm.state() == ForwardedAlarm.State.FIRING ? 1.0 : 0.0;
+
+        // TreeMap keeps labels sorted for stable series identity; __name__ sorts first.
+        Map<String, String> labels = new TreeMap<>(alarm.labels());
+        labels.put("__name__", METRIC_NAME);
+
+        TimeSeries.Builder ts = TimeSeries.newBuilder();
+        labels.forEach((k, v) -> ts.addLabels(Label.newBuilder().setName(k).setValue(v).build()));
+        ts.addSamples(Sample.newBuilder()
+                .setValue(value)
+                .setTimestamp(System.currentTimeMillis())
+                .build());
+
+        WriteRequest request = WriteRequest.newBuilder().addTimeseries(ts).build();
+        byte[] compressed = Snappy.compress(request.toByteArray());
+
+        client.post()
+                .uri(url)
+                .contentType(MediaType.parseMediaType("application/x-protobuf"))
+                .header("Content-Encoding", "snappy")
+                .header("X-Prometheus-Remote-Write-Version", "0.1.0")
+                .body(compressed)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Override
+    public String name() {
+        return "victoriametrics";
+    }
+}

--- a/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSink.java
+++ b/core/alerts-forwarder/src/main/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSink.java
@@ -1,12 +1,14 @@
 /* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
 package org.deltav.alerts.forwarder.sink;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.xerial.snappy.Snappy;
@@ -36,7 +38,10 @@ public class VictoriaMetricsAlarmSink implements AlarmSink {
 
     public VictoriaMetricsAlarmSink(AlertsForwarderProperties props) {
         this.url = props.getVictoriametrics().getUrl();
-        this.client = RestClient.builder().build();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
+        factory.setReadTimeout((int) Duration.ofSeconds(10).toMillis());
+        this.client = RestClient.builder().requestFactory(factory).build();
     }
 
     @Override

--- a/core/alerts-forwarder/src/main/resources/application.yml
+++ b/core/alerts-forwarder/src/main/resources/application.yml
@@ -8,7 +8,6 @@ spring:
 deltav:
   alerts-forwarder:
     alarms-topic: ${DELTAV_ALARMS_STATE_TOPIC:deltav-alarms-state-change}
-    node-context-topic: deltav-node-context
     filter:
       # Minimum severity to forward. One of: WARNING, MINOR, MAJOR, CRITICAL.
       min-severity: ${DELTAV_ALERTS_MIN_SEVERITY:WARNING}

--- a/core/alerts-forwarder/src/main/resources/application.yml
+++ b/core/alerts-forwarder/src/main/resources/application.yml
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later
+spring:
+  application:
+    name: alerts-forwarder
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+
+deltav:
+  alerts-forwarder:
+    alarms-topic: ${DELTAV_ALARMS_STATE_TOPIC:deltav-alarms-state-change}
+    node-context-topic: deltav-node-context
+    filter:
+      # Minimum severity to forward. One of: WARNING, MINOR, MAJOR, CRITICAL.
+      min-severity: ${DELTAV_ALERTS_MIN_SEVERITY:WARNING}
+      # UEIs never forwarded, even above min-severity.
+      uei-denylist: []
+    alertmanager:
+      enabled: ${DELTAV_ALERTS_ALERTMANAGER_ENABLED:true}
+      url: ${DELTAV_ALERTS_ALERTMANAGER_URL:http://alertmanager:9093/api/v2/alerts}
+      # Firing alerts get endsAt = now + this; Alertmanager auto-resolves if no refresh.
+      resolve-timeout-ms: 300000
+    victoriametrics:
+      enabled: ${DELTAV_ALERTS_VM_ENABLED:false}
+      url: ${DELTAV_ALERTS_VM_URL:http://victoriametrics:8428/api/v1/write}
+    dlq:
+      topic: deltav-alerts-forwarder-dlq
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+      # Suppress "no such contributor" until NodeContextCacheHealthIndicator is wired (Task 2).
+      validate-group-membership: false
+      group:
+        readiness:
+          include: readinessState, nodeContextCache

--- a/core/alerts-forwarder/src/main/resources/application.yml
+++ b/core/alerts-forwarder/src/main/resources/application.yml
@@ -35,8 +35,6 @@ management:
       probes:
         enabled: true
       show-details: always
-      # Suppress "no such contributor" until NodeContextCacheHealthIndicator is wired (Task 2).
-      validate-group-membership: false
       group:
         readiness:
           include: readinessState, nodeContextCache

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/AlertsForwarderIntegrationIT.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/AlertsForwarderIntegrationIT.java
@@ -1,0 +1,106 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.enrich.AlarmEnricher;
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.alerts.forwarder.pipeline.AlarmForwardingPipeline;
+import org.deltav.alerts.forwarder.sink.AlarmSink;
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Testcontainers
+class AlertsForwarderIntegrationIT {
+
+    @Container
+    static KafkaContainer kafka = new KafkaContainer("apache/kafka:3.8.0");
+
+    @Test
+    @Timeout(60)
+    void firingThenTombstoneProducesFiringThenResolved() throws Exception {
+        String topic = "deltav-alarms-state-change";
+        CopyOnWriteArrayList<ForwardedAlarm> sent = new CopyOnWriteArrayList<>();
+        AlarmSink sink = new AlarmSink() {
+            public void forward(ForwardedAlarm a) { sent.add(a); }
+            public String name() { return "test"; }
+        };
+
+        AlarmForwardingPipeline pipeline = new AlarmForwardingPipeline(
+                new AlarmFilter("WARNING", List.of()),
+                new AlarmEnricher(new NodeContextCache()),
+                new ActiveAlertRegistry(),
+                List.of(sink),
+                new SimpleMeterRegistry());
+
+        // Publish a firing alarm, then a tombstone, both keyed by reduction key.
+        try (KafkaProducer<byte[], byte[]> producer = producer()) {
+            AlarmState alarm = AlarmState.newBuilder()
+                    .setReductionKey("rk-1").setSeverity(AlarmState.Severity.MAJOR)
+                    .setUei("uei/nodeDown").setNodeId(1).build();
+            producer.send(new ProducerRecord<>(topic, "rk-1".getBytes(), alarm.toByteArray())).get();
+            producer.send(new ProducerRecord<>(topic, "rk-1".getBytes(), null)).get();
+        }
+
+        // Drain the topic through the pipeline, mirroring AlarmStateKafkaConsumer.handle.
+        try (var consumer = consumer()) {
+            consumer.subscribe(List.of(topic));
+            await().atMost(Duration.ofSeconds(30)).until(() -> {
+                var records = consumer.poll(Duration.ofSeconds(2));
+                records.forEach(r -> pipeline.onRecord(
+                        new String(r.key()),
+                        r.value() == null ? null : parse(r.value())));
+                return sent.size() >= 2;
+            });
+        }
+
+        assertThat(sent).hasSize(2);
+        assertThat(sent.get(0).state()).isEqualTo(ForwardedAlarm.State.FIRING);
+        assertThat(sent.get(1).state()).isEqualTo(ForwardedAlarm.State.RESOLVED);
+        assertThat(sent.get(1).labels()).isEqualTo(sent.get(0).labels());
+    }
+
+    private static AlarmState parse(byte[] bytes) {
+        try {
+            return AlarmState.parseFrom(bytes);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static KafkaProducer<byte[], byte[]> producer() {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        return new KafkaProducer<>(p);
+    }
+
+    private static org.apache.kafka.clients.consumer.KafkaConsumer<byte[], byte[]> consumer() {
+        Properties p = new Properties();
+        p.put("bootstrap.servers", kafka.getBootstrapServers());
+        p.put("group.id", "it-" + System.nanoTime());
+        p.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        p.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        p.put("auto.offset.reset", "earliest");
+        return new org.apache.kafka.clients.consumer.KafkaConsumer<>(p);
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/consume/AlarmStateKafkaConsumerIT.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/consume/AlarmStateKafkaConsumerIT.java
@@ -1,0 +1,168 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.consume;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.deltav.alerts.forwarder.enrich.AlarmEnricher;
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCacheReadyEvent;
+import org.deltav.alerts.forwarder.pipeline.AlarmForwardingPipeline;
+import org.deltav.alerts.forwarder.sink.AlarmSink;
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration test for {@link AlarmStateKafkaConsumer}: verifies the seek-to-beginning
+ * replay, the startup gate, the parse-error DLQ path, and successful forwarding through
+ * a recording sink — exercising everything that {@link org.deltav.alerts.forwarder.AlertsForwarderIntegrationIT}
+ * explicitly bypasses by driving the pipeline directly.
+ */
+@Testcontainers
+class AlarmStateKafkaConsumerIT {
+
+    private static final String ALARMS_TOPIC = "deltav-alarms-state-change";
+    private static final String DLQ_TOPIC = "deltav-alerts-forwarder-dlq";
+
+    @Container
+    static KafkaContainer kafka = new KafkaContainer("apache/kafka:3.8.0");
+
+    private AlarmStateKafkaConsumer consumer;
+
+    @AfterEach
+    void tearDown() {
+        if (consumer != null) {
+            consumer.stop();
+        }
+    }
+
+    @Test
+    @Timeout(60)
+    void validAlarmIsForwardedAndInvalidRecordGoesToDlq() throws Exception {
+        // Create both topics before publishing.
+        createTopics(ALARMS_TOPIC, DLQ_TOPIC);
+
+        // Recording sink collects all forwarded alarms.
+        CopyOnWriteArrayList<ForwardedAlarm> forwarded = new CopyOnWriteArrayList<>();
+        AlarmSink recordingSink = new AlarmSink() {
+            public void forward(ForwardedAlarm a) { forwarded.add(a); }
+            public String name() { return "recording"; }
+        };
+
+        // Wire all collaborators directly — no Spring context needed.
+        ActiveAlertRegistry registry = new ActiveAlertRegistry();
+        NodeContextCache nodeContextCache = new NodeContextCache();
+        nodeContextCache.markReady();   // skip bootstrap; test doesn't need node enrichment
+
+        AlarmForwardingPipeline pipeline = new AlarmForwardingPipeline(
+                new AlarmFilter("WARNING", List.of()),
+                new AlarmEnricher(nodeContextCache),
+                registry,
+                List.of(recordingSink),
+                new SimpleMeterRegistry());
+
+        AlertsForwarderProperties props = buildProps();
+
+        consumer = new AlarmStateKafkaConsumer(
+                props,
+                pipeline,
+                registry,
+                new SimpleMeterRegistry(),
+                kafka.getBootstrapServers());
+
+        // Fire the startup gate directly — simulates the NodeContextKafkaBootstrap event.
+        consumer.onNodeContextReady(new NodeContextCacheReadyEvent(this, 0L, 0));
+
+        // Publish one valid AlarmState and one definitly-unparseable record.
+        try (KafkaProducer<byte[], byte[]> producer = buildProducer()) {
+            AlarmState alarm = AlarmState.newBuilder()
+                    .setReductionKey("rk-consumer-it")
+                    .setSeverity(AlarmState.Severity.MAJOR)
+                    .setUei("uei/nodeDown")
+                    .setNodeId(42)
+                    .build();
+            producer.send(new ProducerRecord<>(ALARMS_TOPIC, "rk-consumer-it".getBytes(),
+                    alarm.toByteArray())).get();
+            // Garbage bytes — not valid protobuf for AlarmState.
+            producer.send(new ProducerRecord<>(ALARMS_TOPIC, "bad-key".getBytes(),
+                    new byte[]{0x00, 0x01, 0x02, 0x03})).get();
+        }
+
+        // 1) The recording sink must receive the valid alarm.
+        await().atMost(Duration.ofSeconds(30)).until(() -> !forwarded.isEmpty());
+        assertThat(forwarded).hasSize(1);
+        assertThat(forwarded.get(0).state()).isEqualTo(ForwardedAlarm.State.FIRING);
+        assertThat(forwarded.get(0).reductionKey()).isEqualTo("rk-consumer-it");
+
+        // 2) The DLQ topic must receive the invalid record.
+        await().atMost(Duration.ofSeconds(30)).until(() -> dlqHasRecord());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private boolean dlqHasRecord() {
+        Properties p = new Properties();
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        p.put(ConsumerConfig.GROUP_ID_CONFIG, "it-dlq-checker-" + System.nanoTime());
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        try (KafkaConsumer<byte[], byte[]> dlqConsumer = new KafkaConsumer<>(p)) {
+            dlqConsumer.subscribe(List.of(DLQ_TOPIC));
+            var records = dlqConsumer.poll(Duration.ofSeconds(2));
+            return !records.isEmpty();
+        }
+    }
+
+    private void createTopics(String... topics) throws Exception {
+        Properties adminProps = new Properties();
+        adminProps.put("bootstrap.servers", kafka.getBootstrapServers());
+        try (AdminClient admin = AdminClient.create(adminProps)) {
+            List<NewTopic> newTopics = List.of(
+                    new NewTopic(ALARMS_TOPIC, 1, (short) 1),
+                    new NewTopic(DLQ_TOPIC, 1, (short) 1));
+            admin.createTopics(newTopics).all().get();
+        }
+    }
+
+    private KafkaProducer<byte[], byte[]> buildProducer() {
+        Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        return new KafkaProducer<>(p);
+    }
+
+    private AlertsForwarderProperties buildProps() {
+        AlertsForwarderProperties props = new AlertsForwarderProperties();
+        props.setAlarmsTopic(ALARMS_TOPIC);
+        // DLQ topic via nested Dlq class — default already matches DLQ_TOPIC constant.
+        return props;
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/dlq/DlqPublisherTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/dlq/DlqPublisherTest.java
@@ -1,0 +1,32 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.dlq;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.deltav.alerts.forwarder.metrics.AlertsForwarderMetrics;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DlqPublisherTest {
+
+    @Test
+    void publishesPoisonRecordToDlqTopicWithReasonHeader() {
+        // Kafka client 4.1.1: MockProducer takes (autoComplete, partitioner, keySer, valueSer).
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(
+                true, null, new ByteArraySerializer(), new ByteArraySerializer());
+        SimpleMeterRegistry metrics = new SimpleMeterRegistry();
+        DlqPublisher dlq = new DlqPublisher(producer, "deltav-alerts-forwarder-dlq", metrics);
+
+        dlq.publish("rk".getBytes(), "bad-bytes".getBytes(), "parse-error");
+
+        assertThat(producer.history()).hasSize(1);
+        ProducerRecord<byte[], byte[]> rec = producer.history().get(0);
+        assertThat(rec.topic()).isEqualTo("deltav-alerts-forwarder-dlq");
+        assertThat(new String(rec.headers().lastHeader("x-dlq-reason").value()))
+                .isEqualTo("parse-error");
+        assertThat(metrics.counter(AlertsForwarderMetrics.DLQ_RECORDS).count()).isEqualTo(1.0);
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/enrich/AlarmEnricherTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/enrich/AlarmEnricherTest.java
@@ -1,0 +1,77 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.enrich;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.timeseries.proto.NodeContext;
+import org.deltav.timeseries.proto.SnmpInterfaceContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmEnricherTest {
+
+    @Test
+    void enrichesWithNodeIdentityAndDimensions() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1042", NodeContext.newBuilder()
+                .setNodeId(1042).setLocation("Default").setNodeLabel("web01.corp")
+                .setForeignSource("Servers").setForeignId("web-01")
+                .addCategories("Production").build());
+        AlarmEnricher enricher = new AlarmEnricher(cache);
+
+        AlarmState alarm = AlarmState.newBuilder()
+                .setReductionKey("rk").setAlarmId(7).setNodeId(1042).setLocation("Default")
+                .setSeverity(AlarmState.Severity.MAJOR).setUei("uei/nodeDown")
+                .setDescription("Node is down").setLogMessage("down since 10:00").build();
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+
+        assertThat(e.enrichmentComplete()).isTrue();
+        assertThat(e.labels()).containsEntry("node", "Servers:web-01");
+        assertThat(e.labels()).containsEntry("severity", "MAJOR");
+        assertThat(e.labels()).containsEntry("uei", "uei/nodeDown");
+        assertThat(e.labels()).containsEntry("foreign_source", "Servers");
+        assertThat(e.labels()).containsEntry("categories", "Production");
+        assertThat(e.labels()).containsEntry("alarm_id", "7");
+        assertThat(e.annotations()).containsEntry("description", "Node is down");
+        assertThat(e.annotations()).containsEntry("log_message", "down since 10:00");
+    }
+
+    @Test
+    void addsSnmpInterfaceLabelsWhenIfIndexPresent() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1042", NodeContext.newBuilder()
+                .setNodeId(1042).setLocation("Default")
+                .setForeignSource("Servers").setForeignId("web-01")
+                .putSnmpInterfaceMetadata(3, SnmpInterfaceContext.newBuilder()
+                        .setIfIndex(3).setIfName("Gi0/3").setIfDescr("GigabitEthernet0/3")
+                        .setIfAlias("uplink").setIfSpeed(1_000_000_000L).setIfType(6).build())
+                .build());
+        AlarmEnricher enricher = new AlarmEnricher(cache);
+
+        AlarmState alarm = AlarmState.newBuilder()
+                .setReductionKey("rk").setNodeId(1042).setLocation("Default")
+                .setSeverity(AlarmState.Severity.MINOR).setUei("uei/ifDown").setIfIndex(3).build();
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+
+        assertThat(e.labels()).containsEntry("if_name", "Gi0/3");
+        assertThat(e.labels()).containsEntry("if_alias", "uplink");
+        assertThat(e.labels()).containsEntry("if_speed", "1000000000");
+    }
+
+    @Test
+    void partialEnrichmentWhenNodeMissing() {
+        AlarmEnricher enricher = new AlarmEnricher(new NodeContextCache());
+        AlarmState alarm = AlarmState.newBuilder()
+                .setReductionKey("rk").setNodeId(999).setLocation("Default")
+                .setSeverity(AlarmState.Severity.MAJOR).setUei("uei/x").build();
+
+        EnrichedAlarm e = enricher.enrich(alarm);
+
+        assertThat(e.enrichmentComplete()).isFalse();
+        assertThat(e.labels()).containsEntry("node", "delta-v:999");
+        assertThat(e.labels()).containsEntry("enrichment", "partial");
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/filter/AlarmFilterTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/filter/AlarmFilterTest.java
@@ -1,0 +1,45 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.filter;
+
+import java.util.List;
+
+import org.deltav.alarms.proto.AlarmState;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmFilterTest {
+
+    private AlarmState alarm(AlarmState.Severity severity, String uei) {
+        return AlarmState.newBuilder()
+                .setReductionKey("rk").setSeverity(severity).setUei(uei).build();
+    }
+
+    @Test
+    void acceptsAtOrAboveMinSeverity() {
+        AlarmFilter filter = new AlarmFilter("WARNING", List.of());
+        assertThat(filter.accept(alarm(AlarmState.Severity.WARNING, "uei/x"))).isTrue();
+        assertThat(filter.accept(alarm(AlarmState.Severity.CRITICAL, "uei/x"))).isTrue();
+    }
+
+    @Test
+    void rejectsBelowMinSeverity() {
+        AlarmFilter filter = new AlarmFilter("MAJOR", List.of());
+        assertThat(filter.accept(alarm(AlarmState.Severity.WARNING, "uei/x"))).isFalse();
+        assertThat(filter.accept(alarm(AlarmState.Severity.CLEARED, "uei/x"))).isFalse();
+    }
+
+    @Test
+    void rejectsDenylistedUei() {
+        AlarmFilter filter = new AlarmFilter("WARNING", List.of("uei/noisy"));
+        assertThat(filter.accept(alarm(AlarmState.Severity.CRITICAL, "uei/noisy"))).isFalse();
+        assertThat(filter.accept(alarm(AlarmState.Severity.CRITICAL, "uei/ok"))).isTrue();
+    }
+
+    @Test
+    void invalidMinSeverityFallsBackToWarning() {
+        AlarmFilter filter = new AlarmFilter("NONSENSE", List.of());
+        assertThat(filter.accept(alarm(AlarmState.Severity.WARNING, "uei/x"))).isTrue();
+        assertThat(filter.accept(alarm(AlarmState.Severity.NORMAL, "uei/x"))).isFalse();
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistryTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/lifecycle/ActiveAlertRegistryTest.java
@@ -1,0 +1,44 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.lifecycle;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActiveAlertRegistryTest {
+
+    private ForwardedAlarm firing(String rk) {
+        return new ForwardedAlarm(rk, ForwardedAlarm.State.FIRING,
+                Map.of("node", "Servers:web-01"), Map.of("description", "down"), 1000L);
+    }
+
+    @Test
+    void markFiringThenIsActive() {
+        ActiveAlertRegistry registry = new ActiveAlertRegistry();
+        assertThat(registry.isActive("rk")).isFalse();
+        registry.markFiring(firing("rk"));
+        assertThat(registry.isActive("rk")).isTrue();
+        assertThat(registry.size()).isEqualTo(1);
+    }
+
+    @Test
+    void removeReturnsStoredIdentityAndEvicts() {
+        ActiveAlertRegistry registry = new ActiveAlertRegistry();
+        ForwardedAlarm stored = firing("rk");
+        registry.markFiring(stored);
+
+        Optional<ForwardedAlarm> removed = registry.remove("rk");
+
+        assertThat(removed).contains(stored);
+        assertThat(registry.isActive("rk")).isFalse();
+    }
+
+    @Test
+    void removeUnknownKeyReturnsEmpty() {
+        assertThat(new ActiveAlertRegistry().remove("nope")).isEmpty();
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCacheTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/nodecontext/NodeContextCacheTest.java
@@ -1,0 +1,103 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.nodecontext;
+
+import org.deltav.timeseries.proto.NodeContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeContextCacheTest {
+
+    @Test
+    void get_returns_empty_when_key_absent() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void put_stores_value_and_get_retrieves() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).setLocation("Default").setNodeLabel("lab-1").build();
+        cache.put("Default@1", nc);
+        assertThat(cache.get("Default@1")).contains(nc);
+    }
+
+    @Test
+    void remove_evicts_key() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).build();
+        cache.put("Default@1", nc);
+        cache.remove("Default@1");
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void tombstone_on_put_delegates_to_remove() {
+        NodeContextCache cache = new NodeContextCache();
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).build());
+        NodeContext tombstone = NodeContext.newBuilder().setNodeId(1).setDeleted(true).build();
+        cache.applyUpdate("Default@1", tombstone);
+        assertThat(cache.get("Default@1")).isEmpty();
+    }
+
+    @Test
+    void applyUpdate_live_record_puts() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(1).setDeleted(false).build();
+        cache.applyUpdate("Default@1", nc);
+        assertThat(cache.get("Default@1")).contains(nc);
+    }
+
+    @Test
+    void size_reports_current_entries() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.size()).isZero();
+        cache.put("Default@1", NodeContext.newBuilder().setNodeId(1).build());
+        cache.put("Default@2", NodeContext.newBuilder().setNodeId(2).build());
+        assertThat(cache.size()).isEqualTo(2);
+        cache.remove("Default@1");
+        assertThat(cache.size()).isEqualTo(1);
+    }
+
+    @Test
+    void ready_defaults_false_and_markReady_flips() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.isReady()).isFalse();
+        cache.markReady();
+        assertThat(cache.isReady()).isTrue();
+    }
+
+    @Test
+    void findByNodeId_returns_empty_when_no_entry() {
+        NodeContextCache cache = new NodeContextCache();
+        assertThat(cache.findByNodeId(99)).isEmpty();
+    }
+
+    @Test
+    void findByNodeId_returns_entry_when_node_id_matches_regardless_of_location() {
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc = NodeContext.newBuilder().setNodeId(5).setLocation("Default").setNodeLabel("server-01").build();
+        cache.put("Default@5", nc);
+        assertThat(cache.findByNodeId(5)).contains(nc);
+    }
+
+    @Test
+    void findByNodeId_returns_first_match_when_multiple_locations_share_node_id() {
+        // node_id is normally unique per OnmsNode but the cache is keyed by
+        // {location}@{node_id} which CAN collide if a node migrates location
+        // (relocation). Returning the first match is acceptable — the
+        // stream order is unspecified across HashMap implementations but the
+        // method exists primarily for the location-empty fallback case where
+        // there is exactly one matching entry in practice.
+        NodeContextCache cache = new NodeContextCache();
+        NodeContext nc1 = NodeContext.newBuilder().setNodeId(7).setLocation("a").build();
+        NodeContext nc2 = NodeContext.newBuilder().setNodeId(7).setLocation("b").build();
+        cache.put("a@7", nc1);
+        cache.put("b@7", nc2);
+        assertThat(cache.findByNodeId(7)).isPresent();
+        // either nc1 or nc2 is acceptable; just assert presence and node_id matches
+        assertThat(cache.findByNodeId(7).get().getNodeId()).isEqualTo(7);
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipelineTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipelineTest.java
@@ -15,6 +15,7 @@ import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AlarmForwardingPipelineTest {
 
@@ -82,5 +83,37 @@ class AlarmForwardingPipelineTest {
     void tombstoneForUnknownKeyForwardsNothing() {
         pipeline("WARNING").onRecord("never-seen", null);
         assertThat(sent).isEmpty();
+    }
+
+    @Test
+    void resolveRetainsRegistryEntryWhenSinkFails() {
+        // Sink that throws on the resolve forward (second call) only.
+        AlarmSink flakySink = new AlarmSink() {
+            int calls = 0;
+            public void forward(ForwardedAlarm a) throws Exception {
+                calls++;
+                if (a.state() == ForwardedAlarm.State.RESOLVED) {
+                    throw new RuntimeException("simulated sink failure");
+                }
+            }
+            public String name() { return "flaky"; }
+        };
+        ActiveAlertRegistry registry = new ActiveAlertRegistry();
+        AlarmForwardingPipeline p = new AlarmForwardingPipeline(
+                new AlarmFilter("WARNING", List.of()),
+                new AlarmEnricher(new NodeContextCache()),
+                registry,
+                List.of(flakySink),
+                new SimpleMeterRegistry());
+
+        p.onRecord("rk", AlarmState.newBuilder()
+                .setReductionKey("rk").setSeverity(AlarmState.Severity.MAJOR)
+                .setUei("uei/x").setNodeId(1).build());
+        assertThat(registry.isActive("rk")).isTrue();
+
+        // tombstone → resolve forward throws — registry must still have the entry so the consumer can retry.
+        assertThrows(AlarmForwardingPipeline.SinkForwardException.class,
+                () -> p.onRecord("rk", null));
+        assertThat(registry.isActive("rk")).isTrue();
     }
 }

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipelineTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/pipeline/AlarmForwardingPipelineTest.java
@@ -1,0 +1,86 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.alarms.proto.AlarmState;
+import org.deltav.alerts.forwarder.enrich.AlarmEnricher;
+import org.deltav.alerts.forwarder.filter.AlarmFilter;
+import org.deltav.alerts.forwarder.lifecycle.ActiveAlertRegistry;
+import org.deltav.alerts.forwarder.nodecontext.NodeContextCache;
+import org.deltav.alerts.forwarder.sink.AlarmSink;
+import org.deltav.alerts.forwarder.sink.ForwardedAlarm;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlarmForwardingPipelineTest {
+
+    private final List<ForwardedAlarm> sent = new ArrayList<>();
+
+    private final AlarmSink recordingSink = new AlarmSink() {
+        public void forward(ForwardedAlarm a) { sent.add(a); }
+        public String name() { return "recording"; }
+    };
+
+    private AlarmForwardingPipeline pipeline(String minSeverity) {
+        return new AlarmForwardingPipeline(
+                new AlarmFilter(minSeverity, List.of()),
+                new AlarmEnricher(new NodeContextCache()),
+                new ActiveAlertRegistry(),
+                List.of(recordingSink),
+                new SimpleMeterRegistry());
+    }
+
+    private AlarmState alarm(String rk, AlarmState.Severity sev) {
+        return AlarmState.newBuilder()
+                .setReductionKey(rk).setSeverity(sev).setUei("uei/x").setNodeId(1).build();
+    }
+
+    @Test
+    void firingAlarmAboveThresholdIsForwarded() {
+        pipeline("WARNING").onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        assertThat(sent).hasSize(1);
+        assertThat(sent.get(0).state()).isEqualTo(ForwardedAlarm.State.FIRING);
+    }
+
+    @Test
+    void alarmBelowThresholdIsNotForwarded() {
+        pipeline("MAJOR").onRecord("rk", alarm("rk", AlarmState.Severity.WARNING));
+        assertThat(sent).isEmpty();
+    }
+
+    @Test
+    void tombstoneResolvesActiveAlarm() {
+        AlarmForwardingPipeline p = pipeline("WARNING");
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        p.onRecord("rk", null);
+        assertThat(sent).hasSize(2);
+        assertThat(sent.get(1).state()).isEqualTo(ForwardedAlarm.State.RESOLVED);
+    }
+
+    @Test
+    void clearedSeverityResolvesActiveAlarm() {
+        AlarmForwardingPipeline p = pipeline("WARNING");
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.CLEARED));
+        assertThat(sent).hasSize(2);
+        assertThat(sent.get(1).state()).isEqualTo(ForwardedAlarm.State.RESOLVED);
+    }
+
+    @Test
+    void resolveReusesStoredFiringLabels() {
+        AlarmForwardingPipeline p = pipeline("WARNING");
+        p.onRecord("rk", alarm("rk", AlarmState.Severity.MAJOR));
+        p.onRecord("rk", null);
+        assertThat(sent.get(1).labels()).isEqualTo(sent.get(0).labels());
+    }
+
+    @Test
+    void tombstoneForUnknownKeyForwardsNothing() {
+        pipeline("WARNING").onRecord("never-seen", null);
+        assertThat(sent).isEmpty();
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSinkTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/AlertmanagerAlarmSinkTest.java
@@ -1,0 +1,66 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlertmanagerAlarmSinkTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    private AlertmanagerAlarmSink sink() {
+        AlertsForwarderProperties props = new AlertsForwarderProperties();
+        props.getAlertmanager().setUrl(server.url("/api/v2/alerts").toString());
+        props.getAlertmanager().setResolveTimeoutMs(300000);
+        return new AlertmanagerAlarmSink(props);
+    }
+
+    @Test
+    void postsFiringAlertAsJsonArray() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.FIRING,
+                Map.of("node", "Servers:web-01", "severity", "MAJOR"),
+                Map.of("description", "Node is down"), 1_700_000_000_000L);
+
+        sink().forward(alarm);
+
+        RecordedRequest req = server.takeRequest();
+        assertThat(req.getMethod()).isEqualTo("POST");
+        assertThat(req.getPath()).isEqualTo("/api/v2/alerts");
+        String body = req.getBody().readUtf8();
+        assertThat(body).startsWith("[").endsWith("]");
+        assertThat(body).contains("\"node\":\"Servers:web-01\"");
+        assertThat(body).contains("\"description\":\"Node is down\"");
+        assertThat(body).contains("\"startsAt\"").contains("\"endsAt\"");
+    }
+
+    @Test
+    void throwsOnNon2xx() {
+        server.enqueue(new MockResponse().setResponseCode(503));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.FIRING,
+                Map.of("node", "n"), Map.of(), 1L);
+
+        org.junit.jupiter.api.Assertions.assertThrows(Exception.class,
+                () -> sink().forward(alarm));
+    }
+}

--- a/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSinkTest.java
+++ b/core/alerts-forwarder/src/test/java/org/deltav/alerts/forwarder/sink/VictoriaMetricsAlarmSinkTest.java
@@ -1,0 +1,67 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.alerts.forwarder.sink;
+
+import java.util.Map;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.deltav.alerts.forwarder.config.AlertsForwarderProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xerial.snappy.Snappy;
+import prometheus.prompb.WriteRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VictoriaMetricsAlarmSinkTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    private VictoriaMetricsAlarmSink sink() {
+        AlertsForwarderProperties props = new AlertsForwarderProperties();
+        props.getVictoriametrics().setUrl(server.url("/api/v1/write").toString());
+        return new VictoriaMetricsAlarmSink(props);
+    }
+
+    @Test
+    void remoteWritesFiringAsGaugeValueOne() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.FIRING,
+                Map.of("node", "Servers:web-01", "severity", "MAJOR"), Map.of(), 1000L);
+
+        sink().forward(alarm);
+
+        RecordedRequest req = server.takeRequest();
+        assertThat(req.getHeader("Content-Encoding")).isEqualTo("snappy");
+        WriteRequest wr = WriteRequest.parseFrom(Snappy.uncompress(req.getBody().readByteArray()));
+        assertThat(wr.getTimeseriesCount()).isEqualTo(1);
+        assertThat(wr.getTimeseries(0).getLabelsList())
+                .anyMatch(l -> l.getName().equals("__name__") && l.getValue().equals("deltav_alarm_state"));
+        assertThat(wr.getTimeseries(0).getSamples(0).getValue()).isEqualTo(1.0);
+    }
+
+    @Test
+    void remoteWritesResolvedAsGaugeValueZero() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        ForwardedAlarm alarm = new ForwardedAlarm("rk", ForwardedAlarm.State.RESOLVED,
+                Map.of("node", "n"), Map.of(), 1000L);
+
+        sink().forward(alarm);
+
+        WriteRequest wr = WriteRequest.parseFrom(Snappy.uncompress(server.takeRequest().getBody().readByteArray()));
+        assertThat(wr.getTimeseries(0).getSamples(0).getValue()).isEqualTo(0.0);
+    }
+}

--- a/opennms-container/delta-v/alertmanager/alertmanager.yml
+++ b/opennms-container/delta-v/alertmanager/alertmanager.yml
@@ -1,0 +1,5 @@
+route:
+  receiver: deltav-null
+  group_by: ['node']
+receivers:
+  - name: deltav-null

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -219,6 +219,15 @@ do_prometheus_writer_image() {
     apply_env_version_alias "deltav/prometheus-writer"
 }
 
+do_alerts_forwarder_image() {
+    log "Building alerts-forwarder image (deltav/alerts-forwarder:$VERSION)..."
+    cd "$REPO_ROOT"
+    ./mvnw -B -f core/alerts-forwarder/pom.xml -DskipTests package
+    cd "$REPO_ROOT/core/alerts-forwarder"
+    docker build -t "deltav/alerts-forwarder:$VERSION" -t "deltav/alerts-forwarder:latest" .
+    apply_env_version_alias "deltav/alerts-forwarder"
+}
+
 do_jre_image() {
     log "Building deltav/jre-deltav:21..."
     cd "$SCRIPT_DIR"
@@ -325,6 +334,12 @@ do_deltav_images() {
     # built as a standalone image rather than sharing daemon-base.
     do_prometheus_writer_image
 
+    # --- Build alerts-forwarder (standalone Spring Boot service) ---
+    # alerts-forwarder consumes the Kafka alarms topic and forwards alerts to
+    # Alertmanager. Like prometheus-writer, it has its own Dockerfile in
+    # core/alerts-forwarder/ and does not share the daemon-base layer.
+    do_alerts_forwarder_image
+
     # --- Build minion-gateway (gRPC ingress translator for Minion-facing surface) ---
     # minion-gateway sits between Envoy and the internal Kafka topics, translating
     # gRPC bidi calls from Minions into Kafka publishes. Built standalone (like
@@ -344,7 +359,7 @@ do_deltav_images() {
     do_perspective_app_init_image
 
     log "Delta-V images built:"
-    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy|perspective-app-init" | sort | head -30
+    docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|alerts-forwarder|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|daemon-deltav|minion-deltav|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy|perspective-app-init" | sort | head -30
 }
 
 # Build a single daemon's layered image, reusing the existing cached
@@ -358,10 +373,20 @@ do_single_daemon_image() {
     local name="${1:-}"
     [ -n "$name" ] || err "the 'daemon' command needs a daemon name, e.g. './build.sh daemon alarmd'"
 
+    # Standalone images that have their own Dockerfile in core/<name>/ rather
+    # than going through daemon-base + compute-shared-libs.sh. Route them to
+    # their dedicated build functions and return immediately.
+    case "$name" in
+        alerts-forwarder)
+            do_alerts_forwarder_image
+            return
+            ;;
+    esac
+
     # Validate against the known daemon set (word-boundary match).
     case " $DAEMON_NAMES " in
         *" $name "*) ;;
-        *) err "unknown daemon '$name'. Valid daemons: $DAEMON_NAMES" ;;
+        *) err "unknown daemon '$name'. Valid daemons: $DAEMON_NAMES (plus standalone: alerts-forwarder)" ;;
     esac
 
     # The shared base and JRE images must already exist — single-daemon mode

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -948,6 +948,48 @@ services:
     ports:
       - "18080:8080"
 
+  alertmanager:
+    <<: *no-search-domain
+    image: prom/alertmanager:v0.27.0
+    container_name: delta-v-alertmanager-1
+    profiles: [metrics, metrics-e2e]
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "9093:9093"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9093/-/healthy | grep -q OK"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+
+  alerts-forwarder:
+    <<: *no-search-domain
+    image: ${IMAGE_PREFIX:-deltav}/alerts-forwarder:${VERSION}
+    container_name: delta-v-alerts-forwarder-1
+    profiles: [metrics, metrics-e2e]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      alertmanager:
+        condition: service_healthy
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      DELTAV_ALERTS_ALERTMANAGER_URL: http://alertmanager:9093/api/v2/alerts
+      DELTAV_ALERTS_ALERTMANAGER_ENABLED: "true"
+      DELTAV_ALERTS_VM_ENABLED: "false"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
   victoriametrics:
     <<: *no-search-domain
     image: victoriametrics/victoria-metrics:v1.106.1

--- a/opennms-container/delta-v/grafana/provisioning/datasources/victoriametrics.yml
+++ b/opennms-container/delta-v/grafana/provisioning/datasources/victoriametrics.yml
@@ -17,3 +17,12 @@ datasources:
       manageAlerts: false
       prometheusType: Prometheus
       prometheusVersion: 2.40.0
+
+  - name: Alertmanager
+    uid: alertmanager
+    type: alertmanager
+    access: proxy
+    url: http://alertmanager:9093
+    editable: false
+    jsonData:
+      implementation: prometheus

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <!-- Flow processing services (Spring Cloud Stream) -->
     <module>core/flow-enricher</module>
     <module>core/prometheus-writer</module>
+    <module>core/alerts-forwarder</module>
   </modules>
 
   <!-- ============================================================ -->


### PR DESCRIPTION
## Summary

Track 2b of v1.3.0 "Alarms on Kafka" — the new `core/alerts-forwarder` standalone Spring Boot 4 daemon that consumes the compacted \`deltav-alarms-state-change\` Kafka topic (Track 1) + node-context enrichment (Track 2a) and forwards firing/resolved alerts to Alertmanager and/or VictoriaMetrics through a pluggable \`AlarmSink\` seam.

**Module shape:** ~25 new files under \`core/alerts-forwarder/\`, ~13 commits. Five-layer pipeline — consume → filter → enrich → pipeline → sink:

- **Bootstrap-replay consumer** (\`AlarmStateKafkaConsumer\`) — raw \`KafkaConsumer\` on a random group id, seeks to the beginning every restart so \`ActiveAlertRegistry\` rebuilds correctly. Gated on \`NodeContextCacheReadyEvent\`.
- **Pipeline + lifecycle** — tombstone or sub-threshold-on-active → resolve; above-threshold → enrich + firing; resolve reuses the registry's stored firing identity verbatim so Alertmanager dedup fingerprints match.
- **AlarmSink seam** — \`AlertmanagerAlarmSink\` (JSON \`POST /api/v2/alerts\`, firing/resolved via \`endsAt\`) and \`VictoriaMetricsAlarmSink\` (Prometheus remote-write \`deltav_alarm_state\` gauge 1.0/0.0, Snappy + protobuf). Both behind \`@ConditionalOnProperty\`; operator picks which ship.
- **DLQ** — parse-error records go to \`deltav-alerts-forwarder-dlq\` via a dedicated \`KafkaProducer\`; consumer never wedges.
- **Back-pressure** — sink failure → \`SinkForwardException\` propagates; consumer sleeps 5s and retries the same record. No offset commits, no alarm dropped.

Spec: \`docs/superpowers/specs/2026-05-19-v1.3.0-track2-alerts-forwarder-design.md\` §5 + §6.
Plan: \`docs/superpowers/plans/2026-05-19-v1.3.0-track2b-alerts-forwarder.md\`.

## Notable architectural decisions

- **Raw KafkaConsumer + bootstrap-replay (not Spring Cloud Stream).** A consumer-group binding resumes from committed offsets and would leave \`ActiveAlertRegistry\` empty after a restart — the forwarder couldn't resolve alarms that fired before it. Replaying a compacted topic from the beginning every restart is bounded (one record per active key) and removes all offset-commit bookkeeping. Spec §5.1/§5.5/§5.6 were amended during Track 2 planning to match (already merged via #296).
- **Two \`AlarmSink\` implementations behind one interface, \`@ConditionalOnProperty\` activation.** No transport details leak into the pipeline.
- **Durable \`node\` identity = \`foreignSource:foreignId\` (or \`delta-v:{node_id}\` for discovery nodes).** \`NodeIdentity\` helper duplicated here vs prometheus-writer's \`InstanceLabelResolver.nodeIdentity\` is intentional — no cross-module dependency.

## Test plan

- [x] 32 unit tests across 8 suites, all green (filter, enricher, registry, pipeline, sinks, DLQ, node-context cache).
- [x] Two Testcontainers ITs: \`AlertsForwarderIntegrationIT\` (pipeline end-to-end) and \`AlarmStateKafkaConsumerIT\` (real consumer thread + DLQ on parse failure) — both green under \`./mvnw verify\`.
- [x] Full reactor \`./mvnw -am clean install\` for \`core/alerts-forwarder\` + dependents — BUILD SUCCESS.
- [x] **Docker-compose end-to-end smoke (the spec §5–§6 acceptance test):** stopped \`flow-default-testnode-1\` in the dev stack — alarmd raised an alarm; within ~3 min Alertmanager \`/api/v2/alerts\` returned the active alert with full enrichment (\`node=flow-test:flow-default-testnode-1\`, \`foreign_source\`, \`severity\`, \`ip_address\`, \`service_name\`, description + log_message annotations). Restarted the container — alarm cleared; Alertmanager active-alert list returned \`[]\`. Final forwarder metrics: \`forwarded{outcome=firing}=2\`, \`forwarded{outcome=resolved}=2\`, \`active_alerts=0\`, \`enrichment{result=hit}=2\`.

## Notes for reviewers

- **Build/CI wiring deviation from plan:** the plan said append \`alerts-forwarder\` to \`DAEMON_NAMES\` in build.sh + GHA. That would have fed the \`compute-shared-libs.sh\` step which expects \`core/daemon-boot-*\` modules and broken the build. \`alerts-forwarder\` is structurally parallel to \`prometheus-writer\` (own \`Dockerfile\`, own fat jar) — added dedicated build paths in both build.sh and the workflow instead. Plan annotation TODO.
- **Final-review hygiene fixes** (commit \`5fa142d7f1f\`): a resolve-correctness fix where \`AlarmForwardingPipeline.resolve()\` now peeks the registry, forwards, then removes only on success — previously a sink failure on the resolve forward silently lost the resolve until Alertmanager's 5-min auto-resolve timeout. Also added a real \`AlarmStateKafkaConsumer\` IT, deleted a dead \`nodeContextTopic\` config property, added a 5s/10s timeout to both sinks' RestClient, and closed the DLQ producer on shutdown.
- **AlarmFilter \`@Bean\` registration** (commit \`42196bcfe7d\`): the filter takes constructor args (\`String minSeverity, List<String>\`) sourced from \`AlertsForwarderProperties\` and so can't be component-scanned. Unit tests passed because they hand-construct it; the first docker-compose boot caught the gap — fix is a tiny \`AlertsForwarderBeansConfiguration\` \`@Configuration\` providing the bean.

## Sequencing

- Track 1 (alarm Kafka publisher) — merged via #292.
- Track 2 design + 2a/2b plans — merged via #296.
- Track 2a (node-context enrichment + durable identity) — merged via #295.
- **Track 2b (this PR)** — the alerts-forwarder daemon, the user-visible payoff of v1.3.0.
- Track 3 (alarm state materializer / Phase 2 Kafka SOT) — future.
- Track 4 (Northbounder API retirement) — future.