### PR TITLE
feat(flows-dashboards): configurable topN variable across all Top * panels

### DIFF
--- a/components/grafana/dashboards/flows-forensic.json
+++ b/components/grafana/dashboards/flows-forensic.json
@@ -225,6 +225,48 @@
             "$__all"
           ]
         }
+      },
+      {
+        "name": "topN",
+        "label": "Top N",
+        "type": "custom",
+        "query": "5,10,15,20,50",
+        "multi": false,
+        "includeAll": false,
+        "hide": 0,
+        "skipUrlSync": false,
+        "current": {
+          "selected": true,
+          "text": "10",
+          "value": "10"
+        },
+        "options": [
+          {
+            "text": "5",
+            "value": "5",
+            "selected": false
+          },
+          {
+            "text": "10",
+            "value": "10",
+            "selected": true
+          },
+          {
+            "text": "15",
+            "value": "15",
+            "selected": false
+          },
+          {
+            "text": "20",
+            "value": "20",
+            "selected": false
+          },
+          {
+            "text": "50",
+            "value": "50",
+            "selected": false
+          }
+        ]
       }
     ]
   },
@@ -344,7 +386,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT coalesce(nullIf(max(src_hostname), ''), replaceRegexpOne(IPv6NumToString(src_address), '^::ffff:', '')) AS \"Source\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT coalesce(nullIf(max(src_hostname), ''), replaceRegexpOne(IPv6NumToString(src_address), '^::ffff:', '')) AS \"Source\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address ORDER BY \"Bytes\" DESC LIMIT ${topN}",
           "format": 0
         }
       ]
@@ -415,7 +457,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT coalesce(nullIf(max(dst_hostname), ''), replaceRegexpOne(IPv6NumToString(dst_address), '^::ffff:', '')) AS \"Destination\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY dst_address ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT coalesce(nullIf(max(dst_hostname), ''), replaceRegexpOne(IPv6NumToString(dst_address), '^::ffff:', '')) AS \"Destination\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY dst_address ORDER BY \"Bytes\" DESC LIMIT ${topN}",
           "format": 0
         }
       ]
@@ -474,7 +516,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT coalesce(nullIf(max(src_hostname), ''), replaceRegexpOne(IPv6NumToString(src_address), '^::ffff:', '')) AS \"Source\", src_port AS \"Src port\", coalesce(nullIf(max(dst_hostname), ''), replaceRegexpOne(IPv6NumToString(dst_address), '^::ffff:', '')) AS \"Destination\", dst_port AS \"Dst port\", application AS \"App\", CASE protocol WHEN 6 THEN 'TCP' WHEN 17 THEN 'UDP' WHEN 1 THEN 'ICMP' WHEN 50 THEN 'ESP' ELSE concat('proto=', toString(protocol)) END AS \"L4\", sum(num_bytes) AS \"Bytes\", count() AS \"Records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address, src_port, dst_address, dst_port, application, protocol ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT coalesce(nullIf(max(src_hostname), ''), replaceRegexpOne(IPv6NumToString(src_address), '^::ffff:', '')) AS \"Source\", src_port AS \"Src port\", coalesce(nullIf(max(dst_hostname), ''), replaceRegexpOne(IPv6NumToString(dst_address), '^::ffff:', '')) AS \"Destination\", dst_port AS \"Dst port\", application AS \"App\", CASE protocol WHEN 6 THEN 'TCP' WHEN 17 THEN 'UDP' WHEN 1 THEN 'ICMP' WHEN 50 THEN 'ESP' ELSE concat('proto=', toString(protocol)) END AS \"L4\", sum(num_bytes) AS \"Bytes\", count() AS \"Records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(application, '${application:regex}') AND match(toString(protocol), '^(?:${l4_protocol:regex})$') AND match(IPv6NumToString(src_address), '${src_address:regex}') AND match(IPv6NumToString(dst_address), '${dst_address:regex}') AND match(toString(src_port), '^(?:${src_port:regex})$') AND match(toString(dst_port), '^(?:${dst_port:regex})$') GROUP BY src_address, src_port, dst_address, dst_port, application, protocol ORDER BY \"Bytes\" DESC LIMIT ${topN}",
           "format": 0
         }
       ]

--- a/components/grafana/dashboards/flows-overview.json
+++ b/components/grafana/dashboards/flows-overview.json
@@ -105,6 +105,48 @@
             "$__all"
           ]
         }
+      },
+      {
+        "name": "topN",
+        "label": "Top N",
+        "type": "custom",
+        "query": "5,10,15,20,50",
+        "multi": false,
+        "includeAll": false,
+        "hide": 0,
+        "skipUrlSync": false,
+        "current": {
+          "selected": true,
+          "text": "10",
+          "value": "10"
+        },
+        "options": [
+          {
+            "text": "5",
+            "value": "5",
+            "selected": false
+          },
+          {
+            "text": "10",
+            "value": "10",
+            "selected": true
+          },
+          {
+            "text": "15",
+            "value": "15",
+            "selected": false
+          },
+          {
+            "text": "20",
+            "value": "20",
+            "selected": false
+          },
+          {
+            "text": "50",
+            "value": "50",
+            "selected": false
+          }
+        ]
       }
     ]
   },
