### PR TITLE
feat(grafana): surface + filter flows dashboards on node-label, if-name, categories

### DIFF
--- a/opennms-container/delta-v/grafana/dashboards/flows-forensic.json
+++ b/opennms-container/delta-v/grafana/dashboards/flows-forensic.json
@@ -47,7 +47,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "clickhouse"
         },
-        "query": "SELECT DISTINCT concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}')",
+        "query": "SELECT DISTINCT concat(if(exporter_node_label != '', concat(exporter_node_label, ' '), ''), '(', exporter_node_foreign_source, '/', exporter_node_foreign_id, ')') AS __text, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS __value FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND exporter_node_foreign_id != '' ORDER BY __text",
         "refresh": 1,
         "multi": true,
         "includeAll": true,
@@ -72,6 +72,30 @@
           "uid": "clickhouse"
         },
         "query": "SELECT DISTINCT application FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}')",
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "allowCustomValue": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "category",
+        "label": "Node category",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "clickhouse"
+        },
+        "query": "SELECT DISTINCT arrayJoin(exporter_node_categories) AS category FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') ORDER BY category",
         "refresh": 1,
         "multi": true,
         "includeAll": true,
@@ -235,7 +259,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT $__timeInterval(timestamp) AS time, application, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY time, application ORDER BY time",
+          "rawSql": "SELECT $__timeInterval(timestamp) AS time, application, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY time, application ORDER BY time",
           "format": 1
         }
       ],
@@ -320,7 +344,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT IPv6NumToString(src_address) AS \"Source\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT IPv6NumToString(src_address) AS \"Source\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address ORDER BY \"Bytes\" DESC LIMIT 20",
           "format": 0
         }
       ]
@@ -391,7 +415,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT IPv6NumToString(dst_address) AS \"Destination\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY dst_address ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT IPv6NumToString(dst_address) AS \"Destination\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY dst_address ORDER BY \"Bytes\" DESC LIMIT 20",
           "format": 0
         }
       ]
@@ -450,7 +474,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT IPv6NumToString(src_address) AS \"Source\", src_port AS \"Src port\", IPv6NumToString(dst_address) AS \"Destination\", dst_port AS \"Dst port\", application AS \"App\", CASE protocol WHEN 6 THEN 'TCP' WHEN 17 THEN 'UDP' WHEN 1 THEN 'ICMP' WHEN 50 THEN 'ESP' ELSE concat('proto=', toString(protocol)) END AS \"L4\", sum(num_bytes) AS \"Bytes\", count() AS \"Records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address, src_port, dst_address, dst_port, application, protocol ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT IPv6NumToString(src_address) AS \"Source\", src_port AS \"Src port\", IPv6NumToString(dst_address) AS \"Destination\", dst_port AS \"Dst port\", application AS \"App\", CASE protocol WHEN 6 THEN 'TCP' WHEN 17 THEN 'UDP' WHEN 1 THEN 'ICMP' WHEN 50 THEN 'ESP' ELSE concat('proto=', toString(protocol)) END AS \"L4\", sum(num_bytes) AS \"Bytes\", count() AS \"Records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address, src_port, dst_address, dst_port, application, protocol ORDER BY \"Bytes\" DESC LIMIT 20",
           "format": 0
         }
       ]
@@ -483,7 +507,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT countIf(protocol = 6) AS \"TCP\", countIf(protocol = 17) AS \"UDP\", countIf(protocol = 1) AS \"ICMP\", countIf(protocol = 50) AS \"ESP\", countIf(protocol NOT IN (1, 6, 17, 50) AND protocol IS NOT NULL) AS \"Other\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$')",
+          "rawSql": "SELECT countIf(protocol = 6) AS \"TCP\", countIf(protocol = 17) AS \"UDP\", countIf(protocol = 1) AS \"ICMP\", countIf(protocol = 50) AS \"ESP\", countIf(protocol NOT IN (1, 6, 17, 50) AND protocol IS NOT NULL) AS \"Other\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$')",
           "format": 0
         }
       ]
