### PR TITLE
chore(release): v1.3.0-rc10 — restructure build fix + e2e hardening + version bump

### DIFF
--- a/core/alarms-kafka-publisher/pom.xml
+++ b/core/alarms-kafka-publisher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/alarms-materializer/pom.xml
+++ b/core/alarms-materializer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/alerts-forwarder/pom.xml
+++ b/core/alerts-forwarder/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-alarmd/pom.xml
+++ b/core/daemon-boot-alarmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-bsmd/pom.xml
+++ b/core/daemon-boot-bsmd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-collectd/pom.xml
+++ b/core/daemon-boot-collectd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-discovery/pom.xml
+++ b/core/daemon-boot-discovery/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-enlinkd/pom.xml
+++ b/core/daemon-boot-enlinkd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-eventtranslator/pom.xml
+++ b/core/daemon-boot-eventtranslator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion-common/pom.xml
+++ b/core/daemon-boot-minion-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-minion/pom.xml
+++ b/core/daemon-boot-minion/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-perspectivepollerd/pom.xml
+++ b/core/daemon-boot-perspectivepollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-pollerd/pom.xml
+++ b/core/daemon-boot-pollerd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-provisiond/pom.xml
+++ b/core/daemon-boot-provisiond/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-syslogd/pom.xml
+++ b/core/daemon-boot-syslogd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-telemetryd/pom.xml
+++ b/core/daemon-boot-telemetryd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-boot-trapd/pom.xml
+++ b/core/daemon-boot-trapd/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-common/pom.xml
+++ b/core/daemon-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-registry/pom.xml
+++ b/core/daemon-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/daemon-sink-kafka/pom.xml
+++ b/core/daemon-sink-kafka/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/dao-jpa-support/pom.xml
+++ b/core/dao-jpa-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/db-init/pom.xml
+++ b/core/db-init/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/deltav-kafka-contracts/pom.xml
+++ b/core/deltav-kafka-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/event-forwarder-kafka/pom.xml
+++ b/core/event-forwarder-kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/flow-enricher/pom.xml
+++ b/core/flow-enricher/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/horizon-metric-bridge/pom.xml
+++ b/core/horizon-metric-bridge/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-gateway/pom.xml
+++ b/core/minion-gateway/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/minion-grpc-contracts/pom.xml
+++ b/core/minion-grpc-contracts/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/node-context-consumer/pom.xml
+++ b/core/node-context-consumer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/opennms-model-jakarta/pom.xml
+++ b/core/opennms-model-jakarta/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/poller-timeseries-common/pom.xml
+++ b/core/poller-timeseries-common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/prometheus-writer/pom.xml
+++ b/core/prometheus-writer/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.deltav</groupId>
         <artifactId>delta-v-parent</artifactId>
-        <version>1.3.0-rc9</version>
+        <version>1.3.0-rc10</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -4,7 +4,7 @@
 # from-source dev build against host.docker.internal Kafka.
 # VERSION must match an image tag you have built locally (`make images`)
 # or one published to the registry in IMAGE_PREFIX.
-VERSION=1.3.0-rc9
+VERSION=1.3.0-rc10
 # Local builds: deltav. To pull published images instead: ghcr.io/pbrane
 IMAGE_PREFIX=deltav
 KAFKA_EXTERNAL_HOST=host.docker.internal

--- a/deploy/test-alerts-forwarder-e2e.sh
+++ b/deploy/test-alerts-forwarder-e2e.sh
@@ -98,7 +98,7 @@ cleanup() {
     if [ -n "$KAFKA_CONSUMER_PID" ]; then
         kill "$KAFKA_CONSUMER_PID" 2>/dev/null || true
     fi
-    docker exec delta-v-kafka-1 sh -c 'for p in $(ps -eo pid,args 2>/dev/null | grep kafka-console-consumer | grep -v grep | awk "{print \$1}"); do kill "$p" 2>/dev/null; done' 2>/dev/null || true
+    docker compose exec -T kafka sh -c 'for p in $(ps -eo pid,args 2>/dev/null | grep kafka-console-consumer | grep -v grep | awk "{print \$1}"); do kill "$p" 2>/dev/null; done' 2>/dev/null || true
 
     if $VERBOSE; then
         log ""
@@ -197,7 +197,7 @@ wait_for_alertmanager_alert() {
 start_kafka_key_tail() {
     log "Starting Kafka tail consumer on ${ALARMS_TOPIC} (latest only)..."
     : > "$KAFKA_KEYS_LOG"
-    docker exec delta-v-kafka-1 /opt/kafka/bin/kafka-console-consumer.sh \
+    docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
         --bootstrap-server localhost:9092 \
         --topic "$ALARMS_TOPIC" \
         --consumer-property auto.offset.reset=latest \
@@ -216,14 +216,25 @@ start_kafka_key_tail() {
 wait_for_kafka_key() {
     local needle="$1"
     local timeout="$2"
-    log "Waiting for key '${needle}' in ${ALARMS_TOPIC} tail (timeout: ${timeout}s)..."
-    local elapsed=0
+    log "Waiting for key '${needle}' on ${ALARMS_TOPIC} (timeout: ${timeout}s)..."
+    local elapsed=0 keys
     while [ $elapsed -lt "$timeout" ]; do
-        if grep -F -q "$needle" "$KAFKA_KEYS_LOG" 2>/dev/null; then
+        # Deterministic scan: read the whole (compacted, small) topic from the
+        # beginning and match the key, rather than tailing an ephemeral `latest`
+        # consumer that can miss the record if it has not finished joining its
+        # group before the AlarmState is produced (the 5s join was too tight).
+        # Uses --property (not --formatter-property) like the other e2e scripts,
+        # and a bash substring match (no `| grep -q`) so a hit can never trip
+        # SIGPIPE under `set -o pipefail`.
+        keys=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+            --bootstrap-server localhost:9092 --topic "$ALARMS_TOPIC" \
+            --from-beginning --max-messages 50000 --timeout-ms 5000 \
+            --property print.key=true --property print.value=false 2>/dev/null || true)
+        if [[ "$keys" == *"$needle"* ]]; then
             return 0
         fi
         sleep 2
-        elapsed=$((elapsed + 2))
+        elapsed=$((elapsed + 7))
     done
     return 1
 }

--- a/deploy/test-e2e.sh
+++ b/deploy/test-e2e.sh
@@ -260,12 +260,21 @@ fi
 ALARM_ID=$(psql_query "SELECT alarmid FROM alarms WHERE eventuei = 'uei.opennms.org/translator/traps/SNMP_Link_Down' AND alarmtype = 1 LIMIT 1")
 REDUCTION_KEY=$(psql_query "SELECT reductionkey FROM alarms WHERE alarmid = $ALARM_ID")
 if [ -n "$REDUCTION_KEY" ]; then
-    KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-        --bootstrap-server localhost:9092 \
-        --topic deltav-alarms-state-change \
-        --from-beginning --max-messages 200 --timeout-ms 15000 \
-        --property print.key=true --property print.value=false 2>/dev/null || true)
-    if echo "$KAFKA_KEYS" | grep -Fq "$REDUCTION_KEY"; then
+    KEY_FOUND=false
+    # Poll up to ~48s: alarmd->materializer can lag behind the PG insert under
+    # load, and the topic accumulates many keys over a long-lived stack. Re-scan
+    # the whole topic each pass. Bash substring match (no `| grep -q`) so a hit
+    # can never trip SIGPIPE under `set -o pipefail`.
+    for _ in 1 2 3 4 5 6; do
+        KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+            --bootstrap-server localhost:9092 \
+            --topic deltav-alarms-state-change \
+            --from-beginning --max-messages 50000 --timeout-ms 6000 \
+            --property print.key=true --property print.value=false 2>/dev/null || true)
+        [[ "$KAFKA_KEYS" == *"$REDUCTION_KEY"* ]] && { KEY_FOUND=true; break; }
+        sleep 2
+    done
+    if $KEY_FOUND; then
         ok "Alarm published to deltav-alarms-state-change (reduction_key=$REDUCTION_KEY)"
     else
         fail "Alarm reduction_key '$REDUCTION_KEY' NOT found on deltav-alarms-state-change topic"

--- a/deploy/test-minion-e2e.sh
+++ b/deploy/test-minion-e2e.sh
@@ -353,12 +353,21 @@ fi
 ALARM_ID=$(psql_query "SELECT alarmid FROM alarms WHERE eventuei = 'uei.opennms.org/translator/traps/SNMP_Link_Down' AND alarmtype = 1 LIMIT 1")
 REDUCTION_KEY=$(psql_query "SELECT reductionkey FROM alarms WHERE alarmid = $ALARM_ID")
 if [ -n "$REDUCTION_KEY" ]; then
-    KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-        --bootstrap-server localhost:9092 \
-        --topic deltav-alarms-state-change \
-        --from-beginning --max-messages 200 --timeout-ms 15000 \
-        --property print.key=true --property print.value=false 2>/dev/null || true)
-    if echo "$KAFKA_KEYS" | grep -Fq "$REDUCTION_KEY"; then
+    KEY_FOUND=false
+    # Poll up to ~48s: alarmd->materializer can lag behind the PG insert under
+    # load, and the topic accumulates many keys over a long-lived stack. Re-scan
+    # the whole topic each pass. Bash substring match (no `| grep -q`) so a hit
+    # can never trip SIGPIPE under `set -o pipefail`.
+    for _ in 1 2 3 4 5 6; do
+        KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+            --bootstrap-server localhost:9092 \
+            --topic deltav-alarms-state-change \
+            --from-beginning --max-messages 50000 --timeout-ms 6000 \
+            --property print.key=true --property print.value=false 2>/dev/null || true)
+        [[ "$KAFKA_KEYS" == *"$REDUCTION_KEY"* ]] && { KEY_FOUND=true; break; }
+        sleep 2
+    done
+    if $KEY_FOUND; then
         ok "Alarm published to deltav-alarms-state-change (reduction_key=$REDUCTION_KEY)"
     else
         fail "Alarm reduction_key '$REDUCTION_KEY' NOT found on deltav-alarms-state-change topic"

--- a/deploy/test-node-context-e2e.sh
+++ b/deploy/test-node-context-e2e.sh
@@ -56,7 +56,12 @@ cleanup() {
     # before mutation in Step 3) so this test never leaves the working tree
     # in a state that breaks other e2e tests that depend on the full set of
     # requisition-defs (rpc-canary, cloud-services, nl6-lab, …).
-    if [ -f "${PROVISIOND_CONFIG_BACKUP}" ]; then
+    # Guard with -s (non-empty), not -f: the backup is an empty mktemp file at
+    # trap-arm time and is only populated by the `cp` in Step 3. An early exit
+    # (e.g. stack bring-up fails before Step 3) would otherwise restore the
+    # empty backup OVER the tracked config, truncating it to 0 bytes and
+    # cascading into requisition-import failures across the whole suite.
+    if [ -s "${PROVISIOND_CONFIG_BACKUP}" ]; then
         cp "${PROVISIOND_CONFIG_BACKUP}" "${PROVISIOND_CONFIG}"
         rm -f "${PROVISIOND_CONFIG_BACKUP}"
     fi

--- a/deploy/test-passive-e2e.sh
+++ b/deploy/test-passive-e2e.sh
@@ -420,12 +420,21 @@ fi
 # the lifecycle event within a couple of seconds of the PG insert.
 REDUCTION_KEY=$(psql_query "SELECT reductionkey FROM alarms WHERE eventuei = 'uei.opennms.org/syslogd/cloud/serviceDown' AND alarmtype = 1 LIMIT 1")
 if [ -n "$REDUCTION_KEY" ]; then
-    KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-        --bootstrap-server localhost:9092 \
-        --topic deltav-alarms-state-change \
-        --from-beginning --max-messages 200 --timeout-ms 15000 \
-        --property print.key=true --property print.value=false 2>/dev/null || true)
-    if echo "$KAFKA_KEYS" | grep -Fq "$REDUCTION_KEY"; then
+    KEY_FOUND=false
+    # Poll up to ~48s: alarmd->materializer can lag behind the PG insert under
+    # load, and the topic accumulates many keys over a long-lived stack. Re-scan
+    # the whole topic each pass. Bash substring match (no `| grep -q`) so a hit
+    # can never trip SIGPIPE under `set -o pipefail`.
+    for _ in 1 2 3 4 5 6; do
+        KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+            --bootstrap-server localhost:9092 \
+            --topic deltav-alarms-state-change \
+            --from-beginning --max-messages 50000 --timeout-ms 6000 \
+            --property print.key=true --property print.value=false 2>/dev/null || true)
+        [[ "$KAFKA_KEYS" == *"$REDUCTION_KEY"* ]] && { KEY_FOUND=true; break; }
+        sleep 2
+    done
+    if $KEY_FOUND; then
         ok "Alarm published to deltav-alarms-state-change (reduction_key=$REDUCTION_KEY)"
     else
         fail "Alarm reduction_key '$REDUCTION_KEY' NOT found on deltav-alarms-state-change topic"

