### PR TITLE
fix(provisiond): re-seed requisitions when the seed content changes

### DIFF
--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -590,18 +590,28 @@ services:
       - -c
       - |
         set -e
-        # Use a marker file, not the emptiness check: when the named volume
-        # first mounts into the provisiond container, Docker auto-populates
-        # it from provisiond's image content at /opt/deltav/etc/imports
-        # (which contains a baked `.gitkeep`). That write happens before
-        # this sidecar runs, so an emptiness check was fooled into thinking
-        # the volume was already seeded and skipped the actual seed.
-        if [ ! -f /runtime/.seeded ]; then
-            echo "[provisiond-imports-init] Seeding /runtime from /seed"
+        # Re-seed when the SEED CONTENT changes, not just once. A signature of
+        # /seed is stored in /runtime/.seed-sig and compared on every boot.
+        #
+        # The old one-time `.seeded` marker meant a seed bump (e.g. the nl6-lab
+        # requisition growing 21 -> 29 nodes in 7659e39) never reached an
+        # already-seeded named volume: the marker was present, so the sidecar
+        # skipped the copy and the deployed env stayed permanently diverged from
+        # the committed requisitions. The signature comparison makes the volume
+        # converge to /seed on every image update. (An emptiness check can't be
+        # used either: Docker auto-populates the volume from provisiond's baked
+        # /opt/deltav/etc/imports `.gitkeep` before this sidecar runs.)
+        #
+        # Runtime `last-import=` drift in the copied requisitions is discardable
+        # state; the re-import provisiond runs afterwards is idempotent.
+        NEW_SIG=$$(cd /seed && find . -type f | sort | xargs md5sum 2>/dev/null | md5sum | awk '{print $$1}')
+        OLD_SIG=$$(cat /runtime/.seed-sig 2>/dev/null || echo none)
+        if [ "$$NEW_SIG" != "$$OLD_SIG" ]; then
+            echo "[provisiond-imports-init] Seeding /runtime from /seed (sig $${OLD_SIG} -> $${NEW_SIG})"
             cp -R /seed/. /runtime/
-            touch /runtime/.seeded
+            printf '%s\n' "$$NEW_SIG" > /runtime/.seed-sig
         else
-            echo "[provisiond-imports-init] /runtime already seeded — normalizing perms"
+            echo "[provisiond-imports-init] /runtime seed current (sig $${NEW_SIG}) — normalizing perms"
         fi
         # Always normalize ownership AND permissions, regardless of seed state.
         # Pre-existing volumes from earlier compose iterations occasionally end up


### PR DESCRIPTION
## Problem

The committed requisition seed is already correct — `imports-seed/nl6-lab.xml` has all **29** nodes (since `7659e39`, "expand nl6-lab fleet to 29 devices"). But deployed environments stay stuck at the old node count, which is the **"running 21-node vs committed 29-node" divergence flagged in #319**.

Root cause: `provisiond-imports-init` seeds the `provisiond_imports` named volume **once** and drops a `.seeded` marker. On every later boot it sees the marker and **skips the copy** — so when the seed grows (21 → 29 nodes), an already-seeded volume never gets the update.

## Fix

Replace the one-time marker with a **content signature**: `md5sum` of `/seed`, stored in `/runtime/.seed-sig`, compared on every boot. Seed changed → re-seed; unchanged → skip. The volume converges to the committed requisitions on every image update.

- Runtime `last-import=` drift in the copied files is discardable state; provisiond's follow-on import is idempotent.
- `$$`-escaped in the compose `command` so the shell vars aren't eaten by Compose interpolation (a `docker compose config` warning caught this).

## Validation (busybox 1.36, the init base image)

| Case | Result |
|---|---|
| Fresh/empty volume | RE-SEED → `nl6-lab` = **29** nodes |
| Unchanged seed, second boot | SKIP (idempotent) |
| Stale `.seed-sig` (simulates the 21-node volume) | detect stale → RE-SEED → **29** nodes |

## Test Plan
- [ ] On a stack that deployed before `7659e39`: `make reset`-free upgrade (keep the volume) → provisiond-imports-init logs `Seeding … (sig <old> -> <new>)` and `nl6-lab` ends at 29 nodes / all 29 exporters enrich.