### PR TITLE
feat(flows-dashboards): show topN count in every Top panel title

### DIFF
--- a/components/grafana/dashboards/flows-forensic.json
+++ b/components/grafana/dashboards/flows-forensic.json
@@ -323,7 +323,7 @@
     {
       "id": 2,
       "type": "table",
-      "title": "Top source IPs",
+      "title": "Top ${topN} source IPs",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -394,7 +394,7 @@
     {
       "id": 3,
       "type": "table",
-      "title": "Top destination IPs",
+      "title": "Top ${topN} destination IPs",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -465,7 +465,7 @@
     {
       "id": 4,
       "type": "table",
-      "title": "Top conversations",
+      "title": "Top ${topN} conversations",
       "gridPos": {
         "h": 8,
         "w": 12,

--- a/components/grafana/dashboards/flows-overview.json
+++ b/components/grafana/dashboards/flows-overview.json
@@ -203,7 +203,7 @@
     {
       "id": 2,
       "type": "table",
-      "title": "Top applications by bandwidth",
+      "title": "Top ${topN} applications by bandwidth",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -288,7 +288,7 @@
     {
       "id": 3,
       "type": "table",
-      "title": "Top conversations",
+      "title": "Top ${topN} conversations",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -497,7 +497,7 @@
     {
       "id": 7,
       "type": "table",
-      "title": "Top interfaces by traffic",
+      "title": "Top ${topN} interfaces by traffic",
       "gridPos": {
         "h": 8,
         "w": 24,


### PR DESCRIPTION
The other six Top panels had static titles while Per-exporter showed the count. Add the count inline ('Top ${topN} conversations', 'Top ${topN} source IPs', …) — cleaner than a redundant 'Top X (top N)' suffix. Grafana interpolates ${topN} in titles, so they render 'Top 10 conversations' and track the dropdown.