### PR TITLE
feat(flows): exporter node_label + input/output if_name in the flow document

### DIFF
--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -34,6 +34,7 @@ import org.deltav.flows.enricher.classification.PortBasedApplicationClassifier;
 import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.enricher.enrichment.JdbcSnmpInterfaceLookup;
 import org.deltav.flows.enricher.mapping.FlowToDocumentMapper;
 import org.deltav.flows.enricher.parser.DropwizardToPrometheusBridge;
 import org.deltav.flows.enricher.parser.LoggingEventForwarder;
@@ -81,6 +82,13 @@ public class FlowEnricherConfiguration {
             JdbcTemplate flowEnricherJdbcTemplate,
             @Value("${deltav.flows.node-lookup.cache-ttl:5m}") Duration cacheTtl) {
         return new JdbcNodeInfoLookup(flowEnricherJdbcTemplate, cacheTtl);
+    }
+
+    @Bean
+    JdbcSnmpInterfaceLookup jdbcSnmpInterfaceLookup(
+            JdbcTemplate flowEnricherJdbcTemplate,
+            @Value("${deltav.flows.interface-lookup.cache-ttl:5m}") Duration cacheTtl) {
+        return new JdbcSnmpInterfaceLookup(flowEnricherJdbcTemplate, cacheTtl);
     }
 
     @Bean
@@ -401,6 +409,7 @@ public class FlowEnricherConfiguration {
             InterfaceMarkingCache interfaceMarkingCache,
             ApplicationClassifier applicationClassifier,
             FlowToDocumentMapper flowToDocumentMapper,
+            JdbcSnmpInterfaceLookup snmpInterfaceLookup,
             Netflow5MessageProcessor netflow5Processor,
             Netflow9MessageProcessor netflow9Processor,
             IpfixMessageProcessor ipfixProcessor,
@@ -419,6 +428,7 @@ public class FlowEnricherConfiguration {
                 interfaceMarkingCache,
                 applicationClassifier,
                 flowToDocumentMapper,
+                snmpInterfaceLookup,
                 dispatchMap);
     }
 

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
@@ -26,6 +26,7 @@ import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
 import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator.Locality;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.enricher.enrichment.JdbcSnmpInterfaceLookup;
 import org.deltav.flows.enricher.mapping.FlowToDocumentMapper;
 import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
 import org.deltav.flows.proto.FlowDocumentProtos;
@@ -104,6 +105,7 @@ public class FlowEnrichmentFunction {
     private final InterfaceMarkingCache interfaceMarkingCache;
     private final ApplicationClassifier applicationClassifier;
     private final FlowToDocumentMapper flowToDocumentMapper;
+    private final JdbcSnmpInterfaceLookup snmpInterfaceLookup;
     private final Map<String, ProtocolMessageProcessor> processorsByModuleId;
 
     public FlowEnrichmentFunction(
@@ -113,6 +115,7 @@ public class FlowEnrichmentFunction {
             InterfaceMarkingCache interfaceMarkingCache,
             ApplicationClassifier applicationClassifier,
             FlowToDocumentMapper flowToDocumentMapper,
+            JdbcSnmpInterfaceLookup snmpInterfaceLookup,
             Map<String, ProtocolMessageProcessor> processorsByModuleId) {
         this.deserializer = deserializer;
         this.nodeInfoLookup = nodeInfoLookup;
@@ -120,6 +123,7 @@ public class FlowEnrichmentFunction {
         this.interfaceMarkingCache = interfaceMarkingCache;
         this.applicationClassifier = applicationClassifier;
         this.flowToDocumentMapper = flowToDocumentMapper;
+        this.snmpInterfaceLookup = snmpInterfaceLookup;
         this.processorsByModuleId = Map.copyOf(processorsByModuleId);
     }
 
@@ -217,14 +221,18 @@ public class FlowEnrichmentFunction {
         // the exporter node is known (otherwise nodeId is meaningless) and
         // when the ifindex is present and strictly positive (0 is "unknown"
         // per the Netflow spec).
+        String inputIfName = null;
+        String outputIfName = null;
         if (exporterNodeInfo != null) {
             Integer inputIfIndex = flow.getInputSnmp();
             if (inputIfIndex != null && inputIfIndex > 0) {
                 interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), inputIfIndex);
+                inputIfName = snmpInterfaceLookup.lookupIfName(exporterNodeInfo.nodeId(), inputIfIndex);
             }
             Integer outputIfIndex = flow.getOutputSnmp();
             if (outputIfIndex != null && outputIfIndex > 0) {
                 interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), outputIfIndex);
+                outputIfName = snmpInterfaceLookup.lookupIfName(exporterNodeInfo.nodeId(), outputIfIndex);
             }
         }
 
@@ -244,7 +252,9 @@ public class FlowEnrichmentFunction {
                 localityName(flowLocalityEnum),
                 exporterAddress,
                 location,
-                0L);
+                0L,
+                inputIfName,
+                outputIfName);
         return doc.toByteArray();
     }
 

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookup.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookup.java
@@ -48,20 +48,21 @@ public class JdbcNodeInfoLookup {
     private static final Logger LOG = LoggerFactory.getLogger(JdbcNodeInfoLookup.class);
 
     private static final String SQL_BY_IP =
-            "SELECT n.nodeid, n.foreignsource, n.foreignid, n.location " +
+            "SELECT n.nodeid, n.foreignsource, n.foreignid, n.location, n.nodelabel " +
             "FROM node n JOIN ipinterface i ON n.nodeid = i.nodeid " +
             "WHERE i.ipaddr = ? LIMIT 1";
 
     private static final String SQL_BY_NODE_ID =
-            "SELECT nodeid, foreignsource, foreignid, location FROM node WHERE nodeid = ?";
+            "SELECT nodeid, foreignsource, foreignid, location, nodelabel FROM node WHERE nodeid = ?";
 
     private static final RowMapper<NodeInfo> ROW_MAPPER = (rs, rowNum) -> new NodeInfo(
             rs.getInt("nodeid"),
             rs.getString("foreignsource"),
             rs.getString("foreignid"),
-            rs.getString("location"));
+            rs.getString("location"),
+            rs.getString("nodelabel"));
 
