### PR TITLE
feat(poller): register supported monitors; drop unbundled VMware from catalog

### DIFF
--- a/core/daemon-registry/src/main/java/org/deltav/core/daemon/registry/MonitorRegistryConfiguration.java
+++ b/core/daemon-registry/src/main/java/org/deltav/core/daemon/registry/MonitorRegistryConfiguration.java
@@ -22,19 +22,25 @@ import org.opennms.netmgt.poller.ServiceMonitorRegistry;
 import org.opennms.netmgt.poller.monitors.BgpSessionMonitor;
 import org.opennms.netmgt.poller.monitors.DNSResolutionMonitor;
 import org.opennms.netmgt.poller.monitors.DnsMonitor;
+import org.opennms.netmgt.poller.monitors.FtpMonitor;
 import org.opennms.netmgt.poller.monitors.HttpMonitor;
 import org.opennms.netmgt.poller.monitors.HttpsMonitor;
 import org.opennms.netmgt.poller.monitors.IcmpMonitor;
+import org.opennms.netmgt.poller.monitors.ImapMonitor;
 import org.opennms.netmgt.poller.monitors.MinaSshMonitor;
 import org.opennms.netmgt.poller.monitors.NtpMonitor;
 import org.opennms.netmgt.poller.monitors.PageSequenceMonitor;
 import org.opennms.netmgt.poller.monitors.PassiveServiceMonitor;
+import org.opennms.netmgt.poller.monitors.Pop3Monitor;
+import org.opennms.netmgt.poller.monitors.PtpMonitor;
 import org.opennms.netmgt.poller.monitors.SSLCertMonitor;
+import org.opennms.netmgt.poller.monitors.SmtpMonitor;
 import org.opennms.netmgt.poller.monitors.SnmpMonitor;
 import org.opennms.netmgt.poller.monitors.SshMonitor;
 import org.opennms.netmgt.poller.monitors.StrafePingMonitor;
 import org.opennms.netmgt.poller.monitors.TcpMonitor;
 import org.opennms.netmgt.poller.monitors.WebMonitor;
+import org.opennms.netmgt.poller.monitors.Win32ServiceMonitor;
 import org.opennms.protocols.radius.monitor.RadiusAuthMonitor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -66,7 +72,16 @@ public class MonitorRegistryConfiguration {
             new StrafePingMonitor(),
             new WebMonitor(),
             new PassiveServiceMonitor(),
-            new RadiusAuthMonitor()
+            new RadiusAuthMonitor(),
+            // Catalog service types whose monitors live in the core monitors jar but were
+            // previously unregistered (false-DOWN if provisioned). All no-arg constructible,
+            // no new dependencies. See poller-services.yaml: SMTP/FTP/IMAP/POP3/PTP/Windows-Task-Scheduler.
+            new SmtpMonitor(),
+            new FtpMonitor(),
+            new ImapMonitor(),
+            new Pop3Monitor(),
+            new PtpMonitor(),
+            new Win32ServiceMonitor()
         ));
     }
 }

--- a/deploy/overlays/shared/poller-services.yaml
+++ b/deploy/overlays/shared/poller-services.yaml
@@ -184,22 +184,10 @@ services:
     parameters:
       service-name: "${requisition:service-name|detector:service-name|Task Scheduler}"
 
