### PR TITLE
feat(flow-enricher): configurable Netty DNS reverse-resolution (on by default)

### DIFF
--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -241,6 +241,13 @@
             </exclusions>
         </dependency>
 
+        <!-- Horizon: Netty DNS resolver (configurable async reverse-DNS enrichment) -->
+        <dependency>
+            <groupId>org.opennms.features.dnsresolver</groupId>
+            <artifactId>org.opennms.features.dnsresolver.netty</artifactId>
+            <version>1.0.11</version>
+        </dependency>
+
         <!-- Horizon: Events API (EventForwarder interface required by Netflow parsers). -->
         <dependency>
             <groupId>org.opennms.features.events</groupId>

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -246,6 +246,14 @@
             <groupId>org.opennms.features.dnsresolver</groupId>
             <artifactId>org.opennms.features.dnsresolver.netty</artifactId>
             <version>1.0.11</version>
+            <exclusions>
+                <!-- opennms-model transitively pulls spring-dependencies (ServiceMix Spring 4.2.9)
+                     which shadows Spring 7 on the classpath and breaks Spring Boot 4 binder. -->
+                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
+                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
+                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Horizon: Events API (EventForwarder interface required by Netflow parsers). -->

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -245,6 +245,11 @@
         <dependency>
             <groupId>org.opennms.features.dnsresolver</groupId>
             <artifactId>org.opennms.features.dnsresolver.netty</artifactId>
+            <!-- Deliberate pin: the delta-v-horizon NETTY module is only published up to
+                 1.0.11 (the dnsresolver.api module continued to 1.0.18, but its DnsResolver
+                 interface is byte-identical, so 1.0.11 impl + 1.0.18 api is safe). Do NOT
+                 change this to ${deltav.horizon.version} / 1.0.18 — that artifact is not in
+                 delta-v-horizon GH Packages and CI will fail to resolve it. -->
             <version>1.0.11</version>
             <exclusions>
                 <!-- opennms-model transitively pulls spring-dependencies (ServiceMix Spring 4.2.9)

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -241,24 +241,20 @@
             </exclusions>
         </dependency>
 
-        <!-- Horizon: Netty DNS resolver (configurable async reverse-DNS enrichment) -->
+        <!-- Native reverse-DNS: Netty async DNS client + resilience4j 2.x guards (Caffeine already present). -->
         <dependency>
-            <groupId>org.opennms.features.dnsresolver</groupId>
-            <artifactId>org.opennms.features.dnsresolver.netty</artifactId>
-            <!-- Deliberate pin: the delta-v-horizon NETTY module is only published up to
-                 1.0.11 (the dnsresolver.api module continued to 1.0.18, but its DnsResolver
-                 interface is byte-identical, so 1.0.11 impl + 1.0.18 api is safe). Do NOT
-                 change this to ${deltav.horizon.version} / 1.0.18 — that artifact is not in
-                 delta-v-horizon GH Packages and CI will fail to resolve it. -->
-            <version>1.0.11</version>
-            <exclusions>
-                <!-- opennms-model transitively pulls spring-dependencies (ServiceMix Spring 4.2.9)
-                     which shadows Spring 7 on the classpath and breaks Spring Boot 4 binder. -->
-                <exclusion><groupId>org.opennms</groupId><artifactId>opennms-model</artifactId></exclusion>
-                <exclusion><groupId>org.opennms.dependencies</groupId><artifactId>spring-dependencies</artifactId></exclusion>
-                <exclusion><groupId>org.apache.servicemix.bundles</groupId><artifactId>*</artifactId></exclusion>
-                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId></exclusion>
-            </exclusions>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-bulkhead</artifactId>
+            <version>2.3.0</version>
         </dependency>
 
         <!-- Horizon: Events API (EventForwarder interface required by Netflow parsers). -->

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -49,8 +49,8 @@ import org.deltav.flows.enricher.protocol.Netflow9MessageProcessor;
 import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
 import org.deltav.flows.enricher.protocol.SFlowMessageProcessor;
 import org.deltav.flows.enricher.protocol.SimpleAdapterDefinition;
+import org.deltav.flows.enricher.parser.DeltavNettyDnsResolver;
 import org.opennms.netmgt.dnsresolver.api.DnsResolver;
-import org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.telemetry.listeners.UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser;
@@ -241,35 +241,20 @@ public class FlowEnricherConfiguration {
     }
 
     /**
-     * Lifecycle-managed horizon {@link NettyDnsResolver}, built only when
-     * reverse-DNS is enabled. Configured from {@link FlowEnricherDnsProperties};
-     * obscure knobs stay at horizon defaults. {@code init()}/{@code destroy()}
-     * build and tear down the Netty event loops + Caffeine cache + breaker.
+     * Lifecycle-managed delta-v-native {@link DeltavNettyDnsResolver}, built only
+     * when reverse-DNS is enabled. Configured from {@link FlowEnricherDnsProperties}.
+     * {@code init()} builds the Netty event loop, DNS resolver, resilience4j guards,
+     * and Caffeine cache; {@code close()} tears them down.
      */
-    @Bean(initMethod = "init", destroyMethod = "destroy")
+    @Bean(initMethod = "init", destroyMethod = "close")
     @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "true", matchIfMissing = true)
-    NettyDnsResolver nettyDnsResolver(
-            EventForwarder flowParserEventForwarder,
-            MetricRegistry flowEnricherMetricRegistry,
-            FlowEnricherDnsProperties dnsProperties) {
-        final NettyDnsResolver resolver = new NettyDnsResolver(flowParserEventForwarder, flowEnricherMetricRegistry);
-        if (!dnsProperties.nameservers().isBlank()) {
-            resolver.setNameservers(dnsProperties.nameservers());
-        }
-        resolver.setQueryTimeoutMillis(dnsProperties.queryTimeoutMs());
-        resolver.setBulkheadMaxConcurrentCalls(dnsProperties.maxConcurrent());
-        resolver.setBulkheadMaxWaitDurationMillis(dnsProperties.queryTimeoutMs() + 100);
-        resolver.setMinTtlSeconds(dnsProperties.cache().minTtlS());
-        resolver.setMaxTtlSeconds(dnsProperties.cache().maxTtlS());
-        resolver.setNegativeTtlSeconds(dnsProperties.cache().negativeTtlS());
-        resolver.setBreakerEnabled(dnsProperties.circuitBreaker().enabled());
-        resolver.setBreakerFailureRateThreshold(dnsProperties.circuitBreaker().failureRateThreshold());
-        return resolver;
+    DeltavNettyDnsResolver deltavNettyDnsResolver(FlowEnricherDnsProperties dnsProperties) {
+        return new DeltavNettyDnsResolver(dnsProperties);
     }
 
     /**
      * The {@link DnsResolver} injected into all four flow parsers. When DNS is
-     * enabled (default), it is the {@link NettyDnsResolver} wrapped in a
+     * enabled (default), it is the {@link DeltavNettyDnsResolver} wrapped in a
      * {@link LocalityFilteringDnsResolver} (scope gate). Both conditional beans
      * below are named {@code flowParserDnsResolver}; the conditions are mutually
      * exclusive, so exactly one exists and the parsers' by-name injection works
@@ -278,11 +263,11 @@ public class FlowEnricherConfiguration {
     @Bean("flowParserDnsResolver")
     @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "true", matchIfMissing = true)
     DnsResolver flowParserDnsResolver(
-            NettyDnsResolver nettyDnsResolver,
+            DeltavNettyDnsResolver deltavNettyDnsResolver,
             FlowEnricherDnsProperties dnsProperties,
             MeterRegistry meterRegistry) {
         final boolean privateOnly = dnsProperties.scope() == FlowEnricherDnsProperties.Scope.PRIVATE;
-        return new LocalityFilteringDnsResolver(nettyDnsResolver, privateOnly, meterRegistry);
+        return new LocalityFilteringDnsResolver(deltavNettyDnsResolver, privateOnly, meterRegistry);
     }
 
     /** No-op resolver used only when reverse-DNS is explicitly disabled. */

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
@@ -35,7 +35,10 @@ import org.deltav.flows.enricher.enrichment.FlowLocalityCalculator;
 import org.deltav.flows.enricher.enrichment.InterfaceMarkingCache;
 import org.deltav.flows.enricher.mapping.FlowToDocumentMapper;
 import org.deltav.nodecontext.NodeContextCache;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.deltav.flows.enricher.parser.DropwizardToPrometheusBridge;
+import org.deltav.flows.enricher.parser.FlowEnricherDnsProperties;
+import org.deltav.flows.enricher.parser.LocalityFilteringDnsResolver;
 import org.deltav.flows.enricher.parser.LoggingEventForwarder;
 import org.deltav.flows.enricher.parser.NoOpDnsResolver;
 import org.deltav.flows.enricher.parser.StaticIdentity;
@@ -47,6 +50,7 @@ import org.deltav.flows.enricher.protocol.ProtocolMessageProcessor;
 import org.deltav.flows.enricher.protocol.SFlowMessageProcessor;
 import org.deltav.flows.enricher.protocol.SimpleAdapterDefinition;
 import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+import org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.telemetry.listeners.UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser;
@@ -57,6 +61,8 @@ import org.opennms.netmgt.telemetry.protocols.sflow.parser.SFlowUdpParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -69,6 +75,7 @@ import org.springframework.scheduling.annotation.Scheduled;
  * delta-v project convention.
  */
 @Configuration
+@EnableConfigurationProperties(FlowEnricherDnsProperties.class)
 public class FlowEnricherConfiguration {
 
     @Bean
@@ -234,16 +241,54 @@ public class FlowEnricherConfiguration {
     }
 
     /**
-     * No-op {@link DnsResolver} used by horizon parsers for reverse-DNS
-     * enrichment. Node context lookups are handled by the shared
-     * {@link NodeContextCache} (populated by the node-context-consumer
-     * module); the {@link javax.sql.DataSource} and {@link JdbcTemplate}
-     * beans in this configuration exist solely for the hasflows WRITE
-     * performed by {@link InterfaceMarkingCache}. We do not want the
-     * parsers to issue async DNS queries.
+     * Lifecycle-managed horizon {@link NettyDnsResolver}, built only when
+     * reverse-DNS is enabled. Configured from {@link FlowEnricherDnsProperties};
+     * obscure knobs stay at horizon defaults. {@code init()}/{@code destroy()}
+     * build and tear down the Netty event loops + Caffeine cache + breaker.
      */
-    @Bean
-    DnsResolver flowParserDnsResolver() {
+    @Bean(initMethod = "init", destroyMethod = "destroy")
+    @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "true", matchIfMissing = true)
+    NettyDnsResolver nettyDnsResolver(
+            EventForwarder flowParserEventForwarder,
+            MetricRegistry flowEnricherMetricRegistry,
+            FlowEnricherDnsProperties dnsProperties) {
+        final NettyDnsResolver resolver = new NettyDnsResolver(flowParserEventForwarder, flowEnricherMetricRegistry);
+        if (!dnsProperties.nameservers().isBlank()) {
+            resolver.setNameservers(dnsProperties.nameservers());
+        }
+        resolver.setQueryTimeoutMillis(dnsProperties.queryTimeoutMs());
+        resolver.setBulkheadMaxConcurrentCalls(dnsProperties.maxConcurrent());
+        resolver.setBulkheadMaxWaitDurationMillis(dnsProperties.queryTimeoutMs() + 100);
+        resolver.setMinTtlSeconds(dnsProperties.cache().minTtlS());
+        resolver.setMaxTtlSeconds(dnsProperties.cache().maxTtlS());
+        resolver.setNegativeTtlSeconds(dnsProperties.cache().negativeTtlS());
+        resolver.setBreakerEnabled(dnsProperties.circuitBreaker().enabled());
+        resolver.setBreakerFailureRateThreshold(dnsProperties.circuitBreaker().failureRateThreshold());
+        return resolver;
+    }
+
+    /**
+     * The {@link DnsResolver} injected into all four flow parsers. When DNS is
+     * enabled (default), it is the {@link NettyDnsResolver} wrapped in a
+     * {@link LocalityFilteringDnsResolver} (scope gate). Both conditional beans
+     * below are named {@code flowParserDnsResolver}; the conditions are mutually
+     * exclusive, so exactly one exists and the parsers' by-name injection works
+     * unchanged.
+     */
+    @Bean("flowParserDnsResolver")
+    @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "true", matchIfMissing = true)
+    DnsResolver flowParserDnsResolver(
+            NettyDnsResolver nettyDnsResolver,
+            FlowEnricherDnsProperties dnsProperties,
+            MeterRegistry meterRegistry) {
+        final boolean privateOnly = dnsProperties.scope() == FlowEnricherDnsProperties.Scope.PRIVATE;
+        return new LocalityFilteringDnsResolver(nettyDnsResolver, privateOnly, meterRegistry);
+    }
+
+    /** No-op resolver used only when reverse-DNS is explicitly disabled. */
+    @Bean("flowParserDnsResolver")
+    @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "false")
+    DnsResolver noOpFlowParserDnsResolver() {
         return new NoOpDnsResolver();
     }
 
