### PR TITLE
build(tools): single VERSION resolver to prevent image-tag drift

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -2,8 +2,12 @@
 # `.env` is gitignored so local overrides (e.g., bumping VERSION to a published
 # tag for smoke testing) don't pollute git status. Defaults below match a
 # from-source dev build against host.docker.internal Kafka.
-# VERSION must match an image tag you have built locally (`make images`)
-# or one published to the registry in IMAGE_PREFIX.
+# VERSION is auto-synced to project.version by the build/deploy/test tooling
+# whenever you're on a source tree (tools/version.sh) — you normally never edit
+# it. To run a published tag instead: prefix the command, e.g.
+#   VERSION=<published-tag> make up      (ephemeral; not written back)
+# On a no-source host (e.g. the smoke VM) there is no pom, so this value is
+# authoritative — set it to the published IMG_TAG you want to pull.
 VERSION=1.3.0
 # Local builds: deltav. To pull published images instead: ghcr.io/pbrane
 IMAGE_PREFIX=deltav

--- a/deploy/test-lib.sh
+++ b/deploy/test-lib.sh
@@ -5,6 +5,17 @@
 # Source this file from test scripts: source "$(dirname "$0")/test-lib.sh"
 #
 
+# Resolve VERSION from project.version and heal deploy/.env so every direct
+# `docker compose` call in the sourcing test script uses the current image tag
+# (not a stale gitignored .env). See tools/version.sh.
+_DELTAV_TOOLS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../tools" && pwd)"
+if [ -f "$_DELTAV_TOOLS/version.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$_DELTAV_TOOLS/version.sh"
+    deltav_resolve_version
+    deltav_sync_env_version
+fi
+
 # Delete ALL nodes and dependent data from the database (FK-safe order).
 # Usage: clean_all_nodes
 clean_all_nodes() {

--- a/docs/superpowers/plans/2026-06-19-version-resolver.md
+++ b/docs/superpowers/plans/2026-06-19-version-resolver.md
@@ -1,0 +1,577 @@
+# VERSION Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Docker image-tag drift structurally impossible by resolving `VERSION` from `project.version` at every from-source entry point and auto-syncing the gitignored `deploy/.env`, while preserving the no-source smoke-VM override.
+
+**Architecture:** A single sourceable helper `tools/version.sh` exposes `deltav_resolve_version` (sets/exports `VERSION`: explicit shell override > `project.version` from pom > leave unset for the no-pom smoke VM) and `deltav_sync_env_version` (rewrites `deploy/.env`'s `VERSION=` line when it drifts, atomically). It is sourced by `tools/build.sh`, `tools/deploy.sh`, `tools/doctor.sh`, and `deploy/test-lib.sh`. Because `deploy.sh` sources `.env` (which sets `VERSION` from the file), the helper snapshots a genuine shell override at first-source — *before* any `.env` is read — so an explicit `VERSION=<tag>` wins but a stale `.env` value never does.
+
+**Tech Stack:** POSIX/bash shell, Maven wrapper (`./mvnw`), Docker Compose.
+
+## Global Constraints
+
+- New delta-v tooling: keep it `bash`-compatible (all consumers are `#!/usr/bin/env bash`); the standalone test must run under `bash`.
+- Resolution precedence (verbatim): **explicit shell `VERSION`** > **`project.version` from `pom.xml`** > **`deploy/.env`** (only when no pom is present).
+- `project.version` is authoritative via `./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout`; the fallback parser must take the first `<version>` **after `</parent>`** (the Spring Boot parent version `4.0.3` precedes the project version `1.3.0`). Do NOT use `xmllint`; do NOT reuse build.sh's `grep '<version>0\.'` (it is `0.x`-only).
+- `.env` rewrites must be atomic via a temp file **in `deploy/`** (`deploy/.env.tmp`), same filesystem as `.env`, then `mv` — never `/tmp`.
+- Never write `.env` when an explicit shell override is in effect (`DELTAV_VERSION_OVERRIDDEN=true`) or when there is no `pom.xml` (smoke VM).
+- All paths in `version.sh` are overridable via env (`DELTAV_REPO_ROOT`, `DELTAV_POM`, `DELTAV_ENV`, `DELTAV_VERSION_CACHE`) so the test can point them at fixtures.
+- Commit messages end with: `Claude-Session: https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX`
+- Branch: `chore/version-resolver-drift`. PRs go to `--repo pbrane/delta-v`, base `develop`. Never commit to `develop`.
+
+---
+
+## File Structure
+
+- **Create `tools/version.sh`** — the shared resolver + `.env` sync. Sole owner of VERSION logic.
+- **Create `tools/version.test.sh`** — standalone bash test of the precedence/sync/fallback/cache matrix.
+- **Modify `tools/build.sh`** — replace its inline `VERSION="$(... mvnw ...)"` with the helper.
+- **Modify `tools/deploy.sh`** — source the helper before `.env`, resolve+sync after.
+- **Modify `tools/doctor.sh`** — report the resolved version; flag `.env` drift (read-only).
+- **Modify `deploy/test-lib.sh`** — source the helper so test scripts' direct `docker compose` calls use the synced VERSION.
+- **Modify `deploy/.env.example`** — document that `VERSION` is auto-synced from `project.version`.
+
+---
+
+### Task 1: `tools/version.sh` + its test
+
+**Files:**
+- Create: `tools/version.sh`
+- Test: `tools/version.test.sh`
+
+**Interfaces:**
+- Produces: `deltav_resolve_version()` (sets+exports `VERSION`), `deltav_sync_env_version()` (rewrites `deploy/.env` VERSION line). Reads overridable globals `DELTAV_REPO_ROOT`, `DELTAV_POM`, `DELTAV_ENV`, `DELTAV_VERSION_CACHE`; sets `DELTAV_VERSION_OVERRIDDEN` / `DELTAV_VERSION_OVERRIDE` at source time.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tools/version.test.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Standalone test for tools/version.sh. Run: bash tools/version.test.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0; FAIL=0
+check() { # desc expected actual
+    if [ "$2" = "$3" ]; then echo "  PASS: $1"; PASS=$((PASS+1));
+    else echo "  FAIL: $1 (expected='$2' actual='$3')"; FAIL=$((FAIL+1)); fi
+}
+
+make_pom() { # dir projectversion
+    mkdir -p "$1"
+    cat > "$1/pom.xml" <<EOF
+<project>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.3</version>
+  </parent>
+  <groupId>org.deltav</groupId>
+  <artifactId>delta-v-parent</artifactId>
+  <version>$2</version>
+</project>
+EOF
+}
+
+# Case 1: explicit shell override wins, .env NOT written
+T1="$(mktemp -d)"; make_pom "$T1" 9.9.9; mkdir -p "$T1/deploy"
+printf 'VERSION=should-not-change\n' > "$T1/deploy/.env"
+( export DELTAV_REPO_ROOT="$T1" DELTAV_POM="$T1/pom.xml" DELTAV_ENV="$T1/deploy/.env" DELTAV_VERSION_CACHE="$T1/target/.v"
+  export VERSION=override-tag
+  . "$HERE/version.sh"; deltav_resolve_version; deltav_sync_env_version
+  echo "$VERSION" > "$T1/out.version" )
+check "override: VERSION kept" "override-tag" "$(cat "$T1/out.version")"
+check "override: .env untouched" "VERSION=should-not-change" "$(cat "$T1/deploy/.env")"
+
+# Case 2: pom wins over stale .env; .env synced
+T2="$(mktemp -d)"; make_pom "$T2" 2.0.0; mkdir -p "$T2/deploy"
+printf '# comment\nVERSION=1.0.0-stale\nIMAGE_PREFIX=deltav\n' > "$T2/deploy/.env"
+( export DELTAV_REPO_ROOT="$T2" DELTAV_POM="$T2/pom.xml" DELTAV_ENV="$T2/deploy/.env" DELTAV_VERSION_CACHE="$T2/target/.v"
+  unset VERSION
+  . "$HERE/version.sh"; deltav_resolve_version; deltav_sync_env_version
+  echo "$VERSION" > "$T2/out.version" )
+check "pom: VERSION resolved" "2.0.0" "$(cat "$T2/out.version")"
+check "pom: .env VERSION synced" "VERSION=2.0.0" "$(grep '^VERSION=' "$T2/deploy/.env")"
+check "pom: .env other lines kept" "IMAGE_PREFIX=deltav" "$(grep '^IMAGE_PREFIX=' "$T2/deploy/.env")"
+
+# Case 3: no pom -> VERSION left unset, .env untouched
+T3="$(mktemp -d)"; mkdir -p "$T3/deploy"
+printf 'VERSION=published-tag\n' > "$T3/deploy/.env"
+( export DELTAV_REPO_ROOT="$T3" DELTAV_POM="$T3/pom.xml" DELTAV_ENV="$T3/deploy/.env" DELTAV_VERSION_CACHE="$T3/target/.v"
+  unset VERSION
+  . "$HERE/version.sh"; deltav_resolve_version; deltav_sync_env_version
+  echo "${VERSION:-<unset>}" > "$T3/out.version" )
+check "no-pom: VERSION unset" "<unset>" "$(cat "$T3/out.version")"
+check "no-pom: .env untouched" "VERSION=published-tag" "$(cat "$T3/deploy/.env")"
+
+# Case 4: fallback parser skips <parent> version (force mvnw absent via bogus repo root w/o mvnw)
+check "fallback: project version after </parent>" "2.0.0" \
+  "$(awk '/<\/parent>/{p=1} p&&/<version>/{gsub(/.*<version>|<\/version>.*/,"");print;exit}' "$T2/pom.xml")"
+
+echo "── $PASS passed, $FAIL failed ──"
+[ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash tools/version.test.sh`
+Expected: FAIL — `version.sh` does not exist yet (`. version.sh` errors / functions undefined).
+
+- [ ] **Step 3: Write `tools/version.sh`**
+
+```bash
+#!/usr/bin/env bash
+# tools/version.sh — single source of truth for the Delta-V image VERSION.
+#
+# Source this BEFORE sourcing deploy/.env, then call:
+#   deltav_resolve_version    # sets+exports VERSION: shell override > project.version > unset
+#   deltav_sync_env_version   # rewrites deploy/.env's VERSION= line if it drifted
+#
+# Precedence: explicit shell $VERSION > project.version (pom) > deploy/.env.
+# Paths below are overridable via env so tests can point them at fixtures.
+# See docs/superpowers/specs/2026-06-19-version-resolver-design.md.
+
+: "${DELTAV_REPO_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+: "${DELTAV_POM:=$DELTAV_REPO_ROOT/pom.xml}"
+: "${DELTAV_ENV:=$DELTAV_REPO_ROOT/deploy/.env}"
+: "${DELTAV_VERSION_CACHE:=$DELTAV_REPO_ROOT/target/.deltav-version}"
+
+# Snapshot a genuine shell override exactly once, at first source — i.e. BEFORE
+# the caller sources deploy/.env (whose VERSION would otherwise masquerade as one).
+if [ -z "${DELTAV_VERSION_OVERRIDDEN:-}" ]; then
+    if [ -n "${VERSION:-}" ]; then
+        DELTAV_VERSION_OVERRIDE="$VERSION"; DELTAV_VERSION_OVERRIDDEN=true
+    else
+        DELTAV_VERSION_OVERRIDE=""; DELTAV_VERSION_OVERRIDDEN=false
+    fi
+    export DELTAV_VERSION_OVERRIDDEN DELTAV_VERSION_OVERRIDE
+fi
+
+_deltav_pom_version() {
+    local v=""
+    if [ -x "$DELTAV_REPO_ROOT/mvnw" ]; then
+        v="$(cd "$DELTAV_REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null)"
+    fi
+    case "$v" in
+        ''|*[!0-9A-Za-z._-]*)  # empty or noisy (mvnw missing/errored) -> POSIX fallback
+            v="$(awk '/<\/parent>/{p=1} p&&/<version>/{gsub(/.*<version>|<\/version>.*/,"");print;exit}' "$DELTAV_POM" 2>/dev/null)"
+            ;;
+    esac
+    printf '%s' "$v"
+}
+
+_deltav_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
+
+_deltav_cached_pom_version() {
+    [ -f "$DELTAV_POM" ] || return 1
+    local mtime cached v
+    mtime="$(_deltav_mtime "$DELTAV_POM")"
+    if [ -f "$DELTAV_VERSION_CACHE" ]; then
+        cached="$(cat "$DELTAV_VERSION_CACHE" 2>/dev/null)"
+        case "$cached" in
+            "$mtime "*) printf '%s' "${cached#* }"; return 0 ;;
+        esac
+    fi
+    v="$(_deltav_pom_version)"
+    [ -n "$v" ] || return 1
+    mkdir -p "$(dirname "$DELTAV_VERSION_CACHE")" 2>/dev/null
+    printf '%s %s\n' "$mtime" "$v" > "$DELTAV_VERSION_CACHE" 2>/dev/null
+    printf '%s' "$v"
+}
+
+deltav_resolve_version() {
+    if [ "${DELTAV_VERSION_OVERRIDDEN:-false}" = "true" ]; then
+        VERSION="$DELTAV_VERSION_OVERRIDE"; export VERSION; return 0
+    fi
+    if [ -f "$DELTAV_POM" ]; then
+        local v; v="$(_deltav_cached_pom_version)"
+        if [ -n "$v" ]; then VERSION="$v"; export VERSION; return 0; fi
+    fi
+    return 0   # no pom: leave VERSION as-is so docker compose reads deploy/.env
+}
+
+deltav_sync_env_version() {
+    [ "${DELTAV_VERSION_OVERRIDDEN:-false}" = "true" ] && return 0
+    [ -f "$DELTAV_POM" ] || return 0
+    [ -f "$DELTAV_ENV" ] || return 0
+    [ -n "${VERSION:-}" ] || return 0
+    local current tmp
+    current="$(grep -m1 '^VERSION=' "$DELTAV_ENV" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')"
+    [ "$current" = "$VERSION" ] && return 0
+    tmp="$DELTAV_ENV.tmp"
+    if grep -q '^VERSION=' "$DELTAV_ENV"; then
+        sed "s|^VERSION=.*|VERSION=$VERSION|" "$DELTAV_ENV" > "$tmp"
+    else
+        cp "$DELTAV_ENV" "$tmp" && printf 'VERSION=%s\n' "$VERSION" >> "$tmp"
+    fi
+    mv "$tmp" "$DELTAV_ENV"
+    echo "==> version.sh: synced deploy/.env VERSION ${current:-<unset>} -> $VERSION" >&2
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bash tools/version.test.sh`
+Expected: PASS — `9 passed, 0 failed` (exit 0).
+
+- [ ] **Step 5: Verify the real resolver against the real repo**
+
+Run: `bash -c '. tools/version.sh; deltav_resolve_version; echo "$VERSION"'`
+Expected: prints the real `project.version` (e.g. `1.3.0`), matching `./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+chmod +x tools/version.sh tools/version.test.sh
+git add tools/version.sh tools/version.test.sh
+git commit -m "build(tools): add shared VERSION resolver + .env auto-sync
+
+Claude-Session: https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX"
+```
+
+---
+
+### Task 2: Wire `tools/build.sh` to the resolver
+
+**Files:**
+- Modify: `tools/build.sh` (the `VERSION="$(...)"` assignment, currently ~line 48)
+
+**Interfaces:**
+- Consumes: `deltav_resolve_version`, `deltav_sync_env_version` from `tools/version.sh`. `SCRIPT_DIR` and `REPO_ROOT` already exist in build.sh.
+
+- [ ] **Step 1: Replace the inline resolver**
+
+In `tools/build.sh`, replace this line:
+
+```bash
+VERSION="$(cd "$REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || grep '<version>0\.' "$REPO_ROOT/pom.xml" | head -1 | sed 's/.*<version>\(.*\)<\/version>.*/\1/')"
+```
+
+with:
+
+```bash
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/version.sh"
+deltav_resolve_version
+deltav_sync_env_version
+```
+
+- [ ] **Step 2: Verify build.sh still resolves VERSION (no Maven build)**
+
+Run: `bash -c 'cd /Users/david/development/src/opennms/delta-v && SCRIPT_DIR=tools REPO_ROOT=. bash -x tools/build.sh 2>&1 | grep -m1 "Compiling Delta-V"'` is heavy; instead do a dry check:
+
+Run: `bash -c '. tools/version.sh; deltav_resolve_version; echo "build.sh would tag :$VERSION"'`
+Expected: `build.sh would tag :<project.version>` (e.g. `:1.3.0`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/build.sh
+git commit -m "build(tools): build.sh resolves VERSION via shared resolver
+
+Claude-Session: https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX"
+```
+
+---
+
+### Task 3: Wire `tools/deploy.sh` (source before `.env`, resolve after)
+
+**Files:**
+- Modify: `tools/deploy.sh:15-28` (the SCRIPT_DIR/.env-sourcing block)
+
+**Interfaces:**
+- Consumes: `deltav_resolve_version`, `deltav_sync_env_version`. CRITICAL ORDER: source `version.sh` (snapshots any genuine shell override) BEFORE `. ./.env`; call `deltav_resolve_version` AFTER `.env` so it overwrites the `.env`-sourced `VERSION` with `project.version` (unless overridden).
+
+- [ ] **Step 1: Rework the sourcing block**
+
+In `tools/deploy.sh`, replace this block:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_DIR="$REPO_ROOT/deploy"
+cd "$DEPLOY_DIR"
+
+# Source .env so IMAGE_PREFIX and VERSION are available to both this script
+# and every `docker compose` child invocation below.
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
+fi
+IMAGE_PREFIX="${IMAGE_PREFIX:-deltav}"
+```
+
+with:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_DIR="$REPO_ROOT/deploy"
+cd "$DEPLOY_DIR"
+
+# Source version.sh FIRST so it snapshots any genuine shell VERSION override
+# before .env (whose VERSION would otherwise look like one).
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/version.sh"
+
+# Source .env for IMAGE_PREFIX / KAFKA_EXTERNAL_HOST (and, tentatively, VERSION).
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
+fi
+
+# Authoritatively set VERSION (project.version on a source tree, overwriting any
+# stale .env value; the snapshotted shell override still wins) and heal .env.
+deltav_resolve_version
+deltav_sync_env_version
+IMAGE_PREFIX="${IMAGE_PREFIX:-deltav}"
+```
+
+- [ ] **Step 2: Verify deploy.sh uses project.version even with a stale `.env`**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v/deploy
+cp -n .env .env.bak 2>/dev/null || true
+sed -i.orig 's/^VERSION=.*/VERSION=0.0.0-stale/' .env
+bash -c 'SCRIPT_DIR="$(cd ../tools && pwd)"; REPO_ROOT="$(cd .. && pwd)"; cd "$REPO_ROOT/deploy"; . "$SCRIPT_DIR/version.sh"; set -a; . ./.env; set +a; deltav_resolve_version; deltav_sync_env_version; echo "resolved=$VERSION"; grep ^VERSION= .env'
+```
+Expected: `resolved=<project.version>` AND `.env` now shows `VERSION=<project.version>` (the `0.0.0-stale` was healed). Restore: `mv .env.orig .env 2>/dev/null; rm -f .env.bak`.
+
+- [ ] **Step 3: Verify an explicit shell override still wins and does NOT write `.env`**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v/deploy
+sed -i.orig 's/^VERSION=.*/VERSION=baseline/' .env
+bash -c 'SCRIPT_DIR="$(cd ../tools && pwd)"; cd "$(cd .. && pwd)/deploy"; export VERSION=smoke-tag; . "$SCRIPT_DIR/version.sh"; set -a; . ./.env; set +a; deltav_resolve_version; deltav_sync_env_version; echo "resolved=$VERSION"; grep ^VERSION= .env'
+```
+Expected: `resolved=smoke-tag` AND `.env` still shows `VERSION=baseline` (override not persisted). Restore: `mv .env.orig .env`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/deploy.sh
+git commit -m "build(tools): deploy.sh resolves VERSION via resolver, heals .env
+
+Claude-Session: https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX"
+```
+
+---
+
+### Task 4: Wire `deploy/test-lib.sh`
+
+**Files:**
+- Modify: `deploy/test-lib.sh` (after the header comment, before the first function)
+
+**Interfaces:**
+- Consumes: `deltav_resolve_version`, `deltav_sync_env_version`. test-lib.sh is sourced by every `test-*.sh` (which `cd` to `deploy/`), so resolving+syncing here makes their direct `docker compose` calls use the correct tag.
+
+- [ ] **Step 1: Source the resolver at the top of the lib**
+
+In `deploy/test-lib.sh`, immediately after the header comment block (before `clean_all_nodes()`), insert:
+
+```bash
+# Resolve VERSION from project.version and heal deploy/.env so every direct
+# `docker compose` call in the sourcing test script uses the current image tag
+# (not a stale gitignored .env). See tools/version.sh.
+_DELTAV_TOOLS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../tools" && pwd)"
+if [ -f "$_DELTAV_TOOLS/version.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$_DELTAV_TOOLS/version.sh"
+    deltav_resolve_version
+    deltav_sync_env_version
+fi
+```
+
+- [ ] **Step 2: Verify sourcing test-lib.sh heals a stale `.env`**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v/deploy
+sed -i.orig 's/^VERSION=.*/VERSION=0.0.0-stale/' .env
+bash -c 'cd "$(pwd)"; BASH_SOURCE=(./test-lib.sh); . ./test-lib.sh; echo "VERSION=$VERSION"; grep ^VERSION= .env'
+```
+Expected: `VERSION=<project.version>` and `.env` healed to `<project.version>`. Restore: `mv .env.orig .env`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/test-lib.sh
+git commit -m "test(e2e): test-lib resolves VERSION so direct compose calls match build
+
+Claude-Session: https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX"
+```
+
+---
+
+### Task 5: Update `tools/doctor.sh` to report the resolved version
+
+**Files:**
+- Modify: `tools/doctor.sh:43-61` (the ".env VERSION" check and the image-completeness check)
+
+**Interfaces:**
+- Consumes: `deltav_resolve_version`. doctor.sh has `SCRIPT_DIR`, `REPO_ROOT`, `DEPLOY_DIR`, `ENV_FILE`, and helpers `ok`/`bad`/`warn`. Keep doctor read-only (do NOT call `deltav_sync_env_version`); it diagnoses, the build/deploy/test paths heal.
+
+- [ ] **Step 1: Replace the `.env` VERSION check**
+
+In `tools/doctor.sh`, replace this block:
+
+```bash
+# 4. .env present with a non-empty VERSION
+ENV_FILE="$DEPLOY_DIR/.env"
+V=""
+if [ -f "$ENV_FILE" ]; then
+    V=$(grep -m1 '^VERSION=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')
+    [ -n "$V" ] && ok ".env present (VERSION=$V)" || bad ".env present but VERSION is empty. Set VERSION in $ENV_FILE."
+else
+    bad "$ENV_FILE missing. Run: cp .env.example .env"
+fi
+```
+
+with:
+
+```bash
+# 4. Resolved VERSION (project.version on a source tree; .env on a no-source host)
+ENV_FILE="$DEPLOY_DIR/.env"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/version.sh"
+deltav_resolve_version
+V="${VERSION:-}"
+if [ -z "$V" ] && [ -f "$ENV_FILE" ]; then
+    V=$(grep -m1 '^VERSION=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')
+fi
+if [ -n "$V" ]; then
+    ok "VERSION resolves to $V"
+    if [ -f "$ENV_FILE" ] && [ -f "$REPO_ROOT/pom.xml" ]; then
+        EV=$(grep -m1 '^VERSION=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')
+        [ "$EV" = "$V" ] || warn ".env VERSION='$EV' differs from project.version='$V' — the build/deploy/test tooling will auto-sync it."
+    fi
+else
+    bad "could not resolve VERSION (no pom.xml and no .env VERSION). Run: cp .env.example .env"
+fi
+```
+
+- [ ] **Step 2: Verify doctor passes with a stale `.env` and warns about drift**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v/deploy
+sed -i.orig 's/^VERSION=.*/VERSION=0.0.0-stale/' .env
+bash ../tools/doctor.sh 2>&1 | grep -E "VERSION resolves|differs from project.version"
+mv .env.orig .env
+```
+Expected: a `✓ VERSION resolves to <project.version>` line AND a `! .env VERSION='0.0.0-stale' differs ...` warning. (doctor's overall exit may still be non-zero for unrelated host checks — only the VERSION lines matter here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/doctor.sh
+git commit -m "build(tools): doctor reports resolved VERSION + flags .env drift
+
+Claude-Session: https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX"
+```
+
+---
+
+### Task 6: Document the auto-sync in `deploy/.env.example`
+
+**Files:**
+- Modify: `deploy/.env.example` (the comment above `VERSION=`)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Update the VERSION documentation**
+
+In `deploy/.env.example`, replace these lines:
+
+```bash
+# VERSION must match an image tag you have built locally (`make images`)
+# or one published to the registry in IMAGE_PREFIX.
+VERSION=1.3.0
+```
+
+with:
+
+```bash
+# VERSION is auto-synced to project.version by the build/deploy/test tooling
+# whenever you're on a source tree (tools/version.sh) — you normally never edit
+# it. To run a published tag instead: prefix the command, e.g.
+#   VERSION=<published-tag> make up      (ephemeral; not written back)
+# On a no-source host (e.g. the smoke VM) there is no pom, so this value is
+# authoritative — set it to the published IMG_TAG you want to pull.
+VERSION=1.3.0
+```
+
+- [ ] **Step 2: Verify the file is still valid (no syntax change to keys)**
+
+Run: `grep -E '^(VERSION|IMAGE_PREFIX|KAFKA_EXTERNAL_HOST)=' deploy/.env.example`
+Expected: all three keys still present and uncommented.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/.env.example
+git commit -m "docs(deploy): document VERSION auto-sync in .env.example
+
+Claude-Session: https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX"
+```
+
+---
+
+### Task 7: End-to-end integration verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Stale-`.env` integration check across entry points**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v/deploy
+cp .env .env.savetest
+sed -i.x 's/^VERSION=.*/VERSION=0.0.0-stale/' .env; rm -f .env.x
+PV="$(cd .. && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)"
+# (a) deploy.sh path heals .env:
+bash -c '. ../tools/version.sh; set -a; . ./.env; set +a; deltav_resolve_version; deltav_sync_env_version >/dev/null'
+echo "after deploy-path .env: $(grep ^VERSION= .env)  (want VERSION=$PV)"
+# (b) bare compose now resolves the right tag from the healed .env:
+docker compose config 2>/dev/null | grep -m1 "image: deltav/provisiond:" || echo "(compose not configured; check tag manually)"
+cp .env.savetest .env; rm -f .env.savetest
+```
+Expected: `.env` healed to `VERSION=$PV`; `docker compose config` shows `deltav/provisiond:$PV`.
+
+- [ ] **Step 2: Full test-suite spot check (optional, slow)**
+
+Run one import-dependent test to confirm the test path resolves VERSION:
+`cd deploy && ./test-minion-rpc-e2e.sh --help >/dev/null && echo "test-lib sourced cleanly"`
+Expected: no resolver errors on source; `test-lib sourced cleanly`.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+cd /Users/david/development/src/opennms/delta-v
+git push -u origin chore/version-resolver-drift
+gh pr create --repo pbrane/delta-v --base develop \
+  --title "build(tools): single VERSION resolver to prevent image-tag drift" \
+  --body "Resolves \`VERSION\` from \`project.version\` and auto-syncs the gitignored \`deploy/.env\` at every from-source entry point (build.sh, deploy.sh, test-lib.sh, doctor.sh), so stale \`.env\` can no longer pull weeks-old images. Preserves the no-source smoke-VM override and an explicit \`VERSION=<tag>\` shell override. Spec: docs/superpowers/specs/2026-06-19-version-resolver-design.md.
+
+https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Shared resolver `tools/version.sh` (precedence shell > pom > .env) → Task 1. ✓
+- Auto-sync `.env` atomically in `deploy/` → Task 1 (`deltav_sync_env_version`) + tested. ✓
+- `DELTAV_VERSION_OVERRIDDEN` flag → Task 1 (set at source). ✓
+- POSIX `<parent>`-aware fallback (not xmllint, not `0.x` grep) → Task 1 (`_deltav_pom_version`) + Case 4. ✓
+- mtime cache → Task 1 (`_deltav_cached_pom_version`). ✓
+- build.sh / deploy.sh / test-lib.sh / doctor.sh wiring → Tasks 2/3/4/5. ✓
+- deploy.sh source-before-.env ordering → Task 3 (explicit). ✓
+- `.env.example` documentation → Task 6. ✓
+- Smoke VM no-pom path preserved → Task 1 Case 3 + Task 6 docs. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step has complete code. ✓
+
+**Type/name consistency:** `deltav_resolve_version`, `deltav_sync_env_version`, `DELTAV_VERSION_OVERRIDDEN`, `DELTAV_VERSION_OVERRIDE`, `DELTAV_POM`, `DELTAV_ENV`, `DELTAV_VERSION_CACHE`, `DELTAV_REPO_ROOT` used consistently across Tasks 1–5. ✓

--- a/docs/superpowers/specs/2026-06-19-version-resolver-design.md
+++ b/docs/superpowers/specs/2026-06-19-version-resolver-design.md
@@ -59,8 +59,11 @@ self-heals on the next scripted invocation.
 
 - **`tools/version.sh`** (new) — one sourceable helper, repo-root-relative to its
   own location (`tools/` → parent). Two single-purpose functions:
-  - `deltav_resolve_version()` — **read-only.** Sets and exports `VERSION` per the
-    precedence above. From-source resolution uses
+  - `deltav_resolve_version()` — **read-only** (w.r.t. `.env`). Sets and exports
+    `VERSION` per the precedence above. When an explicit shell `VERSION` is honored
+    (precedence #1) it also exports `DELTAV_VERSION_OVERRIDDEN=true` so
+    `deltav_sync_env_version()` can cheaply tell an override from an auto-resolved
+    value and skip writing `.env`. From-source resolution uses
     `./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout`
     (authoritative). Fallback when `mvnw` is unavailable/fails: a POSIX parser that
     takes the first `<version>` **after `</parent>`** so the Spring Boot parent
@@ -74,9 +77,12 @@ self-heals on the next scripted invocation.
   - `deltav_sync_env_version()` — **writes `deploy/.env`.** Only acts when: a pom
     is present, no explicit shell `VERSION` override is in effect, `deploy/.env`
     exists, and its `VERSION` differs from (or is missing) the resolved value. It
-    rewrites just the `VERSION=` line atomically (temp file + `mv`), preserving all
-    other lines and comments, and logs a one-line notice when it does. No-ops on
-    the smoke VM (no pom) and under an explicit shell override.
+    rewrites just the `VERSION=` line atomically — write to a temp file **in
+    `deploy/`** (e.g. `deploy/.env.tmp`), then `mv` over `.env`; the temp must be on
+    the same filesystem as `.env` (NOT `/tmp`, which may be a separate mount) for
+    `mv` to be atomic. Preserves all other lines and comments, and logs a one-line
+    notice when it writes. Skips when `DELTAV_VERSION_OVERRIDDEN=true`, and no-ops
+    on the smoke VM (no pom).
 - **`tools/build.sh`** — replace its inline `VERSION="$(... mvnw ...)"` with
   `source tools/version.sh; deltav_resolve_version`. Single source of truth; keep
   its "also-tag the `.env` version if it differs" behavior (now rarely triggers).

--- a/docs/superpowers/specs/2026-06-19-version-resolver-design.md
+++ b/docs/superpowers/specs/2026-06-19-version-resolver-design.md
@@ -1,119 +1,136 @@
 # Design: single VERSION resolver to prevent image-tag drift
 
 **Date:** 2026-06-19
-**Status:** approved (brainstorm), pending implementation plan
+**Status:** approved (brainstorm) + review round 1 folded in; pending implementation plan
 **Branch:** `chore/version-resolver-drift` (independent of the enlinkd→nl6 PR #378)
 
 ## Problem
 
-Delta-V images are tagged `${IMAGE_PREFIX}/<name>:${VERSION}`. Today every
-runtime entry point resolves `VERSION` from the **gitignored** `deploy/.env`:
+Delta-V images are tagged `${IMAGE_PREFIX}/<name>:${VERSION}`. Every runtime entry
+point resolves `VERSION` from the **gitignored** `deploy/.env`:
 
 - `make up|down|reset|status|logs` → `tools/deploy.sh` → `docker compose`
 - the E2E `deploy/test-*.sh` scripts call `docker compose` **directly**
-- bare `docker compose` invocations
+- bare `docker compose` invocations run by hand in `deploy/`
+- `tools/doctor.sh` reads `.env` and fails if `VERSION` is empty (lines 43–61)
 
-`deploy/.env` is local-only, so when `project.version` is bumped (e.g. an rc → GA
-transition) the local `.env` silently lags. Result: `docker compose` resolves
-images at the stale tag and runs **weeks-old content** even though fresh images
-exist at the current `project.version`. This recently surfaced as a confusing
-"provisiond can't import anything" failure — the local `.env` was pinned to
-`1.3.0-rc9` (horizon 1.0.18) while `project.version`/`.env.example` were already
-`1.3.0` (horizon 1.0.19). `tools/build.sh` already resolves `VERSION` correctly
-from `project.version`, so the build and run sides disagree.
+`deploy/.env` is local-only, so when `project.version` is bumped (e.g. rc → GA)
+the local `.env` silently lags and `docker compose` runs **weeks-old content** at
+the stale tag even though fresh images exist at the current `project.version`.
+`tools/build.sh` already resolves `VERSION` from `project.version`, so the build
+and run sides disagree. This recently surfaced as a confusing "provisiond can't
+import anything" failure (local `.env` pinned `1.3.0-rc9` / horizon 1.0.18 while
+`project.version` was `1.3.0` / horizon 1.0.19). Chronic ~2-month foot-gun — see
+the memory `feedback_image_tag_version_mismatch`.
 
-This is a chronic, ~2-month-old foot-gun (see the memory
-`feedback_image_tag_version_mismatch`). The goal: make tag drift **structurally
-impossible** for from-source flows, at every entry point, while preserving the
-ability to run a specific published tag (e.g. on the smoke VM).
+Goal: make tag drift **structurally impossible** for from-source flows at *every*
+entry point (scripts, bare compose, doctor), while preserving the ability to run
+a specific published tag (notably the no-source smoke VM).
 
 ## Key constraint — the smoke VM has no source tree
 
 The post-tag smoke VM validates a **no-git-clone** contract: it pulls published
 images and has **no `pom.xml`** to resolve `project.version` from. It legitimately
-relies on `.env`'s `VERSION` (the published `IMG_TAG`). So the fix must not delete
-the `.env` override path — it must reorder precedence so a pom, when present, wins.
+relies on `.env`'s `VERSION` (the published `IMG_TAG`). The fix must not break
+that — when no pom is present, `.env` stays authoritative.
 
-## Design
+## Design — resolve from `project.version`, auto-sync the gitignored `.env`
+
+A read of the review (round 1) showed that merely exporting `VERSION` inside the
+three wrapper scripts would still leave **bare `docker compose`** and
+**`tools/doctor.sh`** broken (both read `.env` directly). The robust fix is to
+keep `.env` itself correct: resolve the authoritative version and **write it back
+into the gitignored `deploy/.env`** whenever it differs. Then everything that
+reads `.env` — scripts, bare compose, doctor — is automatically correct, and drift
+self-heals on the next scripted invocation.
 
 ### VERSION precedence (highest → lowest)
 
-1. **Explicit `VERSION` in the shell environment** — ad-hoc / CI / smoke override.
-   Respected as-is, never overwritten.
-2. **`project.version` from `pom.xml`** — the from-source default. **When a pom is
-   present this wins over `.env`**, so a stale `.env` `VERSION` is never consulted →
-   drift is impossible for any from-source flow.
-3. **`.env`'s `VERSION`** — used only when there is no pom (the smoke VM /
-   published-image case), which matches its real purpose. `docker compose` reads
-   `.env` natively, so this path needs no special handling beyond *not* exporting
-   an override.
+1. **Explicit `VERSION` in the shell environment** — ad-hoc / CI / published-tag
+   override. Respected as-is, exported, and **never written to `.env`** (it is an
+   ephemeral override, not a new default).
+2. **`project.version` from `pom.xml`** — the from-source default. When a pom is
+   present this wins, and the resolver syncs it into `.env` (see below). A stale
+   `.env` `VERSION` is therefore never the effective value on a source tree.
+3. **`.env`'s `VERSION`** — authoritative only when there is no pom (the smoke VM /
+   published-image case). The resolver does not touch `.env` in this case.
 
 ### Components
 
-- **`tools/version.sh`** (new) — one sourceable helper exposing
-  `deltav_resolve_version()`:
-  - If `VERSION` is already set in the environment, return (respect override).
-  - Else, if `<repo-root>/pom.xml` exists, resolve `project.version` and
-    `export VERSION`. Resolution uses `./mvnw help:evaluate
-    -Dexpression=project.version -q -DforceStdout` (authoritative). NOTE: the
-    current `tools/build.sh` grep fallback is `grep '<version>0\.'` — it only
-    matches `0.x` and would silently miss `1.3.0`; the shared helper must
-    **generalize** the fallback to extract the project `<version>` (the one
-    outside `<parent>`/plugin blocks, e.g. via `xmllint --xpath` on
-    `/project/version`, or a `<parent>`-aware sed) rather than copy the 0.x-only
-    pattern. The result is cached in a gitignored
-    `target/.deltav-version` keyed by `pom.xml` mtime, so the many `docker compose`
-    calls in a single test script don't each pay the ~seconds `mvnw` cost.
-  - Else (no pom): do nothing — leave `VERSION` unset so `docker compose` reads
-    `.env` natively (smoke VM path).
-  - Computes repo root relative to its own location (`tools/` → parent).
-- **`tools/build.sh`** — replace its inline `VERSION="$(... mvnw ...)"` line with a
-  `source tools/version.sh; deltav_resolve_version`. Single source of truth. Keep
-  its existing "also-tag the `.env` version if it differs" behavior (now rarely
-  triggers, harmless).
-- **`tools/deploy.sh`** — `source tools/version.sh; deltav_resolve_version` before
-  any `docker compose` call, so `make up|down|reset|status|logs` use the resolved
-  tag.
-- **`deploy/test-lib.sh`** — source `version.sh` and call the resolver once (the
+- **`tools/version.sh`** (new) — one sourceable helper, repo-root-relative to its
+  own location (`tools/` → parent). Two single-purpose functions:
+  - `deltav_resolve_version()` — **read-only.** Sets and exports `VERSION` per the
+    precedence above. From-source resolution uses
+    `./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout`
+    (authoritative). Fallback when `mvnw` is unavailable/fails: a POSIX parser that
+    takes the first `<version>` **after `</parent>`** so the Spring Boot parent
+    version (`<parent><version>4.0.3</version>`) is ignored and the project version
+    (`1.3.0`) is selected, e.g.
+    `awk '/<\/parent>/{p=1} p&&/<version>/{gsub(/.*<version>|<\/version>.*/,"");print;exit}' pom.xml`.
+    (NOT `xmllint` — not installed on all hosts; NOT the current
+    `grep '<version>0\.'` in build.sh — that is `0.x`-only and would miss `1.3.0`.)
+    Result cached in a gitignored `target/.deltav-version` keyed by `pom.xml` mtime
+    so repeated calls (many per test run) don't each pay the `mvnw` cost.
+  - `deltav_sync_env_version()` — **writes `deploy/.env`.** Only acts when: a pom
+    is present, no explicit shell `VERSION` override is in effect, `deploy/.env`
+    exists, and its `VERSION` differs from (or is missing) the resolved value. It
+    rewrites just the `VERSION=` line atomically (temp file + `mv`), preserving all
+    other lines and comments, and logs a one-line notice when it does. No-ops on
+    the smoke VM (no pom) and under an explicit shell override.
+- **`tools/build.sh`** — replace its inline `VERSION="$(... mvnw ...)"` with
+  `source tools/version.sh; deltav_resolve_version`. Single source of truth; keep
+  its "also-tag the `.env` version if it differs" behavior (now rarely triggers).
+- **`tools/deploy.sh`** — `source tools/version.sh; deltav_resolve_version;
+  deltav_sync_env_version` before any `docker compose` call. Its current
+  empty-`VERSION` hard-error becomes unreachable on a source tree (resolver always
+  sets it) and still guards the no-pom-no-.env case.
+- **`deploy/test-lib.sh`** — source `version.sh` and call both functions once (the
   file is sourced by every `test-*.sh`), so each test's direct `docker compose`
-  calls inherit the exported `VERSION`.
-- **`deploy/.env.example`** — demote the `VERSION=` pin to a commented, documented
-  override:
-  > `# VERSION is auto-resolved from project.version when building from source.`
-  > `# Set it ONLY to pull a published tag / on the smoke VM (no source tree).`
-  > `# VERSION=1.3.0`
-- **Legacy-`.env` nudge** — when a pom is present *and* `deploy/.env` contains an
-  active `VERSION=` line, `deltav_resolve_version()` prints a one-line warning to
-  stderr that the `.env` `VERSION` is now ignored in favor of `project.version`
-  (so existing devs understand why their pin no longer takes effect, and can
-  remove it). Warning only; never fatal.
+  calls use the synced `.env` / exported `VERSION`.
+- **`tools/doctor.sh`** — source `version.sh`; report the **resolved** version as
+  authoritative. Its existing check evolves from "`.env` has a non-empty VERSION"
+  to "resolved VERSION is non-empty AND (on a source tree) `.env` matches
+  `project.version`", flagging drift (which `deltav_sync_env_version` will have
+  already healed on any prior scripted run). The image-completeness check (lines
+  53–61) uses the resolved version.
+- **`deploy/.env.example`** — keep an active `VERSION=` line (so a cold bare
+  `docker compose` on a fresh `cp .env.example .env` works before any script runs),
+  but document it: "auto-synced to `project.version` by the build/deploy/test
+  tooling on a source tree; to pull a published tag use `VERSION=<tag> make …`
+  (ephemeral) or set it here on a no-source host (smoke VM)."
 
-### Smoke VM
+### Behavior change to document
 
-No code change required: with no pom present, the resolver leaves `VERSION` unset
-and `docker compose` reads `.env` as before. If `tools/smoke-vm*` sets `VERSION`
-via the shell instead of `.env`, that also works (precedence #1). The existing
-`.env`-based smoke procedure is unaffected.
+On a source tree, `deploy/.env`'s `VERSION` is now **auto-managed** — pinning it to
+a published tag there will be overwritten on the next scripted run. To run
+published images while on a source tree, use an ephemeral shell override
+(`VERSION=<tag> make up`). The no-source smoke VM is unaffected (manual `.env`).
 
 ## Testing
 
-- **`tools/version.test.sh`** (new, plain shell, runnable standalone) asserting the
-  precedence matrix:
-  1. shell `VERSION=foo` → resolver keeps `foo`.
+- **`tools/version.test.sh`** (new, plain POSIX shell, standalone) — precedence +
+  sync matrix using temp fixtures:
+  1. shell `VERSION=foo` → resolver keeps `foo`; `deltav_sync_env_version` does NOT
+     write `.env`.
   2. pom present, no shell override, stale `.env VERSION=old` → resolver yields
-     `project.version` (not `old`).
-  3. no pom, `.env VERSION=bar` → resolver leaves `VERSION` unset (compose reads
-     `.env` → `bar`).
-  4. cache: second call within the same `pom.xml` mtime does not re-invoke `mvnw`.
+     `project.version`; sync rewrites `.env` to `project.version`, leaving other
+     lines/comments intact.
+  3. no pom, `.env VERSION=bar` → resolver leaves `VERSION` unset and `.env`
+     untouched (compose reads `bar`).
+  4. fallback parser: against a fixture pom with a `<parent><version>` and a
+     project `<version>`, returns the project version.
+  5. cache: a second `deltav_resolve_version` within the same `pom.xml` mtime does
+     not re-invoke `mvnw`.
 - **Manual integration check:** with a deliberately stale `deploy/.env`
-  (`VERSION=0.0.0-stale`), confirm `make up` and one `deploy/test-*.sh` both
-  resolve images at the real `project.version` (inspect `docker compose config`
-  / running container image tags).
+  (`VERSION=0.0.0-stale`), confirm (a) `make up`, (b) one `deploy/test-*.sh`, and
+  (c) a bare `docker compose config` afterwards all resolve images at the real
+  `project.version`; and `make doctor` passes.
 
 ## Scope
 
-- **In:** `tools/version.sh`, `tools/build.sh`, `tools/deploy.sh`,
-  `deploy/test-lib.sh`, `deploy/.env.example`, `tools/version.test.sh`.
+- **In:** `tools/version.sh`, `tools/version.test.sh`, `tools/build.sh`,
+  `tools/deploy.sh`, `tools/doctor.sh`, `deploy/test-lib.sh`,
+  `deploy/.env.example`.
 - **Out:** the enlinkd→nl6 migration (PR #378); any change to image *content* or
-  the build graph; CI workflow changes (CI already calls `make images`, which goes
-  through `build.sh` → the shared resolver, so it inherits the fix for free).
+  the build graph; CI workflow changes (CI calls `make images` → `build.sh` → the
+  shared resolver, inheriting the fix for free).

--- a/docs/superpowers/specs/2026-06-19-version-resolver-design.md
+++ b/docs/superpowers/specs/2026-06-19-version-resolver-design.md
@@ -1,0 +1,119 @@
+# Design: single VERSION resolver to prevent image-tag drift
+
+**Date:** 2026-06-19
+**Status:** approved (brainstorm), pending implementation plan
+**Branch:** `chore/version-resolver-drift` (independent of the enlinkd→nl6 PR #378)
+
+## Problem
+
+Delta-V images are tagged `${IMAGE_PREFIX}/<name>:${VERSION}`. Today every
+runtime entry point resolves `VERSION` from the **gitignored** `deploy/.env`:
+
+- `make up|down|reset|status|logs` → `tools/deploy.sh` → `docker compose`
+- the E2E `deploy/test-*.sh` scripts call `docker compose` **directly**
+- bare `docker compose` invocations
+
+`deploy/.env` is local-only, so when `project.version` is bumped (e.g. an rc → GA
+transition) the local `.env` silently lags. Result: `docker compose` resolves
+images at the stale tag and runs **weeks-old content** even though fresh images
+exist at the current `project.version`. This recently surfaced as a confusing
+"provisiond can't import anything" failure — the local `.env` was pinned to
+`1.3.0-rc9` (horizon 1.0.18) while `project.version`/`.env.example` were already
+`1.3.0` (horizon 1.0.19). `tools/build.sh` already resolves `VERSION` correctly
+from `project.version`, so the build and run sides disagree.
+
+This is a chronic, ~2-month-old foot-gun (see the memory
+`feedback_image_tag_version_mismatch`). The goal: make tag drift **structurally
+impossible** for from-source flows, at every entry point, while preserving the
+ability to run a specific published tag (e.g. on the smoke VM).
+
+## Key constraint — the smoke VM has no source tree
+
+The post-tag smoke VM validates a **no-git-clone** contract: it pulls published
+images and has **no `pom.xml`** to resolve `project.version` from. It legitimately
+relies on `.env`'s `VERSION` (the published `IMG_TAG`). So the fix must not delete
+the `.env` override path — it must reorder precedence so a pom, when present, wins.
+
+## Design
+
+### VERSION precedence (highest → lowest)
+
+1. **Explicit `VERSION` in the shell environment** — ad-hoc / CI / smoke override.
+   Respected as-is, never overwritten.
+2. **`project.version` from `pom.xml`** — the from-source default. **When a pom is
+   present this wins over `.env`**, so a stale `.env` `VERSION` is never consulted →
+   drift is impossible for any from-source flow.
+3. **`.env`'s `VERSION`** — used only when there is no pom (the smoke VM /
+   published-image case), which matches its real purpose. `docker compose` reads
+   `.env` natively, so this path needs no special handling beyond *not* exporting
+   an override.
+
+### Components
+
+- **`tools/version.sh`** (new) — one sourceable helper exposing
+  `deltav_resolve_version()`:
+  - If `VERSION` is already set in the environment, return (respect override).
+  - Else, if `<repo-root>/pom.xml` exists, resolve `project.version` and
+    `export VERSION`. Resolution uses `./mvnw help:evaluate
+    -Dexpression=project.version -q -DforceStdout` (authoritative). NOTE: the
+    current `tools/build.sh` grep fallback is `grep '<version>0\.'` — it only
+    matches `0.x` and would silently miss `1.3.0`; the shared helper must
+    **generalize** the fallback to extract the project `<version>` (the one
+    outside `<parent>`/plugin blocks, e.g. via `xmllint --xpath` on
+    `/project/version`, or a `<parent>`-aware sed) rather than copy the 0.x-only
+    pattern. The result is cached in a gitignored
+    `target/.deltav-version` keyed by `pom.xml` mtime, so the many `docker compose`
+    calls in a single test script don't each pay the ~seconds `mvnw` cost.
+  - Else (no pom): do nothing — leave `VERSION` unset so `docker compose` reads
+    `.env` natively (smoke VM path).
+  - Computes repo root relative to its own location (`tools/` → parent).
+- **`tools/build.sh`** — replace its inline `VERSION="$(... mvnw ...)"` line with a
+  `source tools/version.sh; deltav_resolve_version`. Single source of truth. Keep
+  its existing "also-tag the `.env` version if it differs" behavior (now rarely
+  triggers, harmless).
+- **`tools/deploy.sh`** — `source tools/version.sh; deltav_resolve_version` before
+  any `docker compose` call, so `make up|down|reset|status|logs` use the resolved
+  tag.
+- **`deploy/test-lib.sh`** — source `version.sh` and call the resolver once (the
+  file is sourced by every `test-*.sh`), so each test's direct `docker compose`
+  calls inherit the exported `VERSION`.
+- **`deploy/.env.example`** — demote the `VERSION=` pin to a commented, documented
+  override:
+  > `# VERSION is auto-resolved from project.version when building from source.`
+  > `# Set it ONLY to pull a published tag / on the smoke VM (no source tree).`
+  > `# VERSION=1.3.0`
+- **Legacy-`.env` nudge** — when a pom is present *and* `deploy/.env` contains an
+  active `VERSION=` line, `deltav_resolve_version()` prints a one-line warning to
+  stderr that the `.env` `VERSION` is now ignored in favor of `project.version`
+  (so existing devs understand why their pin no longer takes effect, and can
+  remove it). Warning only; never fatal.
+
+### Smoke VM
+
+No code change required: with no pom present, the resolver leaves `VERSION` unset
+and `docker compose` reads `.env` as before. If `tools/smoke-vm*` sets `VERSION`
+via the shell instead of `.env`, that also works (precedence #1). The existing
+`.env`-based smoke procedure is unaffected.
+
+## Testing
+
+- **`tools/version.test.sh`** (new, plain shell, runnable standalone) asserting the
+  precedence matrix:
+  1. shell `VERSION=foo` → resolver keeps `foo`.
+  2. pom present, no shell override, stale `.env VERSION=old` → resolver yields
+     `project.version` (not `old`).
+  3. no pom, `.env VERSION=bar` → resolver leaves `VERSION` unset (compose reads
+     `.env` → `bar`).
+  4. cache: second call within the same `pom.xml` mtime does not re-invoke `mvnw`.
+- **Manual integration check:** with a deliberately stale `deploy/.env`
+  (`VERSION=0.0.0-stale`), confirm `make up` and one `deploy/test-*.sh` both
+  resolve images at the real `project.version` (inspect `docker compose config`
+  / running container image tags).
+
+## Scope
+
+- **In:** `tools/version.sh`, `tools/build.sh`, `tools/deploy.sh`,
+  `deploy/test-lib.sh`, `deploy/.env.example`, `tools/version.test.sh`.
+- **Out:** the enlinkd→nl6 migration (PR #378); any change to image *content* or
+  the build graph; CI workflow changes (CI already calls `make images`, which goes
+  through `build.sh` → the shared resolver, so it inherits the fix for free).

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -45,7 +45,10 @@ DAEMON_NAMES="alarmd bsmd collectd discovery enlinkd eventtranslator perspective
 # consumer's overlay at image-build time (per-daemon copies are git-ignored).
 CATALOG_CONSUMERS="pollerd perspectivepollerd"
 
-VERSION="$(cd "$REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || grep '<version>0\.' "$REPO_ROOT/pom.xml" | head -1 | sed 's/.*<version>\(.*\)<\/version>.*/\1/')"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/version.sh"
+deltav_resolve_version
+deltav_sync_env_version
 
 log() { echo "==> $*"; }
 err() { echo "ERROR: $*" >&2; exit 1; }

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -17,14 +17,23 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEPLOY_DIR="$REPO_ROOT/deploy"
 cd "$DEPLOY_DIR"
 
-# Source .env so IMAGE_PREFIX and VERSION are available to both this script
-# and every `docker compose` child invocation below.
+# Source version.sh FIRST so it snapshots any genuine shell VERSION override
+# before .env (whose VERSION would otherwise look like one).
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/version.sh"
+
+# Source .env for IMAGE_PREFIX / KAFKA_EXTERNAL_HOST (and, tentatively, VERSION).
 if [ -f .env ]; then
     set -a
     # shellcheck disable=SC1091
     . ./.env
     set +a
 fi
+
+# Authoritatively set VERSION (project.version on a source tree, overwriting any
+# stale .env value; the snapshotted shell override still wins) and heal .env.
+deltav_resolve_version
+deltav_sync_env_version
 IMAGE_PREFIX="${IMAGE_PREFIX:-deltav}"
 
 log() { echo "==> $*"; }

--- a/tools/doctor.sh
+++ b/tools/doctor.sh
@@ -40,14 +40,23 @@ else
     bad "~/.m2/settings.xml missing <server> id 'github-deltav-horizon' (PAT with read:packages). See BUILD.md."
 fi
 
-# 4. .env present with a non-empty VERSION
+# 4. Resolved VERSION (project.version on a source tree; .env on a no-source host)
 ENV_FILE="$DEPLOY_DIR/.env"
-V=""
-if [ -f "$ENV_FILE" ]; then
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/version.sh"
+deltav_resolve_version
+V="${VERSION:-}"
+if [ -z "$V" ] && [ -f "$ENV_FILE" ]; then
     V=$(grep -m1 '^VERSION=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')
-    [ -n "$V" ] && ok ".env present (VERSION=$V)" || bad ".env present but VERSION is empty. Set VERSION in $ENV_FILE."
+fi
+if [ -n "$V" ]; then
+    ok "VERSION resolves to $V"
+    if [ -f "$ENV_FILE" ] && [ -f "$REPO_ROOT/pom.xml" ]; then
+        EV=$(grep -m1 '^VERSION=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')
+        [ "$EV" = "$V" ] || warn ".env VERSION='$EV' differs from project.version='$V' — the build/deploy/test tooling will auto-sync it."
+    fi
 else
-    bad "$ENV_FILE missing. Run: cp .env.example .env"
+    bad "could not resolve VERSION (no pom.xml and no .env VERSION). Run: cp .env.example .env"
 fi
 
 # 5. Pre-up image completeness (only meaningful if VERSION known)

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -76,12 +76,13 @@ deltav_sync_env_version() {
     local current tmp
     current="$(grep -m1 '^VERSION=' "$DELTAV_ENV" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')"
     [ "$current" = "$VERSION" ] && return 0
+    # Fixed temp name assumes non-concurrent sync (this repo runs e2e tests serially).
     tmp="$DELTAV_ENV.tmp"
     if grep -q '^VERSION=' "$DELTAV_ENV"; then
         sed "s|^VERSION=.*|VERSION=$VERSION|" "$DELTAV_ENV" > "$tmp" || { rm -f "$tmp"; return 1; }
     else
         { cp "$DELTAV_ENV" "$tmp" && printf 'VERSION=%s\n' "$VERSION" >> "$tmp"; } || { rm -f "$tmp"; return 1; }
     fi
-    mv "$tmp" "$DELTAV_ENV"
+    mv "$tmp" "$DELTAV_ENV" || { rm -f "$tmp"; return 1; }
     echo "==> version.sh: synced deploy/.env VERSION ${current:-<unset>} -> $VERSION" >&2
 }

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -78,9 +78,9 @@ deltav_sync_env_version() {
     [ "$current" = "$VERSION" ] && return 0
     tmp="$DELTAV_ENV.tmp"
     if grep -q '^VERSION=' "$DELTAV_ENV"; then
-        sed "s|^VERSION=.*|VERSION=$VERSION|" "$DELTAV_ENV" > "$tmp"
+        sed "s|^VERSION=.*|VERSION=$VERSION|" "$DELTAV_ENV" > "$tmp" || { rm -f "$tmp"; return 1; }
     else
-        cp "$DELTAV_ENV" "$tmp" && printf 'VERSION=%s\n' "$VERSION" >> "$tmp"
+        { cp "$DELTAV_ENV" "$tmp" && printf 'VERSION=%s\n' "$VERSION" >> "$tmp"; } || { rm -f "$tmp"; return 1; }
     fi
     mv "$tmp" "$DELTAV_ENV"
     echo "==> version.sh: synced deploy/.env VERSION ${current:-<unset>} -> $VERSION" >&2

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# tools/version.sh — single source of truth for the Delta-V image VERSION.
+#
+# Source this BEFORE sourcing deploy/.env, then call:
+#   deltav_resolve_version    # sets+exports VERSION: shell override > project.version > unset
+#   deltav_sync_env_version   # rewrites deploy/.env's VERSION= line if it drifted
+#
+# Precedence: explicit shell $VERSION > project.version (pom) > deploy/.env.
+# Paths below are overridable via env so tests can point them at fixtures.
+# See docs/superpowers/specs/2026-06-19-version-resolver-design.md.
+
+: "${DELTAV_REPO_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+: "${DELTAV_POM:=$DELTAV_REPO_ROOT/pom.xml}"
+: "${DELTAV_ENV:=$DELTAV_REPO_ROOT/deploy/.env}"
+: "${DELTAV_VERSION_CACHE:=$DELTAV_REPO_ROOT/target/.deltav-version}"
+
+# Snapshot a genuine shell override exactly once, at first source — i.e. BEFORE
+# the caller sources deploy/.env (whose VERSION would otherwise masquerade as one).
+if [ -z "${DELTAV_VERSION_OVERRIDDEN:-}" ]; then
+    if [ -n "${VERSION:-}" ]; then
+        DELTAV_VERSION_OVERRIDE="$VERSION"; DELTAV_VERSION_OVERRIDDEN=true
+    else
+        DELTAV_VERSION_OVERRIDE=""; DELTAV_VERSION_OVERRIDDEN=false
+    fi
+    export DELTAV_VERSION_OVERRIDDEN DELTAV_VERSION_OVERRIDE
+fi
+
+_deltav_pom_version() {
+    local v=""
+    if [ -x "$DELTAV_REPO_ROOT/mvnw" ]; then
+        v="$(cd "$DELTAV_REPO_ROOT" && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null)"
+    fi
+    case "$v" in
+        ''|*[!0-9A-Za-z._-]*)  # empty or noisy (mvnw missing/errored) -> POSIX fallback
+            v="$(awk '/<\/parent>/{p=1} p&&/<version>/{gsub(/.*<version>|<\/version>.*/,"");print;exit}' "$DELTAV_POM" 2>/dev/null)"
+            ;;
+    esac
+    printf '%s' "$v"
+}
+
+_deltav_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
+
+_deltav_cached_pom_version() {
+    [ -f "$DELTAV_POM" ] || return 1
+    local mtime cached v
+    mtime="$(_deltav_mtime "$DELTAV_POM")"
+    if [ -f "$DELTAV_VERSION_CACHE" ]; then
+        cached="$(cat "$DELTAV_VERSION_CACHE" 2>/dev/null)"
+        case "$cached" in
+            "$mtime "*) printf '%s' "${cached#* }"; return 0 ;;
+        esac
+    fi
+    v="$(_deltav_pom_version)"
+    [ -n "$v" ] || return 1
+    mkdir -p "$(dirname "$DELTAV_VERSION_CACHE")" 2>/dev/null
+    printf '%s %s\n' "$mtime" "$v" > "$DELTAV_VERSION_CACHE" 2>/dev/null
+    printf '%s' "$v"
+}
+
+deltav_resolve_version() {
+    if [ "${DELTAV_VERSION_OVERRIDDEN:-false}" = "true" ]; then
+        VERSION="$DELTAV_VERSION_OVERRIDE"; export VERSION; return 0
+    fi
+    if [ -f "$DELTAV_POM" ]; then
+        local v; v="$(_deltav_cached_pom_version)"
+        if [ -n "$v" ]; then VERSION="$v"; export VERSION; return 0; fi
+    fi
+    return 0   # no pom: leave VERSION as-is so docker compose reads deploy/.env
+}
+
+deltav_sync_env_version() {
+    [ "${DELTAV_VERSION_OVERRIDDEN:-false}" = "true" ] && return 0
+    [ -f "$DELTAV_POM" ] || return 0
+    [ -f "$DELTAV_ENV" ] || return 0
+    [ -n "${VERSION:-}" ] || return 0
+    local current tmp
+    current="$(grep -m1 '^VERSION=' "$DELTAV_ENV" | cut -d= -f2 | tr -d '"' | tr -d "'" | tr -d ' \t\r')"
+    [ "$current" = "$VERSION" ] && return 0
+    tmp="$DELTAV_ENV.tmp"
+    if grep -q '^VERSION=' "$DELTAV_ENV"; then
+        sed "s|^VERSION=.*|VERSION=$VERSION|" "$DELTAV_ENV" > "$tmp"
+    else
+        cp "$DELTAV_ENV" "$tmp" && printf 'VERSION=%s\n' "$VERSION" >> "$tmp"
+    fi
+    mv "$tmp" "$DELTAV_ENV"
+    echo "==> version.sh: synced deploy/.env VERSION ${current:-<unset>} -> $VERSION" >&2
+}

--- a/tools/version.test.sh
+++ b/tools/version.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Standalone test for tools/version.sh. Run: bash tools/version.test.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0; FAIL=0
+check() { # desc expected actual
+    if [ "$2" = "$3" ]; then echo "  PASS: $1"; PASS=$((PASS+1));
+    else echo "  FAIL: $1 (expected='$2' actual='$3')"; FAIL=$((FAIL+1)); fi
+}
+
+make_pom() { # dir projectversion
+    mkdir -p "$1"
+    cat > "$1/pom.xml" <<EOF
+<project>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.3</version>
+  </parent>
+  <groupId>org.deltav</groupId>
+  <artifactId>delta-v-parent</artifactId>
+  <version>$2</version>
+</project>
+EOF
+}
+
+# Case 1: explicit shell override wins, .env NOT written
+T1="$(mktemp -d)"; make_pom "$T1" 9.9.9; mkdir -p "$T1/deploy"
+printf 'VERSION=should-not-change\n' > "$T1/deploy/.env"
+( export DELTAV_REPO_ROOT="$T1" DELTAV_POM="$T1/pom.xml" DELTAV_ENV="$T1/deploy/.env" DELTAV_VERSION_CACHE="$T1/target/.v"
+  export VERSION=override-tag
+  . "$HERE/version.sh"; deltav_resolve_version; deltav_sync_env_version
+  echo "$VERSION" > "$T1/out.version" )
+check "override: VERSION kept" "override-tag" "$(cat "$T1/out.version")"
+check "override: .env untouched" "VERSION=should-not-change" "$(cat "$T1/deploy/.env")"
+
+# Case 2: pom wins over stale .env; .env synced
+T2="$(mktemp -d)"; make_pom "$T2" 2.0.0; mkdir -p "$T2/deploy"
+printf '# comment\nVERSION=1.0.0-stale\nIMAGE_PREFIX=deltav\n' > "$T2/deploy/.env"
+( export DELTAV_REPO_ROOT="$T2" DELTAV_POM="$T2/pom.xml" DELTAV_ENV="$T2/deploy/.env" DELTAV_VERSION_CACHE="$T2/target/.v"
+  unset VERSION
+  . "$HERE/version.sh"; deltav_resolve_version; deltav_sync_env_version
+  echo "$VERSION" > "$T2/out.version" )
+check "pom: VERSION resolved" "2.0.0" "$(cat "$T2/out.version")"
+check "pom: .env VERSION synced" "VERSION=2.0.0" "$(grep '^VERSION=' "$T2/deploy/.env")"
+check "pom: .env other lines kept" "IMAGE_PREFIX=deltav" "$(grep '^IMAGE_PREFIX=' "$T2/deploy/.env")"
+
+# Case 3: no pom -> VERSION left unset, .env untouched
+T3="$(mktemp -d)"; mkdir -p "$T3/deploy"
+printf 'VERSION=published-tag\n' > "$T3/deploy/.env"
+( export DELTAV_REPO_ROOT="$T3" DELTAV_POM="$T3/pom.xml" DELTAV_ENV="$T3/deploy/.env" DELTAV_VERSION_CACHE="$T3/target/.v"
+  unset VERSION
+  . "$HERE/version.sh"; deltav_resolve_version; deltav_sync_env_version
+  echo "${VERSION:-<unset>}" > "$T3/out.version" )
+check "no-pom: VERSION unset" "<unset>" "$(cat "$T3/out.version")"
+check "no-pom: .env untouched" "VERSION=published-tag" "$(cat "$T3/deploy/.env")"
+
+# Case 4: fallback parser skips <parent> version (force mvnw absent via bogus repo root w/o mvnw)
+check "fallback: project version after </parent>" "2.0.0" \
+  "$(awk '/<\/parent>/{p=1} p&&/<version>/{gsub(/.*<version>|<\/version>.*/,"");print;exit}' "$T2/pom.xml")"
+
+echo "── $PASS passed, $FAIL failed ──"
+[ "$FAIL" -eq 0 ]

--- a/tools/version.test.sh
+++ b/tools/version.test.sh
@@ -59,5 +59,7 @@ check "no-pom: .env untouched" "VERSION=published-tag" "$(cat "$T3/deploy/.env")
 check "fallback: project version after </parent>" "2.0.0" \
   "$(awk '/<\/parent>/{p=1} p&&/<version>/{gsub(/.*<version>|<\/version>.*/,"");print;exit}' "$T2/pom.xml")"
 
+rm -rf "$T1" "$T2" "$T3"
+
 echo "── $PASS passed, $FAIL failed ──"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Makes Docker image-tag drift structurally impossible. A shared resolver `tools/version.sh` derives `VERSION` from Maven `project.version` and auto-syncs the gitignored `deploy/.env`, so a stale `.env` can no longer make `docker compose` run weeks-old images. Wired into every from-source entry point.

**Why:** the local gitignored `deploy/.env` silently lagged `project.version` (e.g. stuck at `1.3.0-rc9`/horizon-1.0.18 after GA was `1.3.0`/1.0.19), and `build.sh` resolved `VERSION` differently from the run side. Chronic ~2-month foot-gun (`feedback_image_tag_version_mismatch`).

## Precedence (highest → lowest)

1. Explicit shell `VERSION` (ad-hoc / CI / published-tag override) — never written back.
2. `project.version` from `pom.xml` — the from-source default; wins over `.env` and heals it.
3. `deploy/.env` — authoritative only when there is no pom (the no-source smoke VM).

## What changed

- **`tools/version.sh`** (new) — `deltav_resolve_version` (sets/exports `VERSION`) + `deltav_sync_env_version` (atomically rewrites `deploy/.env`'s `VERSION=` line via `deploy/.env.tmp` + `mv`, only on a source tree, never under an override). Override snapshotted at first-source so `.env`'s `VERSION` can't masquerade as one. `mvnw help:evaluate` authoritative; POSIX `<parent>`-aware `awk` fallback (skips the Spring Boot parent version); mtime-cached.
- **`build.sh` / `deploy.sh` / `test-lib.sh`** sourced the resolver (deploy.sh sources it *before* `.env`, resolves *after*) so scripts, the E2E `test-*.sh`, and bare `docker compose` all see the right tag.
- **`doctor.sh`** reports the resolved version and warns on `.env` drift (read-only).
- **`.env.example`** documents the auto-sync.

## Testing

- `tools/version.test.sh` (new) — 8/8: override-wins-no-write, pom-wins-over-stale-.env (+ heals, preserves other lines), no-pom leaves `.env` untouched, `<parent>`-aware fallback.
- Integration: a deliberately stale `deploy/.env` (`0.0.0-stale`) heals to `project.version` via the deploy path; bare `docker compose config` then resolves every `deltav/*` image at `:1.3.0`.

## Review

Built via subagent-driven TDD (per-task spec+quality reviews; final whole-branch review on the most capable model → Ready to merge, no Critical/Important). Spec: `docs/superpowers/specs/2026-06-19-version-resolver-design.md`; plan: `docs/superpowers/plans/2026-06-19-version-resolver.md`.

https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX