### PR TITLE
fix(flows-dashboards): timeseries panels render per-exporter/app series (format 1->0)

### DIFF
--- a/components/grafana/dashboards/flows-forensic.json
+++ b/components/grafana/dashboards/flows-forensic.json
@@ -260,7 +260,7 @@
         {
           "refId": "A",
           "rawSql": "SELECT $__timeInterval(timestamp) AS time, application, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY time, application ORDER BY time",
-          "format": 1
+          "format": 0
         }
       ],
       "transformations": [

--- a/components/grafana/dashboards/flows-overview.json
+++ b/components/grafana/dashboards/flows-overview.json
@@ -140,7 +140,7 @@
         {
           "refId": "A",
           "rawSql": "SELECT $__timeInterval(timestamp) AS time, location, sum(num_bytes) * 8 / ($__interval_ms / 1000) AS bps FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY time, location ORDER BY time",
-          "format": 1
+          "format": 0
         }
       ],
       "transformations": [
@@ -345,7 +345,7 @@
         {
           "refId": "A",
           "rawSql": "SELECT $__timeInterval(timestamp) AS time, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS exporter, count() / ($__interval_ms / 1000) AS flows_per_sec FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY time, exporter ORDER BY time",
-          "format": 1
+          "format": 0
         }
       ]
     },


### PR DESCRIPTION
The 3 flows timeseries panels were pinned to `format: 1` = **TABLE** in the official grafana-clickhouse-datasource (AUTO=0, TABLE=1, …, TIMESERIES=3), so the long-format `(time, label, value)` result stayed flat and the panel collapsed all exporters/apps into a single series — the 'web'. Switched to `format: 0` (AUTO), matching the table panels; AUTO applies long→wide and emits one series per label. **Verified** against real Grafana 11.4 + the actual datasource + ClickHouse: format 1/3 → flat 3-field frame; format 0 → time + N exporter-labelled value fields.