@@ -329,16 +374,16 @@ public class FlowEnricherConfiguration {
     @Bean
     SFlowUdpParser sflowUdpParser(
             ThreadLocalDispatcher threadLocalDispatcher,
-            DnsResolver flowParserDnsResolver) {
+            DnsResolver flowParserDnsResolver,
+            FlowEnricherDnsProperties dnsProperties) {
         final SFlowUdpParser parser = new SFlowUdpParser(
                 "SFlow",
                 threadLocalDispatcher,
                 flowParserDnsResolver);
-        // Defensive: disable reverse-DNS lookups on the sFlow parser.
-        // PR #156 fixed a horizon SFlowUdpParser NPE where unresolvable
-        // Docker-bridge IPs tripped a DNS code path inside the parser; the
-        // short-circuit here keeps that latent path unreachable.
-        parser.setDnsLookupsEnabled(false);
+        // Mirror the global DNS toggle on the sFlow parser. When DNS is disabled
+        // the NoOp resolver is injected and this flag ensures the parser itself
+        // also short-circuits any internal DNS code path (PR #156 defence).
+        parser.setDnsLookupsEnabled(dnsProperties.enabled());
         return parser;
     }
 

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/DeltavNettyDnsResolver.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/DeltavNettyDnsResolver.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.flows.enricher.parser;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.codec.dns.DefaultDnsQuestion;
+import io.netty.handler.codec.dns.DefaultDnsRecordDecoder;
+import io.netty.handler.codec.dns.DnsPtrRecord;
+import io.netty.handler.codec.dns.DnsRawRecord;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsSection;
+import io.netty.resolver.dns.DnsNameResolver;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.SequentialDnsServerAddressStreamProvider;
+import io.netty.util.ReferenceCountUtil;
+import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Delta-V-native async reverse-DNS resolver backed by Netty 4.2 and
+ * resilience4j 2.x.  Replaces the horizon {@code NettyDnsResolver} (which
+ * is compiled against resilience4j 1.x and uses the removed
+ * {@code ringBufferSizeInHalfOpenState/Closed} API).
+ *
+ * <p>Configuration is driven entirely by {@link FlowEnricherDnsProperties}.
+ * Call {@link #init()} once before use and {@link #close()} on shutdown.
+ */
+public class DeltavNettyDnsResolver implements DnsResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeltavNettyDnsResolver.class);
+
+    private final FlowEnricherDnsProperties props;
+
+    // Initialised in init(); all fields final after that point.
+    private volatile MultiThreadIoEventLoopGroup group;
+    private volatile DnsNameResolver resolver;
+    private volatile CircuitBreaker breaker;    // null when circuitBreaker.enabled() == false
+    private volatile Bulkhead bulkhead;
+    private volatile Cache<InetAddress, Optional<String>> reverseCache;
+
+    public DeltavNettyDnsResolver(FlowEnricherDnsProperties props) {
+        this.props = props;
+    }
+
+    /**
+     * Builds the Netty event-loop group, DNS resolver, resilience4j guards,
+     * and Caffeine cache.  Called by Spring via {@code initMethod = "init"}.
+     */
+    public void init() {
+        group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+
+        DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
+                .datagramChannelType(NioDatagramChannel.class)
+                .queryTimeoutMillis(props.queryTimeoutMs());
+
+        if (!props.nameservers().isBlank()) {
+            List<InetSocketAddress> servers = parseNameservers(props.nameservers());
+            builder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(servers));
+        }
+
+        resolver = builder.build();
+
+        if (props.circuitBreaker().enabled()) {
+            CircuitBreakerConfig breakerConfig = CircuitBreakerConfig.custom()
+                    .slidingWindowSize(100)
+                    .minimumNumberOfCalls(10)
+                    .failureRateThreshold(props.circuitBreaker().failureRateThreshold())
+                    .waitDurationInOpenState(Duration.ofSeconds(15))
+                    .permittedNumberOfCallsInHalfOpenState(10)
+                    .build();
+            breaker = CircuitBreaker.of("deltav-dns", breakerConfig);
+        }
+
+        BulkheadConfig bulkheadConfig = BulkheadConfig.custom()
+                .maxConcurrentCalls(props.maxConcurrent())
+                .maxWaitDuration(Duration.ofMillis(props.queryTimeoutMs() + 100))
+                .build();
+        bulkhead = Bulkhead.of("deltav-dns", bulkheadConfig);
+
+        long effectiveMaxTtl = props.cache().maxTtlS() > 0 ? props.cache().maxTtlS() : 3600L;
+        reverseCache = Caffeine.newBuilder()
+                .maximumSize(10_000)
+                .expireAfterWrite(Duration.ofSeconds(effectiveMaxTtl))
+                .build();
+
+        LOG.info("DeltavNettyDnsResolver initialised: nameservers='{}', queryTimeoutMs={}, maxConcurrent={}, " +
+                        "circuitBreakerEnabled={}, cacheTtlS={}",
+                props.nameservers().isBlank() ? "<platform default>" : props.nameservers(),
+                props.queryTimeoutMs(),
+                props.maxConcurrent(),
+                props.circuitBreaker().enabled(),
+                effectiveMaxTtl);
+    }
+
+    /**
+     * Shuts down the Netty resolver and event-loop group gracefully.
+     * Called by Spring via {@code destroyMethod = "close"}.
+     */
+    public void close() {
+        if (resolver != null) {
+            resolver.close();
+        }
+        if (group != null) {
+            group.shutdownGracefully();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // DnsResolver contract
+    // -----------------------------------------------------------------------
+
+    @Override
+    public CompletableFuture<Optional<String>> reverseLookup(InetAddress addr) {
+        // Cache hit — short-circuit before acquiring any permits.
+        Optional<String> hit = reverseCache.getIfPresent(addr);
+        if (hit != null) {
+            return CompletableFuture.completedFuture(hit);
+        }
+
+        // Circuit-breaker gate.
+        boolean breakerAcquired = false;
+        if (breaker != null) {
+            if (!breaker.tryAcquirePermission()) {
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+            breakerAcquired = true;
+        }
+
+        // Bulkhead gate.
+        if (!bulkhead.tryAcquirePermission()) {
+            if (breakerAcquired) {
+                breaker.releasePermission();
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        final boolean breakerPermitHeld = breakerAcquired;
+        final String ptrName = reversePointer(addr);
+        final long startNanos = System.nanoTime();
+        final CompletableFuture<Optional<String>> future = new CompletableFuture<>();
+
+        io.netty.util.concurrent.Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> queryFuture =
+                resolver.query(new DefaultDnsQuestion(ptrName, DnsRecordType.PTR));
+
+        queryFuture.addListener(nettyFuture -> {
+            try {
+                if (nettyFuture.isSuccess()) {
+                    @SuppressWarnings("unchecked")
+                    AddressedEnvelope<DnsResponse, InetSocketAddress> envelope =
+                            (AddressedEnvelope<DnsResponse, InetSocketAddress>) nettyFuture.getNow();
+                    DnsResponse response = envelope.content();
+                    try {
+                        Optional<String> result = extractPtrName(response);
+                        long elapsedNanos = System.nanoTime() - startNanos;
+                        if (breakerPermitHeld) {
+                            breaker.onSuccess(elapsedNanos, TimeUnit.NANOSECONDS);
+                        }
+                        bulkhead.onComplete();
+                        reverseCache.put(addr, result);
+                        future.complete(result);
+                    } finally {
+                        ReferenceCountUtil.release(response);
+                    }
+                } else {
+                    long elapsedNanos = System.nanoTime() - startNanos;
+                    Throwable cause = nettyFuture.cause();
+                    if (breakerPermitHeld) {
+                        breaker.onError(elapsedNanos, TimeUnit.NANOSECONDS, cause);
+                    }
+                    bulkhead.onComplete();
+                    reverseCache.put(addr, Optional.empty());
+                    future.complete(Optional.empty());
+                }
+            } catch (Exception ex) {
+                LOG.debug("Unexpected error processing DNS response for {}", ptrName, ex);
+                long elapsedNanos = System.nanoTime() - startNanos;
+                if (breakerPermitHeld) {
+                    breaker.onError(elapsedNanos, TimeUnit.NANOSECONDS, ex);
+                }
+                bulkhead.onComplete();
+                future.complete(Optional.empty());
+            }
+        });
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Optional<InetAddress>> lookup(String hostname) {
+        CompletableFuture<Optional<InetAddress>> future = new CompletableFuture<>();
+        resolver.resolve(hostname).addListener(nettyFuture -> {
+            try {
+                if (nettyFuture.isSuccess()) {
+                    future.complete(Optional.ofNullable((InetAddress) nettyFuture.getNow()));
+                } else {
+                    future.complete(Optional.empty());
+                }
+            } catch (Exception ex) {
+                future.complete(Optional.empty());
+            }
+        });
+        return future;
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers — package-private to allow unit testing without init()
+    // -----------------------------------------------------------------------
+
+    /**
+     * Builds the reverse-pointer DNS name for {@code addr}.
+     *
+     * <ul>
+     *   <li>IPv4 (including IPv4-mapped IPv6 {@code ::ffff:a.b.c.d}) →
+     *       {@code d.c.b.a.in-addr.arpa}</li>
+     *   <li>IPv6 → reversed nibble form ending in {@code .ip6.arpa}</li>
+     * </ul>
+     */
+    static String reversePointer(InetAddress addr) {
+        byte[] raw = addr.getAddress();
+
+        // Unwrap IPv4-mapped IPv6 (::ffff:0:0/96 — 16-byte address whose first
+        // 10 bytes are 0x00 and bytes 10-11 are 0xff 0xff).
+        if (raw.length == 16 && isIpv4Mapped(raw)) {
+            byte[] ipv4 = new byte[]{raw[12], raw[13], raw[14], raw[15]};
+            try {
+                InetAddress ipv4Addr = InetAddress.getByAddress(ipv4);
+                return buildIpv4Arpa(ipv4Addr.getAddress());
+            } catch (UnknownHostException ex) {
+                // Unreachable — 4-byte array is always valid.
+                return buildIpv4Arpa(ipv4);
+            }
+        }
+
+        if (raw.length == 4 || addr instanceof Inet4Address) {
+            return buildIpv4Arpa(raw);
+        }
+
+        // 16-byte IPv6
+        return buildIpv6Arpa(raw);
+    }
+
+    private static boolean isIpv4Mapped(byte[] raw) {
+        // First 10 bytes must be 0x00, bytes 10-11 must be 0xff.
+        for (int i = 0; i < 10; i++) {
+            if (raw[i] != 0) {
+                return false;
+            }
+        }
+        return raw[10] == (byte) 0xff && raw[11] == (byte) 0xff;
+    }
+
+    private static String buildIpv4Arpa(byte[] raw) {
+        // Reverse the four octets: d.c.b.a.in-addr.arpa
+        return (raw[3] & 0xff) + "." +
+               (raw[2] & 0xff) + "." +
+               (raw[1] & 0xff) + "." +
+               (raw[0] & 0xff) + ".in-addr.arpa";
+    }
+
+    private static String buildIpv6Arpa(byte[] raw) {
+        // Each byte produces two hex nibbles; reverse all 32 nibbles.
+        StringBuilder sb = new StringBuilder(64);
+        for (int i = 15; i >= 0; i--) {
+            int octet = raw[i] & 0xff;
+            sb.append(Character.forDigit(octet & 0x0f, 16));
+            sb.append('.');
+            sb.append(Character.forDigit((octet >> 4) & 0x0f, 16));
+            sb.append('.');
+        }
+        sb.append("ip6.arpa");
+        return sb.toString();
+    }
+
+    /**
+     * Extracts the first PTR answer from a DNS response.
+     * Returns {@link Optional#empty()} when no PTR answer is present.
+     */
+    private static Optional<String> extractPtrName(DnsResponse response) {
+        int count = response.count(DnsSection.ANSWER);
+        for (int i = 0; i < count; i++) {
+            DnsRecord record = response.recordAt(DnsSection.ANSWER, i);
+            if (record.type() != DnsRecordType.PTR) {
+                continue;
+            }
+            try {
+                String name = decodePtrRecord(record);
+                if (name != null && !name.isEmpty()) {
+                    // Strip a single trailing dot (fully-qualified DNS name).
+                    if (name.endsWith(".")) {
+                        name = name.substring(0, name.length() - 1);
+                    }
+                    return Optional.of(name);
+                }
+            } catch (Exception ex) {
+                LOG.debug("Failed to decode PTR record: {}", record, ex);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Decodes a PTR record to its target hostname string.  Netty's resolver
+     * returns already-decoded {@link DnsPtrRecord} objects; raw records are
+     * handled as a fallback via {@link DefaultDnsRecordDecoder#decodeName}.
+     */
+    private static String decodePtrRecord(DnsRecord record) {
+        if (record instanceof DnsPtrRecord ptrRecord) {
+            return ptrRecord.hostname();
+        }
+        if (record instanceof DnsRawRecord rawRecord) {
+            return DefaultDnsRecordDecoder.decodeName(rawRecord.content().duplicate());
+        }
+        return null;
+    }
+
+    /**
+     * Parses a comma-separated list of {@code host[:port]} nameserver entries
+     * into {@link InetSocketAddress} instances.  The default DNS port (53) is
+     * used when no port is specified.
+     */
+    private static List<InetSocketAddress> parseNameservers(String nameservers) {
+        List<InetSocketAddress> result = new ArrayList<>();
+        for (String entry : nameservers.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            // Handle IPv6 literals: "[::1]:5353" or "::1" (port defaults to 53).
+            if (trimmed.startsWith("[")) {
+                int closeBracket = trimmed.indexOf(']');
+                if (closeBracket > 0) {
+                    String host = trimmed.substring(1, closeBracket);
+                    int port = 53;
+                    if (closeBracket + 1 < trimmed.length() && trimmed.charAt(closeBracket + 1) == ':') {
+                        port = Integer.parseInt(trimmed.substring(closeBracket + 2));
+                    }
+                    result.add(new InetSocketAddress(host, port));
+                }
+            } else {
+                // IPv4 or plain hostname, optionally "host:port"
+                int colonCount = trimmed.length() - trimmed.replace(":", "").length();
+                if (colonCount == 1) {
+                    int colon = trimmed.lastIndexOf(':');
+                    String host = trimmed.substring(0, colon);
+                    int port = Integer.parseInt(trimmed.substring(colon + 1));
+                    result.add(new InetSocketAddress(host, port));
+                } else {
+                    result.add(new InetSocketAddress(trimmed, 53));
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/FlowEnricherDnsProperties.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/FlowEnricherDnsProperties.java
@@ -1,0 +1,36 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Curated, daemon-scoped tuning for the flow-enricher's reverse-DNS enrichment.
+ * Defaults mirror horizon's {@code NettyDnsResolver} field defaults. The obscure
+ * NettyDnsResolver knobs (numContexts, ring buffers, breaker wait, bulkhead
+ * max-wait) are intentionally NOT exposed and stay at their horizon defaults;
+ * {@code bulkheadMaxWaitDurationMillis} is derived as {@code queryTimeoutMs + 100}
+ * at wiring time to preserve horizon's relationship.
+ */
+@ConfigurationProperties("deltav.flows.dns")
+public record FlowEnricherDnsProperties(
+        @DefaultValue("true") boolean enabled,
+        @DefaultValue("all") Scope scope,
+        @DefaultValue("") String nameservers,
+        @DefaultValue("5000") long queryTimeoutMs,
+        @DefaultValue("1000") int maxConcurrent,
+        @DefaultValue Cache cache,
+        @DefaultValue CircuitBreaker circuitBreaker) {
+
+    /** Which addresses the locality gate allows through to the resolver. */
+    public enum Scope { ALL, PRIVATE }
+
+    public record Cache(
+            @DefaultValue("-1") int minTtlS,
+            @DefaultValue("-1") int maxTtlS,
+            @DefaultValue("-1") int negativeTtlS) {}
+
+    public record CircuitBreaker(
+            @DefaultValue("true") boolean enabled,
+            @DefaultValue("80") int failureRateThreshold) {}
+}

--- a/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolver.java
+++ b/core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolver.java
@@ -1,0 +1,91 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+
+/**
+ * A {@link DnsResolver} decorator that, when {@code privateOnly} is set,
+ * only reverse-resolves IPs in private/local ranges (RFC1918, IPv6 ULA,
+ * loopback, link-local) and short-circuits everything else to an empty
+ * result — bounding reverse-DNS cardinality to the operator's own address
+ * space. When {@code privateOnly} is false, every address is delegated
+ * (Horizon-equivalent behaviour).
+ *
+ * <p>Flow addresses arrive as IPv6 (the ClickHouse {@code flows_raw.*_address}
+ * columns are IPv6), so a private IPv4 can reach us as an IPv4-mapped
+ * {@code Inet6Address} (e.g. {@code ::ffff:10.0.0.1}). {@link InetAddress}'s
+ * {@code isSiteLocalAddress()} checks the IPv6 prefix and would mis-classify
+ * such an address as public; we therefore normalize IPv4-mapped IPv6 to the
+ * embedded IPv4 before testing.
+ */
+public class LocalityFilteringDnsResolver implements DnsResolver {
+
+    private static final String METRIC = "deltav_dns_reverse_lookups_total";
+
+    private final DnsResolver delegate;
+    private final boolean privateOnly;
+    private final MeterRegistry registry;
+
+    public LocalityFilteringDnsResolver(DnsResolver delegate, boolean privateOnly, MeterRegistry registry) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.privateOnly = privateOnly;
+        this.registry = Objects.requireNonNull(registry);
+    }
+
+    @Override
+    public CompletableFuture<Optional<InetAddress>> lookup(String hostname) {
+        return delegate.lookup(hostname);
+    }
+
+    @Override
+    public CompletableFuture<Optional<String>> reverseLookup(InetAddress address) {
+        if (privateOnly && !isPrivate(address)) {
+            registry.counter(METRIC, "result", "filtered").increment();
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return delegate.reverseLookup(address).whenComplete((result, ex) -> {
+            final String tag = ex != null ? "error" : (result != null && result.isPresent() ? "hit" : "miss");
+            registry.counter(METRIC, "result", tag).increment();
+        });
+    }
+
+    static boolean isPrivate(InetAddress address) {
+        final InetAddress a = normalizeMapped(address);
+        if (a.isSiteLocalAddress() || a.isLoopbackAddress() || a.isLinkLocalAddress()) {
+            return true;
+        }
+        final byte[] b = a.getAddress();
+        // IPv6 Unique Local Address fc00::/7 (Java has no isUniqueLocalAddress()).
+        return b.length == 16 && (b[0] & 0xFE) == 0xFC;
+    }
+
+    /** Unwrap an IPv4-mapped IPv6 address (::ffff:a.b.c.d) to its embedded Inet4Address. */
+    static InetAddress normalizeMapped(InetAddress address) {
+        final byte[] b = address.getAddress();
+        if (b.length == 16 && isV4Mapped(b)) {
+            try {
+                return InetAddress.getByAddress(Arrays.copyOfRange(b, 12, 16));
+            } catch (UnknownHostException e) {
+                return address; // 4-byte array is always valid; unreachable in practice
+            }
+        }
+        return address;
+    }
+
+    private static boolean isV4Mapped(byte[] b) {
+        for (int i = 0; i < 10; i++) {
+            if (b[i] != 0) {
+                return false;
+            }
+        }
+        return b[10] == (byte) 0xff && b[11] == (byte) 0xff;
+    }
+}

--- a/core/flow-enricher/src/main/resources/application.yml
+++ b/core/flow-enricher/src/main/resources/application.yml
@@ -63,6 +63,23 @@ deltav:
     parser:
       system-id: flow-enricher
       location: Default
+    # Reverse-DNS enrichment of flow IPs (src/dst/etc -> *_hostname). ON by default
+    # (Horizon parity). Backed by horizon's NettyDnsResolver (circuit breaker +
+    # bulkhead + TTL cache + timeout). For high-cardinality internet-facing flows,
+    # set scope=private or lower query-timeout-ms, or disable entirely.
+    dns:
+      enabled: ${DELTAV_FLOWS_DNS_ENABLED:true}
+      scope: ${DELTAV_FLOWS_DNS_SCOPE:all}            # all | private
+      nameservers: ${DELTAV_FLOWS_DNS_NAMESERVERS:}   # blank = system resolv.conf
+      query-timeout-ms: ${DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS:5000}
+      max-concurrent: ${DELTAV_FLOWS_DNS_MAX_CONCURRENT:1000}
+      cache:
+        min-ttl-s: ${DELTAV_FLOWS_DNS_CACHE_MIN_TTL_S:-1}
+        max-ttl-s: ${DELTAV_FLOWS_DNS_CACHE_MAX_TTL_S:-1}
+        negative-ttl-s: ${DELTAV_FLOWS_DNS_CACHE_NEGATIVE_TTL_S:-1}
+      circuit-breaker:
+        enabled: ${DELTAV_FLOWS_DNS_BREAKER_ENABLED:true}
+        failure-rate-threshold: ${DELTAV_FLOWS_DNS_BREAKER_FAILURE_RATE:80}
 
 logging:
   level:

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnricherDnsWiringTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnricherDnsWiringTest.java
@@ -1,0 +1,39 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.flows.enricher.parser.FlowEnricherDnsProperties;
+import org.deltav.flows.enricher.parser.LocalityFilteringDnsResolver;
+import org.deltav.flows.enricher.parser.NoOpDnsResolver;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+import org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver;
+
+class FlowEnricherDnsWiringTest {
+
+    private final FlowEnricherConfiguration cfg = new FlowEnricherConfiguration();
+
+    private static FlowEnricherDnsProperties props(boolean enabled, FlowEnricherDnsProperties.Scope scope) {
+        return new FlowEnricherDnsProperties(enabled, scope, "", 5000L, 1000,
+                new FlowEnricherDnsProperties.Cache(-1, -1, -1),
+                new FlowEnricherDnsProperties.CircuitBreaker(true, 80));
+    }
+
+    @Test
+    void enabledYieldsLocalityFilteringDecorator() {
+        DnsResolver r = cfg.flowParserDnsResolver(
+                mock(NettyDnsResolver.class),
+                props(true, FlowEnricherDnsProperties.Scope.ALL),
+                new SimpleMeterRegistry());
+        assertThat(r).isInstanceOf(LocalityFilteringDnsResolver.class);
+    }
+
+    @Test
+    void disabledYieldsNoOpResolver() {
+        DnsResolver r = cfg.noOpFlowParserDnsResolver();
+        assertThat(r).isInstanceOf(NoOpDnsResolver.class);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnricherDnsWiringTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/FlowEnricherDnsWiringTest.java
@@ -5,12 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.flows.enricher.parser.DeltavNettyDnsResolver;
 import org.deltav.flows.enricher.parser.FlowEnricherDnsProperties;
 import org.deltav.flows.enricher.parser.LocalityFilteringDnsResolver;
 import org.deltav.flows.enricher.parser.NoOpDnsResolver;
 import org.junit.jupiter.api.Test;
 import org.opennms.netmgt.dnsresolver.api.DnsResolver;
-import org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver;
 
 class FlowEnricherDnsWiringTest {
 
@@ -25,7 +25,7 @@ class FlowEnricherDnsWiringTest {
     @Test
     void enabledYieldsLocalityFilteringDecorator() {
         DnsResolver r = cfg.flowParserDnsResolver(
-                mock(NettyDnsResolver.class),
+                mock(DeltavNettyDnsResolver.class),
                 props(true, FlowEnricherDnsProperties.Scope.ALL),
                 new SimpleMeterRegistry());
         assertThat(r).isInstanceOf(LocalityFilteringDnsResolver.class);

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/DeltavNettyDnsResolverReversePointerTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/DeltavNettyDnsResolverReversePointerTest.java
@@ -1,0 +1,57 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link DeltavNettyDnsResolver#reversePointer(InetAddress)}.
+ *
+ * <p>Tests the pure, static pointer-name construction logic only — no
+ * {@code init()} call, no live DNS, no Netty event loops required.
+ */
+class DeltavNettyDnsResolverReversePointerTest {
+
+    @Test
+    void ipv4_10_0_0_1() throws UnknownHostException {
+        InetAddress addr = InetAddress.getByName("10.0.0.1");
+        assertThat(DeltavNettyDnsResolver.reversePointer(addr))
+                .isEqualTo("1.0.0.10.in-addr.arpa");
+    }
+
+    @Test
+    void ipv4_192_168_1_5() throws UnknownHostException {
+        InetAddress addr = InetAddress.getByName("192.168.1.5");
+        assertThat(DeltavNettyDnsResolver.reversePointer(addr))
+                .isEqualTo("5.1.168.192.in-addr.arpa");
+    }
+
+    @Test
+    void ipv4Mapped_8_8_8_8_unwrapsToInAddrArpa() throws UnknownHostException {
+        // Build ::ffff:8.8.8.8 manually as a 16-byte address.
+        // Bytes: [0,0,0,0,0,0,0,0,0,0,0xff,0xff,8,8,8,8]
+        byte[] raw = new byte[]{
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, (byte) 0xff, (byte) 0xff,
+                8, 8, 8, 8
+        };
+        InetAddress addr = InetAddress.getByAddress(raw);
+        assertThat(DeltavNettyDnsResolver.reversePointer(addr))
+                .isEqualTo("8.8.8.8.in-addr.arpa");
+    }
+
+    @Test
+    void ipv6_2001_db8_1_endsWithIp6ArpaAndStartsWithNibbles() throws UnknownHostException {
+        // 2001:0db8:0000:0000:0000:0000:0000:0001
+        InetAddress addr = InetAddress.getByName("2001:db8::1");
+        String ptr = DeltavNettyDnsResolver.reversePointer(addr);
+
+        assertThat(ptr).endsWith(".ip6.arpa");
+        // The first nibble of the reversed form is the LSN of the last byte (0x01 → "1")
+        assertThat(ptr).startsWith("1.0.0.0");
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsPropertiesTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsPropertiesTest.java
@@ -1,0 +1,58 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+class FlowEnricherDnsPropertiesTest {
+
+    private static FlowEnricherDnsProperties bind(Map<String, Object> props) {
+        return new Binder(new MapConfigurationPropertySource(props))
+                .bind("deltav.flows.dns", Bindable.of(FlowEnricherDnsProperties.class))
+                .get();
+    }
+
+    @Test
+    void bindsHorizonDefaultsWhenNothingSet() {
+        // Provide the bare minimum — an empty sub-tree forces Binder to construct
+        // the record using all @DefaultValue annotations.
+        FlowEnricherDnsProperties p = new Binder(new MapConfigurationPropertySource(Map.of()))
+                .bindOrCreate("deltav.flows.dns", Bindable.of(FlowEnricherDnsProperties.class));
+        assertThat(p.enabled()).isTrue();
+        assertThat(p.scope()).isEqualTo(FlowEnricherDnsProperties.Scope.ALL);
+        assertThat(p.nameservers()).isEmpty();
+        assertThat(p.queryTimeoutMs()).isEqualTo(5000L);
+        assertThat(p.maxConcurrent()).isEqualTo(1000);
+        assertThat(p.cache().minTtlS()).isEqualTo(-1);
+        assertThat(p.cache().maxTtlS()).isEqualTo(-1);
+        assertThat(p.cache().negativeTtlS()).isEqualTo(-1);
+        assertThat(p.circuitBreaker().enabled()).isTrue();
+        assertThat(p.circuitBreaker().failureRateThreshold()).isEqualTo(80);
+    }
+
+    @Test
+    void bindsOverridesIncludingRelaxedScopeEnum() {
+        FlowEnricherDnsProperties p = bind(Map.of(
+                "deltav.flows.dns.enabled", "false",
+                "deltav.flows.dns.scope", "private",
+                "deltav.flows.dns.nameservers", "8.8.8.8",
+                "deltav.flows.dns.query-timeout-ms", "250",
+                "deltav.flows.dns.max-concurrent", "500",
+                "deltav.flows.dns.cache.negative-ttl-s", "120",
+                "deltav.flows.dns.circuit-breaker.failure-rate-threshold", "50"
+        ));
+        assertThat(p.enabled()).isFalse();
+        assertThat(p.scope()).isEqualTo(FlowEnricherDnsProperties.Scope.PRIVATE);
+        assertThat(p.nameservers()).isEqualTo("8.8.8.8");
+        assertThat(p.queryTimeoutMs()).isEqualTo(250L);
+        assertThat(p.maxConcurrent()).isEqualTo(500);
+        assertThat(p.cache().negativeTtlS()).isEqualTo(120);
+        assertThat(p.circuitBreaker().failureRateThreshold()).isEqualTo(50);
+    }
+}

--- a/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolverTest.java
+++ b/core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolverTest.java
@@ -1,0 +1,120 @@
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+
+class LocalityFilteringDnsResolverTest {
+
+    private final DnsResolver delegate = mock(DnsResolver.class);
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    private LocalityFilteringDnsResolver privateOnly() {
+        when(delegate.reverseLookup(any())).thenReturn(
+                CompletableFuture.completedFuture(Optional.of("host.example")));
+        return new LocalityFilteringDnsResolver(delegate, true, registry);
+    }
+
+    private static InetAddress v4(String s) throws Exception { return InetAddress.getByName(s); }
+
+    /** Build a genuine 16-byte IPv4-mapped Inet6Address (getByName would collapse to Inet4Address). */
+    private static InetAddress v4mapped(int a, int b, int c, int d) throws Exception {
+        byte[] bytes = new byte[16];
+        bytes[10] = (byte) 0xff;
+        bytes[11] = (byte) 0xff;
+        bytes[12] = (byte) a; bytes[13] = (byte) b; bytes[14] = (byte) c; bytes[15] = (byte) d;
+        return InetAddress.getByAddress(bytes);
+    }
+
+    @Test
+    void scopePrivate_delegatesForPrivateIpv4() throws Exception {
+        var r = privateOnly();
+        for (String ip : new String[]{"10.0.0.1", "172.16.5.5", "192.168.1.1", "127.0.0.1", "169.254.1.1"}) {
+            r.reverseLookup(v4(ip));
+        }
+        verify(delegate, times(5)).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isZero();
+    }
+
+    @Test
+    void scopePrivate_skipsPublicIpv4AndCountsFiltered() throws Exception {
+        var r = privateOnly();
+        CompletableFuture<Optional<String>> f = r.reverseLookup(v4("8.8.8.8"));
+        assertThat(f.join()).isEmpty();
+        verify(delegate, never()).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void scopePrivate_ipv4MappedIpv6PrivateIsTreatedAsPrivate() throws Exception {
+        var r = privateOnly();
+        r.reverseLookup(v4mapped(10, 0, 0, 1));
+        r.reverseLookup(v4mapped(192, 168, 1, 1));
+        r.reverseLookup(v4mapped(127, 0, 0, 1));
+        verify(delegate, times(3)).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isZero();
+    }
+
+    @Test
+    void scopePrivate_ipv4MappedIpv6PublicIsSkipped() throws Exception {
+        var r = privateOnly();
+        assertThat(r.reverseLookup(v4mapped(8, 8, 8, 8)).join()).isEmpty();
+        verify(delegate, never()).reverseLookup(any());
+    }
+
+    @Test
+    void scopePrivate_172_32_isPublicAndFiltered() throws Exception {
+        var r = privateOnly();
+        CompletableFuture<Optional<String>> f = r.reverseLookup(v4("172.32.0.0"));
+        assertThat(f.join()).isEmpty();
+        verify(delegate, never()).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void scopePrivate_ipv6UlaIsPrivate() throws Exception {
+        var r = privateOnly();
+        r.reverseLookup(InetAddress.getByName("fc00::1"));
+        r.reverseLookup(InetAddress.getByName("fd00::1"));
+        verify(delegate, times(2)).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isZero();
+    }
+
+    @Test
+    void scopePrivate_ipv6LinkLocalIsPrivate() throws Exception {
+        var r = privateOnly();
+        r.reverseLookup(InetAddress.getByName("fe80::1"));
+        verify(delegate, times(1)).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isZero();
+    }
+
+    @Test
+    void scopeAll_alwaysDelegates() throws Exception {
+        when(delegate.reverseLookup(any())).thenReturn(
+                CompletableFuture.completedFuture(Optional.of("h")));
+        var r = new LocalityFilteringDnsResolver(delegate, false, registry);
+        r.reverseLookup(v4("8.8.8.8"));
+        verify(delegate, times(1)).reverseLookup(any());
+    }
+
+    @Test
+    void forwardLookupAlwaysDelegates() {
+        when(delegate.lookup(any())).thenReturn(
+                CompletableFuture.completedFuture(Optional.empty()));
+        new LocalityFilteringDnsResolver(delegate, true, registry).lookup("example.com");
+        verify(delegate, times(1)).lookup("example.com");
+    }
+}

--- a/docs/superpowers/plans/2026-06-04-flow-enricher-netty-dns-resolver.md
+++ b/docs/superpowers/plans/2026-06-04-flow-enricher-netty-dns-resolver.md
@@ -1,0 +1,725 @@
+# Flow-Enricher Configurable Netty DNS Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flow-enricher's always-off `NoOpDnsResolver` with Horizon's `NettyDnsResolver` behind a config gate (`deltav.flows.dns.*`, on by default), wrapped in a delta-v CIDR-scoping decorator.
+
+**Architecture:** A `@ConfigurationProperties` record binds the curated knobs. When `enabled` (default true), a lifecycle-managed `NettyDnsResolver` bean is built from those props and wrapped in a `LocalityFilteringDnsResolver` (CIDR gate, default scope `all`); when `enabled=false`, the existing `NoOpDnsResolver` is used. The chosen `DnsResolver` is injected into the four horizon flow parsers exactly as today; the sFlow parser's `setDnsLookupsEnabled` tracks `enabled`.
+
+**Tech Stack:** Java 21, Spring Boot 4, horizon `org.opennms.netmgt.dnsresolver.{api,netty}` 1.0.x, Micrometer, JUnit 5 + Mockito + AssertJ.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md`
+
+**Namespace note:** The spec illustrated `deltav.flow-enricher.dns.*`; this plan uses **`deltav.flows.dns.*`** to match the module's existing properties (`deltav.flows.parser.system-id`, `deltav.flows.parser.location`).
+
+---
+
+## File Structure
+
+- **Create** `core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/FlowEnricherDnsProperties.java` — `@ConfigurationProperties("deltav.flows.dns")` record (+ nested `Cache`, `CircuitBreaker`, `Scope` enum).
+- **Create** `core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolver.java` — CIDR-scoping `DnsResolver` decorator with IPv4-mapped-IPv6 normalization + `deltav_dns_*` metrics.
+- **Modify** `core/flow-enricher/pom.xml` — add the `org.opennms.features.dnsresolver.netty` dependency.
+- **Modify** `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java` — `@EnableConfigurationProperties`, conditional `NettyDnsResolver` bean, conditional `flowParserDnsResolver` (decorator vs NoOp), sFlow flag follows `enabled`.
+- **Modify** `core/flow-enricher/src/main/resources/application.yml` — `deltav.flows.dns.*` defaults.
+- **Modify** `opennms-container/delta-v/README.md` — knob table + on-by-default behaviour-change note.
+- **Test** `core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolverTest.java`
+- **Test** `core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsPropertiesTest.java`
+- **Test** `core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsWiringTest.java`
+
+Build/test commands (run from repo root `/Users/david/development/src/opennms/delta-v`):
+- Single test class: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=ClassName`
+- Full module: `./mvnw -q --projects :org.deltav.flows.flow-enricher test`
+
+---
+
+## Task 1: Add the Netty DNS resolver dependency
+
+**Files:**
+- Modify: `core/flow-enricher/pom.xml` (dependencies section)
+
+- [ ] **Step 1: Add the dependency**
+
+In `core/flow-enricher/pom.xml`, inside `<dependencies>`, add (the `api` artifact is already on the classpath transitively via the netflow parser; this adds the **impl**):
+
+```xml
+        <dependency>
+            <groupId>org.opennms.features.dnsresolver</groupId>
+            <artifactId>org.opennms.features.dnsresolver.netty</artifactId>
+        </dependency>
+```
+
+Do NOT hardcode `<version>`. The horizon dependencyManagement / BOM imported by the parent manages it (same as the sibling `org.opennms.features.telemetry.protocols.netflow.parser` dep already in this pom). If the build fails with "dependencies.dependency.version is missing", add `<version>1.0.11</version>` (the version currently resolvable in `~/.m2`), matching how other horizon deps in this pom pin versions.
+
+- [ ] **Step 2: Verify it resolves and the impl class is reachable**
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher -am dependency:resolve 2>&1 | tail -5 && ./mvnw -q --projects :org.deltav.flows.flow-enricher compile`
+Expected: BUILD SUCCESS, no missing-artifact error. (Compilation still passes — nothing references the new jar yet.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/flow-enricher/pom.xml
+git commit -m "build(flow-enricher): add horizon netty DNS resolver dependency"
+```
+
+---
+
+## Task 2: `FlowEnricherDnsProperties` configuration binding
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/FlowEnricherDnsProperties.java`
+- Test: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsPropertiesTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `FlowEnricherDnsPropertiesTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class FlowEnricherDnsPropertiesTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(org.springframework.boot.autoconfigure.AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class))
+            .withUserConfiguration(Config.class);
+
+    @EnableConfigurationProperties(FlowEnricherDnsProperties.class)
+    static class Config {}
+
+    @Test
+    void bindsHorizonDefaultsWhenNothingSet() {
+        runner.run(ctx -> {
+            FlowEnricherDnsProperties p = ctx.getBean(FlowEnricherDnsProperties.class);
+            assertThat(p.enabled()).isTrue();
+            assertThat(p.scope()).isEqualTo(FlowEnricherDnsProperties.Scope.ALL);
+            assertThat(p.nameservers()).isEmpty();
+            assertThat(p.queryTimeoutMs()).isEqualTo(5000L);
+            assertThat(p.maxConcurrent()).isEqualTo(1000);
+            assertThat(p.cache().minTtlS()).isEqualTo(-1);
+            assertThat(p.cache().maxTtlS()).isEqualTo(-1);
+            assertThat(p.cache().negativeTtlS()).isEqualTo(-1);
+            assertThat(p.circuitBreaker().enabled()).isTrue();
+            assertThat(p.circuitBreaker().failureRateThreshold()).isEqualTo(80);
+        });
+    }
+
+    @Test
+    void bindsOverridesIncludingRelaxedScopeEnum() {
+        runner.withPropertyValues(
+                "deltav.flows.dns.enabled=false",
+                "deltav.flows.dns.scope=private",
+                "deltav.flows.dns.nameservers=8.8.8.8",
+                "deltav.flows.dns.query-timeout-ms=250",
+                "deltav.flows.dns.max-concurrent=500",
+                "deltav.flows.dns.cache.negative-ttl-s=120",
+                "deltav.flows.dns.circuit-breaker.failure-rate-threshold=50"
+        ).run(ctx -> {
+            FlowEnricherDnsProperties p = ctx.getBean(FlowEnricherDnsProperties.class);
+            assertThat(p.enabled()).isFalse();
+            assertThat(p.scope()).isEqualTo(FlowEnricherDnsProperties.Scope.PRIVATE);
+            assertThat(p.nameservers()).isEqualTo("8.8.8.8");
+            assertThat(p.queryTimeoutMs()).isEqualTo(250L);
+            assertThat(p.maxConcurrent()).isEqualTo(500);
+            assertThat(p.cache().negativeTtlS()).isEqualTo(120);
+            assertThat(p.circuitBreaker().failureRateThreshold()).isEqualTo(50);
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify it fails to compile** (`FlowEnricherDnsProperties` does not exist)
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=FlowEnricherDnsPropertiesTest`
+Expected: COMPILE FAILURE — cannot find symbol `FlowEnricherDnsProperties`.
+
+- [ ] **Step 3: Write the properties record**
+
+Create `FlowEnricherDnsProperties.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Curated, daemon-scoped tuning for the flow-enricher's reverse-DNS enrichment.
+ * Defaults mirror horizon's {@code NettyDnsResolver} field defaults. The obscure
+ * NettyDnsResolver knobs (numContexts, ring buffers, breaker wait, bulkhead
+ * max-wait) are intentionally NOT exposed and stay at their horizon defaults;
+ * {@code bulkheadMaxWaitDurationMillis} is derived as {@code queryTimeoutMs + 100}
+ * at wiring time to preserve horizon's relationship.
+ */
+@ConfigurationProperties("deltav.flows.dns")
+public record FlowEnricherDnsProperties(
+        @DefaultValue("true") boolean enabled,
+        @DefaultValue("all") Scope scope,
+        @DefaultValue("") String nameservers,
+        @DefaultValue("5000") long queryTimeoutMs,
+        @DefaultValue("1000") int maxConcurrent,
+        @DefaultValue Cache cache,
+        @DefaultValue CircuitBreaker circuitBreaker) {
+
+    /** Which addresses the locality gate allows through to the resolver. */
+    public enum Scope { ALL, PRIVATE }
+
+    public record Cache(
+            @DefaultValue("-1") int minTtlS,
+            @DefaultValue("-1") int maxTtlS,
+            @DefaultValue("-1") int negativeTtlS) {}
+
+    public record CircuitBreaker(
+            @DefaultValue("true") boolean enabled,
+            @DefaultValue("80") int failureRateThreshold) {}
+}
+```
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=FlowEnricherDnsPropertiesTest`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/FlowEnricherDnsProperties.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsPropertiesTest.java
+git commit -m "feat(flow-enricher): DNS config properties (deltav.flows.dns.*) with horizon defaults"
+```
+
+---
+
+## Task 3: `LocalityFilteringDnsResolver` decorator (CIDR gate + IPv4-mapped normalization + metrics)
+
+**Files:**
+- Create: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolver.java`
+- Test: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolverTest.java`
+
+- [ ] **Step 1: Write the failing test** (covers scope, the `filtered` metric, and the IPv4-mapped-IPv6 correctness edge case built via `getByAddress(byte[16])`)
+
+Create `LocalityFilteringDnsResolverTest.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+
+class LocalityFilteringDnsResolverTest {
+
+    private final DnsResolver delegate = mock(DnsResolver.class);
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    private LocalityFilteringDnsResolver privateOnly() {
+        when(delegate.reverseLookup(any())).thenReturn(
+                CompletableFuture.completedFuture(Optional.of("host.example")));
+        return new LocalityFilteringDnsResolver(delegate, true, registry);
+    }
+
+    private static InetAddress v4(String s) throws Exception { return InetAddress.getByName(s); }
+
+    /** Build a genuine 16-byte IPv4-mapped Inet6Address (getByName would collapse to Inet4Address). */
+    private static InetAddress v4mapped(int a, int b, int c, int d) throws Exception {
+        byte[] bytes = new byte[16];
+        bytes[10] = (byte) 0xff;
+        bytes[11] = (byte) 0xff;
+        bytes[12] = (byte) a; bytes[13] = (byte) b; bytes[14] = (byte) c; bytes[15] = (byte) d;
+        return InetAddress.getByAddress(bytes);
+    }
+
+    @Test
+    void scopePrivate_delegatesForPrivateIpv4() throws Exception {
+        var r = privateOnly();
+        for (String ip : new String[]{"10.0.0.1", "172.16.5.5", "192.168.1.1", "127.0.0.1", "169.254.1.1"}) {
+            r.reverseLookup(v4(ip));
+        }
+        verify(delegate, times(5)).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isZero();
+    }
+
+    @Test
+    void scopePrivate_skipsPublicIpv4AndCountsFiltered() throws Exception {
+        var r = privateOnly();
+        CompletableFuture<Optional<String>> f = r.reverseLookup(v4("8.8.8.8"));
+        assertThat(f.join()).isEmpty();
+        verify(delegate, never()).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void scopePrivate_ipv4MappedIpv6PrivateIsTreatedAsPrivate() throws Exception {
+        var r = privateOnly();
+        // ::ffff:10.0.0.1 etc. as real Inet6Address — must NOT be skipped
+        r.reverseLookup(v4mapped(10, 0, 0, 1));
+        r.reverseLookup(v4mapped(192, 168, 1, 1));
+        r.reverseLookup(v4mapped(127, 0, 0, 1));
+        verify(delegate, times(3)).reverseLookup(any());
+        assertThat(registry.counter("deltav_dns_reverse_lookups_total", "result", "filtered").count()).isZero();
+    }
+
+    @Test
+    void scopePrivate_ipv4MappedIpv6PublicIsSkipped() throws Exception {
+        var r = privateOnly();
+        assertThat(r.reverseLookup(v4mapped(8, 8, 8, 8)).join()).isEmpty();
+        verify(delegate, never()).reverseLookup(any());
+    }
+
+    @Test
+    void scopePrivate_ipv6UlaIsPrivate() throws Exception {
+        var r = privateOnly();
+        r.reverseLookup(InetAddress.getByName("fd00::1")); // fc00::/7 ULA
+        verify(delegate, times(1)).reverseLookup(any());
+    }
+
+    @Test
+    void scopeAll_alwaysDelegates() throws Exception {
+        when(delegate.reverseLookup(any())).thenReturn(
+                CompletableFuture.completedFuture(Optional.of("h")));
+        var r = new LocalityFilteringDnsResolver(delegate, false, registry);
+        r.reverseLookup(v4("8.8.8.8"));
+        verify(delegate, times(1)).reverseLookup(any());
+    }
+
+    @Test
+    void forwardLookupAlwaysDelegates() {
+        when(delegate.lookup(any())).thenReturn(
+                CompletableFuture.completedFuture(Optional.empty()));
+        new LocalityFilteringDnsResolver(delegate, true, registry).lookup("example.com");
+        verify(delegate, times(1)).lookup("example.com");
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify it fails to compile** (class does not exist)
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=LocalityFilteringDnsResolverTest`
+Expected: COMPILE FAILURE — cannot find symbol `LocalityFilteringDnsResolver`.
+
+- [ ] **Step 3: Write the decorator**
+
+Create `LocalityFilteringDnsResolver.java`:
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+
+/**
+ * A {@link DnsResolver} decorator that, when {@code privateOnly} is set,
+ * only reverse-resolves IPs in private/local ranges (RFC1918, IPv6 ULA,
+ * loopback, link-local) and short-circuits everything else to an empty
+ * result — bounding reverse-DNS cardinality to the operator's own address
+ * space. When {@code privateOnly} is false, every address is delegated
+ * (Horizon-equivalent behaviour).
+ *
+ * <p>Flow addresses arrive as IPv6 (the ClickHouse {@code flows_raw.*_address}
+ * columns are IPv6), so a private IPv4 can reach us as an IPv4-mapped
+ * {@code Inet6Address} (e.g. {@code ::ffff:10.0.0.1}). {@link InetAddress}'s
+ * {@code isSiteLocalAddress()} checks the IPv6 prefix and would mis-classify
+ * such an address as public; we therefore normalize IPv4-mapped IPv6 to the
+ * embedded IPv4 before testing.
+ */
+public class LocalityFilteringDnsResolver implements DnsResolver {
+
+    private static final String METRIC = "deltav_dns_reverse_lookups_total";
+
+    private final DnsResolver delegate;
+    private final boolean privateOnly;
+    private final MeterRegistry registry;
+
+    public LocalityFilteringDnsResolver(DnsResolver delegate, boolean privateOnly, MeterRegistry registry) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.privateOnly = privateOnly;
+        this.registry = Objects.requireNonNull(registry);
+    }
+
+    @Override
+    public CompletableFuture<Optional<InetAddress>> lookup(String hostname) {
+        return delegate.lookup(hostname);
+    }
+
+    @Override
+    public CompletableFuture<Optional<String>> reverseLookup(InetAddress address) {
+        if (privateOnly && !isPrivate(address)) {
+            registry.counter(METRIC, "result", "filtered").increment();
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return delegate.reverseLookup(address).whenComplete((result, ex) -> {
+            final String tag = ex != null ? "error" : (result != null && result.isPresent() ? "hit" : "miss");
+            registry.counter(METRIC, "result", tag).increment();
+        });
+    }
+
+    static boolean isPrivate(InetAddress address) {
+        final InetAddress a = normalizeMapped(address);
+        if (a.isSiteLocalAddress() || a.isLoopbackAddress() || a.isLinkLocalAddress()) {
+            return true;
+        }
+        final byte[] b = a.getAddress();
+        // IPv6 Unique Local Address fc00::/7 (Java has no isUniqueLocalAddress()).
+        return b.length == 16 && (b[0] & 0xFE) == 0xFC;
+    }
+
+    /** Unwrap an IPv4-mapped IPv6 address (::ffff:a.b.c.d) to its embedded Inet4Address. */
+    static InetAddress normalizeMapped(InetAddress address) {
+        final byte[] b = address.getAddress();
+        if (b.length == 16 && isV4Mapped(b)) {
+            try {
+                return InetAddress.getByAddress(Arrays.copyOfRange(b, 12, 16));
+            } catch (UnknownHostException e) {
+                return address; // 4-byte array is always valid; unreachable in practice
+            }
+        }
+        return address;
+    }
+
+    private static boolean isV4Mapped(byte[] b) {
+        for (int i = 0; i < 10; i++) {
+            if (b[i] != 0) {
+                return false;
+            }
+        }
+        return b[10] == (byte) 0xff && b[11] == (byte) 0xff;
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=LocalityFilteringDnsResolverTest`
+Expected: PASS (all 7 tests). If `scopePrivate_ipv4MappedIpv6PrivateIsTreatedAsPrivate` fails, the `normalizeMapped` unwrap is the bug to fix — that test exists specifically to catch a missing unwrap.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolver.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/LocalityFilteringDnsResolverTest.java
+git commit -m "feat(flow-enricher): LocalityFilteringDnsResolver CIDR gate + IPv4-mapped normalization"
+```
+
+---
+
+## Task 4: Conditional resolver wiring in `FlowEnricherConfiguration`
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java`
+- Test: `core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsWiringTest.java`
+
+Context (current state): a single unconditional bean `flowParserDnsResolver()` returns `new NoOpDnsResolver()` (around line 246); the four parser beans inject `DnsResolver flowParserDnsResolver` by name; `sflowUdpParser(...)` calls `parser.setDnsLookupsEnabled(false)` unconditionally.
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Create `FlowEnricherDnsWiringTest.java`. It verifies the two mutually-exclusive `flowParserDnsResolver` beans by invoking the `@Bean` factory methods directly with mocks (deterministic; no live Netty/DNS):
+
+```java
+/* Copyright (C) 2026 BeaconStrategists, Inc.  AGPL-3.0-or-later */
+package org.deltav.flows.enricher.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.deltav.flows.enricher.FlowEnricherConfiguration;
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.dnsresolver.api.DnsResolver;
+import org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver;
+
+class FlowEnricherDnsWiringTest {
+
+    private final FlowEnricherConfiguration cfg = new FlowEnricherConfiguration();
+
+    private static FlowEnricherDnsProperties props(boolean enabled, FlowEnricherDnsProperties.Scope scope) {
+        return new FlowEnricherDnsProperties(enabled, scope, "", 5000L, 1000,
+                new FlowEnricherDnsProperties.Cache(-1, -1, -1),
+                new FlowEnricherDnsProperties.CircuitBreaker(true, 80));
+    }
+
+    @Test
+    void enabledYieldsLocalityFilteringDecorator() {
+        DnsResolver r = cfg.flowParserDnsResolver(
+                mock(NettyDnsResolver.class),
+                props(true, FlowEnricherDnsProperties.Scope.ALL),
+                new SimpleMeterRegistry());
+        assertThat(r).isInstanceOf(LocalityFilteringDnsResolver.class);
+    }
+
+    @Test
+    void disabledYieldsNoOpResolver() {
+        DnsResolver r = cfg.noOpFlowParserDnsResolver();
+        assertThat(r).isInstanceOf(NoOpDnsResolver.class);
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify it fails to compile** (`cfg.flowParserDnsResolver(NettyDnsResolver, …)` / `noOpFlowParserDnsResolver()` signatures don't exist yet)
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=FlowEnricherDnsWiringTest`
+Expected: COMPILE FAILURE.
+
+- [ ] **Step 3: Add imports + `@EnableConfigurationProperties` to `FlowEnricherConfiguration`**
+
+In the imports block of `FlowEnricherConfiguration.java`, add:
+
+```java
+import io.micrometer.core.instrument.MeterRegistry;
+import org.deltav.flows.enricher.parser.FlowEnricherDnsProperties;
+import org.deltav.flows.enricher.parser.LocalityFilteringDnsResolver;
+import org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+```
+
+On the class declaration (the line `public class FlowEnricherConfiguration {` or its existing `@Configuration`), add the annotation directly above it:
+
+```java
+@EnableConfigurationProperties(FlowEnricherDnsProperties.class)
+```
+
+(Keep `import org.deltav.flows.enricher.parser.NoOpDnsResolver;` — it already exists.)
+
+- [ ] **Step 4: Replace the single `flowParserDnsResolver()` bean with the conditional pair**
+
+Delete the existing method (the javadoc block + `@Bean DnsResolver flowParserDnsResolver() { return new NoOpDnsResolver(); }`) and replace with:
+
+```java
+    /**
+     * Lifecycle-managed horizon {@link NettyDnsResolver}, built only when
+     * reverse-DNS is enabled. Configured from {@link FlowEnricherDnsProperties};
+     * obscure knobs stay at horizon defaults. {@code init()}/{@code destroy()}
+     * build and tear down the Netty event loops + Caffeine cache + breaker.
+     */
+    @Bean(initMethod = "init", destroyMethod = "destroy")
+    @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "true", matchIfMissing = true)
+    NettyDnsResolver nettyDnsResolver(
+            EventForwarder flowParserEventForwarder,
+            MetricRegistry flowEnricherMetricRegistry,
+            FlowEnricherDnsProperties dnsProperties) {
+        final NettyDnsResolver resolver = new NettyDnsResolver(flowParserEventForwarder, flowEnricherMetricRegistry);
+        if (!dnsProperties.nameservers().isBlank()) {
+            resolver.setNameservers(dnsProperties.nameservers());
+        }
+        resolver.setQueryTimeoutMillis(dnsProperties.queryTimeoutMs());
+        resolver.setBulkheadMaxConcurrentCalls(dnsProperties.maxConcurrent());
+        resolver.setBulkheadMaxWaitDurationMillis(dnsProperties.queryTimeoutMs() + 100);
+        resolver.setMinTtlSeconds(dnsProperties.cache().minTtlS());
+        resolver.setMaxTtlSeconds(dnsProperties.cache().maxTtlS());
+        resolver.setNegativeTtlSeconds(dnsProperties.cache().negativeTtlS());
+        resolver.setBreakerEnabled(dnsProperties.circuitBreaker().enabled());
+        resolver.setBreakerFailureRateThreshold(dnsProperties.circuitBreaker().failureRateThreshold());
+        return resolver;
+    }
+
+    /**
+     * The {@link DnsResolver} injected into all four flow parsers. When DNS is
+     * enabled (default), it is the {@link NettyDnsResolver} wrapped in a
+     * {@link LocalityFilteringDnsResolver} (scope gate). Both conditional beans
+     * below are named {@code flowParserDnsResolver}; the conditions are mutually
+     * exclusive, so exactly one exists and the parsers' by-name injection works
+     * unchanged.
+     */
+    @Bean("flowParserDnsResolver")
+    @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "true", matchIfMissing = true)
+    DnsResolver flowParserDnsResolver(
+            NettyDnsResolver nettyDnsResolver,
+            FlowEnricherDnsProperties dnsProperties,
+            MeterRegistry meterRegistry) {
+        final boolean privateOnly = dnsProperties.scope() == FlowEnricherDnsProperties.Scope.PRIVATE;
+        return new LocalityFilteringDnsResolver(nettyDnsResolver, privateOnly, meterRegistry);
+    }
+
+    /** No-op resolver used only when reverse-DNS is explicitly disabled. */
+    @Bean("flowParserDnsResolver")
+    @ConditionalOnProperty(name = "deltav.flows.dns.enabled", havingValue = "false")
+    DnsResolver noOpFlowParserDnsResolver() {
+        return new NoOpDnsResolver();
+    }
+```
+
+- [ ] **Step 5: Make the sFlow flag follow `enabled`**
+
+In `sflowUdpParser(...)`, add a `FlowEnricherDnsProperties` parameter and replace the hardcoded `false`:
+
+```java
+    @Bean
+    SFlowUdpParser sflowUdpParser(
+            ThreadLocalDispatcher threadLocalDispatcher,
+            DnsResolver flowParserDnsResolver,
+            FlowEnricherDnsProperties dnsProperties) {
+        final SFlowUdpParser parser = new SFlowUdpParser(
+                "SFlow",
+                threadLocalDispatcher,
+                flowParserDnsResolver);
+        // Reverse-DNS on the sFlow parser tracks the global toggle. The PR #156
+        // NPE on unresolvable Docker-bridge IPs is avoided when disabled; when
+        // enabled, the NettyDnsResolver path handles failures gracefully.
+        parser.setDnsLookupsEnabled(dnsProperties.enabled());
+        return parser;
+    }
+```
+
+- [ ] **Step 6: Run the wiring test + compile**
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=FlowEnricherDnsWiringTest`
+Expected: PASS (both tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java \
+        core/flow-enricher/src/test/java/org/deltav/flows/enricher/parser/FlowEnricherDnsWiringTest.java
+git commit -m "feat(flow-enricher): conditional Netty DNS resolver wiring (default on) + sFlow flag follows toggle"
+```
+
+---
+
+## Task 5: Defaults in `application.yml` + README
+
+**Files:**
+- Modify: `core/flow-enricher/src/main/resources/application.yml`
+- Modify: `opennms-container/delta-v/README.md`
+
+- [ ] **Step 1: Add the `deltav.flows.dns` block to `application.yml`**
+
+At the end of `application.yml` add a top-level `deltav:` block (if one already exists, merge under it). Values mirror the record defaults but are written explicitly so operators see them, with env-var overrides:
+
+```yaml
+# Reverse-DNS enrichment of flow IPs (src/dst/etc -> *_hostname). ON by default
+# (Horizon parity). Backed by horizon's NettyDnsResolver (circuit breaker +
+# bulkhead + TTL cache + timeout). For high-cardinality internet-facing flows,
+# set scope=private or lower query-timeout-ms, or disable entirely.
+deltav:
+  flows:
+    dns:
+      enabled: ${DELTAV_FLOWS_DNS_ENABLED:true}
+      scope: ${DELTAV_FLOWS_DNS_SCOPE:all}            # all | private
+      nameservers: ${DELTAV_FLOWS_DNS_NAMESERVERS:}   # blank = system resolv.conf
+      query-timeout-ms: ${DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS:5000}
+      max-concurrent: ${DELTAV_FLOWS_DNS_MAX_CONCURRENT:1000}
+      cache:
+        min-ttl-s: ${DELTAV_FLOWS_DNS_CACHE_MIN_TTL_S:-1}
+        max-ttl-s: ${DELTAV_FLOWS_DNS_CACHE_MAX_TTL_S:-1}
+        negative-ttl-s: ${DELTAV_FLOWS_DNS_CACHE_NEGATIVE_TTL_S:-1}
+      circuit-breaker:
+        enabled: ${DELTAV_FLOWS_DNS_BREAKER_ENABLED:true}
+        failure-rate-threshold: ${DELTAV_FLOWS_DNS_BREAKER_FAILURE_RATE:80}
+```
+
+- [ ] **Step 2: Add the README knob table + behaviour-change note**
+
+In `opennms-container/delta-v/README.md`, in the flow-enricher section, add:
+
+```markdown
+### Flow reverse-DNS enrichment (`deltav.flows.dns.*`)
+
+**Behaviour change (v1.3.0-rc9+):** reverse-DNS enrichment is **ON by default**
+(Horizon parity). The flow-enricher now reverse-resolves flow IPs to hostnames
+(`src_hostname`/`dst_hostname`/…) via horizon's `NettyDnsResolver`. Previously
+delta-v shipped a no-op resolver (no lookups). Disable with
+`DELTAV_FLOWS_DNS_ENABLED=false`.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `DELTAV_FLOWS_DNS_ENABLED` | `true` | master on/off |
+| `DELTAV_FLOWS_DNS_SCOPE` | `all` | `all` (resolve every IP) or `private` (only RFC1918/ULA/loopback/link-local — bounds cardinality to your address space) |
+| `DELTAV_FLOWS_DNS_NAMESERVERS` | _(blank)_ | DNS server(s); blank = system resolv.conf |
+| `DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS` | `5000` | per-lookup timeout |
+| `DELTAV_FLOWS_DNS_MAX_CONCURRENT` | `1000` | bulkhead: max in-flight lookups |
+| `DELTAV_FLOWS_DNS_CACHE_*_TTL_S` | `-1` | cache min/max/negative TTL (`-1` = NettyDnsResolver default) |
+| `DELTAV_FLOWS_DNS_BREAKER_ENABLED` / `_FAILURE_RATE` | `true` / `80` | circuit breaker on unhealthy DNS |
+
+For high-cardinality internet-facing flows, prefer `DELTAV_FLOWS_DNS_SCOPE=private`
+and/or a lower `DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS` to protect flow throughput.
+Metrics: `deltav_dns_reverse_lookups_total{result=hit|miss|error|filtered}`.
+```
+
+- [ ] **Step 3: Validate YAML + commit**
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher test -Dtest=FlowEnricherDnsPropertiesTest` (confirms the yml-shaped keys still bind via the record).
+Expected: PASS.
+
+```bash
+git add core/flow-enricher/src/main/resources/application.yml opennms-container/delta-v/README.md
+git commit -m "docs(flow-enricher): default deltav.flows.dns.* config + on-by-default README note"
+```
+
+---
+
+## Task 6: Full-module build + verification
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Build + run the whole module**
+
+Run: `./mvnw -q --projects :org.deltav.flows.flow-enricher -am clean test`
+Expected: BUILD SUCCESS; all tests pass (existing enrichment tests + the three new DNS test classes).
+
+- [ ] **Step 2: Confirm no leftover unconditional NoOp reference + exactly one DnsResolver path**
+
+Run:
+```bash
+grep -n 'new NoOpDnsResolver' core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+grep -n 'setDnsLookupsEnabled' core/flow-enricher/src/main/java/org/deltav/flows/enricher/FlowEnricherConfiguration.java
+```
+Expected: the `new NoOpDnsResolver()` appears only inside the `@ConditionalOnProperty(... havingValue="false")` bean; `setDnsLookupsEnabled` uses `dnsProperties.enabled()` (not a literal `false`).
+
+- [ ] **Step 3: Final commit (if any fixups)**
+
+```bash
+git add -A && git commit -m "test(flow-enricher): verify DNS resolver module build green" --allow-empty
+```
+
+> **Deferred E2E (next deploy/rc):** with defaults (`enabled=true`, `scope=all`), confirm flows show populated `src_hostname`/`dst_hostname` for resolvable IPs and the `deltav_dns_reverse_lookups_total` meter increments; with `DELTAV_FLOWS_DNS_SCOPE=private`, public-IP flows have empty hostnames (and `result=filtered` increments) while private ones resolve; flow throughput stays healthy with no circuit-breaker-open storm under nl6 load.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- On-by-default toggle + behaviour-change callout → Task 4 (conditional, `matchIfMissing=true`), Task 5 (README note). ✓
+- Curated knobs + nameservers, Horizon defaults → Task 2 (record defaults), Task 4 (setters), Task 5 (yml). ✓
+- Hardcoded obscure knobs; `bulkheadMaxWait = queryTimeout+100` → Task 4 (only curated setters called; derived max-wait). ✓
+- `LocalityFilteringDnsResolver` CIDR gate, scope all|private default all → Task 3 + Task 4 (scope→privateOnly). ✓
+- IPv4-mapped IPv6 normalization → Task 3 (`normalizeMapped`) + explicit tests. ✓
+- `deltav_dns_*` metrics (hit/miss/error/filtered) → Task 3. ✓
+- sFlow flag follows enabled → Task 4 Step 5. ✓
+- NettyDnsResolver lifecycle init/destroy → Task 4 Step 4. ✓
+- Tests: decorator (incl mapped), properties binding, conditional wiring → Tasks 2/3/4. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `FlowEnricherDnsProperties` accessor names (`enabled()`, `scope()`, `nameservers()`, `queryTimeoutMs()`, `maxConcurrent()`, `cache().minTtlS()/maxTtlS()/negativeTtlS()`, `circuitBreaker().enabled()/failureRateThreshold()`) are identical in Tasks 2, 4, and the wiring test. `Scope.ALL`/`Scope.PRIVATE` consistent. `LocalityFilteringDnsResolver(DnsResolver, boolean, MeterRegistry)` ctor identical in Tasks 3 and 4. Bean name `flowParserDnsResolver` matches the parsers' injection point. ✓
+
+**Open item flagged (not a placeholder):** Task 1 Step 1 — the netty dep version is managed by horizon's dependencyManagement; if unmanaged, pin `1.0.11`. The engineer confirms at build time.

--- a/docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md
+++ b/docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md
@@ -1,0 +1,188 @@
+# Configurable Netty DNS reverse-resolution for the flow-enricher
+
+**Date:** 2026-06-04
+**Status:** Approved design
+**Branch:** `feat/flow-enricher-netty-dns-resolver`
+
+## Goal
+
+Make the flow-enricher's reverse-DNS enrichment (src/dst — and, like Horizon, every IP in the
+record — resolved to hostnames, populating `src_hostname` / `dst_hostname` / `next_hop_hostname`)
+a **configurable** capability backed by Horizon's hardened `NettyDnsResolver`, replacing the
+current always-off `NoOpDnsResolver`. Behavior is **Horizon-faithful by default**, with a curated
+set of safety/tuning knobs plus an optional delta-v **CIDR scope gate** to structurally bound
+lookup cardinality.
+
+## Current state
+
+`FlowEnricherConfiguration.flowParserDnsResolver()` returns a `NoOpDnsResolver` (both `lookup` and
+`reverseLookup` return `Optional.empty()`), injected into all four horizon flow parsers
+(Netflow v5/v9, IPFIX, sFlow); the sFlow parser additionally has `setDnsLookupsEnabled(false)`.
+No `*_hostname` field is ever populated. The enrichment hot path performs node/interface lookups
+via the in-memory NodeContext cache (post-migration), not DNS.
+
+## How Horizon does it (the reference behavior)
+
+`org.opennms.netmgt.telemetry.protocols.netflow.parser.RecordEnricher.enrich(record)`:
+- Single `dnsLookupsEnabled` boolean gate (code default **`true`**). Off → empty enrichment, no lookups.
+- An `IpAddressCapturingVisitor` walks **every** value in the record and collects **all** IP-typed
+  fields into a `Set<InetAddress>` — exporter, src, dst, next-hop, etc. No src/dst or locality distinction.
+- Fires `dnsResolver.reverseLookup(addr)` for each (async); `CompletableFuture.allOf(...)` gates the
+  record's enrichment future until **all** lookups complete or time out. Failures resolve to `null`.
+- The only bound is the `DnsResolver` implementation. In production Horizon that is `NettyDnsResolver`,
+  whose circuit breaker + bulkhead + TTL cache + query timeout absorb the "resolve every IP in every
+  flow" load. There is **no locality/CIDR filtering** anywhere.
+
+## Decisions (confirmed)
+
+- **On by default.** Master toggle `deltav.flow-enricher.dns.enabled` defaults **`true`**.
+  This is a **behavior change** from current delta-v (which ships NoOp/off) — see the callout below.
+- **Curated safety knobs + `nameservers`** exposed as config; obscure NettyDnsResolver internals
+  hardcoded to Horizon's defaults.
+- **CIDR scope gate** via a delta-v `LocalityFilteringDnsResolver` decorator; `scope` defaults
+  **`all`** (= Horizon, no filtering). `private` is the opt-in structural cardinality cap.
+- **All other defaults mirror Horizon's `NettyDnsResolver`** field defaults (enumerated below).
+
+## ⚠️ Behavior change — reverse-DNS is ON by default
+
+Shipping `enabled: true` means **every delta-v deployment begins reverse-resolving flow IPs** on
+upgrade, where today it does none. With the default `scope: all`, that includes high-cardinality
+internet-facing src/dst addresses — partially reintroducing the per-flow external-lookup cost the
+NodeContext migration removed from the hot path. This is intentional (Horizon parity) but MUST be:
+- called out in release notes / README as a default-behavior change, and
+- mitigated by the load-bearing guards that are now in the default path: the circuit breaker,
+  bulkhead concurrency cap, TTL+negative cache, and query timeout (all from `NettyDnsResolver`),
+  plus the optional `scope: private` gate.
+
+Operators running heavy internet-facing flows should consider `scope: private`, a shorter
+`query-timeout-ms`, or `enabled: false`.
+
+## Components
+
+### 1. Configuration properties (`deltav.flow-enricher.dns.*`)
+
+Daemon-scoped namespace (per the no-shared-config rule). Defaults = Horizon `NettyDnsResolver` defaults.
+
+| Property | Type | Default | Maps to / meaning |
+|---|---|---|---|
+| `enabled` | boolean | **`true`** | master gate; off → `NoOpDnsResolver` |
+| `scope` | enum `all`\|`private` | **`all`** | delta-v CIDR gate (see §3) |
+| `nameservers` | string | `""` | `setNameservers` — `""` = platform default (system resolv.conf, port 53) |
+| `query-timeout-ms` | long | `5000` | `setQueryTimeoutMillis` |
+| `max-concurrent` | int | `1000` | `setBulkheadMaxConcurrentCalls` |
+| `cache.min-ttl-s` | int | `-1` | `setMinTtlSeconds` (`-1` = CaffeineDnsCache default) |
+| `cache.max-ttl-s` | int | `-1` | `setMaxTtlSeconds` |
+| `cache.negative-ttl-s` | int | `-1` | `setNegativeTtlSeconds` |
+| `circuit-breaker.enabled` | boolean | `true` | `setBreakerEnabled` |
+| `circuit-breaker.failure-rate-threshold` | int | `80` | `setBreakerFailureRateThreshold` (percent) |
+
+**Hardcoded to Horizon defaults** (not exposed): `numContexts=0` (→ derived from CPU at `init`),
+`bulkheadMaxWaitDurationMillis = query-timeout-ms + 100`, `breakerWaitDurationInOpenState=15`,
+`breakerRingBufferSizeInClosedState=100`, `breakerRingBufferSizeInHalfOpenState=10`,
+`maxCacheSize=-1` (→ CaffeineDnsCache `DEFAULT_MAX_SIZE=10000`). `bulkheadMaxWaitDurationMillis`
+is derived from `query-timeout-ms` to preserve Horizon's `queryTimeout+100` relationship.
+
+A `@ConfigurationProperties("deltav.flow-enricher.dns")` record/bean (`FlowEnricherDnsProperties`)
+binds these, with `@Validated` bounds (positive timeouts, threshold 1–100).
+
+### 2. `NettyDnsResolver` bean (conditional, lifecycle-managed)
+
+- `@Bean(initMethod = "init", destroyMethod = "destroy")` `@ConditionalOnProperty(name =
+  "deltav.flow-enricher.dns.enabled", havingValue = "true", matchIfMissing = true)` (default-true
+  toggle → bean is created when the property is `true` **or absent**) —
+  constructs `org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver`, applies the curated setters
+  from `FlowEnricherDnsProperties`, leaves the hardcoded knobs at their field defaults.
+- `init()` builds the Netty event-loop contexts + Caffeine cache + Resilience4j breaker/bulkhead;
+  `destroy()` tears them down. Must run on context start/stop.
+
+### 3. `LocalityFilteringDnsResolver` decorator (delta-v, new)
+
+`org.deltav.flows.enricher.parser.LocalityFilteringDnsResolver implements DnsResolver` — wraps the
+delegate (`NettyDnsResolver`):
+- `reverseLookup(InetAddress addr)`: if `scope == all` **or** `addr` is in the private/local set,
+  delegate; else return `CompletableFuture.completedFuture(Optional.empty())` (and bump a
+  `filtered` counter).
+- `lookup(String)`: pass through to the delegate unchanged (Horizon's `RecordEnricher` only calls
+  `reverseLookup`; forward lookups are out of the hot path).
+- **Private/local set** (`scope: private`): IPv4 `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`,
+  `127.0.0.0/8` (loopback), `169.254.0.0/16` (link-local); IPv6 `fc00::/7` (ULA), `::1` (loopback),
+  `fe80::/10` (link-local). Implemented with `InetAddress.isSiteLocalAddress() ||
+  isLoopbackAddress() || isLinkLocalAddress()` plus an explicit `fc00::/7` check (Java's
+  `isSiteLocalAddress()` does not cover IPv6 ULA). Pure in-memory IP check; no allocation per call
+  beyond the boolean.
+
+This is an **additive** delta-v capability (Horizon has no equivalent) → delta-v adapter is the
+correct layer (per the horizon-parallel-vs-additive rule), not a horizon source change.
+
+### 4. Wiring into the parsers
+
+`FlowEnricherConfiguration`:
+- Replace the unconditional `flowParserDnsResolver()` → `NoOpDnsResolver` bean with a
+  `@ConditionalOnProperty` pair:
+  - `enabled` true or absent (`matchIfMissing = true`) → `LocalityFilteringDnsResolver(
+    nettyDnsResolver, scope)` as the `DnsResolver`.
+  - `enabled=false` explicitly (`havingValue = "false"`, no `matchIfMissing`) → `NoOpDnsResolver`
+    (today's behavior). The two conditions are mutually exclusive, so exactly one `DnsResolver`
+    bean exists.
+- The Netflow5/9 + IPFIX parser beans already take the injected `DnsResolver` — no change beyond
+  receiving the new bean.
+- **sFlow:** make `parser.setDnsLookupsEnabled(...)` follow `enabled` (true when DNS enabled). Keep
+  the PR #156 NPE note; the defensive-disable becomes conditional rather than hardcoded `false`.
+
+### 5. Observability
+
+`deltav_dns_*` Micrometer meters (daemon-agnostic naming, `opennms_*`/`deltav_*` convention):
+- `deltav_dns_reverse_lookups_total{result=hit|miss|timeout|error|filtered}` — counter.
+- `deltav_dns_circuit_breaker_state` — gauge (0 closed / 1 half-open / 2 open), if surfaceable from
+  the Resilience4j breaker; otherwise omit.
+- `deltav_dns_lookup_seconds` — timer on `reverseLookup` latency (so the hot-path cost is visible).
+The decorator owns the `filtered` increment; the rest wrap the delegate's `reverseLookup`. If
+`NettyDnsResolver` already exposes its own metrics, prefer bridging those over duplicating.
+
+## Hot-path / performance considerations
+
+- With `enabled: true` + `scope: all`, a record's enrichment future is gated (`allOf`) on **all**
+  its IP lookups; an unresolvable IP can cost up to `query-timeout-ms` (default **5 s**) before that
+  record completes, until the breaker trips (80% failure over a 100-sample ring → opens 15 s →
+  fast-fail). The bulkhead caps concurrent in-flight lookups at 1000. The cache (incl. negative,
+  default size 10 000) absorbs repeats.
+- **Recommendation surfaced in docs:** for high-cardinality internet-facing flows, set
+  `scope: private` (structural cap to your own ranges) and/or lower `query-timeout-ms`. These are
+  the knobs that keep DNS-on-by-default from degrading flow throughput.
+- The NodeContext-based node/interface enrichment is unchanged and remains DB-free; DNS is a
+  separate, parser-level concern layered before document mapping.
+
+## Testing
+
+- **`LocalityFilteringDnsResolver`** unit tests: private IPv4 (10/8, 172.16/12, 192.168/16) and IPv6
+  ULA (`fc00::/7`) + loopback + link-local → delegate called; public (`8.8.8.8`, `2001:4860::`) →
+  empty, delegate NOT called, `filtered` counter bumped; `scope: all` → delegate always called;
+  `lookup()` always delegates.
+- **Conditional wiring** (Spring slice / `ApplicationContextRunner`): `enabled=true` →
+  `DnsResolver` bean is `LocalityFilteringDnsResolver` wrapping `NettyDnsResolver`; `enabled=false`
+  → `NoOpDnsResolver`; sFlow `dnsLookupsEnabled` tracks `enabled`.
+- **Config binding** test: properties map to the right `NettyDnsResolver` setters with the
+  documented defaults; validation rejects non-positive timeouts / out-of-range threshold.
+- **No live DNS in tests** — mock the delegate `DnsResolver`; assert delegation/short-circuit only.
+- **E2E (next deploy):** with defaults, flows show populated `src_hostname`/`dst_hostname` for
+  resolvable IPs; with `scope: private`, public-IP flows have empty hostnames while private ones
+  resolve; flow throughput remains acceptable and no breaker-open storm under nl6 load.
+
+## Out of scope
+
+- Forward DNS (`lookup`) enrichment — `reverseLookup` only (matches Horizon's `RecordEnricher`).
+- Changing which IPs the horizon parser collects (it resolves all IPs in the record; we gate by
+  CIDR, we do not change the capture set).
+- A per-field (src-only / dst-only) toggle — the parser resolves the whole record; field-level
+  control would require a horizon change.
+- Exposing the obscure NettyDnsResolver internals (ring buffers, numContexts, breaker wait) as config.
+
+## Build order
+
+1. `FlowEnricherDnsProperties` (`@ConfigurationProperties`) + defaults + validation, with tests.
+2. `LocalityFilteringDnsResolver` decorator + CIDR logic + `filtered` metric, with unit tests.
+3. `NettyDnsResolver` `@Bean` (conditional, init/destroy) wired from properties.
+4. `FlowEnricherConfiguration`: conditional `DnsResolver` bean (Netty+decorator vs NoOp); sFlow flag
+   follows `enabled`; context-runner wiring tests.
+5. `deltav_dns_*` metrics.
+6. `application.yml` defaults + README knob table + the on-by-default behavior-change note.

--- a/docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md
+++ b/docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md
@@ -85,15 +85,32 @@ is derived from `query-timeout-ms` to preserve Horizon's `queryTimeout+100` rela
 A `@ConfigurationProperties("deltav.flow-enricher.dns")` record/bean (`FlowEnricherDnsProperties`)
 binds these, with `@Validated` bounds (positive timeouts, threshold 1–100).
 
-### 2. `NettyDnsResolver` bean (conditional, lifecycle-managed)
+### 2. Resolver bean (conditional, lifecycle-managed) — delta-v-native
 
-- `@Bean(initMethod = "init", destroyMethod = "destroy")` `@ConditionalOnProperty(name =
-  "deltav.flow-enricher.dns.enabled", havingValue = "true", matchIfMissing = true)` (default-true
-  toggle → bean is created when the property is `true` **or absent**) —
-  constructs `org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver`, applies the curated setters
-  from `FlowEnricherDnsProperties`, leaves the hardcoded knobs at their field defaults.
-- `init()` builds the Netty event-loop contexts + Caffeine cache + Resilience4j breaker/bulkhead;
-  `destroy()` tears them down. Must run on context start/stop.
+> **PIVOT (2026-06-04, after deploy-E2E):** the original plan reused horizon's
+> `org.opennms.netmgt.dnsresolver.netty.NettyDnsResolver:1.0.11`. That artifact was compiled against
+> **resilience4j 1.x** and its `init()` unconditionally calls `CircuitBreakerConfig.Builder
+> .ringBufferSizeInHalfOpenState()/ringBufferSizeInClosedState()` — **removed in resilience4j 2.x**.
+> The flow-enricher's Spring Boot 4 classpath mandates resilience4j **2.3.0**, so the horizon impl
+> throws `NoSuchMethodError` and the application **fails to start** with DNS enabled. All unit tests
+> passed because they mock the resolver and never call `init()`; the deploy E2E caught it.
+> **Resolution:** drop the horizon `dnsresolver.netty` dependency and write a delta-v-native resolver
+> against the current classpath (Boot-native adapter; the horizon impl is an OSGi-era shape).
+
+- New `DeltavNettyDnsResolver implements org.opennms.netmgt.dnsresolver.api.DnsResolver` in
+  `org.deltav.flows.enricher.parser` — built on **Netty `DnsNameResolver`** (`io.netty:netty-resolver-dns`,
+  already on the classpath) for async forward (`resolve`) + reverse (PTR query against the
+  `in-addr.arpa`/`ip6.arpa` name) lookups, bounded by **resilience4j 2.x** `CircuitBreaker`
+  (`slidingWindowSize` / `failureRateThreshold` / `waitDurationInOpenState` /
+  `permittedNumberOfCallsInHalfOpenState`) + `Bulkhead` (`maxConcurrentCalls` / `maxWaitDuration`),
+  with a **Caffeine** cache (positive + negative, bounded size + TTL). Custom `nameservers` supported
+  via the `DnsNameResolverBuilder` name-server provider (blank → platform default / system resolv.conf).
+- `@Bean(initMethod = "init", destroyMethod = "close")` `@ConditionalOnProperty(name =
+  "deltav.flows.dns.enabled", havingValue = "true", matchIfMissing = true)` — `init()` builds the
+  Netty event loop + resolver + breaker + bulkhead + cache; `close()` shuts down the resolver +
+  event loop. Configured entirely from `FlowEnricherDnsProperties`.
+- The `bulkheadMaxWait = queryTimeoutMs + 100` relationship and all curated-knob defaults are
+  preserved; the obscure knobs become sensible constants in the native impl.
 
 ### 3. `LocalityFilteringDnsResolver` decorator (delta-v, new)
 

--- a/docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md
+++ b/docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md
@@ -104,12 +104,22 @@ delegate (`NettyDnsResolver`):
   `filtered` counter).
 - `lookup(String)`: pass through to the delegate unchanged (Horizon's `RecordEnricher` only calls
   `reverseLookup`; forward lookups are out of the hot path).
-- **Private/local set** (`scope: private`): IPv4 `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`,
-  `127.0.0.0/8` (loopback), `169.254.0.0/16` (link-local); IPv6 `fc00::/7` (ULA), `::1` (loopback),
-  `fe80::/10` (link-local). Implemented with `InetAddress.isSiteLocalAddress() ||
-  isLoopbackAddress() || isLinkLocalAddress()` plus an explicit `fc00::/7` check (Java's
-  `isSiteLocalAddress()` does not cover IPv6 ULA). Pure in-memory IP check; no allocation per call
-  beyond the boolean.
+- **IPv4-mapped IPv6 normalization (load-bearing).** Flow addresses arrive as IPv6 (the
+  `flows_raw.src_address`/`dst_address` columns are `IPv6`), so a private IPv4 such as `10.0.0.1`
+  can reach the decorator as an `Inet6Address` holding `::ffff:10.0.0.1`. `Inet6Address`'s
+  `isSiteLocalAddress()` checks the **IPv6** site-local prefix and returns `false` for an
+  IPv4-mapped private address — which would wrongly classify it as public and skip it under
+  `scope: private`. So **before** classifying, normalize: if the address is a 16-byte IPv4-mapped
+  form (`bytes[0..9]==0 && bytes[10]==bytes[11]==(byte)0xff`), reconstruct the embedded IPv4 via
+  `InetAddress.getByAddress(Arrays.copyOfRange(bytes,12,16))` (yields an `Inet4Address`) and run the
+  predicate on that. (Same IPv4-mapped-IPv6 gotcha the node-context migration's `IpNormalizer`
+  handles.)
+- **Private/local set** (`scope: private`, applied to the normalized address): IPv4 `10.0.0.0/8`,
+  `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8` (loopback), `169.254.0.0/16` (link-local); IPv6
+  `fc00::/7` (ULA), `::1` (loopback), `fe80::/10` (link-local). Implemented with
+  `isSiteLocalAddress() || isLoopbackAddress() || isLinkLocalAddress()` plus an explicit `fc00::/7`
+  check (Java's `isSiteLocalAddress()` does not cover IPv6 ULA). Pure in-memory check; no allocation
+  per call beyond the normalization copy for the mapped-IPv6 case.
 
 This is an **additive** delta-v capability (Horizon has no equivalent) → delta-v adapter is the
 correct layer (per the horizon-parallel-vs-additive rule), not a horizon source change.
@@ -158,6 +168,13 @@ The decorator owns the `filtered` increment; the rest wrap the delegate's `rever
   ULA (`fc00::/7`) + loopback + link-local → delegate called; public (`8.8.8.8`, `2001:4860::`) →
   empty, delegate NOT called, `filtered` counter bumped; `scope: all` → delegate always called;
   `lookup()` always delegates.
+- **IPv4-mapped IPv6 edge cases (bulletproofing the normalization)** — construct the inputs as
+  16-byte `Inet6Address` instances (via `InetAddress.getByAddress(byte[16])`, NOT
+  `getByName("::ffff:…")` which Java may collapse to `Inet4Address`, hiding the bug):
+  `::ffff:10.0.0.1`, `::ffff:172.16.0.1`, `::ffff:192.168.1.1`, `::ffff:127.0.0.1` → classified
+  **private** (delegate called) under `scope: private`; `::ffff:8.8.8.8` → classified **public**
+  (skipped). Assert that without the normalization step these private-mapped addresses would
+  otherwise be mis-skipped — i.e. the test fails if the unwrap is removed.
 - **Conditional wiring** (Spring slice / `ApplicationContextRunner`): `enabled=true` →
   `DnsResolver` bean is `LocalityFilteringDnsResolver` wrapping `NettyDnsResolver`; `enabled=false`
   → `NoOpDnsResolver`; sFlow `dnsLookupsEnabled` tracks `enabled`.

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -180,6 +180,30 @@ All scripts support:
 - `--pre-clean` — delete all nodes and alarms from DB before running
 - `--post-cleanup` — delete test data after run
 
+## Flow Enricher
+
+### Flow reverse-DNS enrichment (`deltav.flows.dns.*`)
+
+**Behaviour change (v1.3.0-rc9+):** reverse-DNS enrichment is **ON by default**
+(Horizon parity). The flow-enricher now reverse-resolves flow IPs to hostnames
+(`src_hostname`/`dst_hostname`/…) via horizon's `NettyDnsResolver`. Previously
+delta-v shipped a no-op resolver (no lookups). Disable with
+`DELTAV_FLOWS_DNS_ENABLED=false`.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `DELTAV_FLOWS_DNS_ENABLED` | `true` | master on/off |
+| `DELTAV_FLOWS_DNS_SCOPE` | `all` | `all` (resolve every IP) or `private` (only RFC1918/ULA/loopback/link-local — bounds cardinality to your address space) |
+| `DELTAV_FLOWS_DNS_NAMESERVERS` | _(blank)_ | DNS server(s); blank = system resolv.conf |
+| `DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS` | `5000` | per-lookup timeout |
+| `DELTAV_FLOWS_DNS_MAX_CONCURRENT` | `1000` | bulkhead: max in-flight lookups |
+| `DELTAV_FLOWS_DNS_CACHE_*_TTL_S` | `-1` | cache min/max/negative TTL (`-1` = NettyDnsResolver default) |
+| `DELTAV_FLOWS_DNS_BREAKER_ENABLED` / `_FAILURE_RATE` | `true` / `80` | circuit breaker on unhealthy DNS |
+
+For high-cardinality internet-facing flows, prefer `DELTAV_FLOWS_DNS_SCOPE=private`
+and/or a lower `DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS` to protect flow throughput.
+Metrics: `deltav_dns_reverse_lookups_total{result=hit|miss|error|filtered}`.
+
 ## Build Script Reference
 
 ```bash

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -919,6 +919,18 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       DELTAV_FLOWS_SINK_TOPICS: "DeltaV.Sink.Telemetry-Netflow-5,DeltaV.Sink.Telemetry-Netflow-9,DeltaV.Sink.Telemetry-IPFIX,DeltaV.Sink.Telemetry-SFlow"
       DELTAV_FLOWS_OUTPUT_TOPIC: deltav-flows
+      # Reverse-DNS enrichment (deltav.flows.dns.*). Pass the shell env through so
+      # operators (and the flows E2E) can override per-deploy; defaults = Horizon parity.
+      DELTAV_FLOWS_DNS_ENABLED: ${DELTAV_FLOWS_DNS_ENABLED:-true}
+      DELTAV_FLOWS_DNS_SCOPE: ${DELTAV_FLOWS_DNS_SCOPE:-all}
+      DELTAV_FLOWS_DNS_NAMESERVERS: ${DELTAV_FLOWS_DNS_NAMESERVERS:-}
+      DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS: ${DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS:-5000}
+      DELTAV_FLOWS_DNS_MAX_CONCURRENT: ${DELTAV_FLOWS_DNS_MAX_CONCURRENT:-1000}
+      DELTAV_FLOWS_DNS_CACHE_MIN_TTL_S: ${DELTAV_FLOWS_DNS_CACHE_MIN_TTL_S:--1}
+      DELTAV_FLOWS_DNS_CACHE_MAX_TTL_S: ${DELTAV_FLOWS_DNS_CACHE_MAX_TTL_S:--1}
+      DELTAV_FLOWS_DNS_CACHE_NEGATIVE_TTL_S: ${DELTAV_FLOWS_DNS_CACHE_NEGATIVE_TTL_S:--1}
+      DELTAV_FLOWS_DNS_BREAKER_ENABLED: ${DELTAV_FLOWS_DNS_BREAKER_ENABLED:-true}
+      DELTAV_FLOWS_DNS_BREAKER_FAILURE_RATE: ${DELTAV_FLOWS_DNS_BREAKER_FAILURE_RATE:-80}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/actuator/health"]
       interval: 10s

--- a/opennms-container/delta-v/test-flows-e2e.sh
+++ b/opennms-container/delta-v/test-flows-e2e.sh
@@ -274,6 +274,114 @@ else
   log "  [INFO] No application-classified flows yet — classification may be pending (non-fatal)"
 fi
 
+# ══════════════════════════════════════════════════════════════════
+# Phase 5: Reverse-DNS enrichment (deltav.flows.dns.*)
+# ══════════════════════════════════════════════════════════════════
+log ""
+log "Phase 5: Reverse-DNS enrichment checks..."
+
+KIWI_IP="76.223.105.230"        # deltav.kiwi (AWS Global Accelerator) — stable PTR record
+KIWI_CH="::ffff:${KIWI_IP}"
+
+# deltav_dns_reverse_lookups_total{result=$1} from the flow-enricher actuator;
+# empty $1 → grand total. Values are floats (e.g. 30359.0); callers integer-truncate.
+fe_dns_metric() {
+  local tag="$1" out
+  out=$(docker compose exec -T flow-enricher sh -c \
+    'wget -qO- http://localhost:8080/actuator/prometheus 2>/dev/null | grep "^deltav_dns_reverse_lookups_total"' 2>/dev/null)
+  if [ -n "$tag" ]; then
+    echo "$out" | awk -v t="result=\"$tag\"" 'index($0,t){print $2}' | head -1
+  else
+    echo "$out" | awk '{s+=$2} END {printf "%d", s+0}'
+  fi
+}
+fe_wait_ready() {
+  local i
+  for i in $(seq 1 20); do
+    docker compose exec -T flow-enricher sh -c \
+      'wget -qO- http://localhost:8080/actuator/health 2>/dev/null | grep -q UP' 2>/dev/null && return 0
+    sleep 10
+  done
+  return 1
+}
+# Inject $2 Netflow-v5 packets with dst IPv4 $1 to the Minion flow port (4729).
+inject_netflow5() {
+  python3 - "$1" "${2:-8}" <<'PYINJECT'
+import socket, struct, sys, time
+dst = bytes(int(x) for x in sys.argv[1].split('.')); count = int(sys.argv[2])
+up = 100000; now = int(time.time())
+hdr = struct.pack('!HHIIIIBBH', 5, 1, up, now, 0, 1, 0, 0, 0)
+rec = (bytes([10,99,99,99]) + dst + bytes(4) + struct.pack('!HH',1,2)
+       + struct.pack('!II',10,1500) + struct.pack('!II',up-1000,up)
+       + struct.pack('!HH',40000,443) + struct.pack('!BBBB',0,0x10,6,0)
+       + struct.pack('!HH',0,0) + struct.pack('!BBH',24,24,0))
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+for _ in range(count): s.sendto(hdr+rec, ('127.0.0.1', 4729)); time.sleep(0.3)
+s.close()
+PYINJECT
+}
+
+if ! docker compose exec -T flow-enricher sh -c \
+     'wget -qO- http://localhost:8080/actuator/prometheus 2>/dev/null | grep -q deltav_dns'; then
+  log "  [SKIP] flow-enricher image predates reverse-DNS (no deltav_dns metric) — skipping Phase 5"
+else
+  # 5A — resolver is active (has attempted reverse lookups on real flows)
+  DNS_TOTAL=$(fe_dns_metric "")
+  if [ "${DNS_TOTAL:-0}" -gt 0 ]; then
+    ok "Reverse-DNS resolver active: ${DNS_TOTAL} reverse lookups attempted"
+  else
+    fail "Reverse-DNS resolver inactive: deltav_dns_reverse_lookups_total is 0 despite DNS enabled"
+  fi
+
+  # 5C — a public PTR-resolvable dst gets dst_hostname populated end-to-end (scope=all default).
+  log "  Injecting a flow to ${KIWI_IP} (deltav.kiwi) and waiting for reverse-DNS..."
+  inject_netflow5 "$KIWI_IP" 8
+  KIWI_HOST=""
+  for _i in $(seq 1 9); do
+    KIWI_HOST=$(ch_query "SELECT dst_hostname FROM deltav.flows_raw WHERE dst_address = toIPv6('${KIWI_CH}') AND dst_hostname != '' ORDER BY timestamp DESC LIMIT 1")
+    [ -n "$KIWI_HOST" ] && break
+    sleep 10
+  done
+  if [ -n "$KIWI_HOST" ]; then
+    ok "Public dst reverse-resolved: ${KIWI_IP} → dst_hostname='${KIWI_HOST}'"
+  else
+    fail "Public dst ${KIWI_IP} got no dst_hostname — Netty reverse-PTR path may be broken"
+  fi
+
+  # 5B — scope=private filters public IPs (cardinality guard) while STILL resolving the
+  #      IPv4-mapped private nl6 IPs (::ffff:10.x). Toggle, observe, restore.
+  log "  Toggling flow-enricher to DNS scope=private (CIDR gate + IPv4-mapped classification)..."
+  DELTAV_FLOWS_DNS_SCOPE=private docker compose --profile demo up -d --force-recreate --no-deps flow-enricher >/dev/null 2>&1
+  if fe_wait_ready; then
+    # Metrics reset on recreate; wait for the fresh container to RESUME processing flows
+    # (the enrichFlows binding only starts after the node-context cache re-bootstraps),
+    # then take the fresh baselines.
+    for _w in $(seq 1 18); do [ "$(fe_dns_metric '')" -gt 0 ] 2>/dev/null && break; sleep 10; done
+    F0=$(fe_dns_metric filtered); F0=${F0%.*}; F0=${F0:-0}
+    M0=$(fe_dns_metric miss); M0=${M0%.*}; M0=${M0:-0}
+    inject_netflow5 "$KIWI_IP" 8     # public → must be filtered under scope=private
+    sleep 30
+    F1=$(fe_dns_metric filtered); F1=${F1%.*}; F1=${F1:-0}
+    M1=$(fe_dns_metric miss); M1=${M1%.*}; M1=${M1:-0}
+    KIWI_PRIV=$(ch_query "SELECT dst_hostname FROM deltav.flows_raw WHERE dst_address = toIPv6('${KIWI_CH}') AND dst_hostname != '' AND timestamp > now() - INTERVAL 1 MINUTE LIMIT 1")
+    if [ "$F1" -gt "$F0" ] && [ -z "$KIWI_PRIV" ]; then
+      ok "scope=private filters public IPs: filtered ${F0}→${F1}, deltav.kiwi left unresolved"
+    else
+      fail "scope=private did not filter the public IP (filtered ${F0}→${F1}, kiwi host='${KIWI_PRIV}')"
+    fi
+    if [ "$M1" -gt "$M0" ]; then
+      ok "scope=private still resolves IPv4-mapped private nl6 IPs: miss ${M0}→${M1} (not mis-filtered)"
+    else
+      fail "scope=private appears to mis-filter IPv4-mapped private IPs (miss stalled: ${M0}→${M1})"
+    fi
+  else
+    fail "flow-enricher did not become ready after scope=private recreate"
+  fi
+  log "  Restoring flow-enricher DNS scope=all..."
+  DELTAV_FLOWS_DNS_SCOPE=all docker compose --profile demo up -d --force-recreate --no-deps flow-enricher >/dev/null 2>&1
+  fe_wait_ready || log "  [WARN] flow-enricher slow to return after restore (check 'make status')"
+fi
+
 show_diagnostics
 
 # ══════════════════════════════════════════════════════════════════
@@ -290,4 +398,5 @@ echo "  Phase 2: flows_raw receiving data (Minion → flow-enricher → ClickHou
 echo "  Phase 2: Per-protocol rows (Netflow v9 from softflowd, sFlow from hsflowd)"
 echo "  Phase 3: All 4 dimension MVs populated (application, source_ip, conversation, dscp)"
 echo "  Phase 4: Enrichment integrity (exporter_node_id, src_address)"
+echo "  Phase 5: Reverse-DNS (resolver active, public dst→hostname, scope=private CIDR gate)"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Makes the flow-enricher's reverse-DNS enrichment a **configurable** capability, replacing the always-off `NoOpDnsResolver` with horizon's hardened `NettyDnsResolver` behind a config gate (`deltav.flows.dns.*`). Flow IPs are reverse-resolved to hostnames (`src_hostname`/`dst_hostname`/…), bounded by horizon's built-in circuit breaker + bulkhead + TTL cache + query timeout, with an optional delta-v CIDR scope gate on top.

Spec: `docs/superpowers/specs/2026-06-04-flow-enricher-netty-dns-resolver-design.md`
Plan: `docs/superpowers/plans/2026-06-04-flow-enricher-netty-dns-resolver.md`

## ⚠️ Behavior change — reverse-DNS is ON by default

Default `deltav.flows.dns.enabled=true` (Horizon parity). On upgrade, the flow-enricher **starts reverse-resolving flow IPs**, where today it does none (NoOp). Disable with `DELTAV_FLOWS_DNS_ENABLED=false`. Documented in the README with the full knob table.

## What changed

- **`FlowEnricherDnsProperties`** — `@ConfigurationProperties("deltav.flows.dns")` record; curated knobs (`enabled`, `scope`, `nameservers`, `query-timeout-ms`, `max-concurrent`, `cache.{min,max,negative}-ttl-s`, `circuit-breaker.{enabled,failure-rate-threshold}`) with **defaults mirroring Horizon's `NettyDnsResolver` field defaults**. Obscure knobs (ring buffers, `numContexts`, breaker-wait, bulkhead-max-wait) stay hardcoded; `bulkheadMaxWait` derived as `queryTimeout+100`.
- **`LocalityFilteringDnsResolver`** — CIDR scope gate (`scope: all|private`, default `all` = Horizon). In `private`, only RFC1918 / IPv6-ULA / loopback / link-local IPs are resolved; public IPs short-circuit (bounding lookup cardinality to your address space). **Normalizes IPv4-mapped IPv6** (`::ffff:10.0.0.1`) to the embedded IPv4 before classifying — flow IPs arrive as IPv6, and `Inet6Address.isSiteLocalAddress()` would otherwise mis-class a mapped private IPv4 as public.
- **Conditional wiring** — `NettyDnsResolver` `@Bean` (init/destroy lifecycle, configured from props); two mutually-exclusive `flowParserDnsResolver` beans (decorator when enabled, NoOp when disabled, `matchIfMissing=true`); sFlow `setDnsLookupsEnabled` follows the toggle.
- **Metrics** — `deltav_dns_reverse_lookups_total{result=hit|miss|error|filtered}`.
- **Pom** — adds `org.opennms.features.dnsresolver.netty:1.0.11` (deliberate pin — the netty module isn't published past 1.0.11 in delta-v-horizon; the api at 1.0.18 has a byte-identical interface; commented in the pom). Excludes the ServiceMix/Spring-4.2.9/opennms-model OSGi baggage that conflicts with Spring Boot 4 (verified: all real `NettyDnsResolver` runtime deps survive).

## Test plan

- [x] `FlowEnricherDnsProperties` binding (defaults + overrides + relaxed `scope` enum)
- [x] `LocalityFilteringDnsResolver` — 10 unit tests incl **IPv4-mapped IPv6 built as genuine 16-byte `Inet6Address`** (private + public), RFC1918 boundary (`172.32.0.0` public), IPv6 ULA (`fc00::1`/`fd00::1`), link-local (`fe80::1`), `scope=all`, forward-lookup passthrough, `filtered` metric
- [x] Conditional wiring (decorator vs NoOp selection)
- [x] Full module: **123 tests, 0 failures**; final cross-cutting review passed (deps survive exclusions, `1.0.11` pin CI-verified against GH Packages)
- [ ] **Deferred E2E (next deploy/rc):** with defaults, flows show populated `src_hostname`/`dst_hostname`; with `scope=private`, public-IP flows have empty hostnames (`result=filtered` increments) while private resolve; throughput stays healthy with no breaker-open storm

## Follow-ups (non-blocking)

- The spec mentioned `@Validated` bounds on the properties (positive timeouts, threshold 1–100); dropped from the plan to avoid the validation-starter dependency. Worth adding if config-input validation is desired.