@@ -516,7 +540,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT countIf(dscp = 0) AS \"BE (0)\", countIf(dscp = 8) AS \"CS1 (8)\", countIf(dscp = 10) AS \"AF11 (10)\", countIf(dscp = 26) AS \"AF31 (26)\", countIf(dscp = 46) AS \"EF (46)\", countIf(dscp NOT IN (0, 8, 10, 26, 46) AND dscp IS NOT NULL) AS \"Other DSCP\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') AND dscp IS NOT NULL",
+          "rawSql": "SELECT countIf(dscp = 0) AS \"BE (0)\", countIf(dscp = 8) AS \"CS1 (8)\", countIf(dscp = 10) AS \"AF11 (10)\", countIf(dscp = 26) AS \"AF31 (26)\", countIf(dscp = 46) AS \"EF (46)\", countIf(dscp NOT IN (0, 8, 10, 26, 46) AND dscp IS NOT NULL) AS \"Other DSCP\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') AND dscp IS NOT NULL",
           "format": 0
         }
       ]
@@ -548,7 +572,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT countIf(bitTest(toUInt8(tcp_flags), 1)) AS \"SYN\", countIf(bitTest(toUInt8(tcp_flags), 4)) AS \"ACK\", countIf(bitTest(toUInt8(tcp_flags), 2)) AS \"RST\", countIf(bitTest(toUInt8(tcp_flags), 0)) AS \"FIN\", countIf(bitTest(toUInt8(tcp_flags), 3)) AS \"PSH\", countIf(bitTest(toUInt8(tcp_flags), 5)) AS \"URG\", countIf(bitTest(toUInt8(tcp_flags), 6)) AS \"ECE\", countIf(bitTest(toUInt8(tcp_flags), 7)) AS \"CWR\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') AND protocol = 6 AND tcp_flags IS NOT NULL AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}')",
+          "rawSql": "SELECT countIf(bitTest(toUInt8(tcp_flags), 1)) AS \"SYN\", countIf(bitTest(toUInt8(tcp_flags), 4)) AS \"ACK\", countIf(bitTest(toUInt8(tcp_flags), 2)) AS \"RST\", countIf(bitTest(toUInt8(tcp_flags), 0)) AS \"FIN\", countIf(bitTest(toUInt8(tcp_flags), 3)) AS \"PSH\", countIf(bitTest(toUInt8(tcp_flags), 5)) AS \"URG\", countIf(bitTest(toUInt8(tcp_flags), 6)) AS \"ECE\", countIf(bitTest(toUInt8(tcp_flags), 7)) AS \"CWR\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') AND protocol = 6 AND tcp_flags IS NOT NULL AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}')",
           "format": 0
         }
       ]
@@ -599,7 +623,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT src_locality AS \"Src locality\", dst_locality AS \"Dst locality\", count() AS \"Flow records\", sum(num_bytes) AS \"Bytes\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_locality, dst_locality ORDER BY \"Bytes\" DESC",
+          "rawSql": "SELECT src_locality AS \"Src locality\", dst_locality AS \"Dst locality\", count() AS \"Flow records\", sum(num_bytes) AS \"Bytes\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_locality, dst_locality ORDER BY \"Bytes\" DESC",
           "format": 0
         }
       ]
@@ -659,7 +683,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT formatDateTime(timestamp, '%Y-%m-%d %H:%i:%S') AS \"Time\", CASE protocol WHEN 6 THEN 'TCP' WHEN 17 THEN 'UDP' WHEN 1 THEN 'ICMP' WHEN 50 THEN 'ESP' ELSE toString(protocol) END AS \"L4\", IPv6NumToString(src_address) AS \"Src\", src_port AS \"Sport\", IPv6NumToString(dst_address) AS \"Dst\", dst_port AS \"Dport\", application AS \"App\", num_bytes AS \"Bytes\", num_packets AS \"Pkts\", exporter_node_foreign_id AS \"Exporter\", netflow_version AS \"Wire fmt\" FROM deltav.flows_raw WHERE timestamp >= now() - INTERVAL 60 MINUTE AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') ORDER BY timestamp DESC LIMIT 1000",
+          "rawSql": "SELECT formatDateTime(timestamp, '%Y-%m-%d %H:%i:%S') AS \"Time\", CASE protocol WHEN 6 THEN 'TCP' WHEN 17 THEN 'UDP' WHEN 1 THEN 'ICMP' WHEN 50 THEN 'ESP' ELSE toString(protocol) END AS \"L4\", IPv6NumToString(src_address) AS \"Src\", src_port AS \"Sport\", IPv6NumToString(dst_address) AS \"Dst\", dst_port AS \"Dport\", application AS \"App\", num_bytes AS \"Bytes\", num_packets AS \"Pkts\", if(input_if_name != '', input_if_name, toString(input_snmp_ifindex)) AS \"In if\", if(output_if_name != '', output_if_name, toString(output_snmp_ifindex)) AS \"Out if\", concat(if(exporter_node_label != '', concat(exporter_node_label, ' '), ''), '(', exporter_node_foreign_source, '/', exporter_node_foreign_id, ')') AS \"Exporter\", netflow_version AS \"Wire fmt\" FROM deltav.flows_raw WHERE timestamp >= now() - INTERVAL 60 MINUTE AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') ORDER BY timestamp DESC LIMIT 1000",
           "format": 0
         }
       ]

