### PR TITLE
build(docker): add root .dockerignore for repo-root build contexts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# .dockerignore — applies to repo-root build contexts only.
+#
+# build.sh builds the `clickhouse` and `clickhouse-init` images with
+# context=$REPO_ROOT (they COPY from both deploy/clickhouse/ and
+# core/flow-enricher/src/main/proto/). Without this file the entire repo —
+# Maven target/ output, .git history, ui/node_modules — is sent to the Docker
+# daemon on every such build. Subdir-context builds resolve their own
+# .dockerignore (e.g. core/db-init/.dockerignore) and are unaffected.
+#
+# Do NOT ignore deploy/clickhouse/** or core/flow-enricher/src/main/proto/** —
+# those are the COPY sources for the repo-root builds above.
+
+# Version control / CI metadata
+.git
+.gitignore
+.github
+
+# Maven build output (largest offender)
+**/target
+
+# Frontend
+**/node_modules
+ui/dist
+ui/.vite
+
+# AI tool working directories (also gitignored)
+_bmad
+_bmad-output
+.superpowers
+openspec
+
+# Docs and incidental local files
+docs
+*.log
+.DS_Store


### PR DESCRIPTION
## What

Adds the missing root `.dockerignore`. This is **PR 7** of the [container directory restructure](https://github.com/pbrane/delta-v/pull/335) ladder — independent of the de-nest (#335), so it targets `develop` directly.

## Why

`build.sh` builds the `clickhouse` and `clickhouse-init` images with **`context=$REPO_ROOT`** (they `COPY` from both `deploy/clickhouse/` and `core/flow-enricher/src/main/proto/`). With no root `.dockerignore`, every such build streams the **entire repo** — Maven `target/` output, `.git` history, `ui/node_modules`, `_bmad-output/` — to the Docker daemon. This closes a pre-existing gap the restructure research flagged.

## Safety

Only repo-root build contexts are affected; subdir-context builds (e.g. `core/db-init`) resolve their own `.dockerignore` and are untouched. Verified the ignore patterns do **not** match the actual `COPY` sources:
- ✅ `deploy/clickhouse/{config.d,init,user-init,init-runner.sh}` preserved
- ✅ `core/flow-enricher/src/main/proto/` preserved

Excludes only large, never-needed trees: `.git`, `**/target`, `**/node_modules`, `_bmad*`, `docs`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)