### PR TITLE
feat(deploy): ClickHouse schema-drift preflight in make verify (+ fix stale kafka-topic check)

### DIFF
--- a/opennms-container/delta-v/deploy.sh
+++ b/opennms-container/delta-v/deploy.sh
@@ -97,6 +97,54 @@ do_logs() {
     fi
 }
 
+# Verify the live ClickHouse flows_raw schema is not BEHIND the source DDL.
+# A stale clickhouse-init image (its baked DDL never carried newer columns) or a
+# clickhouse-init that never re-ran leaves flows_raw missing columns that the
+# flows dashboards/queries reference — a silent failure. This converts it into a
+# loud one by diffing the expected columns (parsed from clickhouse/init/02-flows-raw.sql:
+# the CREATE TABLE block + every ADD COLUMN IF NOT EXISTS migration) against the
+# live system.columns. Exit: 0 current, 1 drift/missing, 2 skipped (no clickhouse).
+check_clickhouse_schema() {
+    local ddl="clickhouse/init/02-flows-raw.sql"
+
+    # Skip when clickhouse is not part of this profile/run (e.g. passive).
+    if ! docker compose ps --status running --format '{{.Name}}' 2>/dev/null | grep -qw clickhouse; then
+        return 2
+    fi
+    if [ ! -f "$ddl" ]; then
+        log "  [FAIL] ClickHouse schema check: source DDL $ddl not found"
+        return 1
+    fi
+
+    local expected live missing
+    expected=$(awk '
+        /CREATE TABLE IF NOT EXISTS deltav\.flows_raw/ {inblk=1; next}
+        inblk && /^\)/ {inblk=0}
+        inblk && $1 ~ /^[a-z_][a-z0-9_]*$/ {print $1}
+        /ADD COLUMN IF NOT EXISTS/ && !/^[[:space:]]*--/ {for (i=1;i<=NF;i++) if ($i=="EXISTS") print $(i+1)}
+    ' "$ddl" | sort -u)
+    live=$(docker compose exec -T clickhouse clickhouse-client \
+            --user "${CLICKHOUSE_USER:-deltav}" --password "${CLICKHOUSE_PASSWORD:-deltav}" \
+            -q "SELECT name FROM system.columns WHERE database='deltav' AND table='flows_raw'" 2>/dev/null | sort -u)
+
+    if [ -z "$live" ]; then
+        log "  [FAIL] ClickHouse schema: deltav.flows_raw has no columns (clickhouse-init has not applied DDL yet?)"
+        return 1
+    fi
+
+    missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$live"))
+    if [ -n "$missing" ]; then
+        log "  [FAIL] ClickHouse schema is BEHIND source DDL — deltav.flows_raw is missing columns:"
+        printf '             %s\n' $missing
+        echo   "         The clickhouse-init image is stale (baked DDL predates these columns)."
+        echo   "         Rebuild it from source and recreate the sidecar:"
+        echo   "           make images && docker compose up -d --force-recreate clickhouse-init"
+        return 1
+    fi
+    log "  [PASS] ClickHouse schema current (deltav.flows_raw matches source DDL)"
+    return 0
+}
+
 do_test() {
     log "Testing Delta-V deployment..."
     local pass=0
@@ -123,7 +171,7 @@ do_test() {
     fi
 
     # Test 3: Kafka topic exists
-    if docker compose exec -T kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list 2>/dev/null | grep -q "opennms"; then
+    if docker compose exec -T kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list 2>/dev/null | grep -qiE 'deltav[.-]'; then
         log "  [PASS] Kafka topics created"
         pass=$((pass + 1))
     else
@@ -144,6 +192,17 @@ do_test() {
         log "  [FAIL] db-init status: $db_init_status (expected: exited)"
         fail=$((fail + 1))
     fi
+
+    # Test 5: ClickHouse schema currency (stale clickhouse-init detection).
+    # '|| sc=$?' keeps the non-zero return from aborting under set -e and lets
+    # check_clickhouse_schema print its own [PASS]/[FAIL] line to the terminal.
+    local sc=0
+    check_clickhouse_schema || sc=$?
+    case "$sc" in
+        0) pass=$((pass + 1)) ;;
+        2) log "  [SKIP] ClickHouse schema check (clickhouse not in this profile)" ;;
+        *) fail=$((fail + 1)) ;;
+    esac
 
     log ""
     log "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary

A stale `clickhouse-init` image — one whose baked DDL is *behind* the source — leaves `flows_raw` missing columns that the flows dashboards/queries reference. This is a **silent** failure: nothing fails at deploy time, queries just error later. It's exactly how a retagged-old `clickhouse-init` produced a `flows_raw` without `exporter_node_label` / `input_if_name` / `exporter_node_categories` during recent validation.

This adds a **schema-drift preflight** that turns that silent failure into a loud one, and fixes a pre-existing false-failure in the same verify path.

## Changes (`deploy.sh`, one file)

**New `Test 5` in `do_test` (= `make verify`):**
- Parses the columns **expected** for `flows_raw` from `clickhouse/init/02-flows-raw.sql` — the `CREATE TABLE` block **plus** every `ADD COLUMN IF NOT EXISTS` migration.
- Queries the **live** `system.columns` for `deltav.flows_raw`.
- Any expected column missing from live → loud `[FAIL]` listing the missing columns + the remediation and a **non-zero exit**:
  ```
  [FAIL] ClickHouse schema is BEHIND source DDL — deltav.flows_raw is missing columns:
             input_if_name
         The clickhouse-init image is stale (baked DDL predates these columns).
         Rebuild it from source and recreate the sidecar:
           make images && docker compose up -d --force-recreate clickhouse-init
  ```
- **Skips cleanly** (`[SKIP]`, not a failure) when `clickhouse` isn't in the active profile (e.g. `passive`).
- Set-`-e`-safe: invoked as `check_clickhouse_schema || sc=$?` so a non-zero return reports a fail instead of aborting the whole verify.

**Why `make verify`, not `make doctor`:** `doctor` is a *pre-build* environment check (JDK/Docker/images) and runs before the stack exists; the schema check needs a *running* ClickHouse, which is what the post-up `verify` path has.

**Fix `Test 3` (incidental but necessary):** the Kafka-topic check grep'd for `"opennms"`, but delta-v renamed every topic to `deltav-*` / `DeltaV.*` — so `make verify` reported a **permanent false failure** that would have masked the new schema check (and trained people to ignore "1 failed"). Now matches `deltav[.-]`.

## How this closes the gap

`make images` already rebuilds `clickhouse-init` from source, and its `init-runner.sh` re-applies idempotent `ADD COLUMN IF NOT EXISTS` DDL on every start — so `git pull && make images && make up && make verify` lands and *confirms* current schema. The remaining hole was that bare `make up`/`deploy.sh up` only checks an image *exists*, not that it's *current* — a stale same-tagged image is reused silently. This check catches that regardless of cause (stale image, stale volume, skipped rebuild) by verifying the **outcome** (live columns), not the process.

## Test plan

- [x] `bash -n deploy.sh` clean
- [x] Live stack, schema current → `[PASS] ClickHouse schema current`; **5 passed, 0 failed**, exit 0
- [x] Drop `input_if_name` → `[FAIL]` names the column + remediation, **exit 1**; re-add → PASS
- [x] Kafka check now `[PASS]` against real `deltav-*`/`DeltaV.*` topics
- [ ] (Next deploy) confirm `[SKIP]` path on a `passive` profile (no clickhouse)
