### PR TITLE
[#1]: fix(build): dns-lab image build must cd to DEPLOY_DIR (make images regression)

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -269,7 +269,7 @@ do_grafana_image() {
 
 do_dns_lab_image() {
     log "Building ${IMAGE_PREFIX}/dns-lab:$VERSION..."
-    cd "$SCRIPT_DIR"
+    cd "$DEPLOY_DIR"
     build_image dns-lab -f Dockerfile.dns-lab .
 }
 


### PR DESCRIPTION
## Problem

`make images` is **broken on `develop`** — it fails on the `dns-lab` image:

```
ERROR: failed to solve: failed to read dockerfile: open Dockerfile.dns-lab: no such file or directory
make: *** [images] Error 1
```

CI's `make images PUSH=true` hits the same failure.

## Root cause — a semantic merge regression (no textual conflict)

- **#336** (dns-lab profile) branched off `develop` *before* the ops-scripts move and added `do_dns_lab_image()` with `cd "$SCRIPT_DIR"` — correct then, because `SCRIPT_DIR` was `deploy/`.
- **#339** (ops scripts → `tools/`) made `SCRIPT_DIR` the script's own dir (`tools/`) and introduced `DEPLOY_DIR` for deploy artifacts; every aux build was switched to `cd "$DEPLOY_DIR"`.
- The two merged with **no git conflict**, leaving `do_dns_lab_image` cd-ing to `tools/` — where `Dockerfile.dns-lab` doesn't exist.

It was missed because #336's function wasn't present in the #339 branch during that refactor.

## Fix

One line: `cd "$SCRIPT_DIR"` → `cd "$DEPLOY_DIR"` in `do_dns_lab_image`, matching every other aux image build. The context must be `deploy/` because the Dockerfile does `COPY dns-lab/Corefile`.

## Verification

`docker build -f Dockerfile.dns-lab .` from `deploy/` → **exit 0** (image builds, Corefile COPY resolves). `grep '$SCRIPT_DIR' tools/build.sh` now shows only the legitimate `REPO_ROOT` derivation + `compute-shared-libs.sh` sibling calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)