### PR TITLE
chore: bump horizon 1.0.19 + drop the parity <rrd> workaround

### DIFF
--- a/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogTranslator.java
+++ b/core/poller-service-catalog/src/main/java/org/deltav/poller/catalog/CatalogTranslator.java
@@ -25,7 +25,6 @@ import org.opennms.netmgt.config.poller.Downtime;
 import org.opennms.netmgt.config.poller.NodeOutage;
 import org.opennms.netmgt.config.poller.Package;
 import org.opennms.netmgt.config.poller.PollerConfiguration;
-import org.opennms.netmgt.config.poller.Rrd;
 import org.opennms.netmgt.config.poller.Service;
 
 /**
@@ -127,35 +126,13 @@ public final class CatalogTranslator {
         downtime.setInterval(def.interval().longValue());
         pkg.addDowntime(downtime);
 
-        pkg.setRrd(defaultRrd());
+        // No <rrd> block is emitted. delta-v's Pollerd uses a no-op PersisterFactory (no RRD I/O),
+        // and the frozen engine null-guards getRrd() as of horizon 1.0.19 — PollerConfigManager
+        // .getStep()/getRRAList() return a default step / empty RRA list when <rrd> is absent.
+        // (Earlier horizon versions NPE'd on every poll here, force-marking services DOWN; that
+        // parity-only <rrd> workaround was removed once the engine guard shipped. See #362.)
         pkg.addService(toService(def));
         return pkg;
-    }
-
-    /**
-     * Emits a parity-only {@code <rrd>} block. This does <em>not</em> reintroduce RRD persistence:
-     * delta-v's Pollerd wires a <strong>no-op {@code PersisterFactory}</strong>
-     * ({@code PollerdJpaConfiguration#persisterFactory} — "Pollerd does not persist collection
-     * metrics"), so the step/RRAs read here are used only to construct an {@code RrdRepository} that
-     * the no-op persister immediately discards. No RRD file is ever written.
-     *
-     * <p>The block must nonetheless be <em>present</em> because delta-v reuses the <em>frozen</em>
-     * horizon poller engine unchanged, and that engine dereferences {@code getRrd()} with no null
-     * guard on the status-storing poll path: {@code StatusStoringServiceMonitorAdaptor.storeStatus}
-     * → {@code PollerConfigManager.getStep(pkg)}/{@code getRRAList(pkg)} call
-     * {@code pkg.getRrd().getStep()} on <em>every</em> poll result. An absent element NPEs and the
-     * service is force-marked DOWN. We mirror the legacy {@code poller-configuration.xml} block
-     * exactly (step 300, standard RRAs) for parity with pre-flat-catalog behavior. The proper fix —
-     * a null guard in the frozen engine so it skips the RRD path when persistence is a no-op — is
-     * tracked upstream; until then this matches {@link #disabledNodeOutage()} (same null-guard class).
-     */
-    private static Rrd defaultRrd() {
-        return new Rrd(300,
-                "RRA:AVERAGE:0.5:1:2016",
-                "RRA:AVERAGE:0.5:12:1488",
-                "RRA:AVERAGE:0.5:288:366",
-                "RRA:MAX:0.5:288:366",
-                "RRA:MIN:0.5:288:366");
     }
 
     /**

--- a/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/FrozenEngineContractIT.java
+++ b/core/poller-service-catalog/src/test/java/org/deltav/poller/catalog/FrozenEngineContractIT.java
@@ -163,11 +163,12 @@ class FrozenEngineContractIT {
     }
 
     /**
-     * The frozen engine's status-storing path dereferences the per-package {@code Rrd} with no null
-     * guard: on every poll result, {@code StatusStoringServiceMonitorAdaptor.storeStatus} calls
-     * {@code PollerConfigManager.getStep(pkg)} → {@code pkg.getRrd().getStep()}. If the translator
-     * emits no {@code Rrd}, every poll NPEs and the service is force-marked DOWN. The translator must
-     * emit the legacy {@code <rrd step="300">} block, exactly as it emits the disabled node-outage.
+     * The translator emits no {@code <rrd>} block (delta-v's Pollerd uses a no-op persister). The
+     * frozen engine's status-storing path calls {@code PollerConfigManager.getStep(pkg)} /
+     * {@code getRRAList(pkg)} on every poll result; as of horizon 1.0.19 those null-guard
+     * {@code getRrd()} and return a default step (300) / empty RRA list rather than NPE-ing and
+     * force-marking the service DOWN. This pins that the synthetic config (no rrd) + the engine
+     * guard resolve a usable step — so the parity {@code <rrd>} workaround can stay removed (#362).
      */
     @Test
     void rrdStepResolvesOnSyntheticConfig() throws UnknownHostException {
@@ -176,8 +177,8 @@ class FrozenEngineContractIT {
                 List.of(addr("10.0.0.1")));
         final Package pkg = factory.getPackage("catalog-ICMP");
 
-        // getStep() is the exact call that NPE'd at runtime (PollerConfigManager.getStep:991).
-        assertEquals(300, factory.getStep(pkg), "per-package rrd step must resolve (legacy parity)");
+        // getStep() is the exact call that NPE'd at runtime; the engine guard now returns the default.
+        assertEquals(300, factory.getStep(pkg), "engine returns the default step when no <rrd> is present");
         assertDoesNotThrow(() -> factory.getRRAList(pkg), "rra list must resolve without NPE");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Horizon JAR version (published by pbrane/delta-v-horizon) -->
-    <deltav.horizon.version>1.0.18</deltav.horizon.version>
+    <deltav.horizon.version>1.0.19</deltav.horizon.version>
 
     <!-- Spring Cloud release train (for flow-enricher / flow-aggregator) -->
     <spring-cloud.version>2025.1.1</spring-cloud.version>


### PR DESCRIPTION
Completes the chain for issue #362.

Horizon **1.0.19** (delta-v-horizon #22/#23) null-guards `PollerConfigManager.getStep()`/`getRRAList()`, so the flat-catalog translator no longer needs to emit a parity `<rrd step="300">` block just to keep the frozen engine from NPE-ing on every poll result (which previously force-marked every service DOWN).

## Changes
- **`pom.xml`** — `deltav.horizon.version` 1.0.18 → 1.0.19.
- **`CatalogTranslator`** — remove `pkg.setRrd(defaultRrd())`, the `defaultRrd()` factory, and the `Rrd` import; add a comment pointing at the engine guard.
- **`FrozenEngineContractIT.rrdStepResolvesOnSyntheticConfig`** — now pins that the engine guard returns the default step (300) for a no-`<rrd>` package (assertion unchanged: `getStep`→300, `getRRAList` no NPE).

## Verification
`./mvnw -pl :org.opennms.core.poller-service-catalog verify` against the freshly-published 1.0.19 → **32 unit + 9 IT pass**, BUILD SUCCESS. The IT downloads `poller.config:1.0.19` and confirms `getStep`→300 with no `<rrd>` block present.

No conflict with #364 (perspectivepollerd) — it uses the same shared translator and inherits the guard; it touches none of these files.