### PR TITLE
chore(deploy): bump postgres 15 → 16

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ echo "RUNAS=$(id -u -n)" > "target/opennms-${ONMS_RELEASE}/etc/opennms.conf"
 ./target/opennms-"${ONMS_RELEASE}"/bin/opennms -vt start
 ```
 
-A quick PostgreSQL for dev: `docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres:13`
+A quick PostgreSQL for dev: `docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres:16`
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Minion → Kafka Sink → Trapd/Syslogd
 | flow-enricher | Spring Boot 4 + Spring Cloud Stream | Flow decode via horizon UDP parsers, per-flow enrichment, publish to ClickHouse |
 | minion | Spring Boot 4 | Distributed data collection agent (Kafka RPC + Sink + Twin API + UDP flow listener) |
 | db-init | Spring Boot 4 | One-shot Liquibase schema migration |
-| postgres | postgres:15 | PostgreSQL database (alarms only) |
+| postgres | postgres:16 | PostgreSQL database (alarms only) |
 | clickhouse | clickhouse/clickhouse-server | Flow storage: `deltav.flows_raw` + 4 dimension materialized views (application, source_ip, conversation, dscp) |
 | clickhouse-init | one-shot | ClickHouse DDL bootstrap for `deltav.flows_raw` and dimension MVs |
 | kafka | Apache Kafka | Event transport backbone |

--- a/core/alarms-materializer/src/test/java/org/deltav/alarms/materializer/AlarmsMaterializerIT.java
+++ b/core/alarms-materializer/src/test/java/org/deltav/alarms/materializer/AlarmsMaterializerIT.java
@@ -50,7 +50,7 @@ class AlarmsMaterializerIT {
             DockerImageName.parse("confluentinc/cp-kafka:7.4.0"));
 
     @Container
-    static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:15")
+    static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:16")
             .withDatabaseName("opennms")
             .withUsername("opennms")
             .withPassword("opennms")

--- a/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitIntegrationTest.java
+++ b/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitIntegrationTest.java
@@ -38,7 +38,7 @@ class DbInitIntegrationTest {
 
     @Container
     static PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15")
+            new PostgreSQLContainer<>("postgres:16")
                     .withDatabaseName("template1")
                     .withUsername("postgres")
                     .withPassword("postgres");

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -491,6 +491,8 @@ To log in as admin (e.g. to create custom dashboards):
 
 **Database connection errors:** Ensure postgres is healthy before other services start. The compose healthchecks handle this, but initial schema creation takes time.
 
+**postgres won't start after a 15 → 16 upgrade** (`FATAL: database files ... initialized by PostgreSQL 15, not compatible with version 16`): PG16 can't open a PG15 `pgdata` volume. The database is non-precious here (db-init rebuilds the schema via Liquibase; alarms are derivative), so drop the volume and let it reinitialize: `make reset` (or `docker compose down -v`), then `make up`.
+
 **Stale data after rebuild:** Run `make reset` to remove all volumes, then `make up PROFILE=full`.
 
 ## License

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -52,7 +52,7 @@ With all 12 daemons on Spring Boot, the Karaf-based Sentinel image (`deltav/daem
 
 | Service            | Image                         | Purpose                                                                  | Host Port |
 |--------------------|-------------------------------|--------------------------------------------------------------------------|-----------|
-| postgres           | postgres:15                   | Shared database (alarms only)                                            | 5432      |
+| postgres           | postgres:16                   | Shared database (alarms only)                                            | 5432      |
 | kafka              | apache/kafka                  | Event bus (KRaft mode)                                                   | 19092     |
 | db-init            | deltav/db-init               | One-shot PostgreSQL schema migration (exits after init)                  | —         |
 | clickhouse         | clickhouse/clickhouse-server  | Flow storage: `deltav.flows_raw` + 4 dimension MVs                       | 8123      |

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -40,7 +40,7 @@ services:
 
   postgres:
     <<: *no-search-domain
-    image: postgres:15
+    image: postgres:16
     command: ["-c", "max_connections=350"]
     environment:
       POSTGRES_DB: opennms


### PR DESCRIPTION
## What

Bump the deployment PostgreSQL image from `postgres:15` to `postgres:16` in `deploy/compose.yml` (and the `deploy/README.md` service table).

## Why

PostgreSQL **16 is the highest version the bundled OpenNMS schema migrator accepts**. `org.opennms.core.schema-1.0.18`'s `validateDatabaseVersion()` guard allows `>=10 && <17`, so PG 17/18 are rejected before any migration runs — this is independent of Liquibase or the JDBC driver.

## Verification (empirical)

Ran the real `db-init` (Liquibase 3.6.3 + the OpenNMS JDBC driver) against each version:

| Image | Result |
|---|---|
| `postgres:16.14` | ✅ all 392 Liquibase changesets ran, 114 tables created, "Database initialization complete" |
| `postgres:18.4` | ❌ `MigrationException: Unsupported database version "18.4" -- need >=10 and <17` (fails fast) |

15 → 16 is within the supported window and is a fresh-install image bump (no data migration). Reaching PG 17/18 would require bypassing the guard (`Migrator.setValidateDatabaseVersion(false)` in `core/db-init/DbInitRunner`) plus full re-verification — tracked separately, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)