### PR TITLE
fix(grafana): partition flows bandwidth panels into per-value series

### DIFF
--- a/opennms-container/delta-v/grafana/dashboards/flows-forensic.json
+++ b/opennms-container/delta-v/grafana/dashboards/flows-forensic.json
@@ -238,6 +238,20 @@
           "rawSql": "SELECT $__timeInterval(timestamp) AS time, application, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY time, application ORDER BY time",
           "format": 1
         }
+      ],
+      "transformations": [
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "application"
+            ],
+            "keepFields": false,
+            "naming": {
+              "asLabels": false
+            }
+          }
+        }
       ]
     },
     {

--- a/opennms-container/delta-v/grafana/dashboards/flows-overview.json
+++ b/opennms-container/delta-v/grafana/dashboards/flows-overview.json
@@ -119,6 +119,20 @@
           "rawSql": "SELECT $__timeInterval(timestamp) AS time, location, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY time, location ORDER BY time",
           "format": 1
         }
+      ],
+      "transformations": [
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "location"
+            ],
+            "keepFields": false,
+            "naming": {
+              "asLabels": false
+            }
+          }
+        }
       ]
     },
     {


### PR DESCRIPTION
Follow-up to #311. The data-driven `SELECT time, application, bps … GROUP BY time, application` query renders as a **single series named `bps`** when the result has one group (e.g. Application filtered to one app) — the ClickHouse plugin doesn't auto-split by a string label column (same latent issue the 'Per-exporter flow rate' panel has).

Adds a **Partition by values** transformation so each distinct value becomes its own series, named by the value:
- `flows-forensic` → partition on `application`
- `flows-overview` → partition on `location`

Legend now shows the real apps/locations (e.g. `Flow-telemetry`) instead of `bps`, for any number of groups. Takes effect on the next `deltav/grafana` image build.