### PR TITLE
chore(nl6): bump simulator v0.9.1 → v0.11.2

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -131,8 +131,8 @@ services:
     <<: *no-search-domain
     # Upstream simulator image. The project was renamed from
     # labmonkeys-space/l8opensim to labmonkeys-space/nl6 in May 2026.
-    # v0.9.1 release notes: https://github.com/labmonkeys-space/nl6/releases/tag/v0.9.1
-    image: ghcr.io/labmonkeys-space/nl6@sha256:26738adbef8e091df66b29dfb4fce426ddd19973c5695e7069577b093a3de53e  # v0.9.1
+    # v0.11.2 release notes: https://github.com/labmonkeys-space/nl6/releases/tag/v0.11.2
+    image: ghcr.io/labmonkeys-space/nl6@sha256:e628f36ca1702a300533276aecbe452f60826c8207b8d42def3ba8df2caaf0ee  # v0.11.2
     container_name: delta-v-nl6
     profiles: [active, full, metrics, demo]
     # privileged is REQUIRED for namespace mode: creating the 'opensim' netns


### PR DESCRIPTION
First step of the enlinkd E2E → nl6 5-stage Clos migration (#379).

## What
Pins `ghcr.io/labmonkeys-space/nl6` from **v0.9.1** to **v0.11.2** by digest
(`sha256:e628f36c…`), refreshing the release-notes comment.

## Why
v0.11.2 brings what the migration needs:
- inter-device **LLDP topology** served under `1.0.8802.1.1.2` (v0.10.0),
- the **multi-OID SNMP GET fix** enlinkd's `LldpLocPortGetter` relies on (v0.10.1),
- degree-scaled LLDP-walk **CPU fixes** (v0.11.1/.2) — relevant because enlinkd GETBULK-walks the fabric on a schedule.

## Risk
Low. nl6's **read path** (flow/trap/syslog/SNMP collection) is unchanged across the entire v0.9.1→v0.11.2 span. The one behavior change (v0.11.0: link traps/syslog became state-driven, not random-scheduler) doesn't affect this stack — the trap/syslog-asserting E2E inject events by hand and don't touch nl6.

## Verification (reviewer / CI)
- [ ] nl6 comes up healthy under an nl6 profile (`make up PROFILE=full`).
- [ ] Canary the read path: `deploy/test-prometheus-writer-e2e.sh` stays green.

Follow-ups under #379: fork `gen-clos.py` for the 5-stage Clos fabric + requisition (PR2), rewrite `test-enlinkd-e2e.sh` + migrate the other labbox-bound tests (PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)