### PR TITLE
fix(e2e): stop provisiond rescan storm + deliver requisitions into the container

### DIFF
--- a/deploy/overlays/provisiond/etc/foreign-sources/nl6.xml
+++ b/deploy/overlays/provisiond/etc/foreign-sources/nl6.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Foreign source for the nl6 simulator's dynamically-generated requisition
+  (imports/nl6.xml, foreign-source="nl6"). Without this file, nodes provisioned
+  with foreignsource="nl6" matched NO foreign-source definition and fell back to
+  the hardcoded built-in default (17 detectors: WS-Man, SSH, HTTP(S), FTP, IMAP,
+  POP3, SMTP, DNS, LDAP, NRPE, MS-RDP, JMX x3, ...), 15 of which fail against the
+  SNMP-only sim nodes — driving a heavy scan load. Restrict to ICMP + SNMP, exactly
+  like nl6-lab.xml. (The simulator emits foreign-source="nl6"; the pre-existing
+  nl6-lab.xml never matched it — name mismatch.)
+-->
+<foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="nl6">
+    <scan-interval>1d</scan-interval>
+    <detectors>
+        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+        <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector"/>
+    </detectors>
+    <policies/>
+</foreign-source>

--- a/deploy/overlays/provisiond/etc/provisiond-configuration.xml
+++ b/deploy/overlays/provisiond/etc/provisiond-configuration.xml
@@ -1,11 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Scheduled-import policy (delta-v):
+
+  The seed requisitions below are STATIC content. They are scheduled only so a
+  fresh stack imports them shortly after start; they must NOT drive a continuous
+  rescan storm.
+
+  Each scheduled import re-scans existing nodes (provisiond uses rescanExisting=true
+  for scheduled imports — the ?rescanExisting=false URL query is NOT honored on the
+  scheduled-import path), so the import cadence directly sets the rescan load. These
+  are therefore on a 5-minute cron (was 0/30 = every 30s): first import is still
+  prompt, but the steady-state rescan rate is 10x lower. Existing nodes also rescan
+  on their own foreign-source scan-interval (1d) independent of these imports.
+
+  Background: with the prior 0/30, provisiond re-scanned every node every 30s
+  (~4.8 interface-scans/sec sustained on the demo stack), permanently saturating
+  scanThreads. The nl6 foreign-source (foreign-sources/nl6.xml) further caps that
+  to ICMP+SNMP instead of the 17-detector built-in default. See the provisiond
+  E2E slowness investigation.
+-->
 <provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
   foreign-source-dir="/opt/deltav/etc/foreign-sources"
   requistion-dir="/opt/deltav/etc/imports"
   importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
   <requisition-def import-name="delta-v"
                    import-url-resource="file:///opt/deltav/etc/imports/delta-v.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
+    <cron-schedule>0 0/5 * * * ?</cron-schedule>
   </requisition-def>
   <!--
     rpc-canary: self-contained Default-location SNMP canary (node at 172.18.0.2
@@ -22,11 +42,11 @@
   -->
   <requisition-def import-name="rpc-canary"
                    import-url-resource="file:///opt/deltav/etc/imports/rpc-canary.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
+    <cron-schedule>0 0/5 * * * ?</cron-schedule>
   </requisition-def>
   <requisition-def import-name="cloud-services"
                    import-url-resource="file:///opt/deltav/etc/imports/cloud-services.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
+    <cron-schedule>0 0/5 * * * ?</cron-schedule>
   </requisition-def>
   <!--
     mhuot-labs auto-import disabled (delta-v#<this PR>): the requisition
@@ -36,17 +56,17 @@
     re-enable. The imports/mhuot-labs.xml file is preserved on disk.
   <requisition-def import-name="mhuot-labs"
                    import-url-resource="file:///opt/deltav/etc/imports/mhuot-labs.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
+    <cron-schedule>0 0/5 * * * ?</cron-schedule>
   </requisition-def>
   -->
   <requisition-def import-name="nl6-lab"
                    import-url-resource="file:///opt/deltav/etc/imports/nl6-lab.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
+    <cron-schedule>0 0/5 * * * ?</cron-schedule>
   </requisition-def>
   <requisition-def import-name="perspective-test" import-url-resource="file:///opt/deltav/etc/imports/perspective-test.xml">
     <cron-schedule>0 0/1 * * * ? *</cron-schedule>
   </requisition-def>
   <requisition-def import-name="perspective-smoke" import-url-resource="file:///opt/deltav/etc/imports/perspective-smoke.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
+    <cron-schedule>0 0/5 * * * ?</cron-schedule>
   </requisition-def>
 </provisiond-configuration>

--- a/deploy/test-node-context-e2e.sh
+++ b/deploy/test-node-context-e2e.sh
@@ -51,26 +51,17 @@ PROVISIOND_CONFIG_BACKUP="$(mktemp -t provisiond-config.XXXXXX.xml)"
 
 cleanup() {
     echo "==> Tearing down stack"
-    rm -f "${E2E_REQUISITION_FILE}"
-    # Restore provisiond-configuration.xml from the committed state (captured
-    # before mutation in Step 3) so this test never leaves the working tree
-    # in a state that breaks other e2e tests that depend on the full set of
-    # requisition-defs (rpc-canary, cloud-services, nl6-lab, …).
-    # Guard with -s (non-empty), not -f: the backup is an empty mktemp file at
-    # trap-arm time and is only populated by the `cp` in Step 3. An early exit
-    # (e.g. stack bring-up fails before Step 3) would otherwise restore the
-    # empty backup OVER the tracked config, truncating it to 0 bytes and
-    # cascading into requisition-import failures across the whole suite.
-    if [ -s "${PROVISIOND_CONFIG_BACKUP}" ]; then
-        cp "${PROVISIOND_CONFIG_BACKUP}" "${PROVISIOND_CONFIG}"
-        rm -f "${PROVISIOND_CONFIG_BACKUP}"
-    fi
+    rm -f "${PROVISIOND_CONFIG_BACKUP}"
+    # The requisition + requisition-def are written only INTO the provisiond
+    # container (not the host overlays/, which isn't mounted). `down -v` removes
+    # the container, so the baked config resets and nothing leaks into the working
+    # tree or other e2e tests.
     docker compose down -v --remove-orphans || true
 }
 trap cleanup EXIT
 
-echo "==> Starting delta-v Docker Compose (lite profile)"
-docker compose --profile lite up -d --build
+echo "==> Starting delta-v Docker Compose (active profile)"
+docker compose --profile active up -d --build
 
 # ── Step 1: Wait for provisiond /actuator/health ──────────────────────────────
 
@@ -115,9 +106,12 @@ echo "==> bootstrap runner executed — lifecycle wiring verified"
 # after each successful import and the NodeContextChangeFeedListener fan-out
 # enqueues every node in the foreignSource for a "change" publish.
 
-echo "==> Writing E2E requisition ${E2E_FOREIGN_SOURCE}"
-mkdir -p overlays/provisiond/etc/imports
-cat > "${E2E_REQUISITION_FILE}" <<'REQEOF'
+# Write the requisition DIRECTLY into the running provisiond container. The host
+# overlays/provisiond/etc/ path is NOT mounted into provisiond (config is baked into
+# the image; imports/ is a named volume seeded by an init sidecar), so host writes
+# never reach the daemon. See project_provisiond_e2e_slowness_root_cause.
+echo "==> Writing E2E requisition ${E2E_FOREIGN_SOURCE} into the provisiond container"
+docker compose exec -T provisiond tee "/opt/deltav/etc/imports/${E2E_FOREIGN_SOURCE}.xml" >/dev/null <<'REQEOF'
 <model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
               date-stamp="2026-04-16T00:00:00.000-05:00"
               foreign-source="node-context-e2e">
@@ -134,23 +128,26 @@ REQEOF
 # requisition-def (delta-v, rpc-canary, cloud-services, nl6-lab,
 # perspective-test) that other e2e tests depend on.
 # The committed state is backed up in cleanup()'s trap and restored on exit.
-echo "==> Injecting ${E2E_FOREIGN_SOURCE} requisition-def into ${PROVISIOND_CONFIG}"
-cp "${PROVISIOND_CONFIG}" "${PROVISIOND_CONFIG_BACKUP}"
-python3 - "${PROVISIOND_CONFIG}" "${E2E_FOREIGN_SOURCE}" <<'PYEOF'
-import sys
-path, fs = sys.argv[1], sys.argv[2]
+# Add the requisition-def to the IN-CONTAINER provisiond-configuration.xml (the baked
+# config), via a docker cp round-trip. The container is reset by `down -v` in cleanup,
+# so the host config is never mutated and needs no backup/restore.
+echo "==> Injecting ${E2E_FOREIGN_SOURCE} requisition-def into the in-container provisiond config"
+python3 - "${PROVISIOND_CONFIG_BACKUP}" "${E2E_FOREIGN_SOURCE}" <<'PYEOF'
+import subprocess, sys
+tmp, fs = sys.argv[1], sys.argv[2]
+subprocess.run(["docker", "cp", "delta-v-provisiond:/opt/deltav/etc/provisiond-configuration.xml", tmp], check=True)
 snippet = (
     f'  <requisition-def import-name="{fs}"\n'
     f'                   import-url-resource="file:///opt/deltav/etc/imports/{fs}.xml">\n'
     f'    <cron-schedule>0/30 * * * * ?</cron-schedule>\n'
     f'  </requisition-def>\n'
 )
-with open(path) as f: content = f.read()
+with open(tmp) as f: content = f.read()
 marker = '</provisiond-configuration>'
 if marker not in content:
-    sys.exit(f"marker {marker!r} not found in {path}")
-content = content.replace(marker, snippet + marker, 1)
-with open(path, 'w') as f: f.write(content)
+    sys.exit(f"marker {marker!r} not found in container config")
+with open(tmp, 'w') as f: f.write(content.replace(marker, snippet + marker, 1))
+subprocess.run(["docker", "cp", tmp, "delta-v-provisiond:/opt/deltav/etc/provisiond-configuration.xml"], check=True)
 PYEOF
 
 echo "==> Restarting provisiond to pick up E2E requisition"

--- a/deploy/test-pollerd-restart-outage-e2e.sh
+++ b/deploy/test-pollerd-restart-outage-e2e.sh
@@ -106,11 +106,24 @@ target_listener_down() { docker exec "$TARGET_NAME" pkill -x socat 2>/dev/null |
 
 cleanup() {
     docker rm -f "$TARGET_NAME" >/dev/null 2>&1 || true
+    # Remove the in-container provisioning artifacts so the scheduler stops importing
+    # the throwaway requisition and re-runs start clean. (Best-effort; container may
+    # already be gone.)
+    docker exec "$PROV" sh -c "rm -f /opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml \
+        /opt/deltav/etc/foreign-sources/${FOREIGN_SOURCE}.xml" 2>/dev/null || true
+    docker exec "$PROV" sh -c "grep -q 'import-name=\"${FOREIGN_SOURCE}\"' /opt/deltav/etc/provisiond-configuration.xml 2>/dev/null" \
+        && { TMP_C="$(mktemp)"; docker cp "${PROV}:/opt/deltav/etc/provisiond-configuration.xml" "$TMP_C" 2>/dev/null \
+             && python3 -c "import re,sys; p=sys.argv[1]; fs=sys.argv[2]; s=open(p).read(); \
+import_re=re.compile(r'\s*<requisition-def import-name=\"'+re.escape(fs)+r'\".*?</requisition-def>\n', re.S); \
+open(p,'w').write(import_re.sub('', s))" "$TMP_C" "$FOREIGN_SOURCE" \
+             && docker cp "$TMP_C" "${PROV}:/opt/deltav/etc/provisiond-configuration.xml" 2>/dev/null; \
+             rm -f "$TMP_C"; } || true
     if $POST_CLEANUP; then
         log "Post-run cleanup (--post-cleanup): removing test node..."
         psql_query "DELETE FROM node WHERE nodelabel = '${NODE_LABEL}'" 2>/dev/null || true
     fi
 }
+PROV=delta-v-provisiond
 trap cleanup EXIT
 
 # ── Pre-run cleanup (--pre-clean) ─────────────────────────────────
@@ -168,9 +181,16 @@ ok "Listener started on ${TARGET_PORT}"
 log ""
 log "Phase 1: provisioning '${NODE_LABEL}' at ${TARGET_IP} with active '${SERVICE_NAME}'..."
 
-mkdir -p overlays/provisiond/etc/foreign-sources overlays/provisiond/etc/imports
+# Deliver provisioning artifacts DIRECTLY into the running provisiond container.
+# The host overlays/provisiond/etc/ path is NOT mounted into provisiond — config
+# is baked into the image and imports/ is a named volume seeded by an init sidecar
+# (see test-minion-rpc-e2e.sh + project_provisiond_e2e_slowness_root_cause). Writing
+# to the host path silently does nothing; write into the container instead.
+PROV=delta-v-provisiond
 
-cat > "overlays/provisiond/etc/foreign-sources/${FOREIGN_SOURCE}.xml" <<FSEOF
+# 1. Foreign source — empty detectors (the service is declared in the requisition,
+#    so no scan-time detection is needed; this also avoids the 17-detector default).
+docker exec -i "$PROV" tee "/opt/deltav/etc/foreign-sources/${FOREIGN_SOURCE}.xml" >/dev/null <<FSEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="${FOREIGN_SOURCE}">
     <scan-interval>1d</scan-interval>
@@ -179,7 +199,8 @@ cat > "overlays/provisiond/etc/foreign-sources/${FOREIGN_SOURCE}.xml" <<FSEOF
 </foreign-source>
 FSEOF
 
-cat > "overlays/provisiond/etc/imports/${FOREIGN_SOURCE}.xml" <<REQEOF
+# 2. Requisition with the throwaway target IP + the active service.
+docker exec -i "$PROV" tee "/opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml" >/dev/null <<REQEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
               foreign-source="${FOREIGN_SOURCE}"
@@ -192,19 +213,27 @@ cat > "overlays/provisiond/etc/imports/${FOREIGN_SOURCE}.xml" <<REQEOF
 </model-import>
 REQEOF
 
-cat > overlays/provisiond/etc/provisiond-configuration.xml <<PROVEOF
-<?xml version="1.0" encoding="UTF-8"?>
-<provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"
-  foreign-source-dir="/opt/deltav/etc/foreign-sources"
-  requistion-dir="/opt/deltav/etc/imports"
-  importThreads="4" scanThreads="4" rescanThreads="4" writeThreads="4" >
-  <requisition-def import-name="${FOREIGN_SOURCE}"
-                   import-url-resource="file:///opt/deltav/etc/imports/${FOREIGN_SOURCE}.xml">
-    <cron-schedule>0/30 * * * * ?</cron-schedule>
-  </requisition-def>
-</provisiond-configuration>
-PROVEOF
-ok "Requisition, foreign source, and provisiond config written"
+# 3. Add a requisition-def for our foreign source to the in-container config so the
+#    scheduler imports it. Edit via a docker cp round-trip (no reliance on in-container
+#    sed). 0/30 cron = first import within 30s; the def + node are removed in cleanup.
+if ! docker exec "$PROV" grep -q "import-name=\"${FOREIGN_SOURCE}\"" /opt/deltav/etc/provisiond-configuration.xml; then
+    TMP_CFG="$(mktemp)"
+    docker cp "${PROV}:/opt/deltav/etc/provisiond-configuration.xml" "$TMP_CFG"
+    python3 - "$TMP_CFG" "$FOREIGN_SOURCE" <<'PY'
+import sys
+path, fs = sys.argv[1], sys.argv[2]
+defn = (f'  <requisition-def import-name="{fs}"\n'
+        f'                   import-url-resource="file:///opt/deltav/etc/imports/{fs}.xml">\n'
+        f'    <cron-schedule>0/30 * * * * ?</cron-schedule>\n'
+        f'  </requisition-def>\n')
+s = open(path).read()
+s = s.replace('</provisiond-configuration>', defn + '</provisiond-configuration>')
+open(path, 'w').write(s)
+PY
+    docker cp "$TMP_CFG" "${PROV}:/opt/deltav/etc/provisiond-configuration.xml"
+    rm -f "$TMP_CFG"
+fi
+ok "Requisition, foreign source, and provisiond-config delivered into the container"
 
 log "  Restarting Provisiond to import the requisition..."
 docker compose restart provisiond


### PR DESCRIPTION
Root-caused during a provisiond E2E-slowness investigation. Two independent, long-standing problems that make E2E runs slow and several tests silently non-functional.

## 1. Provisiond rescan storm

The seed requisitions ran on `0/30` (every 30s) crons with the default `rescanExisting=true` → provisiond re-scanned **every node every 30s** (~4.8 interface-scans/sec sustained, ~388 rescans/interface over 49 min), permanently saturating `scanThreads`. (Measured: it was *not* detector timeouts — each detector returns in ms; it's rescan volume.)

- Lengthen the 5 static requisitions from `0/30` to a **5-minute cron** (first import still prompt; ~10× lower steady-state rescans).
- Add **`foreign-sources/nl6.xml`** (ICMP+SNMP only). The nl6 simulator imports `foreignsource=nl6`, but the only file was `nl6-lab.xml` (name mismatch) → nodes fell back to the **17-detector built-in default** (15 of which fail on the SNMP-only sim nodes). Now capped to 2 detectors.
- **Note:** `?rescanExisting=false` on the import URL is **not honored** on the scheduled-import path (verified: log shows `rescanExisting ? true`), so cron cadence is the only lever.

## 2. Requisitions never reached provisiond (broken delivery)

provisiond's config + `foreign-sources/` are **baked into the image** and `imports/` is a **named volume** (host `overlays/provisiond/etc/` is intentionally not mounted — macOS VirtioFS bug). Tests that wrote requisitions/config to the host path + `restart provisiond` **silently did nothing** — provisiond never imported them.

Convert to write **directly into the container** (`docker exec tee` + a `docker cp` config round-trip), matching the already-correct `test-minion-rpc-e2e.sh`:

| Test | Change | Validated |
|---|---|---|
| `test-pollerd-restart-outage-e2e.sh` | docker-exec delivery | ✅ Phase 1 (provision + real **Up** poll) on a rebuilt stack |
| `test-node-context-e2e.sh` | docker-exec delivery **+** `lite`→`active` profile (the `lite` profile was renamed and no longer exists) | syntax-checked; runnable (Default-location) |

## Out of scope (tracked follow-up)

- **`test-enlinkd-e2e.sh` / `test-perspective-e2e.sh`** use the same broken delivery but are **labbox/VPN-gated** (the `mhuot-labs` requisition targets real lab devices). Same docker-exec conversion needed — deferred so it can be validated against labbox rather than blind-converted.
- **restart-outage Phase 2** (outage on listener-down) is blocked by a separate pollerd↔minion RPC down-detection issue, **not** this delivery fix.

Companion to #361 (the flat-catalog NPE fix) and #362 (the frozen-engine null-guard).