--- a/opennms-container/delta-v/grafana/dashboards/flows-overview.json
+++ b/opennms-container/delta-v/grafana/dashboards/flows-overview.json
@@ -45,7 +45,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "clickhouse"
         },
-        "query": "SELECT DISTINCT concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}')",
+        "query": "SELECT DISTINCT concat(if(exporter_node_label != '', concat(exporter_node_label, ' '), ''), '(', exporter_node_foreign_source, '/', exporter_node_foreign_id, ')') AS __text, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS __value FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND exporter_node_foreign_id != '' ORDER BY __text",
         "refresh": 1,
         "multi": true,
         "includeAll": true,
@@ -69,6 +69,29 @@
           "uid": "clickhouse"
         },
         "query": "SELECT DISTINCT application FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}')",
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "category",
+        "label": "Node category",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "clickhouse"
+        },
+        "query": "SELECT DISTINCT arrayJoin(exporter_node_categories) AS category FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') ORDER BY category",
         "refresh": 1,
         "multi": true,
         "includeAll": true,
@@ -116,7 +139,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT $__timeInterval(timestamp) AS time, location, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY time, location ORDER BY time",
+          "rawSql": "SELECT $__timeInterval(timestamp) AS time, location, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY time, location ORDER BY time",
           "format": 1
         }
       ],
@@ -215,7 +238,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT application, sum(num_bytes) AS bytes FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') GROUP BY application ORDER BY bytes DESC LIMIT 10",
+          "rawSql": "SELECT application, sum(num_bytes) AS bytes FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') GROUP BY application ORDER BY bytes DESC LIMIT 10",
           "format": 0
         }
       ]
@@ -286,7 +309,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT IPv6NumToString(src_address) AS \"Source\", IPv6NumToString(dst_address) AS \"Destination\", application AS \"Application\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY src_address, dst_address, application ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT IPv6NumToString(src_address) AS \"Source\", IPv6NumToString(dst_address) AS \"Destination\", application AS \"Application\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY src_address, dst_address, application ORDER BY \"Bytes\" DESC LIMIT 20",
           "format": 0
         }
       ]
@@ -321,7 +344,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT $__timeInterval(timestamp) AS time, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS exporter, count() / ($__interval_ms / 1000) AS flows_per_sec FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') GROUP BY time, exporter ORDER BY time",
+          "rawSql": "SELECT $__timeInterval(timestamp) AS time, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS exporter, count() / ($__interval_ms / 1000) AS flows_per_sec FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY time, exporter ORDER BY time",
           "format": 1
         }
       ]
@@ -354,7 +377,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT countIf(netflow_version = 'Netflow5') + countIf(netflow_version = 'V5') AS \"NetFlow v5\", countIf(netflow_version = 'Netflow9') + countIf(netflow_version = 'V9') AS \"NetFlow v9\", countIf(netflow_version = 'IPFIX') AS \"IPFIX\", countIf(netflow_version = 'SFlow') + countIf(netflow_version = 'Sflow') AS \"sFlow\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}')",
+          "rawSql": "SELECT countIf(netflow_version = 'Netflow5') + countIf(netflow_version = 'V5') AS \"NetFlow v5\", countIf(netflow_version = 'Netflow9') + countIf(netflow_version = 'V9') AS \"NetFlow v9\", countIf(netflow_version = 'IPFIX') AS \"IPFIX\", countIf(netflow_version = 'SFlow') + countIf(netflow_version = 'Sflow') AS \"sFlow\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}')",
           "format": 0
         }
       ]
