### PR TITLE
chore(v1.3.0): bump version to 1.3.0-rc9

### DIFF
--- a/core/alarms-kafka-publisher/pom.xml
+++ b/core/alarms-kafka-publisher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/alarms-materializer/pom.xml
+++ b/core/alarms-materializer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/alerts-forwarder/pom.xml
+++ b/core/alerts-forwarder/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/horizon-metric-bridge/pom.xml
+++ b/core/horizon-metric-bridge/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-grpc-contracts/pom.xml
+++ b/core/minion-grpc-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/node-context-consumer/pom.xml
+++ b/core/node-context-consumer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/poller-timeseries-common/pom.xml
+++ b/core/poller-timeseries-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc8</version>
+        <version>1.3.0-rc9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/opennms-container/delta-v/.env.example
+++ b/opennms-container/delta-v/.env.example
@@ -4,7 +4,7 @@
 # from-source dev build against host.docker.internal Kafka.
 # VERSION must match an image tag you have built locally (`make images`)
 # or one published to the registry in IMAGE_PREFIX.
-VERSION=1.3.0-rc8
+VERSION=1.3.0-rc9
 # Local builds: deltav. To pull published images instead: ghcr.io/pbrane
 IMAGE_PREFIX=deltav
 KAFKA_EXTERNAL_HOST=host.docker.internal

--- a/opennms-container/delta-v/smoke-vm.sh
+++ b/opennms-container/delta-v/smoke-vm.sh
@@ -23,8 +23,8 @@ docker system prune -a --volumes -f
 rm -rf ~/delta-v-smoke
 mkdir -p ~/delta-v-smoke && cd ~/delta-v-smoke
 
-GIT_REF=v1.3.0-rc8
-IMG_TAG=1.3.0-rc8
+GIT_REF=v1.3.0-rc9
+IMG_TAG=1.3.0-rc9
 
 BASE=https://raw.githubusercontent.com/pbrane/delta-v/$GIT_REF/opennms-container/delta-v
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>1.3.0-rc8</version>
+  <version>1.3.0-rc9</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>


### PR DESCRIPTION
Bumps rc8 → rc9 across the delta-v module poms + `.env.example` + `smoke-vm.sh`. Cuts the rc9 release including #333 (native Netty DNS reverse-resolution, on by default).