--- a/deploy/test-perspective-e2e.sh
+++ b/deploy/test-perspective-e2e.sh
@@ -640,12 +640,21 @@ REDUCTION_KEY=$(psql_query "SELECT a.reductionkey FROM alarms a
       AND a.alarmtype = 1
     LIMIT 1")
 if [ -n "$REDUCTION_KEY" ]; then
-    KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-        --bootstrap-server localhost:9092 \
-        --topic deltav-alarms-state-change \
-        --from-beginning --max-messages 200 --timeout-ms 15000 \
-        --property print.key=true --property print.value=false 2>/dev/null || true)
-    if echo "$KAFKA_KEYS" | grep -Fq "$REDUCTION_KEY"; then
+    KEY_FOUND=false
+    # Poll up to ~48s: alarmd->materializer can lag behind the PG insert under
+    # load, and the topic accumulates many keys over a long-lived stack. Re-scan
+    # the whole topic each pass. Bash substring match (no `| grep -q`) so a hit
+    # can never trip SIGPIPE under `set -o pipefail`.
+    for _ in 1 2 3 4 5 6; do
+        KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+            --bootstrap-server localhost:9092 \
+            --topic deltav-alarms-state-change \
+            --from-beginning --max-messages 50000 --timeout-ms 6000 \
+            --property print.key=true --property print.value=false 2>/dev/null || true)
+        [[ "$KAFKA_KEYS" == *"$REDUCTION_KEY"* ]] && { KEY_FOUND=true; break; }
+        sleep 2
+    done
+    if $KEY_FOUND; then
         ok "Alarm published to deltav-alarms-state-change (reduction_key=$REDUCTION_KEY)"
     else
         fail "Alarm reduction_key '$REDUCTION_KEY' NOT found on deltav-alarms-state-change topic"

--- a/deploy/test-prometheus-writer-e2e.sh
+++ b/deploy/test-prometheus-writer-e2e.sh
@@ -134,7 +134,22 @@ assert_zero() {
 }
 
 assert_zero 'deltav_prometheus_writer_batches_failed_total'
-assert_zero 'deltav_prometheus_writer_enrichment_missing_total'
+# enrichment_missing_total is a cumulative counter that also counts samples
+# processed during the NodeContext cache warmup window right after startup (the
+# cache fills asynchronously from the node-context Kafka stream), so a strict
+# ==0 assertion is racy. Assert instead that it has STOPPED growing — enrichment
+# is healthy now that the cache is warm. A cache that never warms keeps
+# incrementing and still fails this check.
+em_name='deltav_prometheus_writer_enrichment_missing_total'
+em_before=$({ echo "$metrics" | grep -E "^${em_name}" || true; } | awk '{sum+=$2} END {print sum+0}')
+sleep 20
+metrics_warm=$(docker compose exec -T prometheus-writer curl -sf http://localhost:8080/actuator/prometheus)
+em_after=$({ echo "$metrics_warm" | grep -E "^${em_name}" || true; } | awk '{sum+=$2} END {print sum+0}')
+if (( $(echo "$em_after > $em_before" | bc -l) )); then
+    echo "FAIL: ${em_name} still growing (${em_before} -> ${em_after} over 20s) — NodeContext enrichment not healthy"
+    exit 1
+fi
+echo "==> ${em_name} stable at ${em_after} (no new misses over 20s; ${em_before} warmup-window misses tolerated) ✓"
 # samples_dropped_total: split by reason. "type_unspecified" must stay zero
 # (indicates a producer bug if it ever fires). "string_attribute" is expected
 # correct behavior when SNMP collection surfaces string OIDs (sysDescr,

--- a/deploy/test-syslog-e2e.sh
+++ b/deploy/test-syslog-e2e.sh
@@ -406,12 +406,21 @@ fi
 ALARM_ID=$(psql_query "SELECT alarmid FROM alarms WHERE eventuei = 'uei.opennms.org/syslogd/cisco/linkDown' AND alarmtype = 1 LIMIT 1")
 REDUCTION_KEY=$(psql_query "SELECT reductionkey FROM alarms WHERE alarmid = $ALARM_ID")
 if [ -n "$REDUCTION_KEY" ]; then
-    KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
-        --bootstrap-server localhost:9092 \
-        --topic deltav-alarms-state-change \
-        --from-beginning --max-messages 200 --timeout-ms 15000 \
-        --property print.key=true --property print.value=false 2>/dev/null || true)
-    if echo "$KAFKA_KEYS" | grep -Fq "$REDUCTION_KEY"; then
+    KEY_FOUND=false
+    # Poll up to ~48s: alarmd->materializer can lag behind the PG insert under
+    # load, and the topic accumulates many keys over a long-lived stack. Re-scan
+    # the whole topic each pass. Bash substring match (no `| grep -q`) so a hit
+    # can never trip SIGPIPE under `set -o pipefail`.
+    for _ in 1 2 3 4 5 6; do
+        KAFKA_KEYS=$(docker compose exec -T kafka /opt/kafka/bin/kafka-console-consumer.sh \
+            --bootstrap-server localhost:9092 \
+            --topic deltav-alarms-state-change \
+            --from-beginning --max-messages 50000 --timeout-ms 6000 \
+            --property print.key=true --property print.value=false 2>/dev/null || true)
+        [[ "$KAFKA_KEYS" == *"$REDUCTION_KEY"* ]] && { KEY_FOUND=true; break; }
+        sleep 2
+    done
+    if $KEY_FOUND; then
         ok "Alarm published to deltav-alarms-state-change (reduction_key=$REDUCTION_KEY)"
     else
         fail "Alarm reduction_key '$REDUCTION_KEY' NOT found on deltav-alarms-state-change topic"

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.deltav</groupId>
   <artifactId>delta-v-parent</artifactId>
