### PR TITLE
fix(flows-dashboards): stack per-exporter flow rate as an area chart

### DIFF
--- a/components/grafana/dashboards/flows-overview.json
+++ b/components/grafana/dashboards/flows-overview.json
@@ -337,7 +337,15 @@
               "url": "/d/flows-forensic?var-exporter_instance=${__series.name}&${monitoring_location:queryparam}&var-l4_protocol=$__all&var-src_address=$__all&var-dst_address=$__all&var-src_port=$__all&var-dst_port=$__all&from=${__from}&to=${__to}",
               "targetBlank": false
             }
-          ]
+          ],
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
         },
         "overrides": []
       },


### PR DESCRIPTION
Follow-up to the format:0 multi-series fix. ~30 per-exporter series as overlapping unfilled lines was unreadable; render as a stacked area (total flow-ingest banded by exporter), mirroring the Bandwidth panels: `drawStyle: line, fillOpacity: 40, stacking: {mode: normal}` + `showPoints: never`. Viz config only — data unchanged.