### PR TITLE
chore(smoke): bump smoke-vm.sh to v1.3.0-rc5

### DIFF
--- a/opennms-container/delta-v/smoke-vm.sh
+++ b/opennms-container/delta-v/smoke-vm.sh
@@ -23,8 +23,8 @@ docker system prune -a --volumes -f
 rm -rf ~/delta-v-smoke
 mkdir -p ~/delta-v-smoke && cd ~/delta-v-smoke
 
-GIT_REF=v1.3.0-rc3
-IMG_TAG=1.3.0-rc3
+GIT_REF=v1.3.0-rc5
+IMG_TAG=1.3.0-rc5
 
 BASE=https://raw.githubusercontent.com/pbrane/delta-v/$GIT_REF/opennms-container/delta-v
 


### PR DESCRIPTION
Point the VM smoke runner at the freshly-published **v1.3.0-rc5** image set (`GIT_REF`/`IMG_TAG` rc3 → rc5). rc5 = #315 (nl6 covers all 4 flow protocols, testnodes removed) + #316 (orphaned exporter images removed) + #317 (version bump); all ~28 images live at ghcr.io/pbrane:1.3.0-rc5.