@@ -238,7 +280,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT application, sum(num_bytes) AS bytes FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') GROUP BY application ORDER BY bytes DESC LIMIT 10",
+          "rawSql": "SELECT application, sum(num_bytes) AS bytes FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') GROUP BY application ORDER BY bytes DESC LIMIT ${topN}",
           "format": 0
         }
       ]
@@ -309,7 +351,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT coalesce(nullIf(max(src_hostname), ''), replaceRegexpOne(IPv6NumToString(src_address), '^::ffff:', '')) AS \"Source\", coalesce(nullIf(max(dst_hostname), ''), replaceRegexpOne(IPv6NumToString(dst_address), '^::ffff:', '')) AS \"Destination\", application AS \"Application\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY src_address, dst_address, application ORDER BY \"Bytes\" DESC LIMIT 20",
+          "rawSql": "SELECT coalesce(nullIf(max(src_hostname), ''), replaceRegexpOne(IPv6NumToString(src_address), '^::ffff:', '')) AS \"Source\", coalesce(nullIf(max(dst_hostname), ''), replaceRegexpOne(IPv6NumToString(dst_address), '^::ffff:', '')) AS \"Destination\", application AS \"Application\", sum(num_bytes) AS \"Bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND match(location, '${monitoring_location:regex}') AND match(application, '${application:regex}') GROUP BY src_address, dst_address, application ORDER BY \"Bytes\" DESC LIMIT ${topN}",
           "format": 0
         }
       ]
@@ -317,7 +359,7 @@
     {
       "id": 4,
       "type": "timeseries",
-      "title": "Per-exporter flow rate (top 10)",
+      "title": "Per-exporter flow rate (top ${topN})",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -352,7 +394,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT $__timeInterval(timestamp) AS time, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS exporter, count() / ($__interval_ms / 1000) AS flows_per_sec FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) IN (SELECT concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS e FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY e ORDER BY count() DESC LIMIT 10) GROUP BY time, exporter ORDER BY time",
+          "rawSql": "SELECT $__timeInterval(timestamp) AS time, concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS exporter, count() / ($__interval_ms / 1000) AS flows_per_sec FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) AND concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) IN (SELECT concat(exporter_node_foreign_source, '/', exporter_node_foreign_id) AS e FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY e ORDER BY count() DESC LIMIT ${topN}) GROUP BY time, exporter ORDER BY time",
           "format": 0
         }
       ]
@@ -513,7 +555,7 @@
       "targets": [
         {
           "refId": "A",
-          "rawSql": "SELECT concat(if(exporter_node_label != '', concat(exporter_node_label, ' '), ''), '(', exporter_node_foreign_source, '/', exporter_node_foreign_id, ')') AS \"Exporter\", if(input_if_name != '', input_if_name, toString(input_snmp_ifindex)) AS \"Interface\", sum(num_bytes) AS \"bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY \"Exporter\", \"Interface\" ORDER BY sum(num_bytes) DESC LIMIT 20",
+          "rawSql": "SELECT concat(if(exporter_node_label != '', concat(exporter_node_label, ' '), ''), '(', exporter_node_foreign_source, '/', exporter_node_foreign_id, ')') AS \"Exporter\", if(input_if_name != '', input_if_name, toString(input_snmp_ifindex)) AS \"Interface\", sum(num_bytes) AS \"bytes\", sum(num_packets) AS \"Packets\", count() AS \"Flow records\" FROM deltav.flows_raw WHERE $__timeFilter(timestamp) AND match(location, '${monitoring_location:regex}') AND match(concat(exporter_node_foreign_source, '/', exporter_node_foreign_id), '${exporter_instance:regex}') AND match(application, '${application:regex}') AND (match('', '${category:regex}') OR arrayExists(c -> match(c, '${category:regex}'), exporter_node_categories)) GROUP BY \"Exporter\", \"Interface\" ORDER BY sum(num_bytes) DESC LIMIT ${topN}",
           "format": 0
         }
       ]


### PR DESCRIPTION
Adds a 'Top N' custom dashboard variable (5/10/15/20/50, default 10) to both flows dashboards and wires `LIMIT ${topN}` into all 7 top panels (Top conversations ×2, Top source/destination IPs, Top applications, Top interfaces, Per-exporter flow rate's top-exporters subquery). Raw flow records (LIMIT 1000) left fixed. Default 10 unifies the previously mixed 10/20 limits. Verified live: Grafana 11.4 parses the var (current=10, options=[5,10,15,20,50]); saved query at topN=5 returns exactly 5 rows.