-  <version>1.3.0-rc9</version>
+  <version>1.3.0-rc10</version>
   <packaging>pom</packaging>
   <name>Delta-V Parent</name>
   <description>Delta-V microservice decomposition of OpenNMS Horizon</description>

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -269,7 +269,7 @@ do_grafana_image() {
 
 do_dns_lab_image() {
     log "Building ${IMAGE_PREFIX}/dns-lab:$VERSION..."
-    cd "$SCRIPT_DIR"
+    cd "$DEPLOY_DIR"
     build_image dns-lab -f Dockerfile.dns-lab .
 }
 

--- a/tools/smoke-vm.sh
+++ b/tools/smoke-vm.sh
@@ -23,8 +23,8 @@ docker system prune -a --volumes -f
 rm -rf ~/delta-v-smoke
 mkdir -p ~/delta-v-smoke && cd ~/delta-v-smoke
 
-GIT_REF=v1.3.0-rc9
-IMG_TAG=1.3.0-rc9
+GIT_REF=v1.3.0-rc10
+IMG_TAG=1.3.0-rc10
 
 BASE=https://raw.githubusercontent.com/pbrane/delta-v/$GIT_REF/deploy
 


### PR DESCRIPTION
Final RC for v1.3.0. Cut after housekeeping + a full e2e pass on a clean Mac host (smoke VM down).

## Fixes (real)
- **fix(build): dns-lab image build path** — `do_dns_lab_image()` still `cd "$SCRIPT_DIR"` (now `tools/`) after #339 moved build.sh `deploy/ → tools/`. `make images` failed on the dns-lab image (`open Dockerfile.dns-lab: no such file or directory`). rc9 predates dns-lab so this is the first RC to hit it — CI's `make images PUSH=true` would fail identically at tag time. Now `cd "$DEPLOY_DIR"` like `do_grafana`.

## e2e hardening (test-only; no product change)
Surfaced while validating the restructure — none is a product regression, but all made the suite unreliable:
- **alarms-state-change topic poll** (minion/syslog/passive/perspective/test-e2e): single `--from-beginning --max-messages 200` read missed the recent key once the compacted topic exceeded 200 records, and couldn't tolerate publish lag under shared-stack load. Now polls ~48s, cap 50000, bash substring match (no `| grep -q` → no SIGPIPE under pipefail).
- **alerts-forwarder**: hardcoded `docker exec delta-v-kafka-1` broke when the de-nest changed the compose project `delta-v → deploy` (kafka container is now `deploy-kafka-1`). Switched to project-agnostic `docker compose exec -T kafka`.
- **node-context**: `cleanup()` could restore an empty mktemp backup over the tracked `provisiond-configuration.xml` (truncating it to 0 bytes and cascading into enrichment failures suite-wide). Guarded with `-s`.
- **prometheus-writer**: `enrichment_missing_total` cumulative counter includes NodeContext cache-warmup misses; the `==0` assert was racy. Now asserts it has stopped growing.

## Version
`mvn versions:set` 1.3.0-rc9 → 1.3.0-rc10 (spring-boot parent stays 4.0.3), plus `deploy/.env.example` + `tools/smoke-vm.sh`.

## e2e status
Build validated: 29 images, all daemons healthy. Functional pipelines green — gRPC heartbeat/rpc/twin/sinks, Minion RPC, collectd, timeseries, node-context, and (post-hardening, back-to-back) minion 17/17, syslog 17/17, alerts-forwarder 19/19. Remaining reds are environmental (enlinkd/perspective need the labbox `mhuot-labs` Minion), the known passive AWS-outage issue, and prometheus-writer Step 6b (`deltav_response_time` composite label) — all pre-existing, none caused by rc10. Final gate is the smoke-VM no-clone run.