### PR TITLE
fix(nl6): make nl6-provisioner idempotent (check-first-skip)

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -249,35 +249,53 @@ services:
         case "$$expected" in
             ''|null|0) echo "FAIL /seed/devices.json yields no devices (expected=$$expected)"; exit 1 ;;
         esac
-        echo "provisioner: importing $$expected-device seed via upstream fleet.sh"
-        # fleet.sh import auto-detects the devices.json shape (batch-manifest
-        # array or {data:[...]} GET-response) and POSTs each entry to
-        # /api/v1/devices.
-        sh /seed/fleet.sh import http://127.0.0.1:8080 /seed/devices.json
-        # Verify exact count. Match fleet.sh's shape hedging so a future
-        # response envelope change ({data:[]}, {devices:[]}, or bare array)
-        # doesn't silently null-out the count.
-        body=$$(curl -sf http://127.0.0.1:8080/api/v1/devices) || {
-            echo "FAIL could not GET /api/v1/devices for verification"; exit 1;
-        }
-        count=$$(printf '%s' "$$body" | jq '(.data // .devices // (if type=="array" then . else [] end)) | length' 2>/dev/null) || {
-            echo "FAIL could not parse /api/v1/devices response: $$body"; exit 1;
-        }
-        # Coerce empty/null to 0 so busybox `[` doesn't error out before
-        # the friendly FAIL message can run.
+        # Idempotency: this one-shot sidecar re-runs whenever nl6-minion is
+        # recreated (depends_on: service_completed_successfully). nl6's device +
+        # topology state is in-memory and all-or-nothing per container lifecycle,
+        # so GET the current state and skip a step that's already satisfied.
+        # Re-POSTing existing devices (fleet.sh) or links (the topology API
+        # rejects duplicates with HTTP 400) would otherwise exit non-zero and
+        # wedge nl6-minion's start.
+        count=$$(curl -sf http://127.0.0.1:8080/api/v1/devices | jq '(.data // .devices // (if type=="array" then . else [] end)) | length' 2>/dev/null)
         case "$$count" in ''|null) count=0 ;; esac
-        echo "provisioner: nl6 now reports $$count devices (expected $$expected)"
-        [ "$$count" -eq "$$expected" ] || { echo "FAIL expected $$expected devices got $$count"; exit 1; }
+        if [ "$$count" -eq "$$expected" ]; then
+            echo "provisioner: $$count devices already present (expected $$expected) — skipping import"
+        else
+            echo "provisioner: importing $$expected-device seed via upstream fleet.sh (have $$count)"
+            # fleet.sh auto-detects the devices.json shape (batch-manifest array
+            # or {data:[...]} GET-response) and POSTs each entry to /api/v1/devices.
+            sh /seed/fleet.sh import http://127.0.0.1:8080 /seed/devices.json
+            body=$$(curl -sf http://127.0.0.1:8080/api/v1/devices) || {
+                echo "FAIL could not GET /api/v1/devices for verification"; exit 1;
+            }
+            count=$$(printf '%s' "$$body" | jq '(.data // .devices // (if type=="array" then . else [] end)) | length' 2>/dev/null) || {
+                echo "FAIL could not parse /api/v1/devices response: $$body"; exit 1;
+            }
+            case "$$count" in ''|null) count=0 ;; esac
+            echo "provisioner: nl6 now reports $$count devices (expected $$expected)"
+            [ "$$count" -eq "$$expected" ] || { echo "FAIL expected $$expected devices got $$count"; exit 1; }
+        fi
         # Load the 5-stage Clos LLDP topology (clos.json) so enlinkd can discover
         # inter-device links. nl6 >= v0.10.0 serves the LLDP-MIB (1.0.8802.1.1.2)
-        # for linked ports; -fsS fails fast on any non-2xx. Links resolve lazily
-        # upstream, so this is safe to run right after the device seed.
-        echo "provisioner: loading Clos topology from /seed/clos.json"
-        curl -fsS -X POST http://127.0.0.1:8080/api/v1/topology \
-            -H 'Content-Type: application/json' --data @/seed/clos.json || {
-            echo "FAIL could not POST /api/v1/topology"; exit 1;
+        # for linked ports. Idempotent: skip if the links are already configured
+        # (the topology API rejects duplicate links with HTTP 400, which would
+        # fail this one-shot sidecar on re-run).
+        links=$$(jq '.links | length' /seed/clos.json 2>/dev/null) || {
+            echo "FAIL could not parse /seed/clos.json"; exit 1;
         }
-        echo
+        case "$$links" in ''|null|0) echo "FAIL /seed/clos.json yields no links (links=$$links)"; exit 1 ;; esac
+        configured=$$(curl -sf http://127.0.0.1:8080/api/v1/topology/status | jq '.configured_links // 0' 2>/dev/null)
+        case "$$configured" in ''|null) configured=0 ;; esac
+        if [ "$$configured" -ge "$$links" ]; then
+            echo "provisioner: topology already present ($$configured >= $$links links) — skipping POST"
+        else
+            echo "provisioner: loading Clos topology from /seed/clos.json ($$configured -> $$links links)"
+            curl -fsS -X POST http://127.0.0.1:8080/api/v1/topology \
+                -H 'Content-Type: application/json' --data @/seed/clos.json || {
+                echo "FAIL could not POST /api/v1/topology"; exit 1;
+            }
+            echo
+        fi
         # Informational: report configured vs active link counts (the enlinkd
         # E2E asserts on this; the provisioner only gates on the POST succeeding).
         echo "provisioner: topology/status: $$(curl -sf http://127.0.0.1:8080/api/v1/topology/status || echo unavailable)"


### PR DESCRIPTION
## Summary

The `nl6-provisioner` is a one-shot sidecar that **re-runs whenever `nl6-minion` is recreated** (`depends_on: service_completed_successfully`). On a re-run against an already-seeded nl6 it failed and, because the dependency never "completed successfully," **wedged `nl6-minion`'s start** (observed while deploying the DNS-RPC fix — recreating the Minion re-triggered the provisioner, which exited 1).

Two non-idempotent steps:
- **device import** — `fleet.sh` re-POSTs existing devices → non-2xx → `exit 1`
- **topology POST** — the nl6 topology API rejects duplicate links with HTTP 400 → `curl -f` → `exit 1`

## Fix — check-first-skip

nl6's device + topology state is in-memory and all-or-nothing per container lifecycle, so the command now queries current state and skips a step that's already satisfied:
- skip the device import if `GET /api/v1/devices` count already equals the expected count;
- skip the topology POST if `GET /api/v1/topology/status` `configured_links` ≥ `jq '.links|length' clos.json`.

It's the **inline compose command only** — no provisioner image rebuild (the image just bakes the seed files).

## Verification (live nl6 stack)

- **Re-run vs seeded nl6:** `36 devices already present — skipping import` + `topology already present (48 >= 48 links) — skipping POST`, **exit 0**.
- **Fresh nl6 (0 devices / 0 links):** imports 36 devices + POSTs 48 links (`48 configured / 48 active`), **exit 0**.

Follow-up (separate): `nl6-minion`'s `depends_on: nl6-provisioner (service_completed_successfully)` is still tight coupling; with the provisioner now idempotent it's no longer a hazard, but the dependency could be relaxed to `service_started` later.

https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX