### PR TITLE
fix(minion): register DnsLookupClientRpcModule so reverse-DNS RPC is answered

### DIFF
--- a/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/DnsConfiguration.java
+++ b/core/daemon-boot-minion/src/main/java/org/deltav/minion/boot/DnsConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.boot;
+
+import org.opennms.netmgt.provision.dns.client.rpc.DnsLookupClientRpcModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the DNS lookup RPC module (module ID "DNS").
+ *
+ * <p>provisiond's {@code DefaultHostnameResolver} dispatches reverse-DNS lookups
+ * (and forward lookups) to the node's location Minion via this RPC module.
+ * Without it the Minion has no handler for module id "DNS", so those RPCs go
+ * unanswered: provisiond waits out the RPC timeout (~20s), the empty/timed-out
+ * response fails to unmarshal, and it falls back to using the IP as the
+ * hostname. At scale (e.g. the 36-node nl6 Clos fabric) the cumulative stalls
+ * drop nodes from import cycles and leave SNMP collection partial.</p>
+ *
+ * <p>The Karaf→Spring-Boot Minion migration re-registers each {@code RpcModule}
+ * as an explicit bean (Echo/PingProxy/PingSweep/Poller/Collector/Detector/
+ * SnmpProxy); this one was missed. The default thread count mirrors horizon's
+ * {@code applicationContext-rpc-dns.xml} (64).</p>
+ */
+@Configuration
+@ConditionalOnProperty(name = "opennms.minion.dns.enabled", havingValue = "true", matchIfMissing = true)
+public class DnsConfiguration {
+
+    @Bean
+    public DnsLookupClientRpcModule dnsLookupClientRpcModule(
+            @Value("${opennms.minion.dns.thread-count:64}") int threadCount) {
+        return new DnsLookupClientRpcModule(threadCount);
+    }
+}

--- a/core/daemon-boot-minion/src/test/java/org/deltav/minion/boot/DnsConfigurationTest.java
+++ b/core/daemon-boot-minion/src/test/java/org/deltav/minion/boot/DnsConfigurationTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.minion.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.netmgt.provision.dns.client.rpc.DnsLookupClientRpcModule;
+
+/**
+ * Verifies the Minion registers the DNS lookup RPC module so provisiond's
+ * reverse-DNS lookups (DefaultHostnameResolver) are answered instead of timing
+ * out. Regression guard for the Karaf→Spring-Boot migration gap where module id
+ * "DNS" had no handler.
+ */
+class DnsConfigurationTest {
+
+    @Test
+    void providesDnsLookupRpcModuleWithIdDNS() {
+        DnsLookupClientRpcModule module = new DnsConfiguration().dnsLookupClientRpcModule(64);
+        assertNotNull(module, "DnsConfiguration must provide a DnsLookupClientRpcModule bean");
+        assertEquals("DNS", module.getId(),
+                "Minion must register an RPC module with id 'DNS' for reverse-DNS lookups");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the nl6-lab DNS-RPC flakiness (dropped nodes on import + partial SNMP collection at scale). **Root cause: the Spring-Boot Minion never registered the `DnsLookupClientRpcModule` bean.**

The Karaf→Spring-Boot Minion migration re-registers each `RpcModule` as an explicit `@Bean` (Echo / PingProxy / PingSweep / Poller / Collector / Detector / SnmpProxy). The DNS lookup module was missed — so the Minion has **no handler for RPC module id `DNS`**. provisiond's `DefaultHostnameResolver` dispatches reverse-DNS lookups to the node's location Minion; with no handler they go unanswered → RPC times out (~20s) → the empty/timed-out response fails to unmarshal (`WstxEOFException: Unexpected EOF in prolog [1,0]`) → fallback to IP-as-hostname. Harmless at small scale; at the 36-node nl6 Clos fabric the cumulative ~20s stalls dropped nodes from import cycles and starved SNMP collection.

Not a horizon bug — horizon's `DnsLookupClientRpcModule.execute()` is fine; it just never ran because nothing wired it.

## Change

- **`DnsConfiguration`** (new) in `core/daemon-boot-minion` — registers `new DnsLookupClientRpcModule(threadCount)` as a `@Bean`, `@ConditionalOnProperty(opennms.minion.dns.enabled, matchIfMissing=true)`, thread-count via `${opennms.minion.dns.thread-count:64}` (default 64 = horizon's `applicationContext-rpc-dns.xml`). `RpcModuleRegistry`/`GrpcRpcStreamConfiguration` auto-collect it.
- **`DnsConfigurationTest`** — asserts the bean is a module with id `DNS` (regression guard).

The `opennms-detectorclient-rpc` jar (which contains `DnsLookupClientRpcModule`) is already a minion-boot dependency, so no new dependency.

## Verification

Unit: `DnsConfigurationTest` passes (1/1).

End-to-end on the nl6 stack (rebuilt minion-boot image, both Minions recreated, fresh 36-node import):

| Signal | Before | After |
|--------|--------|-------|
| reverse-lookups failed | 181/181 | **0** (43 succeeded) |
| DNS-RPC unmarshal errors | many | **0** |
| nodes imported per cycle | 34 (2 dropped, needed retry) | **36 in one cycle** |
| snmpinterface nodes | 34 | 35 |

Affects both Minions (Default + nl6-lab); reverse lookups for any IP were previously unanswered.

## Notes / follow-ups (separate from this fix)
- `nl6-provisioner` is non-idempotent (re-POSTs devices/`clos.json` → duplicate → exit 1), which blocks `nl6-minion` restart via its `depends_on`. Worth making the provisioner tolerate duplicates.
- `sysObjectID` collects on ~20/36 nl6 devices (SNMP system-group), independent of this fix — likely an nl6-simulator characteristic; the enlinkd E2E already tolerates it via majority floors.

https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX