### PR TITLE
feat(flows-dashboards): limit per-exporter flow rate to top 10 exporters

### DIFF
--- a/components/grafana/dashboards/flows-overview.json
+++ b/components/grafana/dashboards/flows-overview.json
@@ -317,7 +317,7 @@
     {
       "id": 4,
       "type": "timeseries",
-      "title": "Per-exporter flow rate",
+      "title": "Per-exporter flow rate (top 10)",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -352,7 +352,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT $__timeInterval(timestamp) AS time, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS exporter, count() / ($__interval_ms / 1000) AS flows_per_sec FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY time, exporter ORDER BY time",
+          "rawSql": "SELECT $__timeInterval(timestamp) AS time, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS exporter, count() / ($__interval_ms / 1000) AS flows_per_sec FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) IN (SELECT concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS e FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY e ORDER BY count() DESC LIMIT 10) GROUP BY time, exporter ORDER BY time",
           "format": 0
         }
       ]


### PR DESCRIPTION
Constrains the panel to the 10 busiest exporters (by flow count over the window) via an `IN (… GROUP BY … ORDER BY count() DESC LIMIT 10)` subquery that reuses the outer WHERE filters verbatim (so it honors the location/exporter/category dashboard variables). Low impact: one extra aggregation over the same filtered window, evaluated once; the format:0 pivot + stacked-area render are unaffected. Title → 'Per-exporter flow rate (top 10)'. Validated with clickhouse-local (15 exporters → exactly the busiest 10).