### PR TITLE
test(flows): dns-lab profile — reverse-DNS testing against nl6 traffic

### DIFF
--- a/.github/workflows/delta-v-build-images.yml
+++ b/.github/workflows/delta-v-build-images.yml
@@ -182,7 +182,7 @@ jobs:
           echo "     ./deploy.sh up lite"
           echo ""
           echo "### Images"
-          DAEMONS="alarmd alerts-forwarder bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init flow-enricher prometheus-writer clickhouse clickhouse-init grafana provisiond-imports-init perspective-app-init nl6-provisioner mock-snmp-agent jre-deltav daemon-base"
+          DAEMONS="alarmd alerts-forwarder bsmd collectd discovery enlinkd eventtranslator perspectivepollerd pollerd provisiond syslogd telemetryd trapd minion-boot db-init flow-enricher prometheus-writer clickhouse clickhouse-init grafana dns-lab provisiond-imports-init perspective-app-init nl6-provisioner mock-snmp-agent jre-deltav daemon-base"
           for name in $DAEMONS; do
             echo "  ${{ env.IMAGE_PREFIX }}/$name:${VERSION}"
           done

--- a/opennms-container/delta-v/Dockerfile.dns-lab
+++ b/opennms-container/delta-v/Dockerfile.dns-lab
@@ -1,0 +1,18 @@
+# Delta-V dns-lab image — CoreDNS with a baked Corefile that synthesizes PTR
+# records for the nl6 simulator's 10/8 flow IPs (and forwards everything else
+# upstream). Baked (not bind-mounted) so it works in the no-clone smoke-VM path
+# (curl docker-compose.yml; docker compose up) exactly like clickhouse-init/grafana.
+#
+# Test-only. Activate via the `dns-lab` compose profile + point the flow-enricher
+# at it with DELTAV_FLOWS_DNS_NAMESERVERS=172.18.0.53.
+#
+# Build context is opennms-container/delta-v (build.sh do_dns_lab_image).
+FROM coredns/coredns:1.11.3
+
+LABEL org.opencontainers.image.title="delta-v-dns-lab" \
+      org.opencontainers.image.description="CoreDNS that synthesizes PTR records for the nl6 10/8 flow IPs (reverse-DNS enrichment testing)"
+
+COPY dns-lab/Corefile /etc/coredns/Corefile
+
+ENTRYPOINT ["/coredns"]
+CMD ["-conf", "/etc/coredns/Corefile"]

--- a/opennms-container/delta-v/README.md
+++ b/opennms-container/delta-v/README.md
@@ -186,7 +186,8 @@ All scripts support:
 
 **Behaviour change (v1.3.0-rc9+):** reverse-DNS enrichment is **ON by default**
 (Horizon parity). The flow-enricher now reverse-resolves flow IPs to hostnames
-(`src_hostname`/`dst_hostname`/…) via horizon's `NettyDnsResolver`. Previously
+(`src_hostname`/`dst_hostname`/…) via a delta-v-native Netty `DnsNameResolver`
+(resilience4j 2.x circuit breaker + bulkhead + Caffeine cache). Previously
 delta-v shipped a no-op resolver (no lookups). Disable with
 `DELTAV_FLOWS_DNS_ENABLED=false`.
 
@@ -203,6 +204,25 @@ delta-v shipped a no-op resolver (no lookups). Disable with
 For high-cardinality internet-facing flows, prefer `DELTAV_FLOWS_DNS_SCOPE=private`
 and/or a lower `DELTAV_FLOWS_DNS_QUERY_TIMEOUT_MS` to protect flow throughput.
 Metrics: `deltav_dns_reverse_lookups_total{result=hit|miss|error|filtered}`.
