### PR TITLE
fix(build): make standalone image builds self-contained with -pl … -am install (#367)

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -257,21 +257,29 @@ do_perspective_app_init_image() {
 do_flow_enricher_image() {
     log "Building flow-enricher image (${IMAGE_PREFIX}/flow-enricher:$VERSION)..."
     cd "$REPO_ROOT"
-    ./mvnw -B -f core/flow-enricher/pom.xml -DskipTests package
+    # Reactor mode (-pl … -am install), not single-pom `-f … package`: flow-enricher
+    # depends on the local reactor module org.deltav.core:node-context-consumer,
+    # which is never published to a registry. `-f … package` would try to resolve it
+    # from ~/.m2 and fail on a clean cache (no prior `make build`). `-am` builds it
+    # first; `install` stages it so the Spring Boot repackage resolves it. Mirrors
+    # do_minion_gateway_image. See issue #367.
+    ./mvnw -B -pl core/flow-enricher -am -DskipTests install
     build_image flow-enricher -f "$REPO_ROOT/core/flow-enricher/Dockerfile" "$REPO_ROOT/core/flow-enricher"
 }
 
 do_prometheus_writer_image() {
     log "Building prometheus-writer image (${IMAGE_PREFIX}/prometheus-writer:$VERSION)..."
     cd "$REPO_ROOT"
-    ./mvnw -B -f core/prometheus-writer/pom.xml -DskipTests package
+    # Reactor mode for the local node-context-consumer dep (see do_flow_enricher_image / #367).
+    ./mvnw -B -pl core/prometheus-writer -am -DskipTests install
     build_image prometheus-writer -f "$REPO_ROOT/core/prometheus-writer/Dockerfile" "$REPO_ROOT/core/prometheus-writer"
 }
 
 do_alerts_forwarder_image() {
     log "Building alerts-forwarder image (${IMAGE_PREFIX}/alerts-forwarder:$VERSION)..."
     cd "$REPO_ROOT"
-    ./mvnw -B -f core/alerts-forwarder/pom.xml -DskipTests package
+    # Reactor mode for the local node-context-consumer dep (see do_flow_enricher_image / #367).
+    ./mvnw -B -pl core/alerts-forwarder -am -DskipTests install
     build_image alerts-forwarder -f "$REPO_ROOT/core/alerts-forwarder/Dockerfile" "$REPO_ROOT/core/alerts-forwarder"
 }
 


### PR DESCRIPTION
## Summary

Fixes #367 — `make images` (`build.sh deltav`) aborted at the `flow-enricher`
image on a clean `~/.m2` (no prior `make build`), before the auxiliary images
that follow it.

**Root cause (build ordering, not a registry gap):** `flow-enricher`,
`prometheus-writer`, and `alerts-forwarder` each depend on the local reactor
module `org.deltav.core:node-context-consumer`, which is intentionally never
published to a registry. Their image builds used single-pom
`./mvnw -B -f core/<module>/pom.xml -DskipTests package`, which resolves that
dependency from `~/.m2`/a registry rather than building it — so on a clean cache
it fails with `Could not find artifact …:node-context-consumer`. `minion-gateway`
was unaffected because it already uses reactor mode.

**Fix:** switch all three to reactor mode
`./mvnw -B -pl core/<module> -am -DskipTests install` (mirroring
`do_minion_gateway_image`). `-am` builds `node-context-consumer` first; `install`
stages it so the Spring Boot repackage resolves it. `make images` is now
self-contained.

## Verification

- `bash -n tools/build.sh` — syntax OK.
- `./mvnw -pl core/flow-enricher -am validate` reactor build order now lists
  `org.deltav.core:node-context-consumer` **ahead of** the standalone module
  (BUILD SUCCESS). Same dependency confirmed for all three modules.

## Note (out of scope, follow-up)

The issue also mentions these image builds need a `~/.m2/settings.xml` `<server>`
for the `github-deltav-ipc-contract` repo — worth a `make doctor` check. Left for
a separate change.

https://claude.ai/code/session_01XgRQL9QZcghyiLFXM9ZUnW