-    public record NodeInfo(int nodeId, String foreignSource, String foreignId, String location) {}
+    public record NodeInfo(int nodeId, String foreignSource, String foreignId, String location, String nodeLabel) {}
 
     private final JdbcTemplate jdbc;
     private final Cache<String, Optional<NodeInfo>> ipCache;

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookup.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookup.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * JDBC-based resolver for SNMP interface names. Maps a flow's exporter
+ * {@code (nodeId, ifIndex)} to {@code snmpinterface.snmpifname}.
+ *
+ * <p>Backed by a Caffeine cache keyed by {@link IfKey}; negative results are
+ * cached as {@link Optional#empty()} so unprovisioned interfaces do not retry
+ * the database on every flow. Mirrors {@link JdbcNodeInfoLookup}.
+ */
+public class JdbcSnmpInterfaceLookup {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcSnmpInterfaceLookup.class);
+
+    private static final String SQL =
+            "SELECT snmpifname FROM snmpinterface WHERE nodeid = ? AND snmpifindex = ? LIMIT 1";
+
+    /** Cache key: exporter node id + SNMP ifIndex. */
+    public record IfKey(int nodeId, int ifIndex) {}
+
+    private final JdbcTemplate jdbc;
+    private final Cache<IfKey, Optional<String>> cache;
+
+    public JdbcSnmpInterfaceLookup(JdbcTemplate jdbc, Duration cacheTtl) {
+        this.jdbc = jdbc;
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(cacheTtl)
+                .maximumSize(50_000)
+                .build();
+    }
+
+    /**
+     * @return the SNMP interface name, or {@code null} when the node is
+     *         unresolved ({@code nodeId <= 0}), the interface is unknown, or
+     *         the name is empty.
+     */
+    public String lookupIfName(int nodeId, int ifIndex) {
+        if (nodeId <= 0) {
+            return null;
+        }
+        return cache.get(new IfKey(nodeId, ifIndex), this::query).orElse(null);
+    }
+
+    private Optional<String> query(IfKey key) {
+        try {
+            List<String> results = jdbc.queryForList(SQL, String.class, key.nodeId(), key.ifIndex());
+            if (results.isEmpty()) {
+                return Optional.empty();
+            }
+            String name = results.getFirst();
+            return (name == null || name.isEmpty()) ? Optional.empty() : Optional.of(name);
+        } catch (Exception e) {
+            LOG.debug("Interface name lookup failed for node {} ifindex {}: {}",
+                    key.nodeId(), key.ifIndex(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java
@@ -89,7 +89,9 @@ public class FlowToDocumentMapper {
             String flowLocality,
             String host,
             String location,
-            long clockCorrection) {
+            long clockCorrection,
+            String inputIfName,
+            String outputIfName) {
 
         FlowDocumentProtos.FlowDocument.Builder builder = FlowDocumentProtos.FlowDocument.newBuilder();
 
@@ -263,11 +265,42 @@ public class FlowToDocumentMapper {
             builder.setLocation(location);
         }
 
+        // Exporter SNMP interface names (resolved by the caller from the
+        // exporter node's snmpinterface). proto3 scalar strings default to "",
+        // so only write non-empty values.
+        if (inputIfName != null && !inputIfName.isEmpty()) {
+            builder.setInputIfName(inputIfName);
+        }
+        if (outputIfName != null && !outputIfName.isEmpty()) {
+            builder.setOutputIfName(outputIfName);
+        }
+
         // Clock skew correction (milliseconds). Plain uint64; 0 is a valid value
         // meaning "no correction applied", so we always set it.
         builder.setClockCorrection(clockCorrection);
 
         return builder.build();
+    }
+
+    /**
+     * Backwards-compatible overload for callers without resolved exporter
+     * interface names; delegates with empty {@code inputIfName}/{@code outputIfName}.
+     */
+    public FlowDocumentProtos.FlowDocument map(
+            Flow flow,
+            JdbcNodeInfoLookup.NodeInfo exporterNodeInfo,
+            JdbcNodeInfoLookup.NodeInfo srcNodeInfo,
+            JdbcNodeInfoLookup.NodeInfo destNodeInfo,
+            String application,
+            String srcLocality,
+            String dstLocality,
+            String flowLocality,
+            String host,
+            String location,
+            long clockCorrection) {
+        return map(flow, exporterNodeInfo, srcNodeInfo, destNodeInfo, application,
+                srcLocality, dstLocality, flowLocality, host, location, clockCorrection,
+                null, null);
     }
 
     private static FlowDocumentProtos.NodeInfo toProtoNodeInfo(JdbcNodeInfoLookup.NodeInfo info) {
@@ -278,6 +311,9 @@ public class FlowToDocumentMapper {
         }
         if (info.foreignId() != null) {
             b.setForeignId(info.foreignId());
+        }
+        if (info.nodeLabel() != null && !info.nodeLabel().isEmpty()) {
+            b.setNodeLabel(info.nodeLabel());
         }
         // The JdbcNodeInfoLookup.NodeInfo record does not carry OpenNMS
         // category data; the proto NodeInfo.categories field is left empty

--- a/core/flow-enricher/src/main/proto/deltav-flows.proto
+++ b/core/flow-enricher/src/main/proto/deltav-flows.proto
@@ -43,6 +43,10 @@ message NodeInfo {
     string foreign_source = 2;
     string foreign_id = 3;
     repeated string categories = 4;
+    // Human-readable node label (OnmsNode.label). Populated for all three
+    // NodeInfo sub-messages by the enricher; only the exporter's is persisted
+    // to ClickHouse today.
+    string node_label = 5;
 }
 
 enum Direction {
@@ -124,4 +128,9 @@ message FlowDocument {
     uint64 clock_correction = 45;
     google.protobuf.UInt32Value dscp = 46;
     google.protobuf.UInt32Value ecn = 47;
+    // Resolved SNMP interface names for the exporter's input/output ifIndex
+    // (snmpinterface.snmpifname). Empty when the exporter is unresolved or the
+    // interface is unknown. Fields 25 and 44 are reserved (formerly removed).
+    string input_if_name = 48;
+    string output_if_name = 49;
 }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
@@ -228,7 +228,7 @@ class FlowEnrichmentFunctionTest {
     void callsInterfaceMarkingForInputAndOutputIfindex() {
         // Exporter node resolves, flow has non-zero input/output ifindex.
         JdbcNodeInfoLookup.NodeInfo exporterInfo =
-                new JdbcNodeInfoLookup.NodeInfo(42, "Minions", "exporter-1", MINION_LOCATION);
+                new JdbcNodeInfoLookup.NodeInfo(42, "Minions", "exporter-1", MINION_LOCATION, "exporter-1-label");
         when(nodeInfoLookup.lookupByIpAddress(EXPORTER_ADDRESS)).thenReturn(exporterInfo);
         Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 7, 11);
         when(nf5Processor.process(any())).thenReturn(List.of(flow));
@@ -256,7 +256,7 @@ class FlowEnrichmentFunctionTest {
     @Test
     void skipsInterfaceMarkingWhenIfindexIsZeroOrNull() {
         JdbcNodeInfoLookup.NodeInfo exporterInfo =
-                new JdbcNodeInfoLookup.NodeInfo(99, "Minions", "exporter-9", MINION_LOCATION);
+                new JdbcNodeInfoLookup.NodeInfo(99, "Minions", "exporter-9", MINION_LOCATION, "exporter-9-label");
         when(nodeInfoLookup.lookupByIpAddress(EXPORTER_ADDRESS)).thenReturn(exporterInfo);
         // Ifindex 0 for both directions: "unknown" per Netflow spec.
         Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 0, 0);
@@ -347,7 +347,7 @@ class FlowEnrichmentFunctionTest {
     @Test
     void populatesExporterNodeInfoFromLookup() throws InvalidProtocolBufferException {
         JdbcNodeInfoLookup.NodeInfo exporterInfo =
-                new JdbcNodeInfoLookup.NodeInfo(77, "Minions", "exporter-77", MINION_LOCATION);
+                new JdbcNodeInfoLookup.NodeInfo(77, "Minions", "exporter-77", MINION_LOCATION, "exporter-77-label");
         when(nodeInfoLookup.lookupByIpAddress(EXPORTER_ADDRESS)).thenReturn(exporterInfo);
         Flow flow = buildFlow("10.0.0.1", "10.0.0.2", 111, 222, 6, 1, 2);
         when(nf5Processor.process(any())).thenReturn(List.of(flow));

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnrichmentFunctionTest.java
@@ -40,6 +40,7 @@ import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
 import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator.Locality;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.enrichment.JdbcNodeInfoLookup;
+import org.deltav.flows.enricher.enrichment.JdbcSnmpInterfaceLookup;
 import org.deltav.flows.enricher.mapping.FlowToDocumentMapper;
 import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
 import org.deltav.flows.proto.FlowDocumentProtos;
@@ -66,6 +67,7 @@ class FlowEnrichmentFunctionTest {
     private InterfaceMarkingCache interfaceMarkingCache;
     private ApplicationClassifier applicationClassifier;
     private FlowToDocumentMapper flowToDocumentMapper;
+    private JdbcSnmpInterfaceLookup snmpInterfaceLookup;
     private ProtocolMessageProcessor nf5Processor;
 
     private FlowEnrichmentFunction function;
@@ -78,6 +80,7 @@ class FlowEnrichmentFunctionTest {
         interfaceMarkingCache = mock(InterfaceMarkingCache.class);
         applicationClassifier = mock(ApplicationClassifier.class);
         flowToDocumentMapper = new FlowToDocumentMapper();
+        snmpInterfaceLookup = mock(JdbcSnmpInterfaceLookup.class);
         nf5Processor = mock(ProtocolMessageProcessor.class);
 
         // Default mock behavior: unknown locality for unknown addresses,
@@ -93,6 +96,7 @@ class FlowEnrichmentFunctionTest {
                 interfaceMarkingCache,
                 applicationClassifier,
                 flowToDocumentMapper,
+                snmpInterfaceLookup,
                 Map.of(NF5_MODULE_ID, nf5Processor));
     }
 

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookupTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookupTest.java
@@ -38,7 +38,7 @@ import org.springframework.jdbc.core.RowMapper;
 class JdbcNodeInfoLookupTest {
 
     private static final JdbcNodeInfoLookup.NodeInfo SAMPLE =
-            new JdbcNodeInfoLookup.NodeInfo(5, "delta-v", "router-1", "Default");
+            new JdbcNodeInfoLookup.NodeInfo(5, "delta-v", "router-1", "Default", "router-1-label");
 
     @Test
     void lookupByIpAddressReturnsNodeInfo() {
@@ -129,5 +129,20 @@ class JdbcNodeInfoLookupTest {
         lookup.lookupByNodeId(5);
 
         verify(jdbc, times(1)).query(anyString(), any(RowMapper.class), any(Object[].class));
+    }
+
+    @Test
+    void lookupByNodeIdCarriesNodeLabel() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        JdbcNodeInfoLookup.NodeInfo row =
+                new JdbcNodeInfoLookup.NodeInfo(7, "nl6", "dev-7", "nl6-lab", "cisco-7");
+        when(jdbc.query(contains("nodeid"), any(RowMapper.class), eq(7)))
+                .thenReturn(List.of(row));
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+        JdbcNodeInfoLookup.NodeInfo result = lookup.lookupByNodeId(7);
+
+        assertThat(result).isNotNull();
+        assertThat(result.nodeLabel()).isEqualTo("cisco-7");
     }
 }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookupTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookupTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class JdbcSnmpInterfaceLookupTest {
+
+    @Test
+    void returnsIfNameAndCachesIt() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.queryForList(anyString(), eq(String.class), eq(5), eq(3)))
+                .thenReturn(List.of("Gi0/3"));
+
+        JdbcSnmpInterfaceLookup lookup = new JdbcSnmpInterfaceLookup(jdbc, Duration.ofMinutes(5));
+
+        assertThat(lookup.lookupIfName(5, 3)).isEqualTo("Gi0/3");
+        assertThat(lookup.lookupIfName(5, 3)).isEqualTo("Gi0/3"); // second call cached
+        verify(jdbc, times(1)).queryForList(anyString(), eq(String.class), eq(5), eq(3));
+    }
+
+    @Test
+    void returnsNullWhenInterfaceMissing() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.queryForList(anyString(), eq(String.class), eq(5), eq(99)))
+                .thenReturn(List.of());
+
+        JdbcSnmpInterfaceLookup lookup = new JdbcSnmpInterfaceLookup(jdbc, Duration.ofMinutes(5));
+        assertThat(lookup.lookupIfName(5, 99)).isNull();
+    }
+
+    @Test
+    void skipsQueryForUnresolvedNode() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        JdbcSnmpInterfaceLookup lookup = new JdbcSnmpInterfaceLookup(jdbc, Duration.ofMinutes(5));
+        assertThat(lookup.lookupIfName(0, 3)).isNull();
+        verifyNoInteractions(jdbc);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
@@ -315,4 +315,32 @@ class FlowToDocumentMapperTest {
         assertThat(doc.hasSamplingInterval()).isTrue();
         assertThat(doc.getSamplingInterval().getValue()).isEqualTo(0.0);
     }
+
+    @Test
+    void setsExporterNodeLabelAndInterfaceNames() {
+        JdbcNodeInfoLookup.NodeInfo exporter =
+                new JdbcNodeInfoLookup.NodeInfo(7, "nl6", "dev-7", "nl6-lab", "cisco-7");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, exporter, null, null,
+                "HTTPS", "PRIVATE", "PUBLIC", "PRIVATE",
+                "10.0.0.7", "nl6-lab", 0L,
+                "Gi0/1", "Gi0/2");
+
+        assertThat(doc.getExporterNode().getNodeLabel()).isEqualTo("cisco-7");
+        assertThat(doc.getInputIfName()).isEqualTo("Gi0/1");
+        assertThat(doc.getOutputIfName()).isEqualTo("Gi0/2");
+    }
+
+    @Test
+    void leavesInterfaceNamesEmptyWhenNull() {
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null,
+                "HTTPS", "PRIVATE", "PUBLIC", "PRIVATE",
+                "10.0.0.7", "nl6-lab", 0L,
+                null, null);
+
+        assertThat(doc.getInputIfName()).isEmpty();
+        assertThat(doc.getOutputIfName()).isEmpty();
+    }
 }

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
@@ -121,7 +121,7 @@ class FlowToDocumentMapperTest {
     @Test
     void populatesExporterNodeWhenEnrichmentProvidesIt() {
         JdbcNodeInfoLookup.NodeInfo exporter = new JdbcNodeInfoLookup.NodeInfo(
-                42, "delta-v", "exporter-1", "Default");
+                42, "delta-v", "exporter-1", "Default", "exporter-1-label");
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
                 flow, exporter, null, null, null, null, null, null, null, null, 0L);
@@ -243,11 +243,11 @@ class FlowToDocumentMapperTest {
     @Test
     void mapsSrcAndDstNodeInfoWhenAllProvided() {
         JdbcNodeInfoLookup.NodeInfo exporter = new JdbcNodeInfoLookup.NodeInfo(
-                1, "fs", "exporter", "Default");
+                1, "fs", "exporter", "Default", "exporter-label");
         JdbcNodeInfoLookup.NodeInfo src = new JdbcNodeInfoLookup.NodeInfo(
-                2, "fs", "src", "Default");
+                2, "fs", "src", "Default", "src-label");
         JdbcNodeInfoLookup.NodeInfo dst = new JdbcNodeInfoLookup.NodeInfo(
-                3, "fs", "dst", "Default");
+                3, "fs", "dst", "Default", "dst-label");
 
         FlowDocumentProtos.FlowDocument doc = mapper.map(
                 flow, exporter, src, dst, null, null, null, null, null, null, 0L);

--- a/docs/superpowers/plans/2026-06-01-flow-doc-node-label-ifname.md
+++ b/docs/superpowers/plans/2026-06-01-flow-doc-node-label-ifname.md
@@ -1,0 +1,708 @@
+# Flow Document: exporter node_label + input/output if_name — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the exporter's `node_label` and the input/output SNMP interface names (`if_name`) on each flow record, so flow queries/dashboards show human-readable device + interface identity without a join.
+
+**Architecture:** Add three fields to the single-source `deltav-flows.proto` (consumed by both the Java enricher and ClickHouse's `ProtobufSingle` parser). The enricher resolves `node_label` via the existing `JdbcNodeInfoLookup` and `if_name` via a new cached `JdbcSnmpInterfaceLookup` (keyed by the exporter's `(nodeId, ifIndex)`); the caller passes resolved values into the pure `FlowToDocumentMapper`. ClickHouse gains 3 `LowCardinality(String)` columns via additive `ALTER` on `flows_raw` plus DROP+recreate of the stateless `flows_kafka` + `flows_ingest` objects.
+
+**Tech Stack:** Java 21, Spring Boot, Spring `JdbcTemplate`, Caffeine cache, protobuf, JUnit 5 + AssertJ + Mockito, ClickHouse SQL (Kafka engine + MergeTree + materialized view).
+
+**Spec:** `docs/superpowers/specs/2026-05-31-flow-doc-node-label-ifname-design.md`
+
+**Reference — exact current code:**
+- Proto: `core/flow-enricher/src/main/proto/deltav-flows.proto` (NodeInfo fields 1-4; FlowDocument max field 47; 25 & 44 reserved)
+- `core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookup.java`
+- `core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java`
+- `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java`
+- `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`
+- DDL: `opennms-container/delta-v/clickhouse/init/{02-flows-raw,03-flows-kafka,20-flows-ingest}.sql`
+
+**Build/test commands:**
+- Module build: `./mvnw -q --projects :org.deltav.core.flow-enricher -am -DskipTests install`
+- Module tests: `./mvnw -q --projects :org.deltav.core.flow-enricher test`
+- (Confirm the exact module artifactId with `grep '<artifactId>' core/flow-enricher/pom.xml` if the `--projects` selector errors.)
+
+---
+
+### Task 1: Add the three proto fields
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/proto/deltav-flows.proto`
+
+- [ ] **Step 1: Add `node_label` to `NodeInfo`**
+
+Change the `NodeInfo` message from:
+```proto
+message NodeInfo {
+    uint32 node_id = 1;
+    string foreign_source = 2;
+    string foreign_id = 3;
+    repeated string categories = 4;
+}
+```
+to:
+```proto
+message NodeInfo {
+    uint32 node_id = 1;
+    string foreign_source = 2;
+    string foreign_id = 3;
+    repeated string categories = 4;
+    // Human-readable node label (OnmsNode.label). Populated for all three
+    // NodeInfo sub-messages by the enricher; only the exporter's is persisted
+    // to ClickHouse today.
+    string node_label = 5;
+}
+```
+
+- [ ] **Step 2: Add `input_if_name` / `output_if_name` to `FlowDocument`**
+
+In the `FlowDocument` message, immediately after the last field `google.protobuf.UInt32Value ecn = 47;` and before the closing `}`, add:
+```proto
+    // Resolved SNMP interface names for the exporter's input/output ifIndex
+    // (snmpinterface.snmpifname). Empty when the exporter is unresolved or the
+    // interface is unknown. Fields 25 and 44 are reserved (formerly removed).
+    string input_if_name = 48;
+    string output_if_name = 49;
+```
+
+- [ ] **Step 3: Build to regenerate protobuf Java sources**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher -am -DskipTests install`
+Expected: BUILD SUCCESS; generated `FlowDocumentProtos` now has `setNodeLabel`, `setInputIfName`, `setOutputIfName`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/flow-enricher/src/main/proto/deltav-flows.proto
+git commit -m "feat(flows): add node_label + input/output if_name to FlowDocument proto"
+```
+
+---
+
+### Task 2: Carry `node_label` through `JdbcNodeInfoLookup`
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookup.java`
+- Test: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookupTest.java` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/append `JdbcNodeInfoLookupTest.java`:
+```java
+package org.deltav.flows.enricher.enrichment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class JdbcNodeInfoLookupTest {
+
+    @Test
+    void lookupByNodeIdCarriesNodeLabel() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        JdbcNodeInfoLookup.NodeInfo row =
+                new JdbcNodeInfoLookup.NodeInfo(7, "nl6", "dev-7", "nl6-lab", "cisco-7");
+        when(jdbc.query(any(String.class), any(RowMapper.class), eq(7)))
+                .thenReturn(List.of(row));
+
+        JdbcNodeInfoLookup lookup = new JdbcNodeInfoLookup(jdbc, Duration.ofMinutes(5));
+        JdbcNodeInfoLookup.NodeInfo result = lookup.lookupByNodeId(7);
+
+        assertThat(result).isNotNull();
+        assertThat(result.nodeLabel()).isEqualTo("cisco-7");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher test -Dtest=JdbcNodeInfoLookupTest`
+Expected: COMPILE FAILURE — `NodeInfo` has no 5-arg constructor / no `nodeLabel()` accessor.
+
+- [ ] **Step 3: Add `nodeLabel` to the record, SQL, and row mapper**
+
+In `JdbcNodeInfoLookup.java`:
+
+Change the record (append `nodeLabel` last to minimize disruption):
+```java
+public record NodeInfo(int nodeId, String foreignSource, String foreignId, String location, String nodeLabel) {}
+```
+
+Change `SQL_BY_IP`:
+```java
+private static final String SQL_BY_IP =
+        "SELECT n.nodeid, n.foreignsource, n.foreignid, n.location, n.nodelabel " +
+        "FROM node n JOIN ipinterface i ON n.nodeid = i.nodeid " +
+        "WHERE i.ipaddr = ? LIMIT 1";
+```
+
+Change `SQL_BY_NODE_ID`:
+```java
+private static final String SQL_BY_NODE_ID =
+        "SELECT nodeid, foreignsource, foreignid, location, nodelabel FROM node WHERE nodeid = ?";
+```
+
+Change `ROW_MAPPER`:
+```java
+private static final RowMapper<NodeInfo> ROW_MAPPER = (rs, rowNum) -> new NodeInfo(
+        rs.getInt("nodeid"),
+        rs.getString("foreignsource"),
+        rs.getString("foreignid"),
+        rs.getString("location"),
+        rs.getString("nodelabel"));
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher test -Dtest=JdbcNodeInfoLookupTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookup.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcNodeInfoLookupTest.java
+git commit -m "feat(flows): carry node_label through JdbcNodeInfoLookup"
+```
+
+---
+
+### Task 3: New `JdbcSnmpInterfaceLookup` (resolve `snmpifname`)
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookup.java`
+- Test: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookupTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `JdbcSnmpInterfaceLookupTest.java`:
+```java
+package org.deltav.flows.enricher.enrichment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class JdbcSnmpInterfaceLookupTest {
+
+    @Test
+    void returnsIfNameAndCachesIt() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.queryForList(anyString(), eq(String.class), eq(5), eq(3)))
+                .thenReturn(List.of("Gi0/3"));
+
+        JdbcSnmpInterfaceLookup lookup = new JdbcSnmpInterfaceLookup(jdbc, Duration.ofMinutes(5));
+
+        assertThat(lookup.lookupIfName(5, 3)).isEqualTo("Gi0/3");
+        assertThat(lookup.lookupIfName(5, 3)).isEqualTo("Gi0/3"); // second call cached
+        verify(jdbc, times(1)).queryForList(anyString(), eq(String.class), eq(5), eq(3));
+    }
+
+    @Test
+    void returnsNullWhenInterfaceMissing() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(jdbc.queryForList(anyString(), eq(String.class), eq(5), eq(99)))
+                .thenReturn(List.of());
+
+        JdbcSnmpInterfaceLookup lookup = new JdbcSnmpInterfaceLookup(jdbc, Duration.ofMinutes(5));
+        assertThat(lookup.lookupIfName(5, 99)).isNull();
+    }
+
+    @Test
+    void skipsQueryForUnresolvedNode() {
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        JdbcSnmpInterfaceLookup lookup = new JdbcSnmpInterfaceLookup(jdbc, Duration.ofMinutes(5));
+        assertThat(lookup.lookupIfName(0, 3)).isNull();
+        verifyNoInteractions(jdbc);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher test -Dtest=JdbcSnmpInterfaceLookupTest`
+Expected: COMPILE FAILURE — `JdbcSnmpInterfaceLookup` does not exist.
+
+- [ ] **Step 3: Create the lookup class**
+
+Create `JdbcSnmpInterfaceLookup.java`:
+```java
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.enrichment;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * JDBC-based resolver for SNMP interface names. Maps a flow's exporter
+ * {@code (nodeId, ifIndex)} to {@code snmpinterface.snmpifname}.
+ *
+ * <p>Backed by a Caffeine cache keyed by {@link IfKey}; negative results are
+ * cached as {@link Optional#empty()} so unprovisioned interfaces do not retry
+ * the database on every flow. Mirrors {@link JdbcNodeInfoLookup}.
+ */
+public class JdbcSnmpInterfaceLookup {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcSnmpInterfaceLookup.class);
+
+    private static final String SQL =
+            "SELECT snmpifname FROM snmpinterface WHERE nodeid = ? AND snmpifindex = ? LIMIT 1";
+
+    /** Cache key: exporter node id + SNMP ifIndex. */
+    public record IfKey(int nodeId, int ifIndex) {}
+
+    private final JdbcTemplate jdbc;
+    private final Cache<IfKey, Optional<String>> cache;
+
+    public JdbcSnmpInterfaceLookup(JdbcTemplate jdbc, Duration cacheTtl) {
+        this.jdbc = jdbc;
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(cacheTtl)
+                .maximumSize(50_000)
+                .build();
+    }
+
+    /**
+     * @return the SNMP interface name, or {@code null} when the node is
+     *         unresolved ({@code nodeId <= 0}), the interface is unknown, or
+     *         the name is empty.
+     */
+    public String lookupIfName(int nodeId, int ifIndex) {
+        if (nodeId <= 0) {
+            return null;
+        }
+        return cache.get(new IfKey(nodeId, ifIndex), this::query).orElse(null);
+    }
+
+    private Optional<String> query(IfKey key) {
+        try {
+            List<String> results = jdbc.queryForList(SQL, String.class, key.nodeId(), key.ifIndex());
+            if (results.isEmpty()) {
+                return Optional.empty();
+            }
+            String name = results.getFirst();
+            return (name == null || name.isEmpty()) ? Optional.empty() : Optional.of(name);
+        } catch (Exception e) {
+            LOG.debug("Interface name lookup failed for node {} ifindex {}: {}",
+                    key.nodeId(), key.ifIndex(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher test -Dtest=JdbcSnmpInterfaceLookupTest`
+Expected: PASS (all three tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookup.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/enrichment/JdbcSnmpInterfaceLookupTest.java
+git commit -m "feat(flows): add JdbcSnmpInterfaceLookup for exporter interface names"
+```
+
+---
+
+### Task 4: Populate the new proto fields in `FlowToDocumentMapper`
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java`
+- Test: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java`
+
+> NOTE: `map(...)` gains two trailing params `String inputIfName, String outputIfName`. Every existing `mapper.map(...)` call in the test must add these two args, and every `new JdbcNodeInfoLookup.NodeInfo(...)` in the test must add the trailing `nodeLabel` arg (from Task 2). Update them in this task.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `FlowToDocumentMapperTest.java` (use the same `Flow` mock/builder the existing tests use; the snippet below assumes a minimal `flow` from `@BeforeEach`):
+```java
+    @Test
+    void setsExporterNodeLabelAndInterfaceNames() {
+        JdbcNodeInfoLookup.NodeInfo exporter =
+                new JdbcNodeInfoLookup.NodeInfo(7, "nl6", "dev-7", "nl6-lab", "cisco-7");
+
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, exporter, null, null,
+                "HTTPS", "PRIVATE", "PUBLIC", "PRIVATE",
+                "10.0.0.7", "nl6-lab", 0L,
+                "Gi0/1", "Gi0/2");
+
+        assertThat(doc.getExporterNode().getNodeLabel()).isEqualTo("cisco-7");
+        assertThat(doc.getInputIfName()).isEqualTo("Gi0/1");
+        assertThat(doc.getOutputIfName()).isEqualTo("Gi0/2");
+    }
+
+    @Test
+    void leavesInterfaceNamesEmptyWhenNull() {
+        FlowDocumentProtos.FlowDocument doc = mapper.map(
+                flow, null, null, null,
+                "HTTPS", "PRIVATE", "PUBLIC", "PRIVATE",
+                "10.0.0.7", "nl6-lab", 0L,
+                null, null);
+
+        assertThat(doc.getInputIfName()).isEmpty();
+        assertThat(doc.getOutputIfName()).isEmpty();
+    }
+```
+
+Also update the two pre-existing `mapper.map(...)` calls (around lines 61 and 84) to add `, null, null` as the final two arguments, and any existing `new JdbcNodeInfoLookup.NodeInfo(...)` constructions to add a trailing label arg (e.g. `, "label"`).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher test -Dtest=FlowToDocumentMapperTest`
+Expected: COMPILE FAILURE — `map(...)` has no overload taking the two trailing `String` args.
+
+- [ ] **Step 3: Extend `map(...)` and `toProtoNodeInfo(...)`**
+
+In `FlowToDocumentMapper.java`:
+
+(a) Add two params to the `map(...)` signature — change the final line of the parameter list from:
+```java
+            long clockCorrection) {
+```
+to:
+```java
+            long clockCorrection,
+            String inputIfName,
+            String outputIfName) {
+```
+Update the method Javadoc to document `inputIfName` / `outputIfName` ("resolved exporter SNMP interface names; null/empty leaves the proto field unset").
+
+(b) Set the interface-name fields. Immediately after the existing `host`/`location` block (the `if (location != null && !location.isEmpty()) { builder.setLocation(location); }` block), add:
+```java
+        // Exporter SNMP interface names (resolved by the caller from the
+        // exporter node's snmpinterface). proto3 scalar strings default to "",
+        // so only write non-empty values.
+        if (inputIfName != null && !inputIfName.isEmpty()) {
+            builder.setInputIfName(inputIfName);
+        }
+        if (outputIfName != null && !outputIfName.isEmpty()) {
+            builder.setOutputIfName(outputIfName);
+        }
+```
+
+(c) Set `node_label` in `toProtoNodeInfo(...)`. After the `foreign_id` block and before the `return b.build();`, add:
+```java
+        if (info.nodeLabel() != null && !info.nodeLabel().isEmpty()) {
+            b.setNodeLabel(info.nodeLabel());
+        }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher test -Dtest=FlowToDocumentMapperTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapper.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/mapping/FlowToDocumentMapperTest.java
+git commit -m "feat(flows): map exporter node_label + input/output if_name into FlowDocument"
+```
+
+---
+
+### Task 5: Wire the interface lookup into config + caller
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java`
+
+> This wiring is integration-level (Spring beans + Kafka stream function); it is verified by compilation + the existing context/integration tests rather than a new unit test.
+
+- [ ] **Step 1: Add the `JdbcSnmpInterfaceLookup` bean**
+
+In `FlowEnricherConfiguration.java`, add the import:
+```java
+import org.deltav.flows.enricher.enrichment.JdbcSnmpInterfaceLookup;
+```
+and a bean (place it next to the existing `jdbcNodeInfoLookup` bean, reusing the same `flowEnricherJdbcTemplate`):
+```java
+    @Bean
+    JdbcSnmpInterfaceLookup jdbcSnmpInterfaceLookup(
+            JdbcTemplate flowEnricherJdbcTemplate,
+            @Value("${deltav.flows.interface-lookup.cache-ttl:5m}") Duration cacheTtl) {
+        return new JdbcSnmpInterfaceLookup(flowEnricherJdbcTemplate, cacheTtl);
+    }
+```
+If `FlowEnrichmentFunction` is itself constructed by an `@Bean` method in this class, add the new lookup as a parameter to that method and pass it to the constructor (see Step 2).
+
+- [ ] **Step 2: Inject + use it in `FlowEnrichmentFunction`**
+
+In `FlowEnrichmentFunction.java`:
+
+(a) Import + field:
+```java
+import org.deltav.flows.enricher.enrichment.JdbcSnmpInterfaceLookup;
+```
+Add a field alongside `private final JdbcNodeInfoLookup nodeInfoLookup;`:
+```java
+    private final JdbcSnmpInterfaceLookup snmpInterfaceLookup;
+```
+Add it to the constructor parameter list (next to `JdbcNodeInfoLookup nodeInfoLookup`) and assign `this.snmpInterfaceLookup = snmpInterfaceLookup;`.
+
+(b) Resolve the names in the existing exporter block. That block currently reads (around lines 220-227):
+```java
+        if (exporterNodeInfo != null) {
+            Integer inputIfIndex = flow.getInputSnmp();
+            if (inputIfIndex != null) {
+                interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), inputIfIndex);
+            }
+            Integer outputIfIndex = flow.getOutputSnmp();
+            if (outputIfIndex != null) {
+                interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), outputIfIndex);
+            }
+        }
+```
+Introduce two locals initialised to `null` *before* this block, and resolve them inside it:
+```java
+        String inputIfName = null;
+        String outputIfName = null;
+        if (exporterNodeInfo != null) {
+            Integer inputIfIndex = flow.getInputSnmp();
+            if (inputIfIndex != null) {
+                interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), inputIfIndex);
+                inputIfName = snmpInterfaceLookup.lookupIfName(exporterNodeInfo.nodeId(), inputIfIndex);
+            }
+            Integer outputIfIndex = flow.getOutputSnmp();
+            if (outputIfIndex != null) {
+                interfaceMarkingCache.markIfNeeded(exporterNodeInfo.nodeId(), outputIfIndex);
+                outputIfName = snmpInterfaceLookup.lookupIfName(exporterNodeInfo.nodeId(), outputIfIndex);
+            }
+        }
+```
+
+(c) Pass them to the mapper. The `flowToDocumentMapper.map(...)` call (around line 236) currently ends with `... clockCorrection)`. Add the two new trailing args matching Task 4's signature, e.g.:
+```java
+        FlowDocumentProtos.FlowDocument doc = flowToDocumentMapper.map(
+                flow,
+                exporterNodeInfo,
+                srcNodeInfo,
+                dstNodeInfo,
+                /* ...existing args through clockCorrection... */,
+                inputIfName,
+                outputIfName);
+```
+(Insert `inputIfName, outputIfName` as the final two arguments, preserving every existing argument in between.)
+
+- [ ] **Step 3: Build the module**
+
+Run: `./mvnw -q --projects :org.deltav.core.flow-enricher -am test`
+Expected: BUILD SUCCESS, all existing + new tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java \
+        core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnrichmentFunction.java
+git commit -m "feat(flows): resolve exporter interface names and pass to the mapper"
+```
+
+---
+
+### Task 6: ClickHouse schema — columns, kafka table, ingest view
+
+**Files:**
+- Modify: `opennms-container/delta-v/clickhouse/init/02-flows-raw.sql`
+- Modify: `opennms-container/delta-v/clickhouse/init/03-flows-kafka.sql`
+- Modify: `opennms-container/delta-v/clickhouse/init/20-flows-ingest.sql`
+
+> CRITICAL: the materialized view inserts into `flows_raw` **by column position**. The new `flows_raw` columns and the new MV `SELECT` expressions MUST appear in the same order: `exporter_node_label` directly after `exporter_node_categories`; `input_if_name` + `output_if_name` directly after `output_snmp_ifindex`.
+
+- [ ] **Step 1: `02-flows-raw.sql` — add columns to CREATE + idempotent ALTERs**
+
+In the `CREATE TABLE deltav.flows_raw` column list, change the exporter-node block so it reads (add `exporter_node_label` after `exporter_node_categories`, and `input_if_name` / `output_if_name` after `output_snmp_ifindex`):
+```sql
+    -- Exporter node inventory (from NodeInfo exporter_node)
+    exporter_node_id               UInt32,
+    exporter_node_foreign_source   LowCardinality(String),
+    exporter_node_foreign_id       String,
+    exporter_node_categories       Array(LowCardinality(String)),
+    exporter_node_label            LowCardinality(String),
+    input_snmp_ifindex             UInt32,
+    output_snmp_ifindex            Nullable(UInt32),
+    input_if_name                  LowCardinality(String),
+    output_if_name                 LowCardinality(String),
+```
+Then, at the **end of the file** (after the `CREATE TABLE ... SETTINGS ...;` statement), append idempotent migrations for existing tables:
+```sql
+
+-- Additive migration for clusters created before these columns existed.
+-- ADD COLUMN IF NOT EXISTS is a no-op once applied. Positions are chosen to
+-- match the flows_ingest SELECT order (the MV inserts by position).
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS exporter_node_label LowCardinality(String) AFTER exporter_node_categories;
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS input_if_name  LowCardinality(String) AFTER output_snmp_ifindex;
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS output_if_name LowCardinality(String) AFTER input_if_name;
+```
+
+- [ ] **Step 2: `03-flows-kafka.sql` — drop the MV, recreate the kafka table with the new fields**
+
+Because `flows_kafka` and `flows_ingest` are stateless and `ALTER` on a Kafka-engine table (especially `Tuple` evolution) is finicky, recreate them. Drop the MV **first** (it reads `flows_kafka`), then DROP+CREATE the kafka table.
+
+At the **top** of `03-flows-kafka.sql`, before the `CREATE TABLE`, add:
+```sql
+-- flows_ingest reads flows_kafka; drop it before recreating the kafka table so
+-- no MV is left attached to a dropped table. It is recreated in 20-flows-ingest.sql.
+DROP VIEW IF EXISTS deltav.flows_ingest;
+DROP TABLE IF EXISTS deltav.flows_kafka;
+```
+Change `CREATE TABLE IF NOT EXISTS deltav.flows_kafka` to `CREATE TABLE deltav.flows_kafka` (unconditional, since we just dropped it). Add `node_label String` to the `exporter_node` Tuple and add the two top-level `String` columns after `output_snmp_ifindex`. The exporter-node tuple + ifindex block becomes:
+```sql
+    exporter_node           Tuple(
+        node_id             UInt32,
+        foreign_source      String,
+        foreign_id          String,
+        categories          Array(String),
+        node_label          String
+    ),
+    dest_node               Tuple(
+        node_id             UInt32,
+        foreign_source      String,
+        foreign_id          String,
+        categories          Array(String)
+    ),
+
+    -- SNMP ifindex lives at the top level of the proto, not in NodeInfo
+    input_snmp_ifindex      Tuple(value UInt32),
+    output_snmp_ifindex     Tuple(value UInt32),
+
+    -- Resolved interface names (top-level proto strings)
+    input_if_name           String,
+    output_if_name          String
+```
+(Leave `src_node` and `dest_node` tuples without `node_label` — the proto carries it but ClickHouse only extracts the exporter's.)
+
+- [ ] **Step 3: `20-flows-ingest.sql` — recreate the MV with the new projections in matching order**
+
+Change `CREATE MATERIALIZED VIEW IF NOT EXISTS deltav.flows_ingest` to `CREATE MATERIALIZED VIEW deltav.flows_ingest` (it was dropped in `03`). Add `exporter_node.node_label AS exporter_node_label` after the `exporter_node_categories` projection, and `input_if_name` / `output_if_name` after the `output_snmp_ifindex` projection. The exporter block of the SELECT becomes:
+```sql
+    ifNull(exporter_node.node_id, 0)                 AS exporter_node_id,
+    exporter_node.foreign_source                     AS exporter_node_foreign_source,
+    exporter_node.foreign_id                         AS exporter_node_foreign_id,
+    exporter_node.categories                         AS exporter_node_categories,
+    exporter_node.node_label                         AS exporter_node_label,
+    ifNull(input_snmp_ifindex.value, 0)              AS input_snmp_ifindex,
+    toNullable(output_snmp_ifindex.value)            AS output_snmp_ifindex,
+    input_if_name                                    AS input_if_name,
+    output_if_name                                   AS output_if_name,
+```
+(The `src_node` / `dest_node` projection blocks that follow are unchanged.)
+
+- [ ] **Step 4: Validate the SQL parses (syntax check)**
+
+Run a throwaway ClickHouse to validate the three files parse cleanly (multi-statement, `--multiquery`):
+```bash
+cd opennms-container/delta-v
+docker run --rm -v "$PWD/clickhouse/init:/init:ro" clickhouse/clickhouse-server:latest \
+  sh -c 'clickhouse local --multiquery --query "$(sed s/\${DELTAV_CLICKHOUSE_FLOWS_RAW_TTL_DAYS}/30/ /init/01-database.sql /init/02-flows-raw.sql)"' 2>&1 | tail -5 || true
+```
+Expected: no syntax errors on `02-flows-raw.sql` (the Kafka/MV files need a running broker, so they are validated end-to-end in Task 7, not here). At minimum, eyeball that column lists in `02`/`03`/`20` are in the matching order described above.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add opennms-container/delta-v/clickhouse/init/02-flows-raw.sql \
+        opennms-container/delta-v/clickhouse/init/03-flows-kafka.sql \
+        opennms-container/delta-v/clickhouse/init/20-flows-ingest.sql
+git commit -m "feat(flows): persist exporter_node_label + input/output_if_name in ClickHouse"
+```
+
+---
+
+### Task 7: End-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the flow-enricher + clickhouse images**
+
+Run:
+```bash
+cd opennms-container/delta-v
+docker buildx build --load -t deltav/flow-enricher:dev -f Dockerfile.daemon-per \
+  --build-arg DAEMON_NAME=flow-enricher --build-arg DAEMON_BASE_IMAGE=deltav/daemon-base \
+  --build-arg VERSION=dev --build-arg MAIN_CLASS="$(cat staging/flow-enricher/.main_class 2>/dev/null || echo SKIP)" . 2>&1 | tail -3
+```
+(Or simply `make daemon-image DAEMON=flow-enricher` if staging is already prepared, plus a clickhouse image rebuild so the baked proto is current.)
+Expected: both images build; the clickhouse image bakes the updated `deltav-flows.proto`.
+
+- [ ] **Step 2: Deploy and confirm flows carry the new fields**
+
+Bring up a stack (`make up PROFILE=demo`), wait for the enricher node-context cache to warm (~3-5 min), then query:
+```bash
+docker exec delta-v-clickhouse clickhouse-client -u deltav --password deltav --query \
+  "SELECT host, exporter_node_label, input_if_name, output_if_name FROM deltav.flows_raw WHERE host LIKE '10.0.0.%' AND timestamp > now()-INTERVAL 10 MINUTE LIMIT 10 FORMAT PrettyCompact"
+```
+Expected: rows show a populated `exporter_node_label` (e.g. `cisco-catalyst-9500-10.0.0.1`) and, where the exporter's `snmpinterface` rows exist, populated `input_if_name` / `output_if_name`. Empty strings are acceptable for exporters without resolved SNMP interfaces.
+
+- [ ] **Step 3: Confirm the idempotent migration on an existing volume**
+
+Re-run the clickhouse-init against a pre-existing `clickhouse-data` volume (i.e. without wiping it) and confirm `DESCRIBE deltav.flows_raw` lists the three new columns and that ingest continues (no consumer-group reset errors in the clickhouse logs).
+
+- [ ] **Step 4: Final review commit (if any verification fixes were needed)**
+
+Commit any fixes discovered during verification with a `fix(flows): …` message.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Proto: `node_label`=5, `input_if_name`=48, `output_if_name`=49 → Task 1. ✓
+- Enricher `node_label` (JdbcNodeInfoLookup + toProtoNodeInfo) → Tasks 2, 4. ✓
+- Enricher `if_name` (new JdbcSnmpInterfaceLookup + caller wiring) → Tasks 3, 5. ✓
+- ClickHouse columns + idempotent ALTER (flows_raw) + recreate (kafka, MV) → Task 6. ✓
+- node_label populated on all three NodeInfo, persisted exporter-only → Task 4 (toProtoNodeInfo is shared) + Task 6 (only `exporter_node_label` column). ✓
+- if_name from the exporter node, input+output → Task 5 resolves from `exporterNodeInfo.nodeId()`. ✓
+- LowCardinality(String); migration ordering (position-based MV) → Task 6 (explicit ordering note). ✓
+- Tests → Tasks 2, 3, 4. ✓
+
+**Type consistency:** `NodeInfo` record gains trailing `String nodeLabel` (Task 2), consumed via `info.nodeLabel()` (Task 4); `map(...)` gains trailing `String inputIfName, String outputIfName` (Task 4), supplied by the caller (Task 5) and by the tests (Task 4). `JdbcSnmpInterfaceLookup.lookupIfName(int,int)` returns `String`/null, used directly. Proto accessors `getNodeLabel()/getInputIfName()/getOutputIfName()` match the proto field names. Consistent.
+
+**No placeholders:** every code step shows complete code; SQL column order is explicit; verification queries are concrete.

--- a/docs/superpowers/specs/2026-05-31-flow-doc-node-label-ifname-design.md
+++ b/docs/superpowers/specs/2026-05-31-flow-doc-node-label-ifname-design.md
@@ -1,0 +1,116 @@
+# Flow Document: exporter `node_label` + input/output `if_name`
+
+**Date:** 2026-05-31
+**Status:** Approved design
+**Branch:** `feat/flow-doc-node-label-ifname`
+
+## Goal
+
+Persist the exporter's **node label** and the **input/output SNMP interface names** on each flow record, so flow queries and dashboards can show human-readable device + interface identity without joining back to node-context/DB data.
+
+## Motivation
+
+Today the FlowDocument carries stable identifiers only — `NodeInfo{node_id, foreign_source, foreign_id, categories}` and the numeric `input/output_snmp_ifindex`. The human-readable `node_label` / `if_name` live in the DB and require a join. With per-device flow exporter attribution now working (#319), each nl6 device flows as its own exporter node with SNMP interfaces, so on-flow `exporter_node_label` + `input/output_if_name` become directly useful (e.g. the native Grafana Exporter axis can show `cisco-catalyst-9500-10.0.0.1` + `Gi0/3`).
+
+## Confirmed scope decisions
+
+- **`node_label`** — populated on **all three** `NodeInfo` (exporter/src/dest) in the protobuf (free; the label already rides in the node lookup), but **persisted only** as `exporter_node_label` in ClickHouse.
+- **`if_name`** — **both** `input_if_name` + `output_if_name`, resolved from the **exporter** node's `snmpinterface` by the flow's input/output ifIndex.
+- **Migration** — fully idempotent `ALTER` (existing deployments self-upgrade on boot; fresh deploys get everything from `CREATE`).
+
+## Architecture & single source of truth
+
+`core/flow-enricher/src/main/proto/deltav-flows.proto` is the **single** proto source. It is consumed by:
+1. the **flow-enricher** (Java protobuf codegen), and
+2. the **ClickHouse** image — `build.sh do_clickhouse_image` bakes this exact file to `/delta-v/proto/deltav-flows.proto`, and `flows_kafka` parses the Kafka topic with `kafka_format = 'ProtobufSingle'`, `kafka_schema = 'deltav-flows.proto:FlowDocument'`.
+
+So one proto edit propagates to both sides; no duplicate proto to sync. ProtobufSingle maps proto fields to ClickHouse columns **by name**, so column order is irrelevant and extra proto fields not present as columns are simply skipped.
+
+The ingest path is three ClickHouse objects:
+`flows_kafka` (Kafka engine, parses protobuf) → `flows_ingest` (MATERIALIZED VIEW `TO flows_raw`) → `flows_raw` (MergeTree, queried table).
+
+## Components
+
+### 1. Protobuf — `core/flow-enricher/src/main/proto/deltav-flows.proto`
+
+Additive only (API version stays 1; wire-compatible; old consumers ignore new fields). Current max FlowDocument field is **47**; fields **25** and **44** are reserved.
+
+```proto
+message NodeInfo {
+    uint32 node_id = 1;
+    string foreign_source = 2;
+    string foreign_id = 3;
+    repeated string categories = 4;
+    string node_label = 5;          // NEW — OnmsNode.label
+}
+
+message FlowDocument {
+    // ... existing fields ...
+    string input_if_name  = 48;     // NEW — exporter snmpinterface.snmpifname for input_snmp_ifindex
+    string output_if_name = 49;     // NEW — exporter snmpinterface.snmpifname for output_snmp_ifindex
+}
+```
+
+### 2. Enricher — `core/flow-enricher`
+
+**`node_label` (extend `JdbcNodeInfoLookup` + `FlowToDocumentMapper`):**
+- Add `nodelabel` to both SELECTs in `JdbcNodeInfoLookup`:
+  - by-IP: `SELECT n.nodeid, n.nodelabel, n.foreignsource, n.foreignid, n.location FROM node n JOIN ipinterface i ON n.nodeid = i.nodeid WHERE i.ipaddr = ? ...`
+  - by-nodeId: `SELECT nodeid, nodelabel, foreignsource, foreignid, location FROM node WHERE nodeid = ?`
+- Add `String nodeLabel` to the `JdbcNodeInfoLookup.NodeInfo` record + row mapper.
+- `FlowToDocumentMapper.toProtoNodeInfo(...)`: set `node_label` when non-empty. Because this method builds all three NodeInfo sub-messages, `node_label` is populated uniformly for exporter/src/dest.
+
+**`if_name` (new `JdbcSnmpInterfaceLookup`):**
+- New class mirroring `JdbcNodeInfoLookup`'s structure (Caffeine cache, same JDBC template):
+  - SQL: `SELECT snmpifname FROM snmpinterface WHERE nodeid = ? AND snmpifindex = ?`
+  - Cache key: a `record IfKey(int nodeId, int ifIndex)`; value `Optional<String>`.
+  - `String lookupIfName(int nodeId, int ifIndex)` → ifName or `null`.
+- Bean wired in `FlowEnricherConfiguration` (same datasource as the node lookup) and passed into `FlowEnrichmentFunction` → `FlowToDocumentMapper`.
+- In `FlowToDocumentMapper`, after the exporter node + ifindexes are set, resolve from the **exporter** node:
+  - `input_if_name`  = `lookupIfName(exporterNodeId, inputSnmpIfindex)` when `exporterNodeId > 0` and the input ifindex is present.
+  - `output_if_name` = `lookupIfName(exporterNodeId, outputSnmpIfindex)` when `exporterNodeId > 0` and the output ifindex is present.
+  - Set the proto fields only when the lookup returns a non-empty name; otherwise leave empty (unprovisioned exporter, missing interface, or null ifindex).
+  - `exporterNodeId` comes from the resolved exporter `NodeInfo` (0/absent → skip both).
+
+### 3. ClickHouse DDL
+
+**`02-flows-raw.sql`** — add to `CREATE TABLE deltav.flows_raw` (all `LowCardinality(String)` — bounded by node/interface counts; none are ORDER BY columns):
+```
+exporter_node_label LowCardinality(String),
+input_if_name       LowCardinality(String),
+output_if_name      LowCardinality(String),
+```
+Then idempotent migration for existing tables:
+```sql
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS exporter_node_label LowCardinality(String) AFTER exporter_node_categories;
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS input_if_name  LowCardinality(String) AFTER input_snmp_ifindex;
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS output_if_name LowCardinality(String) AFTER output_snmp_ifindex;
+```
+
+**`03-flows-kafka.sql`** and **`20-flows-ingest.sql`** — migrate by **DROP + recreate**, not `ALTER`.
+
+Both objects are **stateless**: `flows_kafka` is a Kafka-engine consumer view (no stored rows) and `flows_ingest` is a streaming MV (no stored rows). ClickHouse `ALTER` on a Kafka-engine table — especially `MODIFY COLUMN` on a `Tuple` to add a sub-field — is version-sensitive and finicky. Recreating is the cleaner, more predictable path for stateless ingest objects, so it is the **primary** approach (not a fallback):
+
+- `flows_kafka`: add `node_label String` to the **`exporter_node` Tuple** (src/dest tuples unchanged; their proto `node_label` is simply not extracted) and add top-level `input_if_name String`, `output_if_name String`. Migrate with `DROP TABLE IF EXISTS deltav.flows_kafka` then the full `CREATE`. The consumer rejoins group `deltav-clickhouse-persister` at its **committed offset**, so no message loss — just a brief re-attach.
+- `flows_ingest`: add `exporter_node.node_label AS exporter_node_label`, `input_if_name AS input_if_name`, `output_if_name AS output_if_name` to the SELECT. Migrate with `DROP VIEW IF EXISTS deltav.flows_ingest` then the full `CREATE MATERIALIZED VIEW ... TO deltav.flows_raw AS SELECT ...`.
+
+**Ordering (important):** drop the MV **before** recreating `flows_kafka` (so no MV is left attached to a table being dropped), then recreate `flows_kafka`, then recreate the MV. The init files run in numeric order (`02` → `03` → `20`), so the implementation must drop `flows_ingest` at the **top of `03-flows-kafka.sql`** (before the kafka `DROP`/`CREATE`) and recreate it in `20-flows-ingest.sql`. Because both are unconditional `DROP`+`CREATE` (no `IF NOT EXISTS` guard on the create), the init is self-updating on every boot and idempotent in effect (the recreated objects always match the current proto/columns).
+
+### 4. Testing
+
+- **`FlowToDocumentMapperTest`** (extend): exporter `node_label` set on the exporter NodeInfo; `input_if_name`/`output_if_name` resolved via a stubbed `JdbcSnmpInterfaceLookup`; all three empty when the exporter is unresolved (`nodeId=0`) or the lookup returns null.
+- **`JdbcSnmpInterfaceLookupTest`** (new): cache hit/miss, returns null on missing `(nodeid, ifindex)`, caches negatives.
+- **Manual / E2E:** after a deploy, `SELECT exporter_node_label, input_if_name, output_if_name, host FROM deltav.flows_raw WHERE host LIKE '10.0.0.%' LIMIT 10` shows populated label + interface names for the nl6 device exporters (post-#319 they resolve to nodes with SNMP interfaces). Confirm the migration (`flows_raw` additive `ALTER` + `flows_kafka`/`flows_ingest` recreate) upgrades an existing `clickhouse-data` volume without a reset, and that the Kafka consumer resumes at its committed offset.
+
+## Out of scope
+
+- Persisting `src_node_label` / `dest_node_label` (they ride in the protobuf already; a future change only needs the columns + ingest mappings — no proto/enricher change).
+- `if_descr` / `if_alias` / `if_speed` (only `if_name`).
+- Grafana dashboard changes to surface the new fields (separate follow-up).
+- Backfilling existing `flows_raw` rows (new columns default to empty for pre-existing data).
+
+## Risks / notes
+
+- **Cardinality:** all three new columns are `LowCardinality(String)`; node labels and interface names are low-distinct, so storage and merge cost are minimal. None participate in the primary key / `ORDER BY`.
+- **Interface lookup volume:** the `snmpinterface` lookup is per-flow but Caffeine-cached by `(nodeId, ifIndex)`, so steady-state hit rate is high (the device fleet's interface set is small and stable), mirroring the existing node-id cache.
+- **`if_name` only populates** for resolved exporters that have SNMP interfaces; unprovisioned exporters yield empty strings (same graceful-empty behavior as the existing node fields).

--- a/opennms-container/delta-v/clickhouse/init/02-flows-raw.sql
+++ b/opennms-container/delta-v/clickhouse/init/02-flows-raw.sql
@@ -63,8 +63,11 @@ CREATE TABLE IF NOT EXISTS deltav.flows_raw
     exporter_node_foreign_source   LowCardinality(String),
     exporter_node_foreign_id       String,
     exporter_node_categories       Array(LowCardinality(String)),
+    exporter_node_label            LowCardinality(String),
     input_snmp_ifindex             UInt32,
     output_snmp_ifindex            Nullable(UInt32),
+    input_if_name                  LowCardinality(String),
+    output_if_name                 LowCardinality(String),
 
     -- Source node inventory (from NodeInfo src_node)
     src_node_id                    UInt32,
@@ -83,3 +86,11 @@ PARTITION BY toDate(timestamp)
 ORDER BY (exporter_node_id, timestamp, input_snmp_ifindex)
 TTL timestamp + INTERVAL ${DELTAV_CLICKHOUSE_FLOWS_RAW_TTL_DAYS} DAY DELETE
 SETTINGS index_granularity = 8192;
+
+-- Additive migration for clusters created before these columns existed.
+-- ADD COLUMN IF NOT EXISTS is a no-op once applied. Positions are chosen to
+-- match the flows_ingest SELECT order (the materialized view inserts by
+-- column position, so flows_raw column order must equal the SELECT order).
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS exporter_node_label LowCardinality(String) AFTER exporter_node_categories;
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS input_if_name  LowCardinality(String) AFTER output_snmp_ifindex;
+ALTER TABLE deltav.flows_raw ADD COLUMN IF NOT EXISTS output_if_name LowCardinality(String) AFTER input_if_name;

--- a/opennms-container/delta-v/clickhouse/init/03-flows-kafka.sql
+++ b/opennms-container/delta-v/clickhouse/init/03-flows-kafka.sql
@@ -1,4 +1,13 @@
-CREATE TABLE IF NOT EXISTS deltav.flows_kafka
+-- flows_ingest reads flows_kafka; drop it before recreating the kafka table so
+-- no materialized view is left attached to a dropped table. It is recreated in
+-- 20-flows-ingest.sql. Both objects are stateless (a Kafka consumer view and a
+-- streaming MV), so DROP+recreate is the clean migration for schema changes;
+-- the consumer rejoins group 'deltav-clickhouse-persister' at its committed
+-- offset, so no messages are lost.
+DROP VIEW IF EXISTS deltav.flows_ingest;
+DROP TABLE IF EXISTS deltav.flows_kafka;
+
+CREATE TABLE deltav.flows_kafka
 (
     -- Timing and identity
     timestamp               UInt64,
@@ -69,7 +78,8 @@ CREATE TABLE IF NOT EXISTS deltav.flows_kafka
         node_id             UInt32,
         foreign_source      String,
         foreign_id          String,
-        categories          Array(String)
+        categories          Array(String),
+        node_label          String
     ),
     dest_node               Tuple(
         node_id             UInt32,
@@ -80,7 +90,11 @@ CREATE TABLE IF NOT EXISTS deltav.flows_kafka
 
     -- SNMP ifindex lives at the top level of the proto, not in NodeInfo
     input_snmp_ifindex      Tuple(value UInt32),
-    output_snmp_ifindex     Tuple(value UInt32)
+    output_snmp_ifindex     Tuple(value UInt32),
+
+    -- Resolved interface names (top-level proto strings)
+    input_if_name           String,
+    output_if_name          String
 )
 ENGINE = Kafka
 SETTINGS

--- a/opennms-container/delta-v/clickhouse/init/20-flows-ingest.sql
+++ b/opennms-container/delta-v/clickhouse/init/20-flows-ingest.sql
@@ -1,4 +1,8 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS deltav.flows_ingest
+-- Recreated unconditionally (dropped in 03-flows-kafka.sql) so the SELECT stays
+-- in sync with the flows_kafka schema and the flows_raw column order. The MV
+-- inserts into flows_raw BY POSITION, so the projection order below must equal
+-- the flows_raw column order exactly.
+CREATE MATERIALIZED VIEW deltav.flows_ingest
 TO deltav.flows_raw AS
 SELECT
     toDateTime64(timestamp / 1000.0, 3, 'UTC')      AS timestamp,
@@ -53,8 +57,11 @@ SELECT
     exporter_node.foreign_source                     AS exporter_node_foreign_source,
     exporter_node.foreign_id                         AS exporter_node_foreign_id,
     exporter_node.categories                         AS exporter_node_categories,
+    exporter_node.node_label                         AS exporter_node_label,
     ifNull(input_snmp_ifindex.value, 0)              AS input_snmp_ifindex,
     toNullable(output_snmp_ifindex.value)            AS output_snmp_ifindex,
+    input_if_name                                    AS input_if_name,
+    output_if_name                                   AS output_if_name,
 
     ifNull(src_node.node_id, 0)                      AS src_node_id,
     src_node.foreign_source                          AS src_node_foreign_source,


### PR DESCRIPTION
## Summary

Denormalizes human-readable identity onto each flow record so flow queries/dashboards can show device + interface names without a join. Adds:
- **`exporter_node_label`** — the exporter's `OnmsNode.label`
- **`input_if_name` / `output_if_name`** — the exporter's SNMP interface names for the flow's input/output ifIndex

`node_label` rides on all three `NodeInfo` in the protobuf (free from the existing node lookup) but only the exporter's is persisted, per design.

## Changes (8 commits)
- **proto** (`deltav-flows.proto`, single source for the enricher *and* ClickHouse's `ProtobufSingle` parser): `NodeInfo.node_label=5`, `FlowDocument.input_if_name=48`, `output_if_name=49` — additive, wire-compatible.
- **enricher**: `JdbcNodeInfoLookup` carries `node_label`; new cached `JdbcSnmpInterfaceLookup` resolves `snmpifname` by `(exporter nodeId, ifIndex)`; `FlowToDocumentMapper` sets the fields (13-arg overload, 11-arg kept as a delegating overload to avoid churning 23 call sites); wired via a new bean + the existing exporter block in `FlowEnrichmentFunction`.
- **ClickHouse**: `flows_raw` gains 3 `LowCardinality(String)` columns (CREATE + idempotent `ADD COLUMN IF NOT EXISTS`); stateless `flows_kafka` + `flows_ingest` dropped & recreated with the new proto fields. **Column order verified identical** between `flows_raw` and the MV `SELECT` (position-based insert).

Design spec + plan: `docs/superpowers/specs/2026-05-31-flow-doc-node-label-ifname-design.md`, `docs/superpowers/plans/2026-06-01-flow-doc-node-label-ifname.md`.

## Test Plan
- [x] flow-enricher unit tests green (119), incl. new mapper `node_label`/`if_name` tests + `JdbcSnmpInterfaceLookup` cache/negative-cache tests
- [x] `flows_raw` DDL parses in `clickhouse local`, including the idempotent ALTER migration
- [x] `flows_raw` vs MV `SELECT` column order confirmed identical (no silent position corruption)
- [ ] **Deferred E2E (next deploy/rc):** rebuild flow-enricher + clickhouse images, `make up`, confirm `flows_raw` shows populated `exporter_node_label` / `input_if_name` / `output_if_name` for nl6 exporters; confirm idempotent migration upgrades an existing `clickhouse-data` volume