@@ -416,7 +439,73 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT exporter_node_foreign_source, exporter_node_foreign_id, location, host, formatDateTime(max(timestamp), '%Y-%m-%d %H:%i:%S') AS last_seen, count() AS flow_count FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') GROUP BY exporter_node_foreign_source, exporter_node_foreign_id, location, host ORDER BY flow_count DESC",
+          "rawSql": "SELECT exporter_node_foreign_source, exporter_node_foreign_id, location, host, formatDateTime(max(timestamp), '%Y-%m-%d %H:%i:%S') AS last_seen, count() AS flow_count FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') GROUP BY exporter_node_foreign_source, exporter_node_foreign_id, location, host ORDER BY flow_count DESC",
+          "format": 0
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Top interfaces by traffic",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "bytes"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "bytes",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT concat(if(exporter_node_label != '', concat(exporter_node_label, ' '), ''), '(', exporter_node_foreign_source, '/', exporter_node_foreign_id, ')') AS \"Exporter\", if(input_if_name != '', input_if_name, toString(input_snmp_ifindex)) AS \"Interface\", sum(num_bytes) AS \"bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY \"Exporter\", \"Interface\" ORDER BY sum(num_bytes) DESC LIMIT 20",
           "format": 0
         }
       ]


### PR DESCRIPTION
## Summary

The flow document already carries the contextual enrichment fields — `exporter_node_label` + `input/output_if_name` (PR #324) and `exporter_node_categories` (PR #328) — and they land in ClickHouse `flows_raw`. But the **flows dashboards never surfaced, sorted, or filtered on them**: exporters were shown only as `foreign_source/foreign_id`, interfaces only as raw SNMP ifIndex numbers, and there was no way to slice by node category.

This PR wires all three into `flows-overview` and `flows-forensic` (Grafana JSON only — no code, no schema change).

## Changes

**Exporter → `label (foreign-id)`**
The `$exporter_instance` variable now returns `__text`/`__value`: the dropdown *displays* `core-router-3 (nl6/device-1)` but the *filter value* stays the stable `foreign_source/foreign_id`, so **every existing panel WHERE clause is untouched**. Empty label degrades gracefully to `(nl6/device-1)`. The forensic Raw-records "Exporter" column shows the same combined string.

**Interface names** (forensic Raw-records table)
New `In if` / `Out if` columns: `input_if_name`/`output_if_name`, falling back to the SNMP ifIndex when the name is empty.

**Category multi-select filter**
New `$category` template variable (`multi`, `includeAll`, `allValue='.*'`) over `exporter_node_categories`, wired into **every panel** in both dashboards:
```sql
AND (match('', '${category:regex}')
     OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories))
```
The `match('', …)` term is the load-bearing bit: it's true only when **All** (`.*`) is selected — so "All" keeps uncategorized flows, while a specific category correctly excludes exporters that don't carry it.

**Overview: new "Top interfaces by traffic" panel**
A table grouping by exporter label + `input_if_name` (ifIndex fallback), so the summary view surfaces if-names too — not just the forensic per-flow table.

## Validation

Validated against **live ClickHouse** (the running stack's `clickhouse-init` was a retagged rc4 image with a pre-#324 schema, so the table was patched to canonical + seeded with representative synthetic rows):

- `__text`/`__value` exporter query resolves to 2 columns ✓
- `$category` var (`arrayJoin`) returns the categories ✓
- Top-interfaces panel surfaces if-names; ifIndex fallback works (`edge-9 → 5`) ✓
- **Category filter semantics:** All = 3 rows (incl. uncategorized), `Routers` = 1, `Switches` = 1 ✓
- Raw-records shows if-name when present, ifIndex when empty; combined exporter ✓

## Test plan

- [x] Both dashboard JSON files valid; all 9 forensic + 6 overview panels gained the category filter (0 skipped)
- [x] New/changed SQL executes on live ClickHouse with correct filter semantics
- [ ] Visual check in Grafana on next deploy: dropdowns populate, category multi-select filters all panels, Top-interfaces panel renders