+
+#### Testing reverse-DNS against nl6 traffic (`dns-lab` profile)
+
+The nl6 simulator's flow records carry **random `10.x` src/dst** addresses with no
+PTR records, so reverse-DNS against them is all `miss`. The optional **`dns-lab`**
+profile adds a CoreDNS sidecar (static IP `172.18.0.53`) that **synthesizes** a PTR
+for any `10.in-addr.arpa` query (`10.168.74.188` → `nl6-host-10-168-74-188.lab`) and
+forwards everything else (public IPs, etc.) upstream — so the resolver's hit path is
+exercised end-to-end at realistic, high-cardinality volume while public resolution
+still works. Activate by enabling the profile **and** pointing the flow-enricher at it:
+
+```bash
+DELTAV_FLOWS_DNS_NAMESERVERS=172.18.0.53 \
+  docker compose --profile demo --profile dns-lab up -d
+```
+
+Then nl6 flows populate `dst_hostname` with `nl6-host-10-*` names. This works in the
+smoke VM too (the `deltav/dns-lab` image bakes the Corefile — no bind mount needed).
+Test-only; production uses the system/real resolver (blank `DELTAV_FLOWS_DNS_NAMESERVERS`).
 
 ## Build Script Reference
 

--- a/opennms-container/delta-v/build.sh
+++ b/opennms-container/delta-v/build.sh
@@ -266,6 +266,12 @@ do_grafana_image() {
     build_image grafana -f Dockerfile.grafana .
 }
 
