### PR TITLE
chore: remove stray nested provisiond-overlay copy

### DIFF
--- a/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
+++ b/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/provisiond-configuration.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
-                          import-threads="2"
-                          scan-threads="4"
-                          write-threads="2"
-                          rescan-threads="2"
-                          requisition-dir="/opt/deltav/etc/imports"
-                          foreign-source-dir="/opt/deltav/etc/foreign-sources">
-</provisiond-configuration>

--- a/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-asset-adapter-configuration.xml
+++ b/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-asset-adapter-configuration.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<snmp-asset-adapter-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmp-asset-adapter">
-</snmp-asset-adapter-configuration>

--- a/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-config.xml
+++ b/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<snmp-config xmlns="http://xmlns.opennms.org/xsd/config/snmp"
-             port="161" retry="3" timeout="1800"
-             read-community="public" write-community="private"
-             version="v2c">
-</snmp-config>

--- a/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-hardware-inventory-adapter-configuration.xml
+++ b/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-hardware-inventory-adapter-configuration.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<hw-inventory-adapter-configuration xmlns="http://xmlns.opennms.org/xsd/config/hardware-inventory">
-</hw-inventory-adapter-configuration>

--- a/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-metadata-adapter-configuration.xml
+++ b/opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/etc/snmp-metadata-adapter-configuration.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<snmp-metadata-adapter-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmp-metadata-adapter">
-</snmp-metadata-adapter-configuration>


### PR DESCRIPTION
## Summary

Removes an accidental copy of `provisiond-overlay/` committed at the wrong nested path, which produced the confusing quad-nested path:

```
opennms-container/delta-v/opennms-container/delta-v/provisiond-overlay/
```

This is **PR 0** of an incremental series to reduce redundancy in the container directory layout (each PR kept small for easy review/consumption). It is a pure deletion with zero functional impact.

## Why it's safe

- **Stale partial duplicate:** the nested copy has 5 files, all older/divergent variants of files already present (current) in the real `opennms-container/delta-v/provisiond-overlay/` (27 files).
- **Unreferenced:** nothing in the repo references the nested path — `build.sh`/`deploy.sh` derive paths from `SCRIPT_DIR`/`REPO_ROOT` and never reach it (`git grep "opennms-container/delta-v/opennms-container"` → no matches).
- **Origin:** introduced accidentally in `5ec6c6345f4`.

## Verification

- `git grep "opennms-container/delta-v/opennms-container"` → no references remain
- Real `provisiond-overlay/` is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)