### PR TITLE
fix(gateway): fast-NACK RPCs to a minion-less location (#368)

### DIFF
--- a/core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java
+++ b/core/minion-gateway/src/main/java/org/deltav/gateway/rpc/RpcChannelDispatcher.java
@@ -121,8 +121,19 @@ public class RpcChannelDispatcher implements RpcStreamCloseHandler, RpcResponseH
     void dispatch(RpcRequest req) {
         StreamObserver<RpcRequest> stream = pool.pickStream(req.getLocation());
         if (stream == null) {
-            LOG.info("No Minion streams for location={}; dropping rpcId={} (caller will time out)",
+            // No Minion is connected at this location. Don't silently drop: the caller
+            // would wait its full RPC deadline (~30s), and when many services target a
+            // minion-less location (e.g. a seeded requisition with no Minion to serve
+            // it) those timeouts flood the RPC client and starve other locations'
+            // responses. Publish a fast error response so the caller fails immediately
+            // and marks the service UNKNOWN — an RPC error, never a false outage
+            // (feedback_rpc_timeout_no_outages). See #368.
+            LOG.info("No Minion streams for location={}; fast-failing rpcId={} (UNAVAILABLE)",
                 req.getLocation(), req.getRpcId());
+            publisher.publish(RpcResponse.newBuilder()
+                .setRpcId(req.getRpcId())
+                .setErrorMessage("No Minion connected at location=" + req.getLocation())
+                .build());
             return;
         }
 

--- a/core/minion-gateway/src/test/java/org/deltav/gateway/rpc/RpcChannelDispatcherTest.java
+++ b/core/minion-gateway/src/test/java/org/deltav/gateway/rpc/RpcChannelDispatcherTest.java
@@ -25,7 +25,6 @@ import java.time.Instant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class RpcChannelDispatcherTest {
@@ -95,21 +94,29 @@ class RpcChannelDispatcherTest {
     }
 
     @Test
-    void dispatch_noStream_logsAndDropsWithoutFailing() {
+    void dispatch_noStream_publishesFastErrorResponse() {
         MinionStreamPool pool = mock(MinionStreamPool.class);
         InFlightRpcTable table = new InFlightRpcTable();
         RpcResponsePublisher publisher = mock(RpcResponsePublisher.class);
         RpcChannelDispatcher dispatcher = new RpcChannelDispatcher(pool, table, publisher);
 
-        when(pool.pickStream("Default")).thenReturn(null);
+        when(pool.pickStream("nl6-lab")).thenReturn(null);
 
         RpcRequest req = RpcRequest.newBuilder()
-            .setRpcId("xyz").setLocation("Default").build();
+            .setRpcId("xyz").setLocation("nl6-lab").build();
 
-        // Must not throw. Must not record. Must not invoke publisher.
+        // No Minion at the location: rather than dropping (the caller then waits its
+        // full ~30s RPC deadline, and many services targeting a minion-less location
+        // flood the RPC path and starve other locations), publish a fast error
+        // response so the caller fails immediately and marks the service UNKNOWN
+        // (an RPC error, not a false outage — feedback_rpc_timeout_no_outages). See #368.
         dispatcher.dispatch(req);
 
-        assertThat(table.findEntry("xyz")).isNull();
-        verifyNoInteractions(publisher);
+        assertThat(table.findEntry("xyz")).isNull(); // nothing to track without a stream
+        org.mockito.ArgumentCaptor<org.deltav.minion.grpc.v1.RpcResponse> cap =
+            org.mockito.ArgumentCaptor.forClass(org.deltav.minion.grpc.v1.RpcResponse.class);
+        verify(publisher).publish(cap.capture());
+        assertThat(cap.getValue().getRpcId()).isEqualTo("xyz");
+        assertThat(cap.getValue().getErrorMessage()).contains("nl6-lab");
     }
 }


### PR DESCRIPTION
Fixes #368.

## Problem
When `RpcChannelDispatcher.dispatch()` finds **no Minion stream** for a request's location, it dropped the request and the caller waited its full ~30s RPC deadline. When many services target a location with no Minion (e.g. a seeded requisition imported without its Minion), those timeouts **flood pollerd's RPC client and starve responses for healthy locations** — the root cause of the restart-outage Phase-2 down-detection delay (a Default-location service took >4 min to detect DOWN behind 58 nl6-lab timeouts/10min).

## Fix
On `stream == null`, publish an `RpcResponse` carrying the `rpc_id` + a non-empty `error_message` ("No Minion connected at location=…"). The caller's RPC client completes the future as a failure **immediately**, marks the service **UNKNOWN** (an RPC error — never a false outage, per `feedback_rpc_timeout_no_outages`), and frees the RPC slot. No 30s hold, no congestion.

Scope: only the **dispatch-time, never-connected-location** path fast-fails. The `onStreamClosed` mid-flight path keeps its timeout-absorb behavior (it has an at-least-once retry contract — a different decision).

## Test
`RpcChannelDispatcherTest.dispatch_noStream_publishesFastErrorResponse` (TDD): asserts `publisher.publish()` is called with the matching `rpcId` and an `error_message` naming the location. Full module: **51 tests pass**.

Companion to #361/#363/#369/#370; the nl6 profile-gating (#369) already removes the *seeding* of minion-less nodes, and this makes the gateway resilient when they do occur (or a Minion goes offline).