-  - name: VMwareCim-HostSystem
-    monitor: org.opennms.netmgt.poller.monitors.VmwareCimMonitor
-    interval: 300000
-    parameters:
-      retry: "${requisition:poller-retry|requisition:retry|detector:retry|2}"
-      timeout: "${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}"
-      ignoreStandBy: "${requisition:ignoreStandBy|detector:ignoreStandBy|false}"
-
-  - name: VMware-ManagedEntity
-    monitor: org.opennms.netmgt.poller.monitors.VmwareMonitor
-    interval: 300000
-    parameters:
-      retry: "${requisition:poller-retry|requisition:retry|detector:retry|2}"
-      timeout: "${requisition:poller-timeout|requisition:timeout|detector:timeout|3000}"
-      ignoreStandBy: "${requisition:ignoreStandBy|detector:ignoreStandBy|false}"
-      reportAlarms: "${requisition:reportAlarms|detector:reportAlarms|}"
+  # NOTE: VMware monitors (VmwareCimMonitor / VmwareMonitor) are intentionally absent.
+  # delta-v does not bundle the vmware integration module, so those classes are not on
+  # the classpath and cannot be polled. If VMware support is ever added, reintroduce the
+  # module and the catalog entries together.
 
   - name: MS-RDP
     monitor: org.opennms.netmgt.poller.monitors.TcpMonitor


### PR DESCRIPTION
## Summary

Closes the unsupported-monitor registry gap flagged in the Epic 2/3 reviews: the shared catalog shipped 8 service types whose monitors were absent from `LocalServiceMonitorRegistry`. That's a **false-DOWN trap** — the daemon dispatches every poll through the registry regardless of config source, so an unregistered monitor fails the *poll* (not the service) if provisioned. The FR9 unscheduled-services gauge surfaced these; this resolves them.

## Investigation

| Service | Monitor class | On classpath? | Resolution |
|---|---|---|---|
| SMTP | `SmtpMonitor` | ✅ core monitors jar | **register** |
| FTP | `FtpMonitor` | ✅ | **register** |
| IMAP | `ImapMonitor` | ✅ | **register** |
| POP3 | `Pop3Monitor` | ✅ | **register** |
| PTP | `PtpMonitor` | ✅ | **register** |
| Windows-Task-Scheduler | `Win32ServiceMonitor` | ✅ | **register** |
| VMwareCim-HostSystem | `VmwareCimMonitor` | ❌ not bundled | **remove from catalog** |
| VMware-ManagedEntity | `VmwareMonitor` | ❌ not bundled | **remove from catalog** |

## Changes

- **`MonitorRegistryConfiguration`** — register the 6 monitors whose classes are already on the classpath (same core-monitors jar as the existing 17; all no-arg constructible; **no new dependencies**). Makes the catalog entries genuinely pollable and clears them from the gauge. Shared config → benefits both **pollerd and perspectivepollerd**.
- **`poller-services.yaml`** — **delete** the 2 VMware service entries. Their monitor classes aren't bundled in delta-v (no vmware integration module), so they can never be scheduled — and cannot be re-enabled by a flag. An `enabled: false` kill switch would be misleading dead weight (it implies toggleable); deletion is the honest state. A `NOTE` comment records the intentional absence so a future reader doesn't re-add the entries without also bundling the module.

## Why this shape

- Couldn't register VMware — the classes aren't on the classpath (would not compile).
- Didn't disable the 6 — their classes exist and cost nothing to register; disabling would leave the same catalog/registry inconsistency. SMTP/FTP/IMAP/POP3/PTP/Win32 are plain network/SNMP polls with no architectural conflict with the Kafka-first/Minion model (unlike the deliberately-dropped JMX-Cassandra/NRPE/ActiveMQ).
- Deleted rather than `enabled: false`'d VMware — greenfield/no-back-compat, and the entries are permanently unschedulable (not a toggle).

## Verification

- `daemon-registry` compiles with the 6 new monitors.
- `make lint-catalog CATALOG=deploy/overlays/shared/poller-services.yaml` → exit 0.
- Adversarial review (Edge Case Hunter, full access) confirmed: all 6 canonical names match the catalog `monitor:` strings exactly; all 6 have safe no-arg ctors; no remaining false-DOWN traps among enabled services; both daemons import the config.

## Follow-up (not in this PR)

No unit test asserts the registered monitor set. A small test on `MonitorRegistryConfiguration.serviceMonitorRegistry().getMonitorClassNames()` would guard against accidental removal — left out to keep this change focused.
