### PR TITLE
feat(poller): flat poller service-catalog — library, adapter, lint, contract ITs (Epic 1 / PR 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ TOOLS := tools
 
 export MAVEN_OPTS
 
-.PHONY: help build test test-class daemon clean images daemon-image up down reset status logs verify dev doctor c4-edit c4-export
+.PHONY: help build test test-class daemon lint-catalog clean images daemon-image up down reset status logs verify dev doctor c4-edit c4-export
 
 .DEFAULT_GOAL := help
 
@@ -86,6 +86,13 @@ daemon: ## Rebuild a single daemon boot JAR; set DAEMON=provisiond (etc)
 	  --projects :org.opennms.core.daemon-boot-$(DAEMON) \
 	  --also-make \
 	  install
+
+lint-catalog: ## Lint a poller service catalog; set CATALOG=path/to/poller-services.yaml
+	@test -n "$(CATALOG)" || (echo "ERROR: CATALOG is required, e.g.: make lint-catalog CATALOG=deploy/overlays/pollerd/etc/poller-services.yaml" && exit 1)
+	$(MVN) -B -q -DskipTests \
+	  --projects :org.opennms.core.poller-service-catalog \
+	  compile org.codehaus.mojo:exec-maven-plugin:3.5.0:exec \
+	  '-Dlint.catalog=$(CATALOG)'
 
 clean: ## Remove all build artifacts
 	$(MVN) -B clean

--- a/core/poller-service-catalog/pom.xml
+++ b/core/poller-service-catalog/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.deltav</groupId>
+        <artifactId>delta-v-parent</artifactId>
+        <version>1.3.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.deltav.core</groupId>
+    <artifactId>org.opennms.core.poller-service-catalog</artifactId>
+    <name>OpenNMS :: Core :: Poller Service Catalog</name>
+    <description>Spring-free library for the flat poller service-definition catalog:
+        strict YAML parsing, validation, name resolution, and translation of the
+        catalog into the synthetic JAXB PollerConfiguration the frozen poller engine
+        consumes. Shared by daemon-boot-pollerd and daemon-boot-perspectivepollerd.</description>
+
+    <!-- Deliberately Spring-free (plain Java 21 + Jackson + slf4j-api). Daemon-boot
+         modules do all wiring; the FR9 gauge is registered there, not here. -->
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test: plain JUnit 5 (no Spring) -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Required by maven-surefire-plugin 3.5.x to discover JUnit Platform 6.x tests. -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/poller-service-catalog/pom.xml
+++ b/core/poller-service-catalog/pom.xml
@@ -46,6 +46,14 @@
             <version>${deltav.horizon.version}</version>
         </dependency>
 
+        <!-- Test: the REAL frozen poller config layer (PollerConfigFactory/Manager) for the
+             D8 contract ITs — translator output is pinned through the real manager, never mocked. -->
+        <dependency>
+            <groupId>org.opennms.features.poller</groupId>
+            <artifactId>org.opennms.features.poller.config</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Test: plain JUnit 5 (no Spring) -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/core/poller-service-catalog/pom.xml
+++ b/core/poller-service-catalog/pom.xml
@@ -67,4 +67,29 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- `make lint-catalog CATALOG=<file>` -> runs the CatalogLint CLI as a real
+                 subprocess (exec:exec) so its 0/1/2 exit code propagates to the build.
+                 Not bound to any phase; only runs when invoked explicitly. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <executable>java</executable>
+                    <!-- Run from the Maven invocation dir (repo root via `make`), not this
+                         module's dir, so a relative CATALOG path resolves as the user typed it. -->
+                    <workingDirectory>${session.executionRootDirectory}</workingDirectory>
+                    <arguments>
+                        <argument>-classpath</argument>
+                        <classpath/>
+                        <argument>org.deltav.poller.catalog.CatalogLint</argument>
+                        <argument>${lint.catalog}</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/core/poller-service-catalog/pom.xml
+++ b/core/poller-service-catalog/pom.xml
@@ -32,6 +32,20 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <!-- Frozen horizon engine types. The synthetic JAXB PollerConfiguration model
+             (config-jaxb) and the FilterDao interface (config-api) are confined to
+             CatalogTranslator / InventoryFilterDao — the slice-2 deletion surface. -->
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-config-jaxb</artifactId>
+            <version>${deltav.horizon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-config-api</artifactId>
+            <version>${deltav.horizon.version}</version>
+        </dependency>
+
         <!-- Test: plain JUnit 5 (no Spring) -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/Catalog.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/Catalog.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.util.List;
+
+/**
+ * The parsed flat poller service catalog: an ordered list of service definitions.
+ *
+ * <p>Order is significant — among multiple matching pattern definitions, first in file
+ * order wins (D2). The compact constructor normalizes a missing list to empty (an empty
+ * catalog is a lint warning, not a failure, per D5); it never validates.
+ *
+ * @param services the service definitions, in file order
+ */
+public record Catalog(List<ServiceDefinition> services) {
+
+    public Catalog {
+        services = (services == null) ? List.of() : List.copyOf(services);
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogLint.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogLint.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Build-time catalog lint (FR10 / D5). A zero-framework {@code main()} that parses and
+ * validates a catalog and reports every defect in one pass, used both as a Dockerfile build
+ * stage (after the overlay COPY — a malformed catalog can never reach a runnable image) and
+ * locally via {@code make lint-catalog}.
+ *
+ * <p>Exit codes: {@code 0} = clean (warnings allowed); {@code 1} = errors found (or a
+ * malformed/strict-violating catalog); {@code 2} = usage or I/O failure (missing/unreadable
+ * file, wrong arguments). An empty catalog and nested-quantifier patterns are warnings, not
+ * failures (D5).
+ */
+public final class CatalogLint {
+
+    private CatalogLint() {
+    }
+
+    public static void main(final String[] args) {
+        System.exit(run(args, System.out, System.err));
+    }
+
+    /**
+     * Runs the lint. Separated from {@link #main(String[])} (which calls {@link System#exit})
+     * so tests can assert the exit code and captured output.
+     *
+     * @param args single element: the catalog file path
+     * @param out  report stream (findings)
+     * @param err  diagnostics stream (usage / I/O errors)
+     * @return process exit code (0 clean, 1 errors, 2 usage/IO)
+     */
+    static int run(final String[] args, final PrintStream out, final PrintStream err) {
+        if (args.length != 1) {
+            err.println("usage: CatalogLint <poller-services.yaml>");
+            return 2;
+        }
+
+        final Path path = Path.of(args[0]);
+        if (!Files.isRegularFile(path)) {
+            err.println("ERROR: file not found: " + path);
+            return 2;
+        }
+        if (!Files.isReadable(path)) {
+            err.println("ERROR: file not readable: " + path);
+            return 2;
+        }
+
+        final String fileLabel = path.getFileName().toString();
+        final Catalog catalog;
+        try {
+            catalog = new CatalogParser().parse(path);
+        } catch (final CatalogParseException e) {
+            // Catalog content defect (malformed YAML, unknown key, anchors) — operator-fixable.
+            out.println("ERROR: " + fileLabel + ": " + e.getMessage());
+            return 1;
+        } catch (final IOException e) {
+            // A real read failure — environmental, not a catalog defect.
+            err.println("ERROR: cannot read " + path + ": " + e.getMessage());
+            return 2;
+        }
+
+        if (catalog.services().isEmpty()) {
+            out.println("WARN: " + fileLabel + ": catalog is empty (no services defined)");
+        }
+
+        boolean hasError = false;
+        final List<ValidationMessage> messages = new CatalogValidator().validate(catalog);
+        for (final ValidationMessage message : messages) {
+            out.println(message.format(fileLabel));
+            hasError |= message.isError();
+        }
+
+        return hasError ? 1 : 0;
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParseException.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParseException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.io.IOException;
+
+/**
+ * A catalog <em>content</em> defect — malformed YAML, an unknown key, a duplicate key, or an
+ * anchor/alias/merge key. Distinct from a plain {@link IOException} (a real read failure), so
+ * callers keep the two failure classes from blurring: a content defect is the operator's to
+ * fix (lint exit 1; loader → context failure), whereas an I/O failure is environmental (lint
+ * exit 2). It extends {@link IOException} so existing {@code throws}/{@code catch} sites are
+ * unaffected.
+ */
+public class CatalogParseException extends IOException {
+
+    public CatalogParseException(final String message) {
+        super(message);
+    }
+
+    public CatalogParseException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParser.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParser.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -92,9 +93,16 @@ public final class CatalogParser {
      * @throws IOException on read failure or malformed/strict-violating YAML
      */
     public Catalog parse(final Reader reader) throws IOException {
+        // readAll may throw a plain IOException (a real read failure); content defects below
+        // surface as CatalogParseException so callers can tell the two failure classes apart.
         final String content = readAll(reader);
         rejectAnchors(content);
-        final Catalog catalog = mapper.readValue(content, Catalog.class);
+        final Catalog catalog;
+        try {
+            catalog = mapper.readValue(content, Catalog.class);
+        } catch (final JsonProcessingException e) {
+            throw new CatalogParseException(e.getMessage(), e);
+        }
         return (catalog == null) ? new Catalog(null) : catalog;
     }
 
@@ -104,7 +112,7 @@ public final class CatalogParser {
      * string fields — a silent mis-parse. To honor the strict contract (no silent middle
      * ground), a catalog using them fails loudly here with a clear message.
      */
-    private static void rejectAnchors(final String yaml) throws IOException {
+    private static void rejectAnchors(final String yaml) throws CatalogParseException {
         try {
             for (final Event event : new Yaml().parse(new StringReader(yaml))) {
                 if (event instanceof AliasEvent) {
@@ -120,8 +128,9 @@ public final class CatalogParser {
         }
     }
 
-    private static IOException unsupportedAnchors() {
-        return new IOException("YAML anchors, aliases, and merge keys (&, *, <<) are not supported in catalogs");
+    private static CatalogParseException unsupportedAnchors() {
+        return new CatalogParseException(
+                "YAML anchors, aliases, and merge keys (&, *, <<) are not supported in catalogs");
     }
 
     private static String readAll(final Reader reader) throws IOException {

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParser.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParser.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.LoaderOptions;
+
+/**
+ * Strict YAML reader for the flat poller service catalog (FR1 / D1).
+ *
+ * <p><strong>Strict by design:</strong> unknown properties are a hard failure. This is our
+ * own schema, so leniency is pure downside — an {@code intervall:} typo would silently take
+ * a default. A single {@code CatalogParser} instance is the shared parser configuration the
+ * lint CLI and the daemon loader both use, so the two can never disagree on what parses.
+ *
+ * <p>This class only reads structure into the {@link Catalog} model. Structurally-malformed
+ * input (bad YAML, unknown keys, wrong value types) throws here — that is the "malformed
+ * catalog → context failure" path, deliberately distinct from {@link CatalogValidator}'s
+ * collect-all semantic checks on a successfully parsed model.
+ */
+public final class CatalogParser {
+
+    private final ObjectMapper mapper;
+
+    public CatalogParser() {
+        this.mapper = newStrictMapper();
+    }
+
+    /**
+     * Builds the strict {@link ObjectMapper} shared by lint and loader. Unknown properties
+     * fail (catches {@code intervall:}-style typos) and duplicate keys fail (a duplicated
+     * {@code name:} silently taking last-wins is exactly the kind of leniency this schema
+     * rejects). All other defaults are Jackson's.
+     */
+    static ObjectMapper newStrictMapper() {
+        final LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(false);
+        final YAMLFactory yamlFactory = YAMLFactory.builder()
+                .loaderOptions(loaderOptions)
+                .build();
+        return new ObjectMapper(yamlFactory)
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    /**
+     * Parses a catalog file.
+     *
+     * @param file path to {@code poller-services.yaml}
+     * @return the parsed catalog
+     * @throws IOException on I/O failure or malformed/strict-violating YAML (the latter as a
+     *                     {@link com.fasterxml.jackson.core.JsonProcessingException} whose
+     *                     message names the offending key and location)
+     */
+    public Catalog parse(final Path file) throws IOException {
+        try (Reader reader = Files.newBufferedReader(file)) {
+            return parse(reader);
+        }
+    }
+
+    /**
+     * Parses a catalog from an open reader (used by tests and the lint CLI's stream paths).
+     *
+     * @param reader YAML source; the caller owns closing it
+     * @return the parsed catalog
+     * @throws IOException on read failure or malformed/strict-violating YAML
+     */
+    public Catalog parse(final Reader reader) throws IOException {
+        final Catalog catalog = mapper.readValue(reader, Catalog.class);
+        return (catalog == null) ? new Catalog(null) : catalog;
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParser.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogParser.java
@@ -18,6 +18,7 @@ package org.deltav.poller.catalog;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -25,6 +26,11 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.events.AliasEvent;
+import org.yaml.snakeyaml.events.Event;
+import org.yaml.snakeyaml.events.NodeEvent;
 
 /**
  * Strict YAML reader for the flat poller service catalog (FR1 / D1).
@@ -86,7 +92,45 @@ public final class CatalogParser {
      * @throws IOException on read failure or malformed/strict-violating YAML
      */
     public Catalog parse(final Reader reader) throws IOException {
-        final Catalog catalog = mapper.readValue(reader, Catalog.class);
+        final String content = readAll(reader);
+        rejectAnchors(content);
+        final Catalog catalog = mapper.readValue(content, Catalog.class);
         return (catalog == null) ? new Catalog(null) : catalog;
+    }
+
+    /**
+     * Rejects any use of YAML anchors, aliases, or merge keys. jackson-dataformat-yaml does
+     * not resolve these and would silently bind an alias's <em>name</em> as the value on
+     * string fields — a silent mis-parse. To honor the strict contract (no silent middle
+     * ground), a catalog using them fails loudly here with a clear message.
+     */
+    private static void rejectAnchors(final String yaml) throws IOException {
+        try {
+            for (final Event event : new Yaml().parse(new StringReader(yaml))) {
+                if (event instanceof AliasEvent) {
+                    throw unsupportedAnchors();
+                }
+                if (event instanceof NodeEvent nodeEvent && nodeEvent.getAnchor() != null) {
+                    throw unsupportedAnchors();
+                }
+            }
+        } catch (final YAMLException e) {
+            // Let the strict Jackson pass produce the detailed malformed-YAML message.
+            return;
+        }
+    }
+
+    private static IOException unsupportedAnchors() {
+        return new IOException("YAML anchors, aliases, and merge keys (&, *, <<) are not supported in catalogs");
+    }
+
+    private static String readAll(final Reader reader) throws IOException {
+        final StringBuilder sb = new StringBuilder();
+        final char[] buffer = new char[4096];
+        int read;
+        while ((read = reader.read(buffer)) != -1) {
+            sb.append(buffer, 0, read);
+        }
+        return sb.toString();
     }
 }

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogTranslator.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogTranslator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opennms.netmgt.config.poller.Downtime;
+import org.opennms.netmgt.config.poller.Package;
+import org.opennms.netmgt.config.poller.PollerConfiguration;
+import org.opennms.netmgt.config.poller.Service;
+
+/**
+ * Translates the flat catalog into the synthetic JAXB {@link PollerConfiguration} the frozen
+ * poller engine consumes (D3, amended). This is the ONLY class that touches
+ * {@code org.opennms.netmgt.config.poller.*} — the slice-2 deletion surface.
+ *
+ * <p>Model: <strong>one synthetic package per enabled definition</strong>, named
+ * {@code catalog-<name>}, each carrying its own downtime entry ({@code begin=0,
+ * interval=<that service's interval>}). Downtime is package-scoped in the frozen engine, so
+ * per-service intervals require per-definition packages; the synthesized downtime keeps a
+ * down service rescheduling at its own interval (FR5), invisible to operators.
+ *
+ * <p>Exact definitions are emitted <strong>before</strong> pattern definitions so the frozen
+ * manager's first-match iteration honors D2 precedence (exact beats pattern). Disabled
+ * definitions are omitted entirely — the engine then marks affected inventory rows
+ * {@code 'N'} (D4 {@code enabled:false} semantics). Engine scalars come from
+ * {@link EngineSettings}; {@code serviceUnresponsive}/{@code pathOutage} are disabled
+ * adapter constants; {@code nextOutageId} is left unset (dead — Open Verification Item #3).
+ *
+ * <p><strong>Precondition:</strong> the catalog must have passed {@link CatalogValidator}
+ * with no ERRORs (the daemon loader enforces this before calling translate). As
+ * defense-in-depth, translate fail-fasts with a clear message if a load-bearing field of an
+ * enabled definition is missing, rather than emitting a corrupt config or throwing a bare
+ * {@link NullPointerException}.
+ */
+public final class CatalogTranslator {
+
+    static final String PACKAGE_PREFIX = "catalog-";
+    private static final String SERVICE_STATUS_ON = "on";
+    private static final String DISABLED = "false";
+    /** Catch-all filter; content is irrelevant because {@link InventoryFilterDao} ignores the rule. */
+    private static final String CATCH_ALL_FILTER = "IPADDR != '0.0.0.0'";
+
+    /**
+     * Builds the synthetic configuration. Output is fed to the frozen {@code PollerConfigFactory}
+     * by daemon-boot (Story 2.2) and pinned through the real manager by the contract ITs.
+     *
+     * @param catalog  the validated catalog
+     * @param settings engine-tuning scalars bound from application.yml
+     * @return the synthetic {@link PollerConfiguration}
+     */
+    public PollerConfiguration translate(final Catalog catalog, final EngineSettings settings) {
+        final PollerConfiguration config = new PollerConfiguration();
+        config.setThreads(settings.threads());
+        config.setAsyncPollingEngineEnabled(settings.asyncPollingEngineEnabled());
+        config.setMaxConcurrentAsyncPolls(settings.maxConcurrentAsyncPolls());
+        config.setServiceUnresponsiveEnabled(DISABLED);
+        config.setPathOutageEnabled(DISABLED);
+        // nextOutageId intentionally left unset (dead; JAXB default applies harmlessly).
+
+        for (final ServiceDefinition def : orderedExactBeforePattern(catalog)) {
+            config.addPackage(toPackage(def));
+            config.addMonitor(def.name(), def.monitor());
+        }
+        return config;
+    }
+
+    /** Enabled definitions only, exact ones first then pattern ones, each preserving file order. */
+    private static List<ServiceDefinition> orderedExactBeforePattern(final Catalog catalog) {
+        final List<ServiceDefinition> ordered = new ArrayList<>();
+        for (final ServiceDefinition def : catalog.services()) {
+            if (def.enabled() && !def.isPattern()) {
+                ordered.add(def);
+            }
+        }
+        for (final ServiceDefinition def : catalog.services()) {
+            if (def.enabled() && def.isPattern()) {
+                ordered.add(def);
+            }
+        }
+        return ordered;
+    }
+
+    private static Package toPackage(final ServiceDefinition def) {
+        requireTranslatable(def);
+        final Package pkg = new Package(PACKAGE_PREFIX + def.name());
+        pkg.setFilter(CATCH_ALL_FILTER);
+
+        final Downtime downtime = new Downtime();
+        downtime.setBegin(0L);
+        downtime.setInterval(def.interval().longValue());
+        pkg.addDowntime(downtime);
+
+        pkg.addService(toService(def));
+        return pkg;
+    }
+
+    /**
+     * Enforces the load-bearing fields of an enabled definition so a catalog that bypassed
+     * validation fails with a clear message instead of an NPE or a silently corrupt config.
+     */
+    private static void requireTranslatable(final ServiceDefinition def) {
+        if (def.name() == null || def.name().isBlank()) {
+            throw new IllegalArgumentException(
+                    "translate() requires a validated catalog: a service definition has a blank name");
+        }
+        if (def.interval() == null) {
+            throw new IllegalArgumentException(
+                    "translate() requires a validated catalog: service '" + def.name() + "' has no interval");
+        }
+        if (def.monitor() == null || def.monitor().isBlank()) {
+            throw new IllegalArgumentException(
+                    "translate() requires a validated catalog: service '" + def.name() + "' has no monitor");
+        }
+    }
+
+    private static Service toService(final ServiceDefinition def) {
+        final Service service = new Service();
+        service.setName(def.name());
+        if (def.isPattern()) {
+            service.setPattern(def.pattern());
+        }
+        service.setInterval(def.interval());
+        service.setStatus(SERVICE_STATUS_ON);
+        for (final Map.Entry<String, String> param : def.parameters().entrySet()) {
+            // Verbatim: keys and values are never translated (foreign monitor contract).
+            service.addParameter(param.getKey(), param.getValue());
+        }
+        return service;
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogValidator.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogValidator.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.deltav.poller.catalog.ValidationMessage.Level;
+
+/**
+ * Collect-all-then-report validator for the flat catalog (FR10 / D1 / D2).
+ *
+ * <p>Never fail-first: every defect in the catalog is reported in one pass so an operator
+ * fixes a broken catalog in a single iteration. Structural parse failures (bad YAML,
+ * unknown keys) are handled earlier and separately by {@link CatalogParser}; this validator
+ * only sees a successfully-parsed model.
+ *
+ * <p>Checks, per service: {@code name} required; {@code monitor} required and a well-formed
+ * fully-qualified class name; {@code interval} required and positive (WARN below the 5s
+ * floor); {@code pattern} (if present) compiles (WARN on nested quantifiers — a best-effort
+ * catastrophic-backtracking heuristic). Cross-service: duplicate {@code name}s and identical
+ * {@code pattern}s are rejected (D2).
+ */
+public final class CatalogValidator {
+
+    /** Below this interval (ms) a service hot-loops; warn but do not fail (D1). */
+    static final int INTERVAL_FLOOR_MS = 5_000;
+
+    /** Dotted Java identifier with at least one dot (monitor classes are always packaged). */
+    private static final Pattern FQCN =
+            Pattern.compile("^[A-Za-z_$][A-Za-z0-9_$]*(\\.[A-Za-z_$][A-Za-z0-9_$]*)+$");
+
+    /** Best-effort: a group that contains a quantifier and is itself quantified, e.g. {@code (a+)+}. */
+    private static final Pattern NESTED_QUANTIFIER =
+            Pattern.compile("\\([^()]*[*+][^()]*\\)[*+]");
+
+    /**
+     * Validates the catalog and returns all findings (collect-all). An empty list means no
+     * ERROR or WARN was raised.
+     *
+     * @param catalog the parsed catalog
+     * @return all validation messages, in a deterministic order
+     */
+    public List<ValidationMessage> validate(final Catalog catalog) {
+        final List<ValidationMessage> messages = new ArrayList<>();
+        final List<ServiceDefinition> services = catalog.services();
+
+        // Per-service checks.
+        for (int i = 0; i < services.size(); i++) {
+            validateService(i, services.get(i), messages);
+        }
+
+        // Cross-service uniqueness (D2).
+        checkDuplicateNames(services, messages);
+        checkIdenticalPatterns(services, messages);
+
+        return messages;
+    }
+
+    private void validateService(final int index, final ServiceDefinition def,
+                                 final List<ValidationMessage> out) {
+        if (isBlank(def.name())) {
+            out.add(error(index, def.name(), "name is required"));
+        }
+
+        if (isBlank(def.monitor())) {
+            out.add(error(index, def.name(), "monitor is required"));
+        } else if (!FQCN.matcher(def.monitor()).matches()) {
+            out.add(error(index, def.name(),
+                    "monitor is not a well-formed class name: " + def.monitor()));
+        }
+
+        final Integer interval = def.interval();
+        if (interval == null) {
+            out.add(error(index, def.name(), "interval is required (milliseconds)"));
+        } else if (interval <= 0) {
+            out.add(error(index, def.name(), "interval must be positive, was " + interval));
+        } else if (interval < INTERVAL_FLOOR_MS) {
+            out.add(warn(index, def.name(),
+                    "interval " + interval + "ms is below the " + INTERVAL_FLOOR_MS + "ms floor"));
+        }
+
+        if (def.isPattern()) {
+            try {
+                Pattern.compile(def.pattern());
+                if (NESTED_QUANTIFIER.matcher(def.pattern()).find()) {
+                    out.add(warn(index, def.name(),
+                            "pattern has nested quantifiers (possible catastrophic backtracking): "
+                                    + def.pattern()));
+                }
+            } catch (final PatternSyntaxException e) {
+                out.add(error(index, def.name(),
+                        "pattern does not compile: " + e.getDescription()));
+            }
+        }
+    }
+
+    private void checkDuplicateNames(final List<ServiceDefinition> services,
+                                     final List<ValidationMessage> out) {
+        final Map<String, List<Integer>> byName = new LinkedHashMap<>();
+        for (int i = 0; i < services.size(); i++) {
+            final String name = services.get(i).name();
+            if (!isBlank(name)) {
+                byName.computeIfAbsent(name, k -> new ArrayList<>()).add(i);
+            }
+        }
+        for (final Map.Entry<String, List<Integer>> e : byName.entrySet()) {
+            if (e.getValue().size() > 1) {
+                for (final int index : e.getValue()) {
+                    out.add(error(index, e.getKey(), "duplicate service name '" + e.getKey() + "'"));
+                }
+            }
+        }
+    }
+
+    private void checkIdenticalPatterns(final List<ServiceDefinition> services,
+                                        final List<ValidationMessage> out) {
+        final Map<String, List<Integer>> byPattern = new LinkedHashMap<>();
+        for (int i = 0; i < services.size(); i++) {
+            final ServiceDefinition def = services.get(i);
+            if (def.isPattern()) {
+                byPattern.computeIfAbsent(def.pattern(), k -> new ArrayList<>()).add(i);
+            }
+        }
+        for (final Map.Entry<String, List<Integer>> e : byPattern.entrySet()) {
+            if (e.getValue().size() > 1) {
+                for (final int index : e.getValue()) {
+                    out.add(error(index, services.get(index).name(),
+                            "identical pattern '" + e.getKey() + "'"));
+                }
+            }
+        }
+    }
+
+    private static ValidationMessage error(final int index, final String name, final String msg) {
+        return new ValidationMessage(Level.ERROR, index, name, msg);
+    }
+
+    private static ValidationMessage warn(final int index, final String name, final String msg) {
+        return new ValidationMessage(Level.WARN, index, name, msg);
+    }
+
+    private static boolean isBlank(final String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogValidator.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogValidator.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -115,7 +116,9 @@ public final class CatalogValidator {
 
     private void checkDuplicateNames(final List<ServiceDefinition> services,
                                      final List<ValidationMessage> out) {
-        final Map<String, List<Integer>> byName = new LinkedHashMap<>();
+        // Case-insensitive: the engine matches service names with equalsIgnoreCase, so names
+        // differing only in case collide on the same synthetic package.
+        final Map<String, List<Integer>> byName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (int i = 0; i < services.size(); i++) {
             final String name = services.get(i).name();
             if (!isBlank(name)) {

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/EngineSettings.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/EngineSettings.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+/**
+ * Engine-tuning scalars that the frozen poller manager answers from the synthetic
+ * {@code PollerConfiguration} root (amended D3), bound from {@code application.yml} by
+ * daemon-boot. These are plumbing, not monitoring semantics, so they live here rather than
+ * in the catalog file (FR1b's three-way split).
+ *
+ * <p>This is a plain record — no Spring, no JAXB — so the library stays framework-free; the
+ * {@link CatalogTranslator} maps these onto the JAXB root attributes.
+ *
+ * <p>Note: {@code nextOutageIdSql} is deliberately absent — it is dead in delta-v's engine
+ * (Open Verification Item #3: zero call sites; outage ids come from JPA), so the translator
+ * leaves the JAXB default in place rather than carrying a value.
+ *
+ * @param threads                    poller thread-pool size
+ * @param asyncPollingEngineEnabled  whether the async polling engine is enabled (default false)
+ * @param maxConcurrentAsyncPolls    cap on concurrent async polls when async is enabled
+ */
+public record EngineSettings(int threads, boolean asyncPollingEngineEnabled, int maxConcurrentAsyncPolls) {
+
+    /** Conservative defaults (sync engine) for tests and minimal deployments. */
+    public static EngineSettings defaults() {
+        return new EngineSettings(30, false, 100);
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/InventoryFilterDao.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/InventoryFilterDao.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.function.Supplier;
+
+import org.opennms.netmgt.filter.api.FilterDao;
+
+/**
+ * A {@link FilterDao} that replaces {@code JdbcFilterDao}/{@code FilterDaoFactory} in the
+ * flat-catalog poller (FR7). The flat model has no filter rules: every monitored interface
+ * belongs to the synthetic catalog packages, so this implementation answers the only three
+ * methods the frozen {@code PollerConfigManager} actually exercises and rejects the rest.
+ *
+ * <p><strong>VERIFIED necessity</strong> (adversarial review): the manager builds its
+ * package IP map solely from {@link #getActiveIPAddressList(String)} — a data-less stub would
+ * mark every service Not-Polled and silence all monitoring. So this returns ALL active
+ * inventory IPs (the {@code rule} is ignored) via a constructor-injected supplier; daemon-boot
+ * provides an {@code IpInterfaceDao}-backed supplier, keeping this library Spring-free.
+ *
+ * <p>The active-IP list is cached so the manager's repeated calls during package-map rebuild
+ * are cheap; {@link #flushActiveIpAddressListCache()} clears it so a subsequent rebuild picks
+ * up newly provisioned interfaces — which is exactly how {@code rebuildPackageIpListMap()}
+ * sees new inventory.
+ */
+public final class InventoryFilterDao implements FilterDao {
+
+    private final Supplier<List<InetAddress>> activeIpSupplier;
+    private volatile List<InetAddress> cached;
+
+    /**
+     * @param activeIpSupplier supplies all active inventory IP addresses; queried lazily and
+     *                         re-queried after {@link #flushActiveIpAddressListCache()}
+     */
+    public InventoryFilterDao(final Supplier<List<InetAddress>> activeIpSupplier) {
+        this.activeIpSupplier = Objects.requireNonNull(activeIpSupplier, "activeIpSupplier");
+    }
+
+    /** Returns ALL active inventory IPs; the filter {@code rule} is intentionally ignored. */
+    @Override
+    public List<InetAddress> getActiveIPAddressList(final String rule) {
+        List<InetAddress> snapshot = cached;
+        if (snapshot == null) {
+            final List<InetAddress> supplied = activeIpSupplier.get();
+            if (supplied == null) {
+                throw new IllegalStateException("activeIpSupplier returned null (expected a list of active IPs)");
+            }
+            snapshot = List.copyOf(supplied);
+            cached = snapshot;
+        }
+        return snapshot;
+    }
+
+    /** Clears the cache so the next {@link #getActiveIPAddressList(String)} re-queries inventory. */
+    @Override
+    public void flushActiveIpAddressListCache() {
+        cached = null;
+    }
+
+    /** Accepts any rule — the flat model has no filter rules to reject. */
+    @Override
+    public void validateRule(final String rule) {
+        // no-op: all rules are trivially valid in the flat catalog model
+    }
+
+    // --- Everything below is never invoked by the flat-catalog daemon paths. ---
+
+    @Override
+    public SortedMap<Integer, String> getNodeMap(final String rule) {
+        throw unsupported("getNodeMap");
+    }
+
+    @Override
+    public Map<InetAddress, Set<String>> getIPAddressServiceMap(final String rule) {
+        throw unsupported("getIPAddressServiceMap");
+    }
+
+    @Override
+    public Map<Integer, Map<InetAddress, Set<String>>> getNodeIPAddressServiceMap(final String rule) {
+        throw unsupported("getNodeIPAddressServiceMap");
+    }
+
+    @Override
+    public List<InetAddress> getIPAddressList(final String rule) {
+        throw unsupported("getIPAddressList");
+    }
+
+    @Override
+    public boolean isValid(final String addr, final String rule) {
+        throw unsupported("isValid");
+    }
+
+    @Override
+    public boolean isRuleMatching(final String rule) {
+        throw unsupported("isRuleMatching");
+    }
+
+    private static UnsupportedOperationException unsupported(final String method) {
+        return new UnsupportedOperationException(
+                "InventoryFilterDao." + method + " is not used by the flat-catalog poller");
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ServiceDefinition.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ServiceDefinition.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * One flat poller service definition (FR1).
+ *
+ * <p>Shape: {@code { name, pattern?, monitor, interval, enabled?=true, parameters }}.
+ * {@code pattern} (optional regex) preserves dynamic service families — one definition
+ * serving many inventory service names, capture groups feeding the engine's pattern
+ * variables. {@code enabled} is a type-level kill switch (distinct from per-entity
+ * inventory exclusion). {@code parameters} keys are verbatim monitor parameter names,
+ * never translated; values are always strings (metadata DSL chains, block scalars).
+ *
+ * <p>The compact constructor performs <em>normalization only</em> — never validation.
+ * Required-field, interval, pattern-compile, and duplicate checks live in
+ * {@link CatalogValidator}, which collects all problems in one pass; record constructors
+ * can only throw-first. {@code interval} is an {@link Integer} (not {@code int}) so a
+ * missing value surfaces as a validator message rather than a parse-time failure.
+ *
+ * @param name       the definition's unique identity and synthetic package name
+ *                   ({@code catalog-<name>}); always required. For a definition without a
+ *                   {@code pattern} it is also the exact inventory service name matched. A
+ *                   {@code pattern} is an additional regex matcher, not a replacement for name.
+ * @param pattern    optional regex matching a family of inventory service names
+ * @param monitor    fully-qualified monitor class name (required)
+ * @param interval   poll interval in milliseconds (required, positive)
+ * @param enabled    type-level kill switch; defaults {@code true} when omitted
+ * @param parameters verbatim monitor parameters (never translated); defaults empty
+ */
+public record ServiceDefinition(
+        String name,
+        String pattern,
+        String monitor,
+        Integer interval,
+        Boolean enabled,
+        Map<String, String> parameters) {
+
+    public ServiceDefinition {
+        enabled = (enabled == null) ? Boolean.TRUE : enabled;
+        parameters = (parameters == null)
+                ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(parameters));
+    }
+
+    /** @return {@code true} if this definition matches inventory names by regex rather than exact name. */
+    public boolean isPattern() {
+        return pattern != null && !pattern.isBlank();
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ServiceResolver.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ServiceResolver.java
@@ -17,10 +17,10 @@
 package org.deltav.poller.catalog;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -29,8 +29,9 @@ import java.util.regex.PatternSyntaxException;
  *
  * <p>Precedence: an <em>exact</em> definition (one with no {@code pattern}, matched by name
  * equality) beats any pattern; among multiple matching <em>pattern</em> definitions, the
- * first in file order wins. This mirrors the frozen poller manager's matching so that the
- * FR9 startup check and the translator agree with the engine (resolver parity).
+ * first in file order wins. Exact-name matching is <strong>case-insensitive</strong> to
+ * mirror the frozen manager's {@code equalsIgnoreCase}, so the FR9 startup check and the
+ * translator agree with the engine (resolver parity).
  *
  * <p>Expects a validated catalog. As a defensive measure it skips pattern definitions whose
  * regex does not compile (those are reported as ERRORs by {@link CatalogValidator}); it never
@@ -50,7 +51,8 @@ public final class ServiceResolver {
     private final List<CompiledPattern> patterns; // file order preserved
 
     public ServiceResolver(final Catalog catalog) {
-        this.exactByName = new LinkedHashMap<>();
+        // Case-insensitive to match the frozen manager's equalsIgnoreCase exact matching.
+        this.exactByName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         this.patterns = new ArrayList<>();
         for (final ServiceDefinition def : catalog.services()) {
             if (def.isPattern()) {

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ServiceResolver.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ServiceResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Resolves an inventory service name to the catalog definition that serves it (D2).
+ *
+ * <p>Precedence: an <em>exact</em> definition (one with no {@code pattern}, matched by name
+ * equality) beats any pattern; among multiple matching <em>pattern</em> definitions, the
+ * first in file order wins. This mirrors the frozen poller manager's matching so that the
+ * FR9 startup check and the translator agree with the engine (resolver parity).
+ *
+ * <p>Expects a validated catalog. As a defensive measure it skips pattern definitions whose
+ * regex does not compile (those are reported as ERRORs by {@link CatalogValidator}); it never
+ * throws on a bad pattern.
+ *
+ * <p><strong>Resolution ignores {@code enabled}</strong> — a disabled definition still
+ * matches and can win (exact-beats-pattern, or first-in-file-order among patterns). This is
+ * deliberate: the {@code enabled} kill switch is applied by callers per D4 — the translator
+ * omits disabled definitions from the synthetic packages, and the FR9 startup check needs to
+ * tell "matched but disabled" (exclude from the unscheduled gauge) apart from "no match at
+ * all". Callers must therefore consult {@link ServiceDefinition#enabled()} themselves rather
+ * than rely on resolution to filter.
+ */
+public final class ServiceResolver {
+
+    private final Map<String, ServiceDefinition> exactByName;
+    private final List<CompiledPattern> patterns; // file order preserved
+
+    public ServiceResolver(final Catalog catalog) {
+        this.exactByName = new LinkedHashMap<>();
+        this.patterns = new ArrayList<>();
+        for (final ServiceDefinition def : catalog.services()) {
+            if (def.isPattern()) {
+                try {
+                    patterns.add(new CompiledPattern(Pattern.compile(def.pattern()), def));
+                } catch (final PatternSyntaxException ignored) {
+                    // Reported by CatalogValidator; an uncompilable pattern matches nothing.
+                }
+            } else if (def.name() != null) {
+                // Exact definitions: first occurrence wins (duplicates are a validation ERROR).
+                exactByName.putIfAbsent(def.name(), def);
+            }
+        }
+    }
+
+    /**
+     * Resolves the definition serving the given inventory service name.
+     *
+     * @param serviceName the inventory service name (e.g. {@code "HTTP-8080"})
+     * @return the matching definition, exact first then first-in-file-order pattern, or empty
+     */
+    public Optional<ServiceDefinition> resolve(final String serviceName) {
+        if (serviceName == null) {
+            return Optional.empty();
+        }
+        final ServiceDefinition exact = exactByName.get(serviceName);
+        if (exact != null) {
+            return Optional.of(exact);
+        }
+        for (final CompiledPattern cp : patterns) {
+            if (cp.pattern.matcher(serviceName).matches()) {
+                return Optional.of(cp.definition);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private record CompiledPattern(Pattern pattern, ServiceDefinition definition) {
+    }
+}

--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ValidationMessage.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/ValidationMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+/**
+ * One validation finding against a catalog. The {@link CatalogValidator} returns these in
+ * a collect-all pass; the lint CLI and the daemon startup check render them one per line.
+ *
+ * <p>Render format (operator-facing contract): {@code LEVEL: <file>: services[<index>] (<name>): <message>}.
+ * The {@code <file>} label is supplied at render time because the validator works on a
+ * parsed model and does not know the source path.
+ *
+ * @param level       severity (ERROR fails lint; WARN does not)
+ * @param index       zero-based position of the offending service in the catalog
+ * @param serviceName the service definition's {@code name} (may be null/blank if that is the defect)
+ * @param message     the human-readable problem description
+ */
+public record ValidationMessage(Level level, int index, String serviceName, String message) {
+
+    /** Severity levels. Exactly two — anything that must block the build is an ERROR. */
+    public enum Level { ERROR, WARN }
+
+    /** @return {@code true} if this finding is an ERROR (build-blocking). */
+    public boolean isError() {
+        return level == Level.ERROR;
+    }
+
+    /**
+     * Renders this finding in the operator-facing single-line format.
+     *
+     * @param fileLabel the source file label to embed (e.g. {@code poller-services.yaml})
+     * @return {@code LEVEL: <file>: services[<index>] (<name>): <message>}
+     */
+    public String format(final String fileLabel) {
+        return level + ": " + fileLabel + ": services[" + index + "] ("
+                + (serviceName == null ? "" : serviceName) + "): " + message;
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogLintTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogLintTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Story 1.5 acceptance criteria for {@link CatalogLint}: exit 0 clean / 1 errors / 2 usage-IO,
+ * collect-all output, and empty-catalog / nested-quantifier as warnings (not failures).
+ */
+class CatalogLintTest {
+
+    @TempDir
+    Path tmp;
+
+    private final ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+
+    @Test
+    void cleanCatalogExitsZero() throws IOException {
+        final Path file = write("clean.yaml", """
+                services:
+                  - name: ICMP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                """);
+        assertEquals(0, run(file.toString()));
+        assertTrue(out().isBlank(), "clean catalog prints no findings, was: " + out());
+    }
+
+    @Test
+    void defectiveCatalogExitsOneWithCollectAllOutput() throws IOException {
+        final Path file = write("bad.yaml", """
+                services:
+                  - name: DUP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                  - name: DUP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: -5
+                """);
+        assertEquals(1, run(file.toString()));
+        // collect-all: both the duplicate-name and the bad-interval defects appear in one run.
+        assertTrue(out().contains("duplicate service name"), out());
+        assertTrue(out().contains("interval must be positive"), out());
+    }
+
+    @Test
+    void missingFileExitsTwo() {
+        assertEquals(2, run(tmp.resolve("nope.yaml").toString()));
+    }
+
+    @Test
+    void wrongUsageExitsTwo() {
+        assertEquals(2, run());
+        assertTrue(err().contains("usage"), err());
+    }
+
+    @Test
+    void emptyCatalogWarnsButExitsZero() throws IOException {
+        final Path file = write("empty.yaml", "services: []\n");
+        assertEquals(0, run(file.toString()));
+        assertTrue(out().contains("catalog is empty"), out());
+    }
+
+    @Test
+    void anchorsAreReportedAsErrorExitOne() throws IOException {
+        final Path file = write("anchors.yaml", """
+                services:
+                  - name: A
+                    monitor: &mon org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                  - name: B
+                    monitor: *mon
+                    interval: 300000
+                """);
+        assertEquals(1, run(file.toString()));
+        assertTrue(out().contains("anchors"), out());
+    }
+
+    @Test
+    void nestedQuantifierWarnsButExitsZero() throws IOException {
+        final Path file = write("risky.yaml", """
+                services:
+                  - name: Risky
+                    pattern: "(a+)+"
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                """);
+        assertEquals(0, run(file.toString()));
+        assertTrue(out().contains("nested quantifiers"), out());
+    }
+
+    private int run(final String... args) {
+        return CatalogLint.run(args,
+                new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+                new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    }
+
+    private String out() {
+        return outBuf.toString(StandardCharsets.UTF_8);
+    }
+
+    private String err() {
+        return errBuf.toString(StandardCharsets.UTF_8);
+    }
+
+    private Path write(final String name, final String content) throws IOException {
+        final Path file = tmp.resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogParserTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogParserTest.java
@@ -106,6 +106,33 @@ class CatalogParserTest {
                 "nested-XML block scalar must round-trip as a string, was: " + pageSequence);
     }
 
+    /**
+     * D8 pin: YAML anchors / aliases / merge keys are explicitly rejected (jackson-dataformat-yaml
+     * does not resolve them and would otherwise silently bind an alias's name as the value). The
+     * parser detects them and fails loudly with a clear message — no silent middle ground.
+     */
+    @Test
+    void yamlAnchorsAreRejectedAsUnsupported() throws IOException {
+        final IOException ex = assertThrows(IOException.class, () -> parser.parse(fixture("anchors.yaml")));
+        assertTrue(ex.getMessage().contains("anchors"), ex.getMessage());
+    }
+
+    /** Even an anchor/alias on a String field (which jackson would silently mis-bind) is rejected. */
+    @Test
+    void yamlAnchorOnStringFieldIsRejected() {
+        final String yaml = """
+                services:
+                  - name: ICMP
+                    monitor: &mon org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                  - name: ICMP2
+                    monitor: *mon
+                    interval: 300000
+                """;
+        final IOException ex = assertThrows(IOException.class, () -> parse(yaml));
+        assertTrue(ex.getMessage().contains("anchors"), ex.getMessage());
+    }
+
     private Catalog parse(final String yaml) throws IOException {
         try (Reader reader = new StringReader(yaml)) {
             return parser.parse(reader);

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogParserTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogParserTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 1.2 acceptance criteria for {@link CatalogParser} and the catalog model records.
+ */
+class CatalogParserTest {
+
+    private final CatalogParser parser = new CatalogParser();
+
+    /** AC: records carry name/pattern/monitor/interval/enabled/parameters with enabled defaulting true. */
+    @Test
+    void parsesMinimalAndAppliesDefaults() throws IOException {
+        final Catalog catalog = parser.parse(fixture("valid-minimal.yaml"));
+
+        assertEquals(1, catalog.services().size());
+        final ServiceDefinition icmp = catalog.services().get(0);
+        assertEquals("ICMP", icmp.name());
+        assertEquals("org.opennms.netmgt.poller.monitors.IcmpMonitor", icmp.monitor());
+        assertEquals(300000, icmp.interval());
+        assertNull(icmp.pattern(), "pattern omitted -> null");
+        assertFalse(icmp.isPattern());
+        assertEquals(Boolean.TRUE, icmp.enabled(), "enabled omitted -> defaults true");
+        assertTrue(icmp.parameters().isEmpty(), "parameters omitted -> empty map");
+    }
+
+    /** AC: an unknown key fails parsing with an error naming the unknown key (FR1/D1 strict mode). */
+    @Test
+    void unknownKeyFailsNamingTheKey() {
+        final String yaml = """
+                services:
+                  - name: ICMP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    intervall: 30000
+                """;
+        final IOException ex = assertThrows(IOException.class, () -> parse(yaml));
+        assertTrue(ex.getMessage().contains("intervall"),
+                "strict-mode error must name the unknown key, was: " + ex.getMessage());
+    }
+
+    /** Strictness: a duplicate YAML key fails parsing rather than silently taking last-wins. */
+    @Test
+    void duplicateKeyFails() {
+        final String yaml = """
+                services:
+                  - name: ICMP
+                    name: SNMP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                """;
+        final IOException ex = assertThrows(IOException.class, () -> parse(yaml));
+        assertTrue(ex.getMessage().toLowerCase().contains("duplicate"),
+                "duplicate-key error expected, was: " + ex.getMessage());
+    }
+
+    /** AC: metadata DSL chains and a block scalar round-trip verbatim as strings — no key translation. */
+    @Test
+    void parameterValuesAndKeysRoundTripVerbatim() throws IOException {
+        final Catalog catalog = parser.parse(fixture("pattern-family.yaml"));
+        assertEquals(2, catalog.services().size());
+
+        final ServiceDefinition http = catalog.services().get(0);
+        assertEquals("HTTP-8080", http.name());
+        assertEquals("${requisition:port|detector:port|80}", http.parameters().get("port"),
+                "metadata DSL chain must survive verbatim, unquoted of its braces");
+
+        final ServiceDefinition seq = catalog.services().get(1);
+        assertEquals("^HTTP-(\\d+)$", seq.pattern());
+        assertTrue(seq.isPattern());
+        assertEquals(Boolean.FALSE, seq.enabled(), "explicit enabled:false honored");
+        // Key is verbatim (kebab-case, never camelCased) and the block scalar text is preserved.
+        assertTrue(seq.parameters().containsKey("page-sequence"), "parameter key kept verbatim");
+        final String pageSequence = seq.parameters().get("page-sequence");
+        assertTrue(pageSequence.contains("<page-sequence>")
+                        && pageSequence.contains("port=\"8080\""),
+                "nested-XML block scalar must round-trip as a string, was: " + pageSequence);
+    }
+
+    private Catalog parse(final String yaml) throws IOException {
+        try (Reader reader = new StringReader(yaml)) {
+            return parser.parse(reader);
+        }
+    }
+
+    private static Path fixture(final String name) {
+        final URL url = CatalogParserTest.class.getResource("/catalogs/" + name);
+        if (url == null) {
+            throw new IllegalStateException("missing test fixture: catalogs/" + name);
+        }
+        try {
+            return Path.of(url.toURI());
+        } catch (final java.net.URISyntaxException e) {
+            throw new UncheckedIOException(new IOException(e));
+        }
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogTranslatorTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogTranslatorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.config.poller.Downtime;
+import org.opennms.netmgt.config.poller.Monitor;
+import org.opennms.netmgt.config.poller.Package;
+import org.opennms.netmgt.config.poller.PollerConfiguration;
+import org.opennms.netmgt.config.poller.Service;
+
+/**
+ * Story 1.4 acceptance criteria for {@link CatalogTranslator}: one package per definition with
+ * synthesized downtime, exact-before-pattern ordering, monitor bindings, engine scalars on the
+ * root, disabled definitions omitted, and {@code nextOutageId} left unset.
+ */
+class CatalogTranslatorTest {
+
+    private final CatalogTranslator translator = new CatalogTranslator();
+
+    @Test
+    void translatesPackagesDowntimeServicesAndMonitors() {
+        final Catalog catalog = new Catalog(List.of(
+                new ServiceDefinition("ICMP", null, "a.b.IcmpMonitor", 300000, true,
+                        Map.of("retry", "2")),
+                new ServiceDefinition("HttpFamily", "^HTTP-(\\d+)$", "a.b.PageSequenceMonitor",
+                        30000, true, Map.of())));
+
+        final PollerConfiguration config = translator.translate(catalog, EngineSettings.defaults());
+
+        assertEquals(2, config.getPackages().size());
+
+        final Package icmp = config.getPackage("catalog-ICMP");
+        assertEquals(1, icmp.getDowntimes().size());
+        final Downtime downtime = icmp.getDowntimes().get(0);
+        assertEquals(0L, downtime.getBegin());
+        assertEquals(300000L, downtime.getInterval());
+
+        final Service icmpSvc = icmp.getServices().get(0);
+        assertEquals("ICMP", icmpSvc.getName());
+        assertEquals(300000L, icmpSvc.getInterval());
+        assertEquals("on", icmpSvc.getStatus());
+        assertNull(icmpSvc.getPattern());
+        assertEquals("2", icmpSvc.getParameterMap().get("retry"));
+
+        final Service httpSvc = config.getPackage("catalog-HttpFamily").getServices().get(0);
+        assertEquals("^HTTP-(\\d+)$", httpSvc.getPattern());
+
+        // Monitor bindings: one per definition, keyed by the definition name.
+        assertEquals(2, config.getMonitors().size());
+        final Monitor icmpMonitor = config.getMonitors().stream()
+                .filter(m -> "ICMP".equals(m.getService())).findFirst().orElseThrow();
+        assertEquals("a.b.IcmpMonitor", icmpMonitor.getClassName());
+    }
+
+    @Test
+    void emitsExactPackagesBeforePatternPackages() {
+        final Catalog catalog = new Catalog(List.of(
+                new ServiceDefinition("PatternA", "^A-(\\d+)$", "a.b.M1", 30000, true, Map.of()),
+                new ServiceDefinition("ExactB", null, "a.b.M2", 30000, true, Map.of()),
+                new ServiceDefinition("PatternC", "^C-(\\d+)$", "a.b.M3", 30000, true, Map.of()),
+                new ServiceDefinition("ExactD", null, "a.b.M4", 30000, true, Map.of())));
+
+        final List<String> packageNames = translator.translate(catalog, EngineSettings.defaults())
+                .getPackages().stream().map(Package::getName).toList();
+
+        // Exact definitions first (in file order), then pattern definitions (in file order).
+        assertEquals(List.of("catalog-ExactB", "catalog-ExactD", "catalog-PatternA", "catalog-PatternC"),
+                packageNames);
+    }
+
+    @Test
+    void omitsDisabledDefinitionsEntirely() {
+        final Catalog catalog = new Catalog(List.of(
+                new ServiceDefinition("Live", null, "a.b.M1", 30000, true, Map.of()),
+                new ServiceDefinition("Killed", null, "a.b.M2", 30000, false, Map.of())));
+
+        final PollerConfiguration config = translator.translate(catalog, EngineSettings.defaults());
+
+        assertEquals(1, config.getPackages().size());
+        assertNull(config.getPackage("catalog-Killed"), "disabled definition must be omitted");
+        assertTrue(config.getMonitors().stream().noneMatch(m -> "Killed".equals(m.getService())));
+    }
+
+    @Test
+    void failsFastWhenAnEnabledDefinitionMissesALoadBearingField() {
+        // A catalog that bypassed validation (null interval) must fail with a clear message, not an NPE.
+        final Catalog badInterval = new Catalog(List.of(
+                new ServiceDefinition("ICMP", null, "a.b.IcmpMonitor", null, true, Map.of())));
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> translator.translate(badInterval, EngineSettings.defaults()));
+        assertTrue(ex.getMessage().contains("interval"), ex.getMessage());
+    }
+
+    @Test
+    void mapsEngineSettingsAndDisablesAdapterConstantsAndLeavesNextOutageIdUnset() {
+        final PollerConfiguration config = translator.translate(
+                new Catalog(List.of()), new EngineSettings(12, true, 50));
+
+        assertEquals(12, config.getThreads());
+        assertEquals(Boolean.TRUE, config.getAsyncPollingEngineEnabled());
+        assertEquals(50, config.getMaxConcurrentAsyncPolls());
+        assertEquals("false", config.getServiceUnresponsiveEnabled());
+        assertEquals("false", config.getPathOutageEnabled());
+        // nextOutageId dropped (OVI #3): translator never sets it, so the JAXB default is left
+        // untouched. Assert against a freshly-constructed default rather than a hardcoded string,
+        // so this pins "translator does not interfere" without coupling to the frozen model's literal.
+        assertEquals(new PollerConfiguration().getNextOutageId(), config.getNextOutageId(),
+                "translator must not set nextOutageId; the JAXB default must remain unchanged");
+        assertTrue(config.getPackages().isEmpty(), "empty catalog yields no packages");
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogValidatorTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/CatalogValidatorTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+
+import org.deltav.poller.catalog.ValidationMessage.Level;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 1.3 acceptance criteria for {@link CatalogValidator}: collect-all (never first-fail)
+ * and the single-line message format.
+ */
+class CatalogValidatorTest {
+
+    private final CatalogParser parser = new CatalogParser();
+    private final CatalogValidator validator = new CatalogValidator();
+
+    /** AC: a catalog with N distinct defects yields all N messages in one pass — never first-fail. */
+    @Test
+    void collectsAllDefectsInOnePass() throws IOException {
+        final Catalog catalog = parser.parse(load("""
+                services:
+                  - name: DUP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                  - name: DUP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                  - name: BadInterval
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: -5
+                  - name: BadPattern
+                    pattern: "(unclosed"
+                    monitor: org.opennms.netmgt.poller.monitors.HttpMonitor
+                    interval: 300000
+                """));
+
+        final List<ValidationMessage> messages = validator.validate(catalog);
+        final List<ValidationMessage> errors = messages.stream().filter(ValidationMessage::isError).toList();
+
+        // 2 duplicate-name + 1 bad-interval + 1 bad-pattern = 4 distinct ERRORs.
+        assertEquals(4, errors.size(), "all four defects must be collected, not first-failed: " + render(errors));
+        assertEquals(2, errors.stream().filter(m -> m.message().contains("duplicate service name")).count());
+        assertTrue(errors.stream().anyMatch(m -> m.message().contains("interval must be positive")));
+        assertTrue(errors.stream().anyMatch(m -> m.message().contains("pattern does not compile")));
+    }
+
+    /** AC: messages render as {@code LEVEL: <file>: services[<index>] (<name>): <message>}. */
+    @Test
+    void rendersInTheSingleLineFormat() throws IOException {
+        final Catalog catalog = parser.parse(load("""
+                services:
+                  - name: ICMP
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: 300000
+                  - name: BadInterval
+                    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                    interval: -5
+                """));
+
+        final ValidationMessage badInterval = validator.validate(catalog).stream()
+                .filter(m -> "BadInterval".equals(m.serviceName()))
+                .findFirst().orElseThrow();
+
+        assertEquals("ERROR: poller-services.yaml: services[1] (BadInterval): interval must be positive, was -5",
+                badInterval.format("poller-services.yaml"));
+    }
+
+    /** AC: an interval below the 5s floor yields a WARN-level message (not an ERROR). */
+    @Test
+    void intervalBelowFloorIsWarn() {
+        final Catalog catalog = new Catalog(List.of(
+                new ServiceDefinition("Fast", null, "a.b.FastMonitor", 1000, null, Map.of())));
+
+        final List<ValidationMessage> messages = validator.validate(catalog);
+
+        assertEquals(1, messages.size());
+        assertEquals(Level.WARN, messages.get(0).level());
+        assertTrue(messages.get(0).message().contains("below the 5000ms floor"));
+    }
+
+    /** A clean catalog produces no findings. */
+    @Test
+    void cleanCatalogHasNoMessages() throws IOException {
+        final Catalog catalog = parser.parse(CatalogParserTestFixtures.minimal());
+        assertTrue(validator.validate(catalog).isEmpty());
+    }
+
+    private static Reader load(final String yaml) {
+        return new StringReader(yaml);
+    }
+
+    private static String render(final List<ValidationMessage> messages) {
+        return messages.stream().map(m -> m.format("test.yaml")).reduce("", (a, b) -> a + "\n" + b);
+    }
+
+    /** Tiny inline fixture helper to avoid a redundant resource file for the clean case. */
+    private static final class CatalogParserTestFixtures {
+        static Reader minimal() {
+            return new StringReader("""
+                    services:
+                      - name: ICMP
+                        monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+                        interval: 300000
+                    """);
+        }
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/FrozenEngineContractIT.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/FrozenEngineContractIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.config.PollerConfigFactory;
+import org.opennms.netmgt.config.poller.Package;
+import org.opennms.netmgt.config.poller.PollerConfiguration;
+
+/**
+ * D8 contract suite: pins translator output through the REAL frozen {@code PollerConfigFactory}
+ * (never mocking {@code PollerConfig}), with JARs resolved via {@code ${deltav.horizon.version}}
+ * so a horizon bump re-proves the adapter. Constructed directly from the in-memory synthetic
+ * {@link PollerConfiguration} + {@link InventoryFilterDao} via
+ * {@code PollerConfigFactory(long, PollerConfiguration, FilterDao)} — confirming the D3 strategy
+ * end-to-end.
+ *
+ * <p>Pins covered here are the config-layer behaviors. The remaining behavioral pins that need
+ * the full poller.impl runtime (PollableServiceConfig downtime-reschedule of a down service,
+ * Poller.scheduleService {@code 'N'}-marking + {@code 'N'->'A'} restoration, pattern-variable
+ * flow through a live poll) are tracked in deferred-work for completion within Story 1.6.
+ */
+class FrozenEngineContractIT {
+
+    private final CatalogTranslator translator = new CatalogTranslator();
+
+    /** Empty-catalog boot tolerance: the real factory constructs with no packages and no throw. */
+    @Test
+    void emptyCatalogBootTolerance() {
+        assertDoesNotThrow(() -> factory(new Catalog(List.of()), List.of()));
+    }
+
+    /** Package re-fetch by stable name: PollableServiceConfig re-obtains its package by name. */
+    @Test
+    void packageReFetchByStableName() throws UnknownHostException {
+        final PollerConfigFactory factory = factory(
+                catalog(def("ICMP", null, "org.opennms.netmgt.poller.monitors.IcmpMonitor", 300000)),
+                List.of(addr("10.0.0.1")));
+
+        final Package pkg = factory.getPackage("catalog-ICMP");
+        assertNotNull(pkg, "synthetic package must be re-fetchable by its stable name");
+        assertEquals("catalog-ICMP", pkg.getName());
+    }
+
+    /** isInterfaceInPackage matches via InventoryFilterDao-supplied IPs (VERIFIED necessity). */
+    @Test
+    void isInterfaceInPackageMatchesViaInventoryFilterDao() throws UnknownHostException {
+        final PollerConfigFactory factory = factory(
+                catalog(def("ICMP", null, "org.opennms.netmgt.poller.monitors.IcmpMonitor", 300000)),
+                List.of(addr("10.0.0.1"), addr("10.0.0.2")));
+
+        final Package pkg = factory.getPackage("catalog-ICMP");
+        assertTrue(factory.isInterfaceInPackage("10.0.0.1", pkg));
+        assertTrue(factory.isInterfaceInPackage("10.0.0.2", pkg));
+    }
+
+    /** With no inventory IPs the package matches nothing — proving the data-less-stub failure mode. */
+    @Test
+    void emptyInventoryYieldsNoPackageMatch() throws UnknownHostException {
+        final PollerConfigFactory factory = factory(
+                catalog(def("ICMP", null, "org.opennms.netmgt.poller.monitors.IcmpMonitor", 300000)),
+                List.of());
+
+        final Package pkg = factory.getPackage("catalog-ICMP");
+        assertFalse(factory.isInterfaceInPackage("10.0.0.1", pkg),
+                "an empty active-IP list must not match — this is why InventoryFilterDao must carry data");
+    }
+
+    /** Per-package downtime is present in the real manager's config: begin=0, interval=service interval. */
+    @Test
+    void perPackageDowntimeSynthesized() throws UnknownHostException {
+        final Package pkg = factory(
+                catalog(def("ICMP", null, "org.opennms.netmgt.poller.monitors.IcmpMonitor", 300000)),
+                List.of(addr("10.0.0.1"))).getPackage("catalog-ICMP");
+
+        assertEquals(1, pkg.getDowntimes().size());
+        assertEquals(0L, pkg.getDowntimes().get(0).getBegin());
+        assertEquals(300000L, pkg.getDowntimes().get(0).getInterval());
+    }
+
+    /** Resolver parity: ServiceResolver's verdict equals the frozen manager's on every fixture name. */
+    @Test
+    void resolverParityWithFrozenManager() throws UnknownHostException {
+        final Catalog catalog = catalog(
+                def("HTTP-8080", null, "org.opennms.netmgt.poller.monitors.HttpMonitor", 30000),
+                def("HttpFamily", "^HTTP-(\\d+)$", "org.opennms.netmgt.poller.monitors.PageSequenceMonitor", 30000));
+        final ServiceResolver resolver = new ServiceResolver(catalog);
+        final PollerConfigFactory factory = factory(catalog, List.of(addr("10.0.0.1")));
+
+        // Includes a case-variant ("http-8080") to pin that ServiceResolver matches the frozen
+        // manager's case-insensitive exact match — the FR9 gauge must agree with what the engine schedules.
+        for (final String name : List.of("HTTP-8080", "http-8080", "HTTP-9090", "SNMP")) {
+            final String resolverVerdict = resolver.resolve(name)
+                    .map(d -> "catalog-" + d.name()).orElse(null);
+            final String managerVerdict = factory.getPackages().stream()
+                    .filter(p -> factory.isServiceInPackageAndEnabled(name, p))
+                    .map(Package::getName)
+                    .findFirst().orElse(null);
+            assertEquals(resolverVerdict, managerVerdict, "resolver parity for '" + name + "'");
+        }
+    }
+
+    /** update() no-ops under the setPollerConfigFile/version trick — XML is never reloaded over the synthetic config. */
+    @Test
+    void updateNoOpsUnderVersionTrick() throws Exception {
+        final File configFile = Files.createTempFile("poller-services", ".yaml").toFile();
+        configFile.deleteOnExit();
+        PollerConfigFactory.setPollerConfigFile(configFile);
+
+        final PollerConfiguration config = translator.translate(
+                catalog(def("ICMP", null, "org.opennms.netmgt.poller.monitors.IcmpMonitor", 300000)),
+                EngineSettings.defaults());
+        // currentVersion == file's lastModified -> update()'s `lastModified > version` guard is false,
+        // so it never tries to parse the (non-XML) yaml file and keeps the synthetic config.
+        final PollerConfigFactory factory =
+                new PollerConfigFactory(configFile.lastModified(), config, filterDao(List.of(addr("10.0.0.1"))));
+
+        assertDoesNotThrow(factory::update);
+        assertNotNull(factory.getPackage("catalog-ICMP"), "synthetic config must survive update()");
+    }
+
+    // --- helpers ---
+
+    private PollerConfigFactory factory(final Catalog catalog, final List<InetAddress> ips) {
+        final PollerConfiguration config = translator.translate(catalog, EngineSettings.defaults());
+        return new PollerConfigFactory(1L, config, filterDao(ips));
+    }
+
+    private static InventoryFilterDao filterDao(final List<InetAddress> ips) {
+        return new InventoryFilterDao(() -> ips);
+    }
+
+    private static Catalog catalog(final ServiceDefinition... defs) {
+        return new Catalog(List.of(defs));
+    }
+
+    private static ServiceDefinition def(final String name, final String pattern,
+                                         final String monitor, final int interval) {
+        return new ServiceDefinition(name, pattern, monitor, interval, Boolean.TRUE, Map.of());
+    }
+
+    private static InetAddress addr(final String ip) throws UnknownHostException {
+        return InetAddress.getByName(ip);
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/InventoryFilterDaoTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/InventoryFilterDaoTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 1.4 acceptance criteria for {@link InventoryFilterDao}: three real methods, the rest
+ * throw {@link UnsupportedOperationException}.
+ */
+class InventoryFilterDaoTest {
+
+    /** AC: getActiveIPAddressList returns all supplied IPs, ignoring the rule. */
+    @Test
+    void returnsAllSuppliedIpsIgnoringRule() throws UnknownHostException {
+        final List<InetAddress> ips = List.of(
+                InetAddress.getByName("10.0.0.1"), InetAddress.getByName("10.0.0.2"));
+        final InventoryFilterDao dao = new InventoryFilterDao(() -> ips);
+
+        assertEquals(ips, dao.getActiveIPAddressList("any rule is ignored"));
+        assertEquals(ips, dao.getActiveIPAddressList(null));
+    }
+
+    /** AC: flushActiveIpAddressListCache triggers a re-query of the supplier. */
+    @Test
+    void flushTriggersRequery() throws UnknownHostException {
+        final InetAddress a = InetAddress.getByName("10.0.0.1");
+        final InetAddress b = InetAddress.getByName("10.0.0.2");
+        final AtomicInteger calls = new AtomicInteger();
+        final Supplier<List<InetAddress>> supplier = () ->
+                calls.getAndIncrement() == 0 ? List.of(a) : List.of(a, b);
+
+        final InventoryFilterDao dao = new InventoryFilterDao(supplier);
+
+        final List<InetAddress> first = dao.getActiveIPAddressList(null);
+        assertEquals(List.of(a), first);
+        assertSame(first, dao.getActiveIPAddressList(null), "second call is cached, no re-query");
+        assertEquals(1, calls.get());
+
+        dao.flushActiveIpAddressListCache();
+        assertEquals(List.of(a, b), dao.getActiveIPAddressList(null), "re-query after flush");
+        assertEquals(2, calls.get());
+    }
+
+    /** AC: validateRule accepts (no throw). */
+    @Test
+    void validateRuleAccepts() {
+        new InventoryFilterDao(List::of).validateRule("anything");
+    }
+
+    /** A supplier that returns null fails with a clear message rather than a bare NPE. */
+    @Test
+    void nullSupplierResultFailsClearly() {
+        final InventoryFilterDao dao = new InventoryFilterDao(() -> null);
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> dao.getActiveIPAddressList(null));
+        assertTrue(ex.getMessage().contains("returned null"), ex.getMessage());
+    }
+
+    /** AC: every other FilterDao method throws UnsupportedOperationException. */
+    @Test
+    void unusedMethodsThrow() {
+        final InventoryFilterDao dao = new InventoryFilterDao(List::of);
+        assertThrows(UnsupportedOperationException.class, () -> dao.getNodeMap("r"));
+        assertThrows(UnsupportedOperationException.class, () -> dao.getIPAddressServiceMap("r"));
+        assertThrows(UnsupportedOperationException.class, () -> dao.getNodeIPAddressServiceMap("r"));
+        assertThrows(UnsupportedOperationException.class, () -> dao.getIPAddressList("r"));
+        assertThrows(UnsupportedOperationException.class, () -> dao.isValid("10.0.0.1", "r"));
+        assertThrows(UnsupportedOperationException.class, () -> dao.isRuleMatching("r"));
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/ServiceResolverTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/ServiceResolverTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.poller.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 1.3 acceptance criteria for {@link ServiceResolver}: exact beats pattern, and among
+ * patterns the first in file order wins (D2).
+ */
+class ServiceResolverTest {
+
+    /** AC: a name matching both an exact and a pattern definition resolves to the exact one. */
+    @Test
+    void exactBeatsPatternEvenWhenPatternIsListedFirst() {
+        final ServiceDefinition pattern =
+                def("HttpFamily", "^HTTP-(\\d+)$", "a.b.PageSequenceMonitor");
+        final ServiceDefinition exact =
+                def("HTTP-8080", null, "a.b.HttpMonitor");
+        // Pattern deliberately precedes the exact definition in file order.
+        final ServiceResolver resolver = new ServiceResolver(new Catalog(List.of(pattern, exact)));
+
+        assertEquals("HTTP-8080", resolver.resolve("HTTP-8080").orElseThrow().name());
+    }
+
+    /** AC: among multiple matching patterns, the first in file order wins. */
+    @Test
+    void firstMatchingPatternInFileOrderWins() {
+        final ServiceDefinition first = def("First", "^HTTP-(\\d+)$", "a.b.M1");
+        final ServiceDefinition second = def("Second", "^HTTP-9.*$", "a.b.M2");
+        final ServiceResolver resolver = new ServiceResolver(new Catalog(List.of(first, second)));
+
+        // "HTTP-9090" matches both patterns; file order puts First ahead of Second.
+        assertEquals("First", resolver.resolve("HTTP-9090").orElseThrow().name());
+    }
+
+    /** A name matching nothing resolves to empty (the FR9 unscheduled path). */
+    @Test
+    void noMatchResolvesEmpty() {
+        final ServiceResolver resolver = new ServiceResolver(new Catalog(List.of(
+                def("ICMP", null, "a.b.IcmpMonitor"))));
+        assertTrue(resolver.resolve("SNMP").isEmpty());
+    }
+
+    private static ServiceDefinition def(final String name, final String pattern, final String monitor) {
+        return new ServiceDefinition(name, pattern, monitor, 300000, Boolean.TRUE, Map.of());
+    }
+}

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/ServiceResolverTest.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/ServiceResolverTest.java
@@ -54,6 +54,15 @@ class ServiceResolverTest {
         assertEquals("First", resolver.resolve("HTTP-9090").orElseThrow().name());
     }
 
+    /** Exact matching is case-insensitive, mirroring the frozen manager's equalsIgnoreCase. */
+    @Test
+    void exactMatchIsCaseInsensitive() {
+        final ServiceResolver resolver = new ServiceResolver(new Catalog(List.of(
+                def("HTTP-8080", null, "a.b.HttpMonitor"))));
+        assertEquals("HTTP-8080", resolver.resolve("http-8080").orElseThrow().name());
+        assertEquals("HTTP-8080", resolver.resolve("HTTP-8080").orElseThrow().name());
+    }
+
     /** A name matching nothing resolves to empty (the FR9 unscheduled path). */
     @Test
     void noMatchResolvesEmpty() {

--- a/core/poller-service-catalog/src/test/resources/catalogs/anchors.yaml
+++ b/core/poller-service-catalog/src/test/resources/catalogs/anchors.yaml
@@ -1,0 +1,22 @@
+# D8 anchor-behavior fixture: a scalar anchor, a map alias, and a merge key (<<).
+services:
+  - name: HTTP-8080
+    monitor: org.opennms.netmgt.poller.monitors.HttpMonitor
+    interval: &std-interval 300000
+    parameters: &common-params
+      retry: "2"
+      timeout: "3000"
+
+  # Map alias: reuse the whole parameters map verbatim.
+  - name: HTTPS-8443
+    monitor: org.opennms.netmgt.poller.monitors.HttpsMonitor
+    interval: *std-interval
+    parameters: *common-params
+
+  # Merge key: inherit common params, then add/override one.
+  - name: HTTP-9090
+    monitor: org.opennms.netmgt.poller.monitors.HttpMonitor
+    interval: *std-interval
+    parameters:
+      <<: *common-params
+      banner: "OK"

--- a/core/poller-service-catalog/src/test/resources/catalogs/pattern-family.yaml
+++ b/core/poller-service-catalog/src/test/resources/catalogs/pattern-family.yaml
@@ -1,0 +1,19 @@
+services:
+  # Exact definition with a metadata DSL parameter value (must round-trip verbatim).
+  - name: HTTP-8080
+    monitor: org.opennms.netmgt.poller.monitors.HttpMonitor
+    interval: 300000
+    parameters:
+      port: "${requisition:port|detector:port|80}"
+
+  # Pattern definition with a nested-XML block scalar (FR4: first-class, no DOM workaround).
+  - name: PageSequenceHTTP
+    pattern: "^HTTP-(\\d+)$"
+    monitor: org.opennms.netmgt.poller.monitors.PageSequenceMonitor
+    interval: 30000
+    enabled: false
+    parameters:
+      page-sequence: |
+        <page-sequence>
+          <page path="/" port="8080" successMatch="OK"/>
+        </page-sequence>

--- a/core/poller-service-catalog/src/test/resources/catalogs/valid-minimal.yaml
+++ b/core/poller-service-catalog/src/test/resources/catalogs/valid-minimal.yaml
@@ -1,0 +1,4 @@
+services:
+  - name: ICMP
+    monitor: org.opennms.netmgt.poller.monitors.IcmpMonitor
+    interval: 300000   # 5m

--- a/images/Dockerfile.daemon-per
+++ b/images/Dockerfile.daemon-per
@@ -32,4 +32,16 @@ COPY staging/${DAEMON_NAME}/app/ /opt/app/
 # provisiond-imports-init sidecar with a uid:100:101 host-path chown).
 COPY --chown=opennms:opennms overlays/${DAEMON_NAME}/etc /opt/deltav/etc
 
+# Catalog lint (FR10/D5): fail the image build on a malformed poller catalog, after the
+# overlay COPY so it is unbypassable. No-op for daemons that ship no poller-services.yaml.
+# Uses the SAME 5-segment classpath as deploy/entrypoint.sh — CatalogLint's deps (Jackson,
+# SnakeYAML) live in /opt/libs/external, not /opt/libs/daemon. The `java` invocation must
+# remain the LAST command in the branch so its 0/1/2 exit status fails the build (exit 1 =
+# errors abort; warnings pass).
+RUN if [ -f /opt/deltav/etc/poller-services.yaml ]; then \
+        echo "Linting poller-services.yaml ..."; \
+        java -cp "/opt/libs/priority/*:/opt/libs/external/*:/opt/libs/internal/*:/opt/libs/daemon/*:/opt/app/*" \
+            org.deltav.poller.catalog.CatalogLint /opt/deltav/etc/poller-services.yaml; \
+    fi
+
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <module>core/minion-grpc-contracts</module>
     <module>core/opennms-model-jakarta</module>
     <module>core/poller-timeseries-common</module>
+    <module>core/poller-service-catalog</module>
 
     <!-- Daemon boots (Spring Boot fat JARs) -->
     <module>core/daemon-boot-alarmd</module>


### PR DESCRIPTION
## Epic 1 / PR 1 — Proven Flat Poller Service Catalog (library + adapter + lint + contract ITs)

Slice-1 foundation for replacing the package/filter-based `poller-configuration.xml` with a flat
YAML service-definition catalog. **No daemon changes** — this PR adds a self-contained, Spring-free
library whose translation into the *frozen* poller engine is contract-proven before any daemon is
switched (PR 2/3). The adapter risk is retired here.

### What's included

- **New module `core/poller-service-catalog`** (registered in the root reactor; mirrors
  `core/poller-timeseries-common`). Spring-free: plain Java 21 + Jackson + slf4j only.
- **Config model + strict parser** (FR1/D1): immutable `Catalog`/`ServiceDefinition` records;
  `CatalogParser` fails on unknown keys, duplicate keys, and YAML anchors/aliases/merge-keys
  (jackson-yaml can't resolve them — rejected loudly rather than silently mis-parsed).
- **Collect-all validation + resolution** (D2): `CatalogValidator` reports every defect in one pass
  (`LEVEL: <file>: services[<index>] (<name>): <message>`); `ServiceResolver` does exact > pattern,
  first-in-file-order, **case-insensitive** to match the engine's `equalsIgnoreCase` (resolver parity).
- **Translator + adapter** (D3): `CatalogTranslator` builds the synthetic JAXB `PollerConfiguration`
  — one package per enabled definition (`catalog-<name>`), per-package downtime `begin=0/interval`,
  exact-before-pattern ordering, monitor bindings, engine scalars; disabled definitions omitted (D4).
  `InventoryFilterDao` replaces `JdbcFilterDao`/`FilterDaoFactory` (FR7) — 3 real methods, the rest throw.
- **Frozen-engine contract ITs** (D8): pin translator output through the **real** `PollerConfigFactory`
  (1.0.18 JARs, never mocked) — `isInterfaceInPackage` via `InventoryFilterDao`, resolver parity,
  `update()` no-op under the version trick, package re-fetch, per-package downtime, empty-catalog boot.
- **Build-time lint** (FR10/D5): `CatalogLint` (exit 0 clean / 1 errors / 2 usage-IO; empty +
  nested-quantifier are warnings), `make lint-catalog CATALOG=<file>`, and a guarded lint stage in
  `images/Dockerfile.daemon-per` (unbypassable; no-op until a daemon ships a catalog in PR 2).

### Verification

- **38 tests green** (31 surefire + 7 Failsafe contract ITs) via `make verify`.
- Every story passed a 3-layer adversarial review (Blind Hunter / Edge Case Hunter / Acceptance
  Auditor) before commit; findings fixed or tracked in deferred-work.
- Open Verification Items #1–#5 investigated against frozen source (`fb0362ff32c^`): adapter strategy
  confirmed; `nextOutageIdSql` dropped (dead); FR2 reworded (slice-1 exclusion = de-provision).

### Explicitly deferred (tracked)

- Behavioral pins needing poller runtime/DB (down-service reschedule, `'N'`-marking + restoration,
  pattern-variable live flow) → Epic 2 e2e.
- Negative-build CI gate (broken overlay must fail the image build) → Epic 2, when the first overlay
  catalog exists.
- FR2 service-exclusion REST endpoint → follow-up scope.

### Commits

- `feat(poller): add flat poller service-catalog module (stories 1.1-1.3)`
- `feat(poller): add catalog translator, EngineSettings and InventoryFilterDao (story 1.4)`
- `test(poller): frozen-engine contract ITs + anchor rejection and case-insensitive parity (story 1.6)`
- `feat(poller): build-time catalog lint - CLI, make target, Dockerfile stage (story 1.5)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
