### PR TITLE
fix(nl6): host tier uses dell_poweredge_r750 so sysObjectID collects

### DIFF
--- a/components/nl6/devices.json
+++ b/components/nl6/devices.json
@@ -81,7 +81,7 @@
     "start_ip": "10.0.0.61",
     "device_count": 16,
     "netmask": "24",
-    "resource_file": "linux_server.json",
+    "resource_file": "dell_poweredge_r750.json",
     "flow": {
       "collector": "10.254.0.1:4729",
       "protocol": "netflow9",

--- a/components/nl6/gen-fabric.py
+++ b/components/nl6/gen-fabric.py
@@ -63,7 +63,11 @@ RES = {
     "core": "cisco_crs_x.json",
     "agg": "arista_7280r3.json",
     "edge": "cisco_catalyst_9500.json",
-    "host": "linux_server.json",
+    # NOT linux_server.json: that nl6 resource file serves a degenerate system
+    # group (sysObjectID = 0.0/ccitt, no sysDescr — "OID not supported"), so
+    # provisiond stores NULL sysObjectID for every host. dell_poweredge_r750 is
+    # a real compute-leaf model with a valid sysObjectID (enterprises.674...).
+    "host": "dell_poweredge_r750.json",
 }
 
 # delta-v per-device export collectors — the veth host end where nl6-minion


### PR DESCRIPTION
## Summary

The Clos **host tier (16 nodes) mapped to `linux_server.json`** — the one nl6 resource file with a **degenerate SNMP system group**: `sysObjectID = 0.0` (ccitt) and `sysDescr = "OID not supported"`. provisiond correctly stores NULL for the bogus `0.0`, so all 16 host nodes had no sysObjectID (the "20/36" we saw). SNMP itself works (interfaces, LLDP all collect) — only the system-group identity is junk, and **only for this model**.

Swap the host tier to **`dell_poweredge_r750.json`** (a real compute-leaf model, `sysObjectID = enterprises.674.10892…`, proper `sysDescr`) in `gen-fabric.py` and regenerate.

## Why this is a clean, minimal change

Node-labels are role-based (`host-10.0.0.x`) and links are IP-based — both model-independent — so regenerating produces **byte-identical `clos.json` and `nl6-lab.xml`**; only `devices.json`'s host batch `resource_file` changes. Fabric size unchanged (36 devices / 48 links).

## Evidence

Tested every candidate model on a throwaway nl6 v0.11.2 — `linux_server` is the only broken one:

| model | sysObjectID |
|---|---|
| linux_server | `0.0` (ccitt), sysDescr "OID not supported" |
| dell_poweredge_r750 | `enterprises.674.10892.5.4.300.50` ✓ |
| hpe_proliant_dl380 / ibm_power_s922 / nvidia_dgx_h100 / netapp_ontap | all valid ✓ |

Verified end-to-end: rebuilt `nl6-provisioner`, reseeded a fresh nl6 — hosts `10.0.0.61`/`.76` now serve `sysObjectID enterprises.674.10892.5.4.300.50` + `"Dell Inc. PowerEdge R750"` (was `0.0`); topology `48/48` active; provisioner exit 0. With valid OIDs, provisiond now records sysObjectID for all 36 nodes.

## Notes
- `@indigo423` — this edits your `gen-fabric.py` (#381); flagged you as reviewer. Happy to use `hpe_proliant_dl380` instead if you prefer a different compute-leaf model.
- Separate follow-up: file an upstream nl6 issue that `linux_server.json` is missing `sysDescr`/`sysObjectID`.
- The enlinkd E2E's `SYSOID_FLOOR` (12) can be tightened to 36 once this lands; left as-is here to keep the PR scoped.

https://claude.ai/code/session_01NBzhzbdGaSePxMnqzzuqzX