### PR TITLE
fix(e2e): restore provisiond-configuration.xml after tests overwrite it (#201)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,11 @@ auth.json
 deploy/overlays/provisiond/etc/imports/*
 !deploy/overlays/provisiond/etc/imports/.gitkeep
 
+# E2E backup files: test-collectd-e2e.sh / test-passive-e2e.sh back up the canonical
+# provisiond-configuration.xml before overwriting it and restore it on EXIT (#201).
+# A *.e2e-backup only lingers after an abnormal exit and must never be committed.
+*.e2e-backup
+
 # Flat poller service catalog — the single source of truth is committed at
 # overlays/shared/poller-services.yaml; build.sh stages a copy into each
 # consuming daemon's overlay at image-build time. Those copies are generated,

--- a/deploy/test-collectd-e2e.sh
+++ b/deploy/test-collectd-e2e.sh
@@ -66,6 +66,13 @@ fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
 err()  { echo "ERROR: $*" >&2; exit 2; }
 
 cleanup() {
+    # Restore the canonical provisiond-configuration.xml if this run overwrote it
+    # (#201): it is a git-tracked file shipping the full requisition set, so leaving
+    # it mutated drifts the working tree and wipes the other requisitions for later runs.
+    if [ -f overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup ]; then
+        mv -f overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup \
+              overlays/provisiond/etc/provisiond-configuration.xml
+    fi
     if $POST_CLEANUP; then
         log "Post-run cleanup (--post-cleanup): removing test data..."
         clean_all_nodes
@@ -215,6 +222,13 @@ REQEOF
 
         # Add requisition-def so Provisiond auto-imports on startup
         mkdir -p overlays/provisiond/etc
+        # Back up the canonical config so cleanup() can restore it (#201). Skip if a
+        # backup already exists (a prior run exited abnormally) so we keep the true
+        # original rather than a backup of the already-overwritten file.
+        [ -f overlays/provisiond/etc/provisiond-configuration.xml ] \
+            && [ ! -f overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup ] \
+            && cp overlays/provisiond/etc/provisiond-configuration.xml \
+                  overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup
         cat > overlays/provisiond/etc/provisiond-configuration.xml <<PROVEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"

--- a/deploy/test-passive-e2e.sh
+++ b/deploy/test-passive-e2e.sh
@@ -58,6 +58,13 @@ fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
 err()  { echo "ERROR: $*" >&2; exit 2; }
 
 cleanup() {
+    # Restore the canonical provisiond-configuration.xml if this run overwrote it
+    # (#201): it is a git-tracked file shipping the full requisition set, so leaving
+    # it mutated drifts the working tree and wipes the other requisitions for later runs.
+    if [ -f overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup ]; then
+        mv -f overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup \
+              overlays/provisiond/etc/provisiond-configuration.xml
+    fi
     [ -n "$FAULT_CONSUMER_PID" ] && kill "$FAULT_CONSUMER_PID" 2>/dev/null || true
     [ -n "$IPC_CONSUMER_PID" ] && kill "$IPC_CONSUMER_PID" 2>/dev/null || true
 
@@ -294,6 +301,13 @@ REQEOF
     cp "$TEST_TMPDIR/cloud-services-req.xml" "overlays/provisiond/etc/imports/${FOREIGN_SOURCE}.xml"
 
     # Add a requisition-def so Provisiond auto-imports the requisition on startup
+    # Back up the canonical config so cleanup() can restore it (#201). Skip if a
+    # backup already exists (a prior run exited abnormally) so we keep the true
+    # original rather than a backup of the already-overwritten file.
+    [ -f overlays/provisiond/etc/provisiond-configuration.xml ] \
+        && [ ! -f overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup ] \
+        && cp overlays/provisiond/etc/provisiond-configuration.xml \
+              overlays/provisiond/etc/provisiond-configuration.xml.e2e-backup
     cat > overlays/provisiond/etc/provisiond-configuration.xml <<PROVEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <provisiond-configuration xmlns="http://xmlns.opennms.org/xsd/config/provisiond-configuration"


### PR DESCRIPTION
## Summary

Fixes #201 — `test-collectd-e2e.sh` and `test-passive-e2e.sh` overwrite the
**git-tracked** canonical `overlays/provisiond/etc/provisiond-configuration.xml`
(via `cat >`) with a throwaway single-requisition config, and never restore it.
That (a) leaves the working tree dirty and (b) silently wipes the other shipped
requisitions, so a later run on the same checkout imports a truncated set and fails
with no obvious signal — exactly the v1.1.1 "regression" that turned out to be this
harness bug.

## Fix

Back up the file immediately before the overwrite and restore it from each test's
`EXIT`-trap `cleanup()`:

- Backup is skipped if one already exists, so a re-run after an abnormal exit keeps
  the **true** original (not a backup of the already-overwritten file).
- `*.e2e-backup` is gitignored so a lingering backup (only possible after a `kill -9`)
  can't be accidentally committed.

Kept deliberately simple (backup/restore) rather than the docker-cp round-trip in
`test-pollerd-restart-outage-e2e.sh`; both leave the canonical config intact.

## Verification

- `bash -n` on both scripts.
- A `backup → cat-overwrite → restore` round-trip restores the file byte-for-byte
  and removes the backup (confirmed via md5 round-trip).

https://claude.ai/code/session_01XgRQL9QZcghyiLFXM9ZUnW