+do_dns_lab_image() {
+    log "Building ${IMAGE_PREFIX}/dns-lab:$VERSION..."
+    cd "$SCRIPT_DIR"
+    build_image dns-lab -f Dockerfile.dns-lab .
+}
+
 do_provisiond_imports_init_image() {
     log "Building ${IMAGE_PREFIX}/provisiond-imports-init:$VERSION..."
     cd "$SCRIPT_DIR"
@@ -435,6 +441,7 @@ do_deltav_images() {
     do_clickhouse_image
     do_clickhouse_init_image
     do_grafana_image
+    do_dns_lab_image
     do_provisiond_imports_init_image
     do_nl6_provisioner_image
     do_mock_snmp_agent_image
@@ -448,7 +455,7 @@ do_deltav_images() {
         log "Delta-V images pushed to ${IMAGE_PREFIX} (multi-arch; not loaded locally)."
     else
         log "Delta-V images built:"
-        docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|alerts-forwarder|alarms-materializer|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy|perspective-app-init|clickhouse|clickhouse-init|grafana|provisiond-imports-init|nl6-provisioner|mock-snmp-agent" | sort | head -60 || true
+        docker images --format "  {{.Repository}}:{{.Tag}}\t{{.Size}}" | grep -E "daemon-base|alarmd|alerts-forwarder|alarms-materializer|bsmd|collectd|discovery|enlinkd|eventtranslator|perspectivepollerd|pollerd|provisiond|syslogd|telemetryd|trapd|minion-boot|flow-enricher|prometheus-writer|minion-gateway|envoy|perspective-app-init|clickhouse|clickhouse-init|grafana|dns-lab|provisiond-imports-init|nl6-provisioner|mock-snmp-agent" | sort | head -60 || true
     fi
 }
 

--- a/opennms-container/delta-v/dns-lab/Corefile
+++ b/opennms-container/delta-v/dns-lab/Corefile
@@ -1,0 +1,28 @@
+# Delta-V dns-lab — CoreDNS for exercising the flow-enricher's reverse-DNS
+# enrichment against the nl6 simulator's traffic.
+#
+# The nl6 flow records carry RANDOM src/dst addresses across 10/8 (effectively
+# unbounded cardinality), so we cannot enumerate PTR records for them. Instead we
+# SYNTHESIZE a PTR answer for any 10.in-addr.arpa query, turning every nl6 flow IP
+# into a resolvable hostname (e.g. 10.168.74.188 -> nl6-host-10-168-74-188.lab).
+# Everything else (public IPs like deltav.kiwi, container names) is forwarded to
+# the normal upstream resolver, so non-lab resolution is unaffected.
+#
+# TEST-ONLY. Activate via the `dns-lab` compose profile and point the
+# flow-enricher at it: DELTAV_FLOWS_DNS_NAMESERVERS=172.18.0.53
+
+10.in-addr.arpa:53 {
+    # Reverse name for 10.b.c.d is d.c.b.10.in-addr.arpa — capture the octets and
+    # reconstruct the address in the synthesized name.
+    template IN PTR {
+        match "^(?P<d>[0-9]+)\.(?P<c>[0-9]+)\.(?P<b>[0-9]+)\.10\.in-addr\.arpa\.$"
+        answer "{{ .Name }} 60 IN PTR nl6-host-10-{{ .Group.b }}-{{ .Group.c }}-{{ .Group.d }}.lab."
+    }
+    errors
+}
+
+. {
+    forward . /etc/resolv.conf
+    cache 30
+    errors
+}

--- a/opennms-container/delta-v/docker-compose.yml
+++ b/opennms-container/delta-v/docker-compose.yml
@@ -193,6 +193,24 @@ services:
       default:
         ipv4_address: 172.18.0.30
 
+  # dns-lab — CoreDNS that synthesizes PTR records for the nl6 simulator's 10/8
+  # flow IPs (and forwards everything else upstream), so the flow-enricher's
+  # reverse-DNS enrichment can be exercised end-to-end against realistic,
+  # high-cardinality flow traffic. TEST-ONLY: activate the `dns-lab` profile AND
+  # point the flow-enricher at it via DELTAV_FLOWS_DNS_NAMESERVERS=172.18.0.53
+  # (the static IP below). Without that env, the flow-enricher uses the normal
+  # system resolver and dns-lab is unused even if running.
+  dns-lab:
+    <<: *no-search-domain
+    profiles: [dns-lab]
+    image: ${IMAGE_PREFIX:-deltav}/dns-lab:${VERSION}
+    container_name: delta-v-dns-lab
+    hostname: dns-lab
+    restart: unless-stopped
+    networks:
+      default:
+        ipv4_address: 172.18.0.53   # nameserver IP for DELTAV_FLOWS_DNS_NAMESERVERS
+
   nl6-provisioner:
     <<: *no-search-domain
     image: ${IMAGE_PREFIX:-deltav}/nl6-provisioner:${VERSION}


### PR DESCRIPTION
## Summary

Optional **`dns-lab`** profile: a CoreDNS sidecar that **synthesizes PTR records** for the nl6 simulator's random `10/8` flow IPs (`10.168.74.188` → `nl6-host-10-168-74-188.lab`) and **forwards everything else upstream**, so the flow-enricher's reverse-DNS hit path can be exercised end-to-end at realistic high-cardinality volume — while public resolution (e.g. deltav.kiwi) still works.

Motivation: nl6 flow records carry random `10.x` src/dst with no PTRs, so reverse-DNS against them is all `miss`. A wildcard PTR responder is the only way to enumerate-free test the hit path on real flow traffic (and it load-tests the resolver's cache/bulkhead/breaker, the actual hot-path concern).

## Changes (config-only; the resolver already supports `nameservers`)
- `dns-lab/Corefile` + `Dockerfile.dns-lab` — CoreDNS `template` plugin synthesizing PTR for `10.in-addr.arpa`; **baked image** (no bind mount) so it works in the no-clone smoke VM.
- `docker-compose.yml`: `dns-lab` service, profile `[dns-lab]`, static IP `172.18.0.53`.
- `build.sh`: `do_dns_lab_image` in `do_deltav_images` → `make images` + CI publish `deltav/dns-lab`.
- CI workflow + build.sh image-summary lists synced; README activation docs (+ fixed stale 'horizon NettyDnsResolver' → native resolver).

## Smoke-VM compatibility
✅ Works in the smoke VM: the Corefile is **baked into `deltav/dns-lab`** (built by `make images`, published by CI), so the no-clone `curl docker-compose.yml; docker compose --profile dns-lab up` path pulls it like any other image.

## Activation
```bash
DELTAV_FLOWS_DNS_NAMESERVERS=172.18.0.53 docker compose --profile demo --profile dns-lab up -d
```

## Test plan
- [x] bash / YAML / workflow syntax valid
- [ ] **Live (deferred — Mac freed for rc9 smoke):** `make images` builds `deltav/dns-lab`; with the profile active, nl6 flows populate `dst_hostname LIKE 'nl6-host-%'` and `deltav_dns_reverse_lookups_total{result=hit}` climbs; public deltav.kiwi still resolves (forwarded). Worth a Phase 6 flows-E2E once validated.