### PR TITLE
fix(db-init): allow PostgreSQL 17.x via OPENNMS_DBINIT_SKIP_VERSION_CHECK (#243)

### DIFF
--- a/core/db-init/src/main/java/org/deltav/core/dbinit/DbInitProperties.java
+++ b/core/db-init/src/main/java/org/deltav/core/dbinit/DbInitProperties.java
@@ -31,5 +31,10 @@ public record DbInitProperties(
     boolean iplike,
     boolean timescaleDb,
     boolean vacuum,
-    boolean fullVacuum
+    boolean fullVacuum,
+    // When true, skip the schema migrator's database-version check (the "-Q" escape
+    // hatch). Lets deployments opt into PostgreSQL versions above the migrator's
+    // hardcoded ceiling — e.g. PostgreSQL 17, the CloudNativePG 1.29 default — once
+    // they've accepted the compatibility risk. Bound from OPENNMS_DBINIT_SKIP_VERSION_CHECK.
+    boolean skipVersionCheck
 ) {}

--- a/core/db-init/src/main/java/org/deltav/core/dbinit/DbInitRunner.java
+++ b/core/db-init/src/main/java/org/deltav/core/dbinit/DbInitRunner.java
@@ -51,6 +51,24 @@ public class DbInitRunner implements CommandLineRunner {
         LOG.info("Starting database initialization...");
 
         var migrator = new Migrator();
+        configureMigrator(migrator);
+
+        migrator.setupDatabase(
+            true,
+            properties.vacuum(),
+            properties.fullVacuum(),
+            properties.iplike(),
+            properties.timescaleDb()
+        );
+
+        LOG.info("Database initialization complete.");
+    }
+
+    /**
+     * Configures the migrator from the bound properties. Package-private so the
+     * version-check wiring can be unit-tested without a database.
+     */
+    void configureMigrator(Migrator migrator) {
         migrator.setAdminDataSource(adminDataSource);
         migrator.setDataSource(dataSource);
         migrator.setApplicationContext(context);
@@ -62,14 +80,11 @@ public class DbInitRunner implements CommandLineRunner {
         migrator.setCreateUser(properties.createUser());
         migrator.setCreateDatabase(properties.createDatabase());
 
-        migrator.setupDatabase(
-            true,
-            properties.vacuum(),
-            properties.fullVacuum(),
-            properties.iplike(),
-            properties.timescaleDb()
-        );
-
-        LOG.info("Database initialization complete.");
+        if (properties.skipVersionCheck()) {
+            LOG.warn("OPENNMS_DBINIT_SKIP_VERSION_CHECK=true: skipping the schema migrator's "
+                + "database-version check. The target PostgreSQL version will NOT be validated "
+                + "against the migrator's supported range (e.g. this allows PostgreSQL 17.x).");
+            migrator.setValidateDatabaseVersion(false);
+        }
     }
 }

--- a/core/db-init/src/main/resources/application.yml
+++ b/core/db-init/src/main/resources/application.yml
@@ -17,6 +17,11 @@ opennms:
     timescale-db: false
     vacuum: false
     full-vacuum: false
+    # Skip the schema migrator's database-version check (the "-Q" escape hatch).
+    # Set OPENNMS_DBINIT_SKIP_VERSION_CHECK=true to run against a PostgreSQL version
+    # above the migrator's hardcoded ceiling — e.g. PostgreSQL 17, the CloudNativePG
+    # 1.29 default. Off by default; the version is validated as normal.
+    skip-version-check: false
 
 logging:
   level:

--- a/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitPostgres17IntegrationTest.java
+++ b/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitPostgres17IntegrationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.core.dbinit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.ResultSet;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies issue #243: db-init must initialize a schema on PostgreSQL 17.x — the
+ * CloudNativePG 1.29 default — which the schema migrator otherwise rejects with its
+ * hardcoded {@code < 17.0} version ceiling. With {@code skip-version-check=true}
+ * (OPENNMS_DBINIT_SKIP_VERSION_CHECK) the ceiling is bypassed and migration succeeds.
+ *
+ * <p>Without the flag this same container would fail context startup with
+ * {@code MigrationException: Unsupported database version "17.x"} — which is exactly
+ * the production failure #243 reports.
+ */
+@SpringBootTest
+@Testcontainers
+class DbInitPostgres17IntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:17")
+                    .withDatabaseName("template1")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("opennms.dbinit.admin-url", postgres::getJdbcUrl);
+        registry.add("opennms.dbinit.admin-user", postgres::getUsername);
+        registry.add("opennms.dbinit.admin-password", postgres::getPassword);
+        registry.add("opennms.dbinit.database-name", () -> "opennms");
+        registry.add("opennms.dbinit.database-user", () -> "opennms");
+        registry.add("opennms.dbinit.database-password", () -> "opennms");
+        // The fix under test: opt past the migrator's PostgreSQL-version ceiling.
+        registry.add("opennms.dbinit.skip-version-check", () -> "true");
+    }
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void migrationSucceedsOnPostgres17() throws Exception {
+        // Reaching this test at all means DbInitRunner completed setupDatabase against
+        // PostgreSQL 17 during context startup (it would have thrown otherwise).
+        try (var conn = dataSource.getConnection();
+             ResultSet rs = conn.getMetaData().getTables(null, "public", "alarms", null)) {
+            assertThat(rs.next())
+                    .as("alarms table should exist after migration on PostgreSQL 17")
+                    .isTrue();
+        }
+    }
+}

--- a/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitRunnerTest.java
+++ b/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitRunnerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 BeaconStrategists, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.deltav.core.dbinit;
+
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+import org.opennms.core.schema.Migrator;
+import org.springframework.context.ApplicationContext;
+
+class DbInitRunnerTest {
+
+    private static DbInitRunner runnerWith(boolean skipVersionCheck) {
+        DbInitProperties props = new DbInitProperties(
+            "opennms", "opennms", "opennms",                 // databaseName, databaseUser, databasePassword
+            "postgres", "postgres",                          // adminUser, adminPassword
+            "jdbc:postgresql://localhost:5432/template1",    // adminUrl
+            false, false,                                    // createUser, createDatabase
+            false, false, false, false,                      // iplike, timescaleDb, vacuum, fullVacuum
+            skipVersionCheck);
+        return new DbInitRunner(mock(DataSource.class), mock(DataSource.class),
+            mock(ApplicationContext.class), props);
+    }
+
+    @Test
+    void skipVersionCheckTrue_disablesMigratorVersionValidation() {
+        Migrator migrator = mock(Migrator.class);
+
+        runnerWith(true).configureMigrator(migrator);
+
+        // The "-Q" escape hatch: skip the migrator's hardcoded version ceiling so
+        // PostgreSQL 17.x (CNPG 1.29 default) is not rejected (issue #243).
+        verify(migrator).setValidateDatabaseVersion(false);
+    }
+
+    @Test
+    void skipVersionCheckFalse_leavesMigratorVersionValidationEnabled() {
+        Migrator migrator = mock(Migrator.class);
+
+        runnerWith(false).configureMigrator(migrator);
+
+        // Default: the migrator keeps its built-in version validation.
+        verify(migrator, never()).setValidateDatabaseVersion(anyBoolean());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #243 — db-init rejects PostgreSQL 17.x (CloudNativePG 1.29 default) with the
schema migrator's hardcoded `< 17.0` version ceiling:

```
MigrationException: Unsupported database version "17.200001" --
  you need at least 10.000000 and less than 17.000000.
```

The Job exits non-zero → `BackoffLimitExceeded` → cluster rollout stalls (every
daemon depends on db-init). The operator currently pins CNPG to PG 16 as a
workaround.

## Fix (issue option C — delta-v only, no horizon change)

Surfaces the migrator's existing `-Q` escape hatch as declarative config. New
`opennms.dbinit.skip-version-check` property (env **`OPENNMS_DBINIT_SKIP_VERSION_CHECK`**);
when true, `DbInitRunner` calls `Migrator.setValidateDatabaseVersion(false)` so the
version check is bypassed. **Off by default** — the version is validated exactly as
before. Documented in `application.yml`.

Lifting/validating the ceiling itself (option A) stays a separate future option; this
unblocks PG17 now for deployments that accept the (well-understood, low) risk.

## Verification

- **Unit** (`DbInitRunnerTest`, TDD red→green): `skip-version-check=true` disables
  the migrator's version validation; default leaves it enabled.
- **Integration** (`DbInitPostgres17IntegrationTest`): the full Liquibase migration
  **succeeds against a real `postgres:17` Testcontainer** with the flag set, and the
  log shows `OPENNMS_DBINIT_SKIP_VERSION_CHECK=true: skipping the schema migrator's
  database-version check`. The same container fails context startup without the flag.
- Full `core/db-init` suite: **7 passed** (4 existing PG15 + 1 PG17 + 2 unit).

## Note

The operator (`cloudnative-dv`) can now set `OPENNMS_DBINIT_SKIP_VERSION_CHECK=true`
and bump its default CNPG image back to PG 17.

https://claude.ai/code/session_01XgRQL9QZcghyiLFXM9ZUnW
