### PR TITLE
chore(db): rename database identity opennms → deltav (#388)

### DIFF
--- a/core/alarms-materializer/src/main/resources/application.yml
+++ b/core/alarms-materializer/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
   kafka:
     bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
 
 deltav:

--- a/core/alarms-materializer/src/test/java/org/deltav/alarms/materializer/AlarmsMaterializerIT.java
+++ b/core/alarms-materializer/src/test/java/org/deltav/alarms/materializer/AlarmsMaterializerIT.java
@@ -51,9 +51,9 @@ class AlarmsMaterializerIT {
 
     @Container
     static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:15")
-            .withDatabaseName("opennms")
-            .withUsername("opennms")
-            .withPassword("opennms")
+            .withDatabaseName("deltav")
+            .withUsername("deltav")
+            .withPassword("deltav")
             .withInitScript("schema/alarms.sql");
 
     @DynamicPropertySource

--- a/core/daemon-boot-alarmd/src/main/resources/application.yml
+++ b/core/daemon-boot-alarmd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10

--- a/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/AlarmdApplicationIT.java
+++ b/core/daemon-boot-alarmd/src/test/java/org/deltav/netmgt/alarmd/boot/AlarmdApplicationIT.java
@@ -57,9 +57,9 @@ class AlarmdApplicationIT {
 
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
-            .withDatabaseName("opennms")
-            .withUsername("opennms")
-            .withPassword("opennms")
+            .withDatabaseName("deltav")
+            .withUsername("deltav")
+            .withPassword("deltav")
             .withInitScript("schema.sql");
 
     @DynamicPropertySource

--- a/core/daemon-boot-bsmd/src/main/resources/application.yml
+++ b/core/daemon-boot-bsmd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10

--- a/core/daemon-boot-bsmd/src/test/java/org/deltav/netmgt/bsm/boot/BsmdApplicationIT.java
+++ b/core/daemon-boot-bsmd/src/test/java/org/deltav/netmgt/bsm/boot/BsmdApplicationIT.java
@@ -54,9 +54,9 @@ class BsmdApplicationIT {
 
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
-            .withDatabaseName("opennms")
-            .withUsername("opennms")
-            .withPassword("opennms")
+            .withDatabaseName("deltav")
+            .withUsername("deltav")
+            .withPassword("deltav")
             .withInitScript("schema.sql");
 
     @DynamicPropertySource

--- a/core/daemon-boot-bsmd/src/test/java/org/deltav/netmgt/bsm/rest/BsmdRestControllerIT.java
+++ b/core/daemon-boot-bsmd/src/test/java/org/deltav/netmgt/bsm/rest/BsmdRestControllerIT.java
@@ -75,9 +75,9 @@ class BsmdRestControllerIT {
 
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
-            .withDatabaseName("opennms")
-            .withUsername("opennms")
-            .withPassword("opennms")
+            .withDatabaseName("deltav")
+            .withUsername("deltav")
+            .withPassword("deltav")
             .withInitScript("schema.sql");
 
     @DynamicPropertySource

--- a/core/daemon-boot-collectd/src/main/resources/application.yml
+++ b/core/daemon-boot-collectd/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   application:
     name: collectd
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     hikari:
       maximum-pool-size: 10
       minimum-idle: 2

--- a/core/daemon-boot-discovery/src/main/resources/application.yml
+++ b/core/daemon-boot-discovery/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 5

--- a/core/daemon-boot-enlinkd/src/main/resources/application.yml
+++ b/core/daemon-boot-enlinkd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     hikari:
       maximum-pool-size: 10
       minimum-idle: 2

--- a/core/daemon-boot-enlinkd/src/test/java/org/deltav/netmgt/enlinkd/persistence/TopologyEntityDaoJpaIT.java
+++ b/core/daemon-boot-enlinkd/src/test/java/org/deltav/netmgt/enlinkd/persistence/TopologyEntityDaoJpaIT.java
@@ -103,9 +103,9 @@ class TopologyEntityDaoJpaIT {
 
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16")
-            .withDatabaseName("opennms")
-            .withUsername("opennms")
-            .withPassword("opennms");
+            .withDatabaseName("deltav")
+            .withUsername("deltav")
+            .withPassword("deltav");
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {

--- a/core/daemon-boot-eventtranslator/src/main/resources/application.yml
+++ b/core/daemon-boot-eventtranslator/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 5

--- a/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-perspectivepollerd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     hikari:
       maximum-pool-size: 10
       minimum-idle: 2

--- a/core/daemon-boot-pollerd/src/main/resources/application.yml
+++ b/core/daemon-boot-pollerd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     hikari:
       maximum-pool-size: 10
       minimum-idle: 2

--- a/core/daemon-boot-provisiond/src/main/resources/application.yml
+++ b/core/daemon-boot-provisiond/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10

--- a/core/daemon-boot-syslogd/src/main/resources/application.yml
+++ b/core/daemon-boot-syslogd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 5

--- a/core/daemon-boot-telemetryd/src/main/resources/application.yml
+++ b/core/daemon-boot-telemetryd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     hikari:
       maximum-pool-size: 5
       minimum-idle: 1

--- a/core/daemon-boot-trapd/src/main/resources/application.yml
+++ b/core/daemon-boot-trapd/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 5

--- a/core/db-init/src/main/resources/application.yml
+++ b/core/db-init/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
 
 opennms:
   dbinit:
-    database-name: opennms
-    database-user: opennms
-    database-password: opennms
+    database-name: deltav
+    database-user: deltav
+    database-password: deltav
     admin-user: postgres
     admin-password: ""
     admin-url: jdbc:postgresql://localhost:5432/template1

--- a/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitIntegrationTest.java
+++ b/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitIntegrationTest.java
@@ -48,9 +48,9 @@ class DbInitIntegrationTest {
         registry.add("opennms.dbinit.admin-url", postgres::getJdbcUrl);
         registry.add("opennms.dbinit.admin-user", postgres::getUsername);
         registry.add("opennms.dbinit.admin-password", postgres::getPassword);
-        registry.add("opennms.dbinit.database-name", () -> "opennms");
-        registry.add("opennms.dbinit.database-user", () -> "opennms");
-        registry.add("opennms.dbinit.database-password", () -> "opennms");
+        registry.add("opennms.dbinit.database-name", () -> "deltav");
+        registry.add("opennms.dbinit.database-user", () -> "deltav");
+        registry.add("opennms.dbinit.database-password", () -> "deltav");
     }
 
     @Autowired

--- a/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitPostgres17IntegrationTest.java
+++ b/core/db-init/src/test/java/org/deltav/core/dbinit/DbInitPostgres17IntegrationTest.java
@@ -57,9 +57,9 @@ class DbInitPostgres17IntegrationTest {
         registry.add("opennms.dbinit.admin-url", postgres::getJdbcUrl);
         registry.add("opennms.dbinit.admin-user", postgres::getUsername);
         registry.add("opennms.dbinit.admin-password", postgres::getPassword);
-        registry.add("opennms.dbinit.database-name", () -> "opennms");
-        registry.add("opennms.dbinit.database-user", () -> "opennms");
-        registry.add("opennms.dbinit.database-password", () -> "opennms");
+        registry.add("opennms.dbinit.database-name", () -> "deltav");
+        registry.add("opennms.dbinit.database-user", () -> "deltav");
+        registry.add("opennms.dbinit.database-password", () -> "deltav");
         // The fix under test: opt past the migrator's PostgreSQL-version ceiling.
         registry.add("opennms.dbinit.skip-version-check", () -> "true");
     }

--- a/core/flow-enricher/src/main/resources/application.yml
+++ b/core/flow-enricher/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}  # bootstrap consumer needs this; binder brokers alone do NOT satisfy a plain spring.kafka property — #170 lesson
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opennms}
-    username: ${SPRING_DATASOURCE_USERNAME:opennms}
-    password: ${SPRING_DATASOURCE_PASSWORD:opennms}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/deltav}
+    username: ${SPRING_DATASOURCE_USERNAME:deltav}
+    password: ${SPRING_DATASOURCE_PASSWORD:deltav}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 10

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -43,9 +43,9 @@ services:
     image: postgres:15
     command: ["-c", "max_connections=350"]
     environment:
-      POSTGRES_DB: opennms
-      POSTGRES_USER: opennms
-      POSTGRES_PASSWORD: opennms
+      POSTGRES_DB: deltav
+      POSTGRES_USER: deltav
+      POSTGRES_PASSWORD: deltav
       POSTGRES_HOST_AUTH_METHOD: md5
       POSTGRES_INITDB_ARGS: --auth=md5
     volumes:
@@ -53,7 +53,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U opennms -d opennms"]
+      test: ["CMD-SHELL", "pg_isready -U deltav -d deltav"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -101,11 +101,11 @@ services:
         condition: service_healthy
     environment:
       OPENNMS_DBINIT_ADMIN_URL: jdbc:postgresql://postgres:5432/template1
-      OPENNMS_DBINIT_ADMIN_USER: opennms
-      OPENNMS_DBINIT_ADMIN_PASSWORD: opennms
-      OPENNMS_DBINIT_DATABASE_NAME: opennms
-      OPENNMS_DBINIT_DATABASE_USER: opennms
-      OPENNMS_DBINIT_DATABASE_PASSWORD: opennms
+      OPENNMS_DBINIT_ADMIN_USER: deltav
+      OPENNMS_DBINIT_ADMIN_PASSWORD: deltav
+      OPENNMS_DBINIT_DATABASE_NAME: deltav
+      OPENNMS_DBINIT_DATABASE_USER: deltav
+      OPENNMS_DBINIT_DATABASE_PASSWORD: deltav
       OPENNMS_DBINIT_CREATE_USER: "false"
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m
 
@@ -438,9 +438,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=256m -Dorg.opennms.core.ipc.twin.kafka.bootstrap.servers=kafka:9092 -Dorg.opennms.core.ipc.rpc.force-remote=true"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-pollerd
       OPENNMS_HOME: /opt/deltav
@@ -474,9 +474,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms512m -Xmx1g -Dorg.opennms.tsid.node-id=5"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
       # Vestigial — selects the strategy for horizon's stock TimeseriesPersister
@@ -510,9 +510,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
       INTERFACE_NODE_CACHE_REFRESH_MS: "15000"
@@ -541,9 +541,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-trapd
       KAFKA_SINK_CONSUMER_GROUP: opennms-trapd-sink
@@ -571,9 +571,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-syslogd
       KAFKA_SINK_CONSUMER_GROUP: opennms-syslogd-sink
@@ -601,9 +601,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-eventtranslator
       OPENNMS_HOME: /opt/deltav
@@ -624,9 +624,9 @@ services:
     hostname: enlinkd
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -Dopennms.home=/opt/deltav"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: enlinkd
       OPENNMS_HOME: /opt/deltav
@@ -755,9 +755,9 @@ services:
       - "mhuot-lab-6:172.20.20.6"
     environment:
       JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=256m"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENNMS_HOME: /opt/deltav
       OPENNMS_INSTANCE_ID: DeltaV
@@ -802,9 +802,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -Dorg.opennms.alarms.snapshot.sync.ms=10000"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-bsmd
       OPENNMS_HOME: /opt/deltav
@@ -863,9 +863,9 @@ services:
         condition: service_completed_successfully
     environment:
       JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=256m -Dorg.opennms.core.ipc.rpc.force-remote=true"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-perspectivepollerd
       OPENNMS_HOME: /opt/deltav
@@ -897,9 +897,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms512m -Xmx1g -XX:MaxMetaspaceSize=256m"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-alarmd
       OPENNMS_HOME: /opt/deltav
@@ -925,9 +925,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -Dorg.opennms.core.ipc.sink.kafka.bootstrap.servers=kafka:9092 -Dorg.opennms.core.ipc.sink.kafka.group.id=opennms-telemetryd-sink -Dorg.opennms.core.ipc.twin.kafka.bootstrap.servers=kafka:9092"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       KAFKA_CONSUMER_GROUP: opennms-telemetryd
       OPENNMS_HOME: /opt/deltav
@@ -999,9 +999,9 @@ services:
         condition: service_healthy
     environment:
       JAVA_OPTS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m"
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       DELTAV_FLOWS_SINK_TOPICS: "DeltaV.Sink.Telemetry-Netflow-5,DeltaV.Sink.Telemetry-Netflow-9,DeltaV.Sink.Telemetry-IPFIX,DeltaV.Sink.Telemetry-SFlow"
       DELTAV_FLOWS_OUTPUT_TOPIC: deltav-flows
@@ -1111,9 +1111,9 @@ services:
         condition: service_healthy
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/opennms
-      SPRING_DATASOURCE_USERNAME: opennms
-      SPRING_DATASOURCE_PASSWORD: opennms
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/deltav
+      SPRING_DATASOURCE_USERNAME: deltav
+      SPRING_DATASOURCE_PASSWORD: deltav
       DELTAV_ALARMS_STATE_TOPIC: deltav-alarms-state-change
     restart: unless-stopped
     healthcheck:

--- a/deploy/overlays/bsmd/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/deploy/overlays/bsmd/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,9 +1,9 @@
 # Distributed datasource configuration for Delta-V bsmd
 # Light daemon — minimal DB access
-datasource.url=jdbc:postgresql://postgres:5432/opennms
-datasource.username=opennms
-datasource.password=opennms
-datasource.databaseName=opennms
+datasource.url=jdbc:postgresql://postgres:5432/deltav
+datasource.username=deltav
+datasource.password=deltav
+datasource.databaseName=deltav
 connection.pool.minPool=3
 connection.pool.maxPool=10
 connection.pool.maxSize=10

--- a/deploy/overlays/collectd/etc/collectd-configuration.xml
+++ b/deploy/overlays/collectd/etc/collectd-configuration.xml
@@ -146,7 +146,7 @@
          <parameter key="driver" value="${requisition:driver|detector:driver|org.postgresql.Driver}" />
          <parameter key="user" value="${requisition:pg-user|postgres}" />
          <parameter key="password" value="${requisition:pg-pass|postgres}" />
-         <parameter key="url" value="${requisition:url|detector:url|'jdbc:postgresql://OPENNMS_JDBC_HOSTNAME:5432/opennms'}" />
+         <parameter key="url" value="${requisition:url|detector:url|'jdbc:postgresql://OPENNMS_JDBC_HOSTNAME:5432/deltav'}" />
       </service>
       <service name="Elasticsearch" interval="300000" user-defined="false" status="on">
          <parameter key="collection" value="${requisition:collection|detector:collection|xml-elasticsearch-cluster-stats}" />

--- a/deploy/overlays/collectd/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/deploy/overlays/collectd/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,9 +1,9 @@
 # Distributed datasource configuration for Delta-V collectd-daemon
 # Medium daemon — active polling/collection/scanning workload
-datasource.url=jdbc:postgresql://postgres:5432/opennms
-datasource.username=opennms
-datasource.password=opennms
-datasource.databaseName=opennms
+datasource.url=jdbc:postgresql://postgres:5432/deltav
+datasource.username=deltav
+datasource.password=deltav
+datasource.databaseName=deltav
 connection.pool.minPool=5
 connection.pool.maxPool=25
 connection.pool.maxSize=25

--- a/deploy/overlays/discovery/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/deploy/overlays/discovery/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,9 +1,9 @@
 # Distributed datasource configuration for Delta-V discovery
 # Medium daemon — active polling/collection/scanning workload
-datasource.url=jdbc:postgresql://postgres:5432/opennms
-datasource.username=opennms
-datasource.password=opennms
-datasource.databaseName=opennms
+datasource.url=jdbc:postgresql://postgres:5432/deltav
+datasource.username=deltav
+datasource.password=deltav
+datasource.databaseName=deltav
 connection.pool.minPool=5
 connection.pool.maxPool=25
 connection.pool.maxSize=25

--- a/deploy/overlays/enlinkd/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/deploy/overlays/enlinkd/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,9 +1,9 @@
 # Distributed datasource configuration for Delta-V enlinkd
 # Medium daemon — active polling/collection/scanning workload
-datasource.url=jdbc:postgresql://postgres:5432/opennms
-datasource.username=opennms
-datasource.password=opennms
-datasource.databaseName=opennms
+datasource.url=jdbc:postgresql://postgres:5432/deltav
+datasource.username=deltav
+datasource.password=deltav
+datasource.databaseName=deltav
 connection.pool.minPool=5
 connection.pool.maxPool=25
 connection.pool.maxSize=25

--- a/deploy/overlays/provisiond/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/deploy/overlays/provisiond/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,9 +1,9 @@
 # Distributed datasource configuration for Delta-V provisiond
 # Medium daemon — active polling/collection/scanning workload
-datasource.url=jdbc:postgresql://postgres:5432/opennms
-datasource.username=opennms
-datasource.password=opennms
-datasource.databaseName=opennms
+datasource.url=jdbc:postgresql://postgres:5432/deltav
+datasource.username=deltav
+datasource.password=deltav
+datasource.databaseName=deltav
 connection.pool.minPool=5
 connection.pool.maxPool=25
 connection.pool.maxSize=25

--- a/deploy/overlays/syslogd/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/deploy/overlays/syslogd/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,9 +1,9 @@
 # Distributed datasource configuration for Delta-V syslogd
 # Light daemon — minimal DB access
-datasource.url=jdbc:postgresql://postgres:5432/opennms
-datasource.username=opennms
-datasource.password=opennms
-datasource.databaseName=opennms
+datasource.url=jdbc:postgresql://postgres:5432/deltav
+datasource.username=deltav
+datasource.password=deltav
+datasource.databaseName=deltav
 connection.pool.minPool=3
 connection.pool.maxPool=10
 connection.pool.maxSize=10

--- a/deploy/overlays/trapd/etc/org.opennms.netmgt.distributed.datasource.cfg
+++ b/deploy/overlays/trapd/etc/org.opennms.netmgt.distributed.datasource.cfg
@@ -1,9 +1,9 @@
 # Distributed datasource configuration for Delta-V trapd
 # Light daemon — minimal DB access
-datasource.url=jdbc:postgresql://postgres:5432/opennms
-datasource.username=opennms
-datasource.password=opennms
-datasource.databaseName=opennms
+datasource.url=jdbc:postgresql://postgres:5432/deltav
+datasource.username=deltav
+datasource.password=deltav
+datasource.databaseName=deltav
 connection.pool.minPool=3
 connection.pool.maxPool=10
 connection.pool.maxSize=10

--- a/deploy/test-alerts-forwarder-e2e.sh
+++ b/deploy/test-alerts-forwarder-e2e.sh
@@ -126,8 +126,8 @@ cleanup() {
 trap cleanup EXIT
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 wait_for_db() {

--- a/deploy/test-collectd-e2e.sh
+++ b/deploy/test-collectd-e2e.sh
@@ -82,8 +82,8 @@ cleanup() {
 trap cleanup EXIT
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 wait_for_db() {

--- a/deploy/test-e2e.sh
+++ b/deploy/test-e2e.sh
@@ -94,8 +94,8 @@ cleanup() {
 
     if $POST_CLEANUP; then
         log "Post-run cleanup (--post-cleanup): removing test data..."
-        docker compose exec -T -e PGPASSWORD=opennms postgres \
-            psql -U opennms -d opennms -q \
+        docker compose exec -T -e PGPASSWORD=deltav postgres \
+            psql -U deltav -d deltav -q \
             -c "DELETE FROM alarms WHERE eventuei LIKE '%translator/traps/SNMP_Link%'" \
             2>/dev/null || true
     fi
@@ -126,8 +126,8 @@ wait_for_kafka_event() {
 }
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 # ── Pre-run cleanup (--pre-clean) ─────────────────────────────────

--- a/deploy/test-enlinkd-e2e.sh
+++ b/deploy/test-enlinkd-e2e.sh
@@ -137,8 +137,8 @@ cleanup() {
 trap cleanup EXIT
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 wait_for_db() {

--- a/deploy/test-minion-e2e.sh
+++ b/deploy/test-minion-e2e.sh
@@ -107,8 +107,8 @@ cleanup() {
 
     if $POST_CLEANUP; then
         log "Post-run cleanup (--post-cleanup): removing test data..."
-        docker compose exec -T -e PGPASSWORD=opennms postgres \
-            psql -U opennms -d opennms -q \
+        docker compose exec -T -e PGPASSWORD=deltav postgres \
+            psql -U deltav -d deltav -q \
             -c "DELETE FROM alarms WHERE eventuei LIKE '%translator/traps/SNMP_Link%'" \
             2>/dev/null || true
     fi
@@ -137,8 +137,8 @@ wait_for_kafka_event() {
 }
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 # ── Pre-run cleanup (--pre-clean) ─────────────────────────────────

--- a/deploy/test-minion-rpc-e2e.sh
+++ b/deploy/test-minion-rpc-e2e.sh
@@ -84,8 +84,8 @@ cleanup() {
 trap cleanup EXIT
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 wait_for_db() {

--- a/deploy/test-passive-e2e.sh
+++ b/deploy/test-passive-e2e.sh
@@ -115,8 +115,8 @@ wait_for_kafka_event() {
 }
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 wait_for_db() {

--- a/deploy/test-perspective-e2e.sh
+++ b/deploy/test-perspective-e2e.sh
@@ -84,8 +84,8 @@ fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
 err()  { echo "ERROR: $*" >&2; exit 2; }
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 wait_for_db() {

--- a/deploy/test-pollerd-restart-outage-e2e.sh
+++ b/deploy/test-pollerd-restart-outage-e2e.sh
@@ -61,8 +61,8 @@ fail() { echo "  [FAIL] $*"; FAIL=$((FAIL + 1)); }
 err()  { echo "ERROR: $*" >&2; exit 2; }
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 wait_for_db() {

--- a/deploy/test-syslog-e2e.sh
+++ b/deploy/test-syslog-e2e.sh
@@ -110,8 +110,8 @@ cleanup() {
 
     if $POST_CLEANUP; then
         log "Post-run cleanup (--post-cleanup): removing test data..."
-        docker compose exec -T -e PGPASSWORD=opennms postgres \
-            psql -U opennms -d opennms -q \
+        docker compose exec -T -e PGPASSWORD=deltav postgres \
+            psql -U deltav -d deltav -q \
             -c "DELETE FROM alarms WHERE eventuei LIKE '%syslogd/cisco/link%'" \
             2>/dev/null || true
     fi
@@ -153,8 +153,8 @@ wait_for_kafka_event() {
 }
 
 psql_query() {
-    docker compose exec -T -e PGPASSWORD=opennms postgres \
-        psql -U opennms -d opennms -t -A -c "$1" 2>/dev/null
+    docker compose exec -T -e PGPASSWORD=deltav postgres \
+        psql -U deltav -d deltav -t -A -c "$1" 2>/dev/null
 }
 
 # ── Pre-run cleanup (--pre-clean) ─────────────────────────────────

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -173,7 +173,7 @@ do_test() {
     fi
 
     # Test 2: Database accessible
-    if docker compose exec -T -e PGPASSWORD=opennms postgres psql -U opennms -d opennms -c "SELECT 1" >/dev/null 2>&1; then
+    if docker compose exec -T -e PGPASSWORD=deltav postgres psql -U deltav -d deltav -c "SELECT 1" >/dev/null 2>&1; then
         log "  [PASS] PostgreSQL accessible"
         pass=$((pass + 1))
     else


### PR DESCRIPTION
## Summary

Fixes #388 — renames the PostgreSQL **database identity** triplet (database name,
role/user, password) from the upstream-inherited `opennms` to `deltav`, so the
deployed footprint matches the Delta-V fork. Greenfield fork → the dev DB is
recreated, no backward compatibility.

**Strictly a value rename.** Anchored to DB-identity contexts only — never a bare
`s/opennms/deltav/`. Deliberately **not** touched:
- `org.opennms.*` Java packages, `org.opennms.instance.id`
- `OPENNMS_DBINIT_*` / `SPRING_DATASOURCE_*` env-var **keys** and `opennms.dbinit.*`
  property **keys** (framework conventions — only values change)
- OSGi PID filename `org.opennms.netmgt.distributed.datasource.cfg`
- `OPENNMS_JDBC_HOSTNAME`; collectd collection identifiers (`<package name="opennms">`,
  `ds-name`); Kafka consumer-group names

## Surface (42 files, 173/173 symmetric)

| Area | What changed |
|------|--------------|
| `deploy/compose.yml` | `POSTGRES_DB/USER/PASSWORD`, `pg_isready`, `OPENNMS_DBINIT_*` admin+database **values**, 14× `SPRING_DATASOURCE_URL`(`5432/deltav`)`/USERNAME/PASSWORD` |
| 7× overlay `…distributed.datasource.cfg` | `url`/`username`/`password`/`databaseName` |
| collectd-configuration.xml | JDBC self-monitoring collector URL (db name only) |
| 16× daemon `application.yml` | datasource fallbacks + db-init defaults |
| 11× e2e/system scripts | `PGPASSWORD` + `psql -U/-d` |
| 6× IT tests | Testcontainers `withDatabaseName/Username/Password`; db-init `registry.add` values |

No production Java hardcodes the DB identity (all via config/env).

## Verification

- **db-init IT** (`DbInitIntegrationTest`) now creates + runs the full Liquibase
  migration against a **`deltav`** database — Migrator logs
  `checking ... database "deltav"` → `Database initialization complete`. db-init
  module tests: **6/0**.
- Repo-wide grep: **zero** in-scope `opennms` DB-identity remain; all out-of-scope
  refs (packages, keys, PID filename, collectd identifiers) intact.
- No live operational doc references the DB name.

## Remaining gate (destructive — not yet run)

`make down -v` (drop the `opennms` volumes) + `make up PROFILE=full` to bring the stack
up on the `deltav` DB, then run the `deploy/test-*-e2e.sh` suite. Held back because it
tears down the running stack.

https://claude.ai/code/session_01XgRQL9QZcghyiLFXM9ZUnW
