### PR TITLE
fix(compose): embed alertmanager + vmagent configs (RC2 smoke wiring)

### DIFF
--- a/opennms-container/delta-v/alertmanager/alertmanager.yml
+++ b/opennms-container/delta-v/alertmanager/alertmanager.yml
@@ -1,5 +1,0 @@
-route:
-  receiver: deltav-null
-  group_by: ['node']
-receivers:
-  - name: deltav-null

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -955,8 +955,10 @@ services:
     profiles: [metrics, metrics-e2e]
     command:
       - --config.file=/etc/alertmanager/alertmanager.yml
-    volumes:
-      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    configs:
+      - source: alertmanager_config
+        target: /etc/alertmanager/alertmanager.yml
+        mode: 0444
     ports:
       - "9093:9093"
     restart: unless-stopped
@@ -1013,6 +1015,27 @@ services:
     ports:
       - "18428:8428"
 
+  # Scrape sidecar: pulls deltav_* metrics from all daemon /actuator/prometheus
+  # endpoints and remote-writes them into VictoriaMetrics so the Grafana
+  # alerts-pipeline dashboard has data. Without this, VM runs in receiver-only
+  # mode and daemon Micrometer metrics never appear.
+  vmagent:
+    <<: *no-search-domain
+    image: victoriametrics/vmagent:v1.106.1
+    container_name: delta-v-vmagent-1
+    profiles: [metrics, metrics-e2e]
+    restart: unless-stopped
+    depends_on:
+      victoriametrics:
+        condition: service_started
+    command:
+      - -promscrape.config=/etc/vmagent/scrape.yml
+      - -remoteWrite.url=http://victoriametrics:8428/api/v1/write
+    configs:
+      - source: vmagent_scrape
+        target: /etc/vmagent/scrape.yml
+        mode: 0444
+
   grafana:
     <<: *no-search-domain
     image: ${IMAGE_PREFIX:-deltav}/grafana:${VERSION}
@@ -1053,6 +1076,47 @@ services:
       start_period: 10s
     ports:
       - "13000:3000"
+
+configs:
+  # Alertmanager routing config — embedded here so no host file is required on
+  # no-git-clone smoke deployments (fixes Bug #39: Docker was creating a
+  # directory at ./alertmanager/alertmanager.yml when the path was missing,
+  # causing "not a directory" failures in the alertmanager container).
+  alertmanager_config:
+    content: |
+      route:
+        receiver: deltav-null
+        group_by: ['node']
+      receivers:
+        - name: deltav-null
+  # vmagent scrape config — enumerates all daemon actuator endpoints so
+  # deltav_* Micrometer metrics reach VictoriaMetrics and the Grafana
+  # alerts-pipeline dashboard shows data instead of "No data".
+  vmagent_scrape:
+    content: |
+      global:
+        scrape_interval: 15s
+      scrape_configs:
+        - job_name: deltav-daemons
+          metrics_path: /actuator/prometheus
+          static_configs:
+            - targets:
+                - alarmd:8080
+                - alerts-forwarder:8080
+                - bsmd:8080
+                - collectd:8080
+                - discovery:8080
+                - enlinkd:8080
+                - eventtranslator:8080
+                - perspectivepollerd:8080
+                - pollerd:8080
+                - provisiond:8080
+                - syslogd:8080
+                - telemetryd:8080
+                - trapd:8080
+                - prometheus-writer:8080
+                - flow-enricher:8080
+                - minion-gateway:8080
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Two coordinated SMOKE-VM wiring fixes surfaced by the v1.3.0-rc1 smoke run on a no-git-clone Ubuntu/UTM VM. Both close gaps that were hand-worked-around during that smoke; this PR is the proper code fix that lets future smoke runs (RC2+) come up cleanly with zero manual intervention.

### Bug #39 — alertmanager bind-mount fails on no-git-clone
Old compose bind-mounted \`./alertmanager/alertmanager.yml\` from the host. On smoke VMs that path doesn't exist; Docker auto-creates the missing source as a **directory**, then the alertmanager container fails to start with \`not a directory: Are you trying to mount a directory onto a file\`. New: top-level \`configs: alertmanager_config: content:\` embeds the YAML literally in the compose file; alertmanager service references it via \`configs:\` (with \`mode: 0444\`). The standalone \`opennms-container/delta-v/alertmanager/alertmanager.yml\` file is deleted — no longer referenced.

### Actuator-scrape gap
VictoriaMetrics was in receiver-only mode (no \`-promscrape.config\`, no scrape sidecar). The 13 Spring Boot daemons + 3 standalone services emit \`deltav_*\` Micrometer metrics at \`/actuator/prometheus\` but nothing pulled them, so the new \`alerts-pipeline\` Grafana dashboard (and the existing pollerd/perspective dashboards) showed "No data" for every panel that queries daemon counters. New: \`vmagent\` sidecar service (\`victoriametrics/vmagent:v1.106.1\`) scrapes 16 daemon targets at \`:8080/actuator/prometheus\` every 15s and remote-writes to \`http://victoriametrics:8428/api/v1/write\`. Scrape config embedded via top-level \`configs: vmagent_scrape: content:\` — no host files.

## Why \`configs: content:\` not bind-mounts

Both gaps had the same root cause: bind-mount source files that exist in the repo but not on a no-git-clone smoke. Docker's auto-create-as-directory behavior was actively destructive (the alertmanager one) or silently absent (the scrape config one). Compose \`configs: content:\` (compose v2.23+) embeds file content directly in the compose definition — works identically on dev (Mac Docker Desktop) and SMOKE VM (Ubuntu/UTM), no host artifacts required.

## Test Plan

- [x] \`docker compose -f opennms-container/delta-v/docker-compose.yml config --quiet\` — parses cleanly, no schema errors.
- [x] \`bash -n opennms-container/delta-v/test-alerts-forwarder-e2e.sh\` — unaffected (test was already self-bootstrapping after Item A's PR #298).
- [x] Pre-validated empirically: identical alertmanager YAML + identical vmagent scrape config + identical 16-target list were verified working on the SMOKE VM (as the throwaway fix), then 16 \`deltav_alerts_forwarder_*\` series appeared in VM and the synthetic-MAJOR alarm injection successfully lit up the dashboard's "Active forwarded alerts" panel from 0 → 1 → 0 with full Track 2a enrichment (\`node=flow-test:flow-default-testnode-1\`, \`ip_address=172.18.0.21\`, \`service_name=ICMP\`).

## Sequencing

This is the v1.3.0-rc2 fix PR. Merge → bump to 1.3.0-rc2 → tag → re-smoke.

## Out of scope (filed separately)

**Minion IcmpDetector NPE on aarch64.** \`IcmpDetector.isServiceDetected\` throws \`java.lang.NullPointerException\` for every address (incl. localhost) on the aarch64 SMOKE VM, even though CAP_NET_RAW is granted and raw \`ping\` works. Blocks the standard pollerd→Minion ICMP path for raising real \`nodeLostService\` events on this hardware. Pre-existing Minion-side issue; not in v1.3.0-rc2 scope. The synthetic-injection technique (publish AlarmState protobuf directly to \`deltav-alarms-state-change\`) was proven as a workable smoke validation that bypasses the broken ICMP path.

## Files changed

2 — \`opennms-container/delta-v/docker-compose.yml\` (modified) + \`opennms-container/delta-v/alertmanager/alertmanager.yml